### PR TITLE
refactor(rome_js_formatter): Remove `format_root` from `Formatter`

### DIFF
--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -511,8 +511,9 @@ fn format_file(params: FormatFileParams) -> FormatResult {
             });
         }
 
-        let result = rome_js_formatter::format(params.options, &root.syntax())
-            .with_file_id_and_code(params.file_id, "Format")?;
+        let result = rome_js_formatter::format_node(params.options, &root.syntax())
+            .with_file_id_and_code(params.file_id, "Format")?
+            .print();
 
         let output = result.as_code().as_bytes();
 

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -26,7 +26,7 @@ pub fn empty_element() -> FormatElement {
 /// Soft line breaks are omitted if the enclosing `Group` fits on a single line
 ///
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break, FormatOptions};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break, FormatOptions};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("a,"),
@@ -34,14 +34,14 @@ pub fn empty_element() -> FormatElement {
 ///   token("b"),
 /// ]);
 ///
-/// assert_eq!("a,b", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("a,b", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 /// See [soft_line_break_or_space] if you want to insert a space between the elements if the enclosing
 /// `Group` fits on a single line.
 ///
 /// Soft line breaks are emitted if the enclosing `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break, FormatOptions, LineWidth};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break, FormatOptions, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("a long word,"),
@@ -54,7 +54,7 @@ pub fn empty_element() -> FormatElement {
 ///  ..FormatOptions::default()
 /// };
 ///
-/// assert_eq!("a long word,\nso that the group doesn't fit on a single line", format_element(&elements, options).as_code());
+/// assert_eq!("a long word,\nso that the group doesn't fit on a single line", Formatted::new(elements, options).print().as_code());
 /// ```
 #[inline]
 pub const fn soft_line_break() -> FormatElement {
@@ -68,7 +68,7 @@ pub const fn soft_line_break() -> FormatElement {
 ///
 /// It forces a line break, even if the enclosing `Group` would otherwise fit on a single line.
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, FormatOptions, hard_line_break};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, FormatOptions, hard_line_break};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("a,"),
@@ -77,7 +77,7 @@ pub const fn soft_line_break() -> FormatElement {
 ///   hard_line_break()
 /// ]);
 ///
-/// assert_eq!("a,\nb\n", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("a,\nb\n", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub const fn hard_line_break() -> FormatElement {
@@ -90,7 +90,7 @@ pub const fn hard_line_break() -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, FormatOptions, empty_line};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, FormatOptions, empty_line};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("a,"),
@@ -99,7 +99,7 @@ pub const fn hard_line_break() -> FormatElement {
 ///   empty_line()
 /// ]);
 ///
-/// assert_eq!("a,\n\nb\n\n", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("a,\n\nb\n\n", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub const fn empty_line() -> FormatElement {
@@ -112,7 +112,7 @@ pub const fn empty_line() -> FormatElement {
 ///
 /// The line breaks are emitted as spaces if the enclosing `Group` fits on a a single line:
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("a,"),
@@ -120,12 +120,12 @@ pub const fn empty_line() -> FormatElement {
 ///   token("b"),
 /// ]);
 ///
-/// assert_eq!("a, b", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("a, b", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 ///
 /// The printer breaks the lines if the enclosing `Group` doesn't fit on a single line:
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, LineWidth};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("a long word,"),
@@ -138,7 +138,7 @@ pub const fn empty_line() -> FormatElement {
 ///  ..FormatOptions::default()
 /// };
 ///
-/// assert_eq!("a long word,\nso that the group doesn't fit on a single line", format_element(&elements, options).as_code());
+/// assert_eq!("a long word,\nso that the group doesn't fit on a single line", Formatted::new(elements, options).print().as_code());
 /// ```
 #[inline]
 pub const fn soft_line_break_or_space() -> FormatElement {
@@ -155,22 +155,22 @@ pub const fn soft_line_break_or_space() -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{token, format_element, FormatOptions};
+/// use rome_formatter::{token, Formatted, FormatOptions};
 /// let elements = token("Hello World");
 ///
-/// assert_eq!("Hello World", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("Hello World", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 ///
 /// Printing a string literal as a literal requires that the string literal is properly escaped and
 /// enclosed in quotes (depending on the target language).
 ///
 /// ```
-/// use rome_formatter::{FormatOptions, token, format_element};
+/// use rome_formatter::{FormatOptions, token, Formatted};
 ///
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
 /// let elements = token("\"Hello\\tWorld\"");
 ///
-/// assert_eq!(r#""Hello\tWorld""#, format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!(r#""Hello\tWorld""#, Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub const fn token(text: &'static str) -> FormatElement {
@@ -186,11 +186,11 @@ pub const fn token(text: &'static str) -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{FormatOptions, token, format_element, line_suffix, format_elements};
+/// use rome_formatter::{FormatOptions, token, Formatted, line_suffix, format_elements};
 ///
 /// let elements = format_elements![token("a"), line_suffix(token("c")), token("b")];
 ///
-/// assert_eq!("abc", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("abc", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub fn line_suffix(element: impl Into<FormatElement>) -> FormatElement {
@@ -205,11 +205,11 @@ pub fn line_suffix(element: impl Into<FormatElement>) -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{FormatOptions, token, format_element, comment, format_elements, group_elements, empty_line, soft_line_break_or_space};
+/// use rome_formatter::{FormatOptions, token, Formatted, comment, format_elements, group_elements, empty_line, soft_line_break_or_space};
 ///
 /// let elements = group_elements(format_elements![comment(empty_line()), token("a"), soft_line_break_or_space(), token("b")]);
 ///
-/// assert_eq!("\na b", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("\na b", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub fn comment(element: impl Into<FormatElement>) -> FormatElement {
@@ -221,12 +221,12 @@ pub fn comment(element: impl Into<FormatElement>) -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{FormatOptions, token, format_element, space_token, format_elements};
+/// use rome_formatter::{FormatOptions, token, Formatted, space_token, format_elements};
 ///
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
 /// let elements = format_elements![token("a"), space_token(), token("b")];
 ///
-/// assert_eq!("a b", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("a b", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub const fn space_token() -> FormatElement {
@@ -238,10 +238,10 @@ pub const fn space_token() -> FormatElement {
 /// ## Examples
 ///
 /// ```rust
-/// use rome_formatter::{concat_elements, FormatElement, space_token, token, format_element, FormatOptions};
+/// use rome_formatter::{concat_elements, FormatElement, space_token, token, Formatted, FormatOptions};
 /// let expr = concat_elements(vec![token("a"), space_token(), token("+"), space_token(), token("b")]);
 ///
-/// assert_eq!("a + b", format_element(&expr, FormatOptions::default()).as_code())
+/// assert_eq!("a + b", Formatted::new(expr, FormatOptions::default()).print().as_code())
 /// ```
 pub fn concat_elements<I>(elements: I) -> FormatElement
 where
@@ -296,14 +296,14 @@ where
 ///
 /// ```rust
 /// use std::str::from_utf8;
-/// use rome_formatter::{fill_elements, FormatElement, space_token, token, format_element, FormatOptions};
+/// use rome_formatter::{fill_elements, FormatElement, space_token, token, Formatted, FormatOptions};
 /// let a = from_utf8(&[b'a'; 30]).unwrap();
 /// let b = from_utf8(&[b'b'; 30]).unwrap();
 /// let c = from_utf8(&[b'c'; 30]).unwrap();
 /// let d = from_utf8(&[b'd'; 30]).unwrap();
 /// let expr = fill_elements([token(a), token(b), token(c), token(d)]);
 ///
-/// assert_eq!(format!("{a} {b}\n{c} {d}"), format_element(&expr, FormatOptions::default()).into_code())
+/// assert_eq!(format!("{a} {b}\n{c} {d}"), Formatted::new(expr, FormatOptions::default()).print().as_code())
 /// ```
 pub fn fill_elements(elements: impl IntoIterator<Item = FormatElement>) -> FormatElement {
     let mut list: Vec<_> = elements.into_iter().collect();
@@ -321,12 +321,12 @@ pub fn fill_elements(elements: impl IntoIterator<Item = FormatElement>) -> Forma
 /// Joining different tokens by separating them with a comma and a space.
 ///
 /// ```
-/// use rome_formatter::{concat_elements, FormatOptions, join_elements, space_token, token, format_element};
+/// use rome_formatter::{concat_elements, FormatOptions, join_elements, space_token, token, Formatted};
 ///
 /// let separator = concat_elements(vec![token(","), space_token()]);
 /// let elements = join_elements(separator, vec![token("1"), token("2"), token("3"), token("4")]);
 ///
-/// assert_eq!("1, 2, 3, 4", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("1, 2, 3, 4", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub fn join_elements<TSep, I>(separator: TSep, elements: I) -> FormatElement
@@ -351,7 +351,7 @@ where
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{format_elements, format_element, FormatOptions, hard_line_break, block_indent, token, indent};
+/// use rome_formatter::{format_elements, Formatted, FormatOptions, hard_line_break, block_indent, token, indent};
 /// let block = (format_elements![
 ///   token("switch {"),
 ///   block_indent(format_elements![
@@ -366,7 +366,7 @@ where
 ///
 /// assert_eq!(
 ///   "switch {\n\tdefault:\n\t\tbreak;\n}",
-///   format_element(&block, FormatOptions::default()).as_code()
+///   Formatted::new(block, FormatOptions::default()).print().as_code()
 /// );
 /// ```
 #[inline]
@@ -390,7 +390,7 @@ pub fn indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{format_element, format_elements, token, FormatOptions, hard_line_break, block_indent};
+/// use rome_formatter::{Formatted, format_elements, token, FormatOptions, hard_line_break, block_indent};
 ///
 /// let block = (format_elements![
 ///   token("{"),
@@ -404,7 +404,7 @@ pub fn indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// assert_eq!(
 ///   "{\n\tlet a = 10;\n\tlet c = a + 5;\n}",
-///   format_element(&block, FormatOptions::default()).as_code()
+///   Formatted::new(block, FormatOptions::default()).print().as_code()
 /// );
 /// ```
 #[inline]
@@ -430,7 +430,7 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// Indents the content by one level and puts in new lines if the enclosing `Group` doesn't fit on a single line
 ///
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, LineWidth};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -447,12 +447,12 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///  ..FormatOptions::default()
 /// };
 ///
-/// assert_eq!("[\n\t'First string',\n\t'second string',\n]", format_element(&elements, options).as_code());
+/// assert_eq!("[\n\t'First string',\n\t'second string',\n]", Formatted::new(elements, options).print().as_code());
 /// ```
 ///
 /// Doesn't change the formatting if the enclosing `Group` fits on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -466,7 +466,7 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// assert_eq!(
 ///   "[5, 10]",
-///   format_element(&elements, FormatOptions::default()).as_code()
+///   Formatted::new(elements, FormatOptions::default()).print().as_code()
 /// );
 /// ```
 ///
@@ -496,7 +496,7 @@ pub fn soft_block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// fit on a single line. Otherwise, just inserts a space.
 ///
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_indent_or_space, FormatOptions, soft_block_indent, space_token, LineWidth};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_indent_or_space, FormatOptions, soft_block_indent, space_token, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("name"),
@@ -516,12 +516,12 @@ pub fn soft_block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///  ..FormatOptions::default()
 /// };
 ///
-/// assert_eq!("name =\n\tfirstName + lastName", format_element(&elements, options).as_code());
+/// assert_eq!("name =\n\tfirstName + lastName", Formatted::new(elements, options).print().as_code());
 /// ```
 ///
 /// Only adds a space if the enclosing `Group` fits on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_indent_or_space, FormatOptions, soft_block_indent, space_token};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_indent_or_space, FormatOptions, soft_block_indent, space_token};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("a"),
@@ -534,7 +534,7 @@ pub fn soft_block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// assert_eq!(
 ///   "a = 10",
-///   format_element(&elements, FormatOptions::default()).as_code()
+///   Formatted::new(elements, FormatOptions::default()).print().as_code()
 /// );
 /// ```
 ///
@@ -566,7 +566,7 @@ pub fn soft_line_indent_or_space<T: Into<FormatElement>>(content: T) -> FormatEl
 /// `Group` that fits on a single line
 ///
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -580,12 +580,12 @@ pub fn soft_line_indent_or_space<T: Into<FormatElement>>(content: T) -> FormatEl
 ///   token("]"),
 /// ]);
 ///
-/// assert_eq!("[1, 2, 3]", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("[1, 2, 3]", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 ///
 /// The printer breaks the `Group` over multiple lines if its content doesn't fit on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, LineWidth};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -604,7 +604,7 @@ pub fn soft_line_indent_or_space<T: Into<FormatElement>>(content: T) -> FormatEl
 ///   ..FormatOptions::default()
 /// };
 ///
-/// assert_eq!("[\n\t'Good morning! How are you today?',\n\t2,\n\t3\n]", format_element(&elements, options).as_code());
+/// assert_eq!("[\n\t'Good morning! How are you today?',\n\t2,\n\t3\n]", Formatted::new(elements, options).print().as_code());
 /// ```
 #[inline]
 pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
@@ -629,7 +629,8 @@ pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// # Example
 /// ```
 /// use rome_formatter::{
-///   group_elements, format_element, format_elements, token, hard_group_elements,
+///   group_elements, Formatted, format_elements, token, hard_group_elements,
+///
 ///   FormatOptions, empty_line, if_group_breaks, if_group_fits_on_single_line
 /// };
 ///
@@ -639,7 +640,7 @@ pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///   if_group_fits_on_single_line(token("printed")),
 /// ]));
 ///
-/// assert_eq!("\nprinted", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("\nprinted", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
@@ -668,7 +669,7 @@ pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement 
 ///
 /// Omits the trailing comma for the last array element if the `Group` fits on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_breaks};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_breaks};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -682,12 +683,12 @@ pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement 
 ///   ]),
 ///   token("]"),
 /// ]);
-/// assert_eq!("[1, 2, 3]", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("[1, 2, 3]", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 ///
 /// Prints the trailing comma for the last array element if the `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_breaks, LineWidth};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_breaks, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -705,7 +706,7 @@ pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement 
 /// let options = FormatOptions { line_width: LineWidth::try_from(20).unwrap(), ..FormatOptions::default() };
 /// assert_eq!(
 ///   "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3,\n]",
-///   format_element(&elements, options).as_code()
+///   Formatted::new(elements, options).print().as_code()
 /// );
 /// ```
 #[inline]
@@ -731,7 +732,7 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// Adds the trailing comma for the last array element if the `Group` fits on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_fits_on_single_line};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_fits_on_single_line};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -745,12 +746,12 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///   ]),
 ///   token("]"),
 /// ]);
-/// assert_eq!("[1, 2, 3,]", format_element(&elements, FormatOptions::default()).as_code());
+/// assert_eq!("[1, 2, 3,]", Formatted::new(elements, FormatOptions::default()).print().as_code());
 /// ```
 ///
 /// Omits the trailing comma for the last array element if the `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_fits_on_single_line, LineWidth};
+/// use rome_formatter::{group_elements, Formatted, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_fits_on_single_line, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -768,7 +769,7 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// let options = FormatOptions { line_width: LineWidth::try_from(20).unwrap(), ..FormatOptions::default() };
 /// assert_eq!(
 ///   "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3\n]",
-///   format_element(&elements, options).as_code()
+///   Formatted::new(elements, options).print().as_code()
 /// );
 /// ```
 #[inline]

--- a/crates/rome_formatter/src/format_elements.rs
+++ b/crates/rome_formatter/src/format_elements.rs
@@ -21,7 +21,7 @@
 /// You would write it like the following:
 ///
 /// ```rust
-/// use rome_formatter::{format_elements, format_element, FormatOptions, space_token, token};
+/// use rome_formatter::{format_elements, Formatted, FormatOptions, space_token, token};
 /// let element = format_elements![
 ///   token("foo:"),
 ///   space_token(),
@@ -33,13 +33,13 @@
 ///   space_token(),
 ///   token("}")
 /// ];
-/// assert_eq!(r#"foo: { bar: lorem }"#, format_element(&element, FormatOptions::default()).as_code());
+/// assert_eq!(r#"foo: { bar: lorem }"#, Formatted::new(element, FormatOptions::default()).print().as_code());
 /// ```
 /// Or you can also create single element:
 /// ```
-/// use rome_formatter::{format_elements, format_element, FormatOptions, token};
+/// use rome_formatter::{format_elements, Formatted, FormatOptions, token};
 /// let element = format_elements![token("single")];
-/// assert_eq!(r#"single"#, format_element(&element, FormatOptions::default()).as_code());
+/// assert_eq!(r#"single"#, Formatted::new(element, FormatOptions::default()).print().as_code());
 /// ```
 #[macro_export]
 macro_rules! format_elements {

--- a/crates/rome_formatter/src/printer.rs
+++ b/crates/rome_formatter/src/printer.rs
@@ -3,7 +3,7 @@ use crate::format_element::{
 };
 use crate::intersperse::Intersperse;
 use crate::{
-    hard_line_break, space_token, FormatElement, FormatOptions, Formatted, IndentStyle, LineWidth,
+    hard_line_break, space_token, FormatElement, FormatOptions, IndentStyle, LineWidth, Printed,
     SourceMarker, TextRange,
 };
 use rome_rowan::TextSize;
@@ -102,13 +102,13 @@ impl<'a> Printer<'a> {
     }
 
     /// Prints the passed in element as well as all its content
-    pub fn print(self, element: &'a FormatElement) -> Formatted {
+    pub fn print(self, element: &'a FormatElement) -> Printed {
         tracing::debug_span!("Printer::print").in_scope(move || self.print_with_indent(element, 0))
     }
 
     /// Prints the passed in element as well as all its content,
     /// starting at the specified indentation level
-    pub fn print_with_indent(mut self, element: &'a FormatElement, indent: u16) -> Formatted {
+    pub fn print_with_indent(mut self, element: &'a FormatElement, indent: u16) -> Printed {
         let mut queue = ElementCallQueue::new();
 
         queue.enqueue(PrintElementCall::new(
@@ -131,7 +131,7 @@ impl<'a> Printer<'a> {
             }
         }
 
-        Formatted::new(
+        Printed::new(
             self.state.buffer,
             None,
             self.state.source_markers,
@@ -646,11 +646,11 @@ mod tests {
     use crate::{
         block_indent, empty_line, format_elements, group_elements, hard_line_break,
         if_group_breaks, soft_block_indent, soft_line_break, soft_line_break_or_space, token,
-        FormatElement, Formatted, LineWidth,
+        FormatElement, LineWidth, Printed,
     };
 
     /// Prints the given element with the default printer options
-    fn print_element<T: Into<FormatElement>>(element: T) -> Formatted {
+    fn print_element<T: Into<FormatElement>>(element: T) -> Printed {
         let options = PrinterOptions {
             indent_string: String::from("  "),
             ..PrinterOptions::default()

--- a/crates/rome_js_formatter/src/check_reformat.rs
+++ b/crates/rome_js_formatter/src/check_reformat.rs
@@ -1,4 +1,4 @@
-use crate::{format_element, to_format_element, FormatOptions};
+use crate::{format_node, FormatOptions};
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
 use rome_js_parser::{parse, SourceType};
 use rome_js_syntax::JsSyntaxNode;
@@ -44,22 +44,18 @@ pub fn check_reformat(params: CheckReformatParams) {
         )
     }
 
-    let output_format_element = to_format_element(format_options, &re_parse.syntax()).unwrap();
-    let output_formatted = format_element(&output_format_element, format_options);
+    let formatted = format_node(format_options, &re_parse.syntax()).unwrap();
+    let printed = formatted.print();
 
-    if text != output_formatted.as_code() {
-        let input_format_element = to_format_element(format_options, root).unwrap();
+    if text != printed.as_code() {
+        let input_formatted = format_node(format_options, root).unwrap();
 
         // Print a diff of the Formatter IR emitted for the input and the output
-        let diff = similar_asserts::Diff::from_debug(
-            &input_format_element,
-            &output_format_element,
-            "input",
-            "output",
-        );
+        let diff =
+            similar_asserts::Diff::from_debug(&input_formatted, &formatted, "input", "output");
 
         println!("{diff}");
 
-        similar_asserts::assert_str_eq!(text, output_formatted.as_code());
+        similar_asserts::assert_str_eq!(text, printed.as_code());
     }
 }

--- a/crates/rome_js_formatter/src/cst.rs
+++ b/crates/rome_js_formatter/src/cst.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{map_syntax_node, JsSyntaxNode};
 
 impl Format for JsSyntaxNode {

--- a/crates/rome_js_formatter/src/format.rs
+++ b/crates/rome_js_formatter/src/format.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 impl Format for rome_js_syntax::JsScript {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         self.format_node(formatter)

--- a/crates/rome_js_formatter/src/format_traits.rs
+++ b/crates/rome_js_formatter/src/format_traits.rs
@@ -1,5 +1,6 @@
 use crate::Format;
-use crate::{empty_element, FormatElement, FormatResult, Formatter};
+use crate::{empty_element, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_rowan::SyntaxResult;
 

--- a/crates/rome_js_formatter/src/formatter.rs
+++ b/crates/rome_js_formatter/src/formatter.rs
@@ -2,9 +2,9 @@ use crate::{
     block_indent, concat_elements, empty_element, empty_line, format_elements, group_elements,
     hard_line_break, if_group_breaks, if_group_fits_on_single_line, indent,
     join_elements_hard_line, line_suffix, soft_block_indent, soft_line_break_or_space, space_token,
-    Format, FormatElement, FormatOptions, FormatResult, TextRange, Token, Verbatim,
+    Format, FormatElement, FormatOptions, TextRange, Token, Verbatim,
 };
-use rome_formatter::{normalize_newlines, LINE_TERMINATORS};
+use rome_formatter::{normalize_newlines, FormatResult, LINE_TERMINATORS};
 use rome_js_syntax::{JsLanguage, JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, AstNodeList, AstSeparatedList, Language, SyntaxTriviaPiece};
 #[cfg(debug_assertions)]
@@ -61,28 +61,6 @@ impl Formatter {
     #[inline]
     pub fn options(&self) -> &FormatOptions {
         &self.options
-    }
-
-    /// Formats a CST
-    pub(crate) fn format_root(self, root: &JsSyntaxNode) -> FormatResult<FormatElement> {
-        tracing::debug_span!("Formatter::format_root").in_scope(move || {
-            let element = root.format(&self)?;
-
-            cfg_if::cfg_if! {
-                if #[cfg(debug_assertions)] {
-                    let printed_tokens = self.printed_tokens.into_inner();
-                    for token in root.descendants_tokens() {
-                        assert!(
-                            printed_tokens.contains(&token),
-                            "token was not seen by the formatter: {:?}",
-                            token
-                        );
-                    }
-                }
-            }
-
-            Ok(element)
-        })
     }
 
     /// Formats a group delimited by an opening and closing token,

--- a/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyArrayAssignmentPatternElement;
 impl Format for JsAnyArrayAssignmentPatternElement {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyArrayBindingPatternElement;
 impl Format for JsAnyArrayBindingPatternElement {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/array_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_element.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyArrayElement;
 impl Format for JsAnyArrayElement {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
+++ b/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyArrowFunctionParameters;
 impl Format for JsAnyArrowFunctionParameters {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/assignment.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyAssignment;
 impl Format for JsAnyAssignment {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyAssignmentPattern;
 impl Format for JsAnyAssignmentPattern {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/binding.rs
+++ b/crates/rome_js_formatter/src/js/any/binding.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyBinding;
 impl Format for JsAnyBinding {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/binding_pattern.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyBindingPattern;
 impl Format for JsAnyBindingPattern {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/call_argument.rs
+++ b/crates/rome_js_formatter/src/js/any/call_argument.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyCallArgument;
 impl Format for JsAnyCallArgument {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/class.rs
+++ b/crates/rome_js_formatter/src/js/any/class.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
-use crate::{
-    format_elements, join_elements_hard_line, space_token, FormatElement, FormatResult, Formatter,
-};
+use crate::{format_elements, join_elements_hard_line, space_token, FormatElement, Formatter};
 use crate::{hard_group_elements, Format};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsAnyClass;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/js/any/class_member.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyClassMember;
 impl Format for JsAnyClassMember {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/class_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member_name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyClassMemberName;
 impl Format for JsAnyClassMemberName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyConstructorParameter;
 impl Format for JsAnyConstructorParameter {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyDeclaration;
 impl Format for JsAnyDeclaration {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration_clause.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyDeclarationClause;
 impl Format for JsAnyDeclarationClause {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/export_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/export_clause.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyExportClause;
 impl Format for JsAnyExportClause {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyExportDefaultDeclaration;
 impl Format for JsAnyExportDefaultDeclaration {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyExportNamedSpecifier;
 impl Format for JsAnyExportNamedSpecifier {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/expression.rs
+++ b/crates/rome_js_formatter/src/js/any/expression.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyExpression;
 impl Format for JsAnyExpression {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyForInOrOfInitializer;
 impl Format for JsAnyForInOrOfInitializer {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/for_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_initializer.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyForInitializer;
 impl Format for JsAnyForInitializer {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/formal_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/formal_parameter.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyFormalParameter;
 impl Format for JsAnyFormalParameter {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -3,8 +3,9 @@ use crate::utils::is_simple_expression;
 use crate::{
     concat_elements, empty_element, format_elements, group_elements, hard_group_elements,
     if_group_breaks, soft_block_indent, soft_line_indent_or_space, space_token, token, Format,
-    FormatElement, FormatNode, FormatResult, Formatter,
+    FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::{
     JsAnyArrowFunctionParameters, JsAnyExpression, JsAnyFunction, JsAnyFunctionBody,

--- a/crates/rome_js_formatter/src/js/any/function_body.rs
+++ b/crates/rome_js_formatter/src/js/any/function_body.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyFunctionBody;
 impl Format for JsAnyFunctionBody {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyImportAssertionEntry;
 impl Format for JsAnyImportAssertionEntry {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/import_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/import_clause.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyImportClause;
 impl Format for JsAnyImportClause {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/in_property.rs
+++ b/crates/rome_js_formatter/src/js/any/in_property.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyInProperty;
 impl Format for JsAnyInProperty {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/any/literal_expression.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyLiteralExpression;
 impl Format for JsAnyLiteralExpression {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/method_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/method_modifier.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyMethodModifier;
 impl Format for JsAnyMethodModifier {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/module_item.rs
+++ b/crates/rome_js_formatter/src/js/any/module_item.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyModuleItem;
 impl Format for JsAnyModuleItem {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/name.rs
+++ b/crates/rome_js_formatter/src/js/any/name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyName;
 impl Format for JsAnyName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/named_import.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyNamedImport;
 impl Format for JsAnyNamedImport {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyNamedImportSpecifier;
 impl Format for JsAnyNamedImportSpecifier {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyObjectAssignmentPatternMember;
 impl Format for JsAnyObjectAssignmentPatternMember {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyObjectBindingPatternMember;
 impl Format for JsAnyObjectBindingPatternMember {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/object_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyObjectMember;
 impl Format for JsAnyObjectMember {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/object_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member_name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyObjectMemberName;
 impl Format for JsAnyObjectMemberName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/parameter.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyParameter;
 impl Format for JsAnyParameter {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/property_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/property_modifier.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyPropertyModifier;
 impl Format for JsAnyPropertyModifier {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/root.rs
+++ b/crates/rome_js_formatter/src/js/any/root.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyRoot;
 impl Format for JsAnyRoot {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/statement.rs
+++ b/crates/rome_js_formatter/src/js/any/statement.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyStatement;
 impl Format for JsAnyStatement {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/switch_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/switch_clause.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnySwitchClause;
 impl Format for JsAnySwitchClause {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/any/template_element.rs
+++ b/crates/rome_js_formatter/src/js/any/template_element.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsAnyTemplateElement;
 impl Format for JsAnyTemplateElement {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsArrayAssignmentPattern;
 use rome_js_syntax::JsArrayAssignmentPatternFields;

--- a/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
+++ b/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsArrayAssignmentPatternRestElement;
 use rome_js_syntax::JsArrayAssignmentPatternRestElementFields;

--- a/crates/rome_js_formatter/src/js/assignments/assignment_with_default.rs
+++ b/crates/rome_js_formatter/src/js/assignments/assignment_with_default.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsAssignmentWithDefault;
 use rome_js_syntax::JsAssignmentWithDefaultFields;

--- a/crates/rome_js_formatter/src/js/assignments/computed_member_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/computed_member_assignment.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsComputedMemberAssignment;
 use rome_js_syntax::JsComputedMemberAssignmentFields;

--- a/crates/rome_js_formatter/src/js/assignments/identifier_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/identifier_assignment.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsIdentifierAssignment;
 use rome_js_syntax::JsIdentifierAssignmentFields;

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectAssignmentPattern;
 use rome_js_syntax::JsObjectAssignmentPatternFields;

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_property.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_property.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsObjectAssignmentPatternProperty;
 use rome_js_syntax::JsObjectAssignmentPatternPropertyFields;

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_rest.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_rest.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectAssignmentPatternRest;
 use rome_js_syntax::JsObjectAssignmentPatternRestFields;

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsObjectAssignmentPatternShorthandProperty;
 use rome_js_syntax::JsObjectAssignmentPatternShorthandPropertyFields;

--- a/crates/rome_js_formatter/src/js/assignments/parenthesized_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/parenthesized_assignment.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsParenthesizedAssignment;
 use rome_js_syntax::JsParenthesizedAssignmentFields;

--- a/crates/rome_js_formatter/src/js/assignments/static_member_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/static_member_assignment.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsStaticMemberAssignment;
 use rome_js_syntax::JsStaticMemberAssignmentFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/array_hole.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/array_hole.rs
@@ -1,4 +1,5 @@
-use crate::{empty_element, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{empty_element, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsArrayHole;
 

--- a/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
@@ -1,4 +1,4 @@
-use crate::FormatResult;
+use rome_formatter::FormatResult;
 
 use crate::{
     format_elements, hard_line_break, indent, space_token, Format, FormatElement, FormatNode,

--- a/crates/rome_js_formatter/src/js/auxiliary/catch_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/catch_clause.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsCatchClause;
 use rome_js_syntax::JsCatchClauseFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
@@ -1,7 +1,8 @@
+use crate::Format;
 use crate::{
     format_elements, hard_line_break, indent, space_token, FormatElement, FormatNode, Formatter,
 };
-use crate::{Format, FormatResult};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsDefaultClause;
 use rome_js_syntax::JsDefaultClauseFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/directive.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/directive.rs
@@ -1,5 +1,6 @@
 use crate::utils::{format_string_literal_token, format_with_semicolon};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsDirective;
 use rome_js_syntax::JsDirectiveFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/else_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/else_clause.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsElseClause;
 use rome_js_syntax::JsElseClauseFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/expression_snipped.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/expression_snipped.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsExpressionSnipped;
 use rome_js_syntax::JsExpressionSnippedFields;
 

--- a/crates/rome_js_formatter/src/js/auxiliary/finally_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/finally_clause.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsFinallyClause;
 use rome_js_syntax::JsFinallyClauseFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsFunctionBody;
 use rome_js_syntax::JsFunctionBodyFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/initializer_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/initializer_clause.rs
@@ -1,7 +1,7 @@
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsInitializerClause;
 use rome_js_syntax::JsInitializerClauseFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/module.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/module.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_interpreter;
-use crate::{
-    format_elements, hard_line_break, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, hard_line_break, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsModule;
 use rome_js_syntax::JsModuleFields;
 

--- a/crates/rome_js_formatter/src/js/auxiliary/name.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/name.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsName;
 use rome_js_syntax::JsNameFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/new_target.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/new_target.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::NewTarget;
 use rome_js_syntax::NewTargetFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/private_name.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/private_name.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsPrivateName;
 use rome_js_syntax::JsPrivateNameFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/reference_identifier.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/reference_identifier.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsReferenceIdentifier;
 use rome_js_syntax::JsReferenceIdentifierFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/script.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/script.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_interpreter;
-use crate::{
-    format_elements, hard_line_break, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, hard_line_break, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsScript;
 use rome_js_syntax::JsScriptFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/spread.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/spread.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsSpread;
 use rome_js_syntax::JsSpreadFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/static_modifier.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/static_modifier.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsStaticModifier;
 use rome_js_syntax::JsStaticModifierFields;
 

--- a/crates/rome_js_formatter/src/js/auxiliary/variable_declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/variable_declaration_clause.rs
@@ -1,5 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsVariableDeclarationClause;
 use rome_js_syntax::JsVariableDeclarationClauseFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
@@ -1,9 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_initializer_clause;
-use crate::{
-    format_elements, hard_group_elements, Format, FormatElement, FormatNode, FormatResult,
-    Formatter,
-};
+use crate::{format_elements, hard_group_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsVariableDeclarator;
 use rome_js_syntax::JsVariableDeclaratorFields;
 

--- a/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsArrayBindingPattern;
 use rome_js_syntax::JsArrayBindingPatternFields;

--- a/crates/rome_js_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
+++ b/crates/rome_js_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsArrayBindingPatternRestElement;
 use rome_js_syntax::JsArrayBindingPatternRestElementFields;

--- a/crates/rome_js_formatter/src/js/bindings/binding_pattern_with_default.rs
+++ b/crates/rome_js_formatter/src/js/bindings/binding_pattern_with_default.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsBindingPatternWithDefault;
 use rome_js_syntax::JsBindingPatternWithDefaultFields;

--- a/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsConstructorParameters;
 use rome_js_syntax::JsConstructorParametersFields;

--- a/crates/rome_js_formatter/src/js/bindings/formal_parameter.rs
+++ b/crates/rome_js_formatter/src/js/bindings/formal_parameter.rs
@@ -1,6 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_initializer_clause;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsFormalParameter;
 use rome_js_syntax::JsFormalParameterFields;
 

--- a/crates/rome_js_formatter/src/js/bindings/identifier_binding.rs
+++ b/crates/rome_js_formatter/src/js/bindings/identifier_binding.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsIdentifierBinding;
 use rome_js_syntax::JsIdentifierBindingFields;

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectBindingPattern;
 use rome_js_syntax::JsObjectBindingPatternFields;

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsObjectBindingPatternProperty;
 use rome_js_syntax::JsObjectBindingPatternPropertyFields;

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_rest.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_rest.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectBindingPatternRest;
 use rome_js_syntax::JsObjectBindingPatternRestFields;

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsObjectBindingPatternShorthandProperty;
 use rome_js_syntax::JsObjectBindingPatternShorthandPropertyFields;

--- a/crates/rome_js_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/parameters.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsParameters;
 use rome_js_syntax::JsParametersFields;

--- a/crates/rome_js_formatter/src/js/bindings/rest_parameter.rs
+++ b/crates/rome_js_formatter/src/js/bindings/rest_parameter.rs
@@ -1,6 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsRestParameter;
 use rome_js_syntax::JsRestParameterFields;

--- a/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
@@ -1,7 +1,7 @@
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsConstructorClassMember;
 use rome_js_syntax::JsConstructorClassMemberFields;

--- a/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
@@ -1,4 +1,5 @@
-use crate::{empty_element, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{empty_element, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsEmptyClassMember;
 use rome_js_syntax::JsEmptyClassMemberFields;

--- a/crates/rome_js_formatter/src/js/classes/extends_clause.rs
+++ b/crates/rome_js_formatter/src/js/classes/extends_clause.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsExtendsClause;
 use rome_js_syntax::JsExtendsClauseFields;

--- a/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
@@ -1,8 +1,8 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
 
 use rome_js_syntax::JsGetterClassMember;

--- a/crates/rome_js_formatter/src/js/classes/method_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/method_class_member.rs
@@ -1,7 +1,8 @@
 use crate::format_traits::FormatOptional;
 use crate::{hard_group_elements, Format};
+use rome_formatter::FormatResult;
 
-use crate::{format_elements, space_token, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, space_token, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsMethodClassMember;
 use rome_js_syntax::JsMethodClassMemberFields;

--- a/crates/rome_js_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/property_class_member.rs
@@ -1,9 +1,8 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsPropertyClassMember;
 use rome_js_syntax::JsPropertyClassMemberFields;

--- a/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
@@ -1,7 +1,7 @@
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsSetterClassMember;
 use rome_js_syntax::JsSetterClassMemberFields;

--- a/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsStaticInitializationBlockClassMember;
 use rome_js_syntax::JsStaticInitializationBlockClassMemberFields;

--- a/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
@@ -1,6 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsCatchDeclaration;
 use rome_js_syntax::JsCatchDeclarationFields;

--- a/crates/rome_js_formatter/src/js/declarations/class_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/class_declaration.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyClass, JsClassDeclaration};
 
 impl FormatNode for JsClassDeclaration {

--- a/crates/rome_js_formatter/src/js/declarations/class_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/class_export_default_declaration.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsAnyClass;
 use rome_js_syntax::JsClassExportDefaultDeclaration;
 

--- a/crates/rome_js_formatter/src/js/declarations/for_variable_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/for_variable_declaration.rs
@@ -1,8 +1,7 @@
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsForVariableDeclaration;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 use rome_js_syntax::JsForVariableDeclarationFields;
 
 impl FormatNode for JsForVariableDeclaration {

--- a/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyFunction, JsFunctionDeclaration};
 
 impl FormatNode for JsFunctionDeclaration {

--- a/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsAnyFunction;
 use rome_js_syntax::JsFunctionExportDefaultDeclaration;
 

--- a/crates/rome_js_formatter/src/js/declarations/variable_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/variable_declaration.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsVariableDeclaration;
 use rome_js_syntax::JsVariableDeclarationFields;

--- a/crates/rome_js_formatter/src/js/expressions/array_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/array_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsArrayExpression;
 use rome_js_syntax::JsArrayExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyFunction, JsArrowFunctionExpression};
 
 impl FormatNode for JsArrowFunctionExpression {

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -1,7 +1,8 @@
 use crate::{
     format_elements, group_elements, soft_line_indent_or_space, space_token, Format, FormatElement,
-    FormatNode, FormatResult, Formatter,
+    FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsAssignmentExpression;
 use rome_js_syntax::JsAssignmentExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/await_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/await_expression.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsAwaitExpression;
 use rome_js_syntax::JsAwaitExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
 use crate::utils::string_utils::ToAsciiLowercaseCow;
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
 
-use rome_formatter::Token;
+use rome_formatter::{FormatResult, Token};
 use rome_js_syntax::JsBigIntLiteralExpression;
 use rome_js_syntax::JsBigIntLiteralExpressionFields;
 

--- a/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
@@ -1,5 +1,6 @@
 use crate::utils::{format_binary_like_expression, JsAnyBinaryLikeExpression};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsBinaryExpression;
 
 impl FormatNode for JsBinaryExpression {

--- a/crates/rome_js_formatter/src/js/expressions/boolean_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/boolean_literal_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsBooleanLiteralExpression;
 use rome_js_syntax::JsBooleanLiteralExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -1,6 +1,7 @@
 use crate::utils::{is_simple_expression, token_has_comments};
 use crate::{format_elements, hard_group_elements, Format};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsCallArgumentsFields;
 use rome_js_syntax::{JsAnyCallArgument, JsCallArguments};

--- a/crates/rome_js_formatter/src/js/expressions/call_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_expression.rs
@@ -1,5 +1,6 @@
 use crate::utils::format_call_expression;
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsCallExpression;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/js/expressions/class_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/class_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyClass, JsClassExpression};
 
 impl FormatNode for JsClassExpression {

--- a/crates/rome_js_formatter/src/js/expressions/computed_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/computed_member_expression.rs
@@ -1,6 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsComputedMemberExpression;
 use rome_js_syntax::JsComputedMemberExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
@@ -1,5 +1,6 @@
 use crate::utils::{format_conditional, Conditional};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsConditionalExpression;
 
 impl FormatNode for JsConditionalExpression {

--- a/crates/rome_js_formatter/src/js/expressions/function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/function_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyFunction, JsFunctionExpression};
 
 impl FormatNode for JsFunctionExpression {

--- a/crates/rome_js_formatter/src/js/expressions/identifier_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/identifier_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsIdentifierExpression;
 use rome_js_syntax::JsIdentifierExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/import_call_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/import_call_expression.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsImportCallExpression;
 use rome_js_syntax::JsImportCallExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/in_expression.rs
@@ -1,5 +1,6 @@
 use crate::utils::{format_binary_like_expression, JsAnyBinaryLikeExpression};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsInExpression;
 
 impl FormatNode for JsInExpression {

--- a/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -1,5 +1,6 @@
 use crate::utils::{format_binary_like_expression, JsAnyBinaryLikeExpression};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsInstanceofExpression;
 
 impl FormatNode for JsInstanceofExpression {

--- a/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
@@ -1,5 +1,6 @@
 use crate::utils::{format_binary_like_expression, JsAnyBinaryLikeExpression};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsLogicalExpression;
 
 impl FormatNode for JsLogicalExpression {

--- a/crates/rome_js_formatter/src/js/expressions/new_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/new_expression.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsNewExpression;
 use rome_js_syntax::JsNewExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/null_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/null_literal_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsNullLiteralExpression;
 use rome_js_syntax::JsNullLiteralExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsNumberLiteralExpression;
 use rome_js_syntax::JsNumberLiteralExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/object_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/object_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectExpression;
 use rome_js_syntax::JsObjectExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -1,8 +1,9 @@
 use crate::utils::{is_simple_expression, FormatPrecedence};
 use crate::{
     empty_element, format_elements, group_elements, hard_group_elements, Format, FormatElement,
-    FormatNode, FormatResult, Formatter,
+    FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{
     JsAnyExpression, JsParenthesizedExpression, JsParenthesizedExpressionFields, JsSyntaxKind,
     JsSyntaxNode,

--- a/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsPostUpdateExpression;
 use rome_js_syntax::JsPostUpdateExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsPreUpdateExpression;
 use rome_js_syntax::JsPreUpdateExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsRegexLiteralExpression;
 use rome_js_syntax::JsRegexLiteralExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -1,8 +1,6 @@
-use rome_formatter::concat_elements;
+use rome_formatter::{concat_elements, FormatResult};
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::{JsSequenceExpression, JsSequenceExpressionFields};
 use rome_rowan::AstNode;

--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, group_elements, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, group_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsStaticMemberExpression;
 use rome_js_syntax::JsStaticMemberExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use crate::utils::format_string_literal_token;
 use rome_js_syntax::JsStringLiteralExpression;

--- a/crates/rome_js_formatter/src/js/expressions/super_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/super_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsSuperExpression;
 use rome_js_syntax::JsSuperExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/template.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template.rs
@@ -1,9 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, hard_group_elements, Format, FormatElement, FormatNode, FormatResult,
-    Formatter,
-};
+use crate::{format_elements, hard_group_elements, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsTemplate;
 use rome_js_syntax::JsTemplateFields;

--- a/crates/rome_js_formatter/src/js/expressions/template_chunk_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_chunk_element.rs
@@ -1,5 +1,6 @@
 use crate::utils::format_template_chunk;
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsTemplateChunkElement, JsTemplateChunkElementFields};
 
 impl FormatNode for JsTemplateChunkElement {

--- a/crates/rome_js_formatter/src/js/expressions/template_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_element.rs
@@ -1,5 +1,6 @@
 use crate::utils::{format_template_literal, TemplateElement};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsTemplateElement;
 
 impl FormatNode for JsTemplateElement {

--- a/crates/rome_js_formatter/src/js/expressions/this_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/this_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsThisExpression;
 use rome_js_syntax::JsThisExpressionFields;

--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -1,8 +1,9 @@
 use crate::utils::is_simple_expression;
 use crate::{
     format_elements, group_elements, soft_block_indent, space_token, token, Format, FormatElement,
-    FormatNode, FormatResult, Formatter,
+    FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsPreUpdateOperator;
 use rome_js_syntax::{JsAnyExpression, JsUnaryExpression};

--- a/crates/rome_js_formatter/src/js/expressions/yield_argument.rs
+++ b/crates/rome_js_formatter/src/js/expressions/yield_argument.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsYieldArgument;
 use rome_js_syntax::JsYieldArgumentFields;

--- a/crates/rome_js_formatter/src/js/expressions/yield_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/yield_expression.rs
@@ -1,6 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsYieldExpression;
 use rome_js_syntax::JsYieldExpressionFields;

--- a/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
@@ -1,5 +1,6 @@
 use crate::utils::array::format_array_node;
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsArrayAssignmentPatternElementList;
 
 impl Format for JsArrayAssignmentPatternElementList {

--- a/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
@@ -1,5 +1,6 @@
 use crate::utils::array::format_array_node;
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsArrayBindingPatternElementList;
 
 impl Format for JsArrayBindingPatternElementList {

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -1,11 +1,9 @@
+use rome_formatter::FormatResult;
 use std::convert::Infallible;
 
 use crate::formatter::TrailingSeparator;
 use crate::utils::array::format_array_node;
-use crate::{
-    fill_elements, token, utils::has_formatter_trivia, Format, FormatElement, FormatResult,
-    Formatter,
-};
+use crate::{fill_elements, token, utils::has_formatter_trivia, Format, FormatElement, Formatter};
 
 use rome_js_syntax::{JsAnyExpression, JsArrayElementList};
 use rome_rowan::{AstNode, AstSeparatedList};

--- a/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsCallArgumentList;
 
 impl Format for JsCallArgumentList {

--- a/crates/rome_js_formatter/src/js/lists/class_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/class_member_list.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsClassMemberList;
 impl Format for JsClassMemberList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
@@ -1,4 +1,5 @@
-use crate::{join_elements, space_token, Format, FormatElement, FormatResult, Formatter};
+use crate::{join_elements, space_token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsConstructorModifierList;
 use rome_rowan::AstNodeList;
 

--- a/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsConstructorParameterList;
 
 impl Format for JsConstructorParameterList {

--- a/crates/rome_js_formatter/src/js/lists/directive_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/directive_list.rs
@@ -1,6 +1,5 @@
-use crate::{
-    empty_element, format_elements, hard_line_break, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{empty_element, format_elements, hard_line_break, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsDirectiveList;
 use rome_rowan::AstNodeList;
 

--- a/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsExportNamedFromSpecifierList;
 
 impl Format for JsExportNamedFromSpecifierList {

--- a/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsExportNamedSpecifierList;
 
 impl Format for JsExportNamedSpecifierList {

--- a/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsImportAssertionEntryList;
 
 impl Format for JsImportAssertionEntryList {

--- a/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
@@ -1,5 +1,6 @@
 use crate::utils::sort_modifiers_by_precedence;
-use crate::{join_elements, space_token, Format, FormatElement, FormatResult, Formatter};
+use crate::{join_elements, space_token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsMethodModifierList;
 
 impl Format for JsMethodModifierList {

--- a/crates/rome_js_formatter/src/js/lists/module_item_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/module_item_list.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsModuleItemList;
 impl Format for JsModuleItemList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsNamedImportSpecifierList;
 
 impl Format for JsNamedImportSpecifierList {

--- a/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyObjectAssignmentPatternMember, JsObjectAssignmentPatternPropertyList};
 
 impl Format for JsObjectAssignmentPatternPropertyList {

--- a/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyObjectBindingPatternMember, JsObjectBindingPatternPropertyList};
 
 impl Format for JsObjectBindingPatternPropertyList {

--- a/crates/rome_js_formatter/src/js/lists/object_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_member_list.rs
@@ -1,5 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements_soft_line, token, Format, FormatElement, FormatResult, Formatter};
+use crate::{join_elements_soft_line, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectMemberList;
 use rome_rowan::{AstNode, AstSeparatedList};

--- a/crates/rome_js_formatter/src/js/lists/parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/parameter_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyParameter, JsParameterList};
 
 impl Format for JsParameterList {

--- a/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
@@ -1,5 +1,6 @@
 use crate::utils::sort_modifiers_by_precedence;
-use crate::{join_elements, space_token, Format, FormatElement, FormatResult, Formatter};
+use crate::{join_elements, space_token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsPropertyModifierList;
 
 impl Format for JsPropertyModifierList {

--- a/crates/rome_js_formatter/src/js/lists/statement_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/statement_list.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsStatementList;
 impl Format for JsStatementList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsSwitchCaseList;
 impl Format for JsSwitchCaseList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/template_element_list.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsTemplateElementList;
 impl Format for JsTemplateElementList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
@@ -1,8 +1,8 @@
 use crate::{
     concat_elements, empty_element, format_elements, format_traits::FormatOptional, group_elements,
-    indent, join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult,
-    Formatter,
+    indent, join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsVariableDeclaratorList;
 use rome_rowan::AstSeparatedList;
 

--- a/crates/rome_js_formatter/src/js/module/default_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/default_import_specifier.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsDefaultImportSpecifier;
 use rome_js_syntax::JsDefaultImportSpecifierFields;

--- a/crates/rome_js_formatter/src/js/module/export.rs
+++ b/crates/rome_js_formatter/src/js/module/export.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsExport;
 use rome_js_syntax::JsExportFields;

--- a/crates/rome_js_formatter/src/js/module/export_as_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_as_clause.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsExportAsClause;
 use rome_js_syntax::JsExportAsClauseFields;

--- a/crates/rome_js_formatter/src/js/module/export_default_declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_default_declaration_clause.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsExportDefaultDeclarationClause;
 
 impl FormatNode for JsExportDefaultDeclarationClause {

--- a/crates/rome_js_formatter/src/js/module/export_default_expression_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_default_expression_clause.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsExportDefaultExpressionClause;
 use rome_js_syntax::JsExportDefaultExpressionClauseFields;

--- a/crates/rome_js_formatter/src/js/module/export_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_from_clause.rs
@@ -1,9 +1,8 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsExportFromClause;
 use rome_js_syntax::JsExportFromClauseFields;

--- a/crates/rome_js_formatter/src/js/module/export_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_clause.rs
@@ -1,9 +1,8 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsExportNamedClause;
 use rome_js_syntax::JsExportNamedClauseFields;

--- a/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
@@ -1,9 +1,8 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsExportNamedFromClause;
 use rome_js_syntax::JsExportNamedFromClauseFields;

--- a/crates/rome_js_formatter/src/js/module/export_named_from_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_specifier.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsExportNamedFromSpecifier;
 use rome_js_syntax::JsExportNamedFromSpecifierFields;

--- a/crates/rome_js_formatter/src/js/module/export_named_shorthand_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_shorthand_specifier.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsExportNamedShorthandSpecifier;
 use rome_js_syntax::JsExportNamedShorthandSpecifierFields;

--- a/crates/rome_js_formatter/src/js/module/export_named_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_specifier.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsExportNamedSpecifier;
 use rome_js_syntax::JsExportNamedSpecifierFields;

--- a/crates/rome_js_formatter/src/js/module/import.rs
+++ b/crates/rome_js_formatter/src/js/module/import.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsImport;
 use rome_js_syntax::JsImportFields;

--- a/crates/rome_js_formatter/src/js/module/import_assertion.rs
+++ b/crates/rome_js_formatter/src/js/module/import_assertion.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsImportAssertion;
 use rome_js_syntax::JsImportAssertionFields;

--- a/crates/rome_js_formatter/src/js/module/import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/module/import_assertion_entry.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use crate::utils::format_string_literal_token;
 use rome_js_syntax::JsImportAssertionEntryFields;

--- a/crates/rome_js_formatter/src/js/module/import_bare_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_bare_clause.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsImportBareClause;
 use rome_js_syntax::JsImportBareClauseFields;

--- a/crates/rome_js_formatter/src/js/module/import_default_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_default_clause.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsImportDefaultClause;
 use rome_js_syntax::JsImportDefaultClauseFields;

--- a/crates/rome_js_formatter/src/js/module/import_meta.rs
+++ b/crates/rome_js_formatter/src/js/module/import_meta.rs
@@ -1,6 +1,7 @@
+use rome_formatter::FormatResult;
 use rome_js_syntax::ImportMeta;
 
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
 use rome_js_syntax::ImportMetaFields;
 
 impl FormatNode for ImportMeta {

--- a/crates/rome_js_formatter/src/js/module/import_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_named_clause.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsImportNamedClause;
 use rome_js_syntax::JsImportNamedClauseFields;

--- a/crates/rome_js_formatter/src/js/module/import_namespace_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_namespace_clause.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsImportNamespaceClause;
 use rome_js_syntax::JsImportNamespaceClauseFields;

--- a/crates/rome_js_formatter/src/js/module/literal_export_name.rs
+++ b/crates/rome_js_formatter/src/js/module/literal_export_name.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use crate::utils::format_string_literal_token;
 use rome_js_syntax::JsLiteralExportName;

--- a/crates/rome_js_formatter/src/js/module/module_source.rs
+++ b/crates/rome_js_formatter/src/js/module/module_source.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use crate::utils::format_string_literal_token;
 use rome_js_syntax::JsModuleSource;

--- a/crates/rome_js_formatter/src/js/module/named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/named_import_specifier.rs
@@ -1,8 +1,9 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::{
     format_elements, soft_line_break_or_space, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    Formatter,
 };
 
 use rome_js_syntax::JsNamedImportSpecifier;

--- a/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
+++ b/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsNamedImportSpecifiers;
 use rome_js_syntax::JsNamedImportSpecifiersFields;

--- a/crates/rome_js_formatter/src/js/module/namespace_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/namespace_import_specifier.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsNamespaceImportSpecifier;
 use rome_js_syntax::JsNamespaceImportSpecifierFields;

--- a/crates/rome_js_formatter/src/js/module/shorthand_named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/shorthand_named_import_specifier.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsShorthandNamedImportSpecifier;
 use rome_js_syntax::JsShorthandNamedImportSpecifierFields;

--- a/crates/rome_js_formatter/src/js/objects/computed_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/computed_member_name.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsComputedMemberName;
 use rome_js_syntax::JsComputedMemberNameFields;

--- a/crates/rome_js_formatter/src/js/objects/getter_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/getter_object_member.rs
@@ -1,8 +1,8 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
 
 use rome_js_syntax::JsGetterObjectMember;

--- a/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use crate::utils::format_string_literal_token;
 use rome_js_syntax::JsLiteralMemberNameFields;

--- a/crates/rome_js_formatter/src/js/objects/method_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/method_object_member.rs
@@ -1,9 +1,8 @@
 use crate::format_traits::FormatOptional;
 use crate::hard_group_elements;
+use rome_formatter::FormatResult;
 
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsMethodObjectMember;
 use rome_js_syntax::JsMethodObjectMemberFields;

--- a/crates/rome_js_formatter/src/js/objects/private_class_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/private_class_member_name.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsPrivateClassMemberName;
 use rome_js_syntax::JsPrivateClassMemberNameFields;

--- a/crates/rome_js_formatter/src/js/objects/property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/property_object_member.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsPropertyObjectMember;
 use rome_js_syntax::JsPropertyObjectMemberFields;

--- a/crates/rome_js_formatter/src/js/objects/setter_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/setter_object_member.rs
@@ -1,7 +1,7 @@
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsSetterObjectMember;
 use rome_js_syntax::JsSetterObjectMemberFields;

--- a/crates/rome_js_formatter/src/js/objects/shorthand_property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/shorthand_property_object_member.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsShorthandPropertyObjectMember;
 use rome_js_syntax::JsShorthandPropertyObjectMemberFields;

--- a/crates/rome_js_formatter/src/js/statements/block_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/block_statement.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, hard_line_break, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, hard_line_break, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsBlockStatement;
 

--- a/crates/rome_js_formatter/src/js/statements/break_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/break_statement.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsBreakStatement;
 use rome_js_syntax::JsBreakStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/continue_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/continue_statement.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsContinueStatement;
 use rome_js_syntax::JsContinueStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/debugger_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/debugger_statement.rs
@@ -1,5 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsDebuggerStatement;
 use rome_js_syntax::JsDebuggerStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
@@ -1,8 +1,9 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::{
     format_elements, hard_group_elements, space_token, token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    Formatter,
 };
 
 use rome_js_syntax::JsDoWhileStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/empty_statement.rs
@@ -1,4 +1,5 @@
-use crate::{empty_element, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{empty_element, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsEmptyStatement;
 use rome_js_syntax::JsEmptyStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/expression_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/expression_statement.rs
@@ -1,5 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsExpressionStatement;
 use rome_js_syntax::JsExpressionStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
@@ -1,9 +1,10 @@
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsForInStatement;
 
 use crate::utils::format_head_body_statement;
 use crate::{
     format_elements, soft_line_break_or_space, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    Formatter,
 };
 use rome_js_syntax::JsForInStatementFields;
 

--- a/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
@@ -1,3 +1,4 @@
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsForOfStatement;
 
 use crate::format_traits::FormatOptional;
@@ -5,7 +6,7 @@ use crate::format_traits::FormatOptional;
 use crate::utils::format_head_body_statement;
 use crate::{
     format_elements, soft_line_break_or_space, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    Formatter,
 };
 use rome_js_syntax::JsForOfStatementFields;
 

--- a/crates/rome_js_formatter/src/js/statements/for_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_statement.rs
@@ -1,8 +1,9 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::{
     format_elements, group_elements, soft_line_break_or_space, space_token, token, Format,
-    FormatElement, FormatNode, FormatResult, Formatter,
+    FormatElement, FormatNode, Formatter,
 };
 
 use rome_js_syntax::JsAnyStatement;

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -3,8 +3,9 @@ use crate::{
     block_indent, concat_elements, group_elements, hard_group_elements, hard_line_break, token,
     Format,
 };
+use rome_formatter::FormatResult;
 
-use crate::{format_elements, space_token, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, space_token, FormatElement, FormatNode, Formatter};
 
 use rome_js_syntax::JsSyntaxToken;
 use rome_js_syntax::{JsAnyStatement, JsElseClauseFields, JsIfStatement};

--- a/crates/rome_js_formatter/src/js/statements/labeled_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/labeled_statement.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsLabeledStatementFields;
 use rome_js_syntax::{JsAnyStatement, JsLabeledStatement};

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -1,8 +1,9 @@
 use crate::utils::format_with_semicolon;
 use crate::{
     empty_element, format_elements, group_elements, soft_block_indent, space_token, token, Format,
-    FormatElement, FormatNode, FormatResult, Formatter,
+    FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsReturnStatement, JsReturnStatementFields, JsSyntaxKind};
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/js/statements/switch_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/switch_statement.rs
@@ -1,8 +1,9 @@
+use crate::hard_group_elements;
 use crate::{
     format_elements, join_elements_hard_line, space_token, Format, FormatElement, FormatNode,
     Formatter,
 };
-use crate::{hard_group_elements, FormatResult};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsSwitchStatement, JsSwitchStatementFields};
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/js/statements/throw_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/throw_statement.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsThrowStatement;
 use rome_js_syntax::JsThrowStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/try_finally_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/try_finally_statement.rs
@@ -1,8 +1,8 @@
 use crate::format_traits::FormatOptional;
+use rome_formatter::FormatResult;
 
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
 
 use rome_js_syntax::JsTryFinallyStatement;

--- a/crates/rome_js_formatter/src/js/statements/try_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/try_statement.rs
@@ -1,7 +1,7 @@
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsTryStatement;
 use rome_js_syntax::JsTryStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/variable_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/variable_statement.rs
@@ -1,5 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsVariableStatement;
 use rome_js_syntax::JsVariableStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/while_statement.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_head_body_statement;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsWhileStatement;
 use rome_js_syntax::JsWhileStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/with_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/with_statement.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_head_body_statement;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsWithStatement;
 use rome_js_syntax::JsWithStatementFields;

--- a/crates/rome_js_formatter/src/js/unknown/unknown.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsUnknown;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsUnknownAssignment;
 use rome_rowan::AstNode;
 impl FormatNode for JsUnknownAssignment {

--- a/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsUnknownBinding;
 use rome_rowan::AstNode;

--- a/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsUnknownExpression;
 use rome_rowan::AstNode;

--- a/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsUnknownImportAssertionEntry;
 use rome_rowan::AstNode;

--- a/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsUnknownMember;
 use rome_rowan::AstNode;

--- a/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsUnknownNamedImportSpecifier;
 use rome_rowan::AstNode;

--- a/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsUnknownParameter;
 use rome_rowan::AstNode;

--- a/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsUnknownStatement;
 use rome_rowan::AstNode;

--- a/crates/rome_js_formatter/src/jsx/any/attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsxAnyAttribute;
 impl Format for JsxAnyAttribute {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsxAnyAttributeName;
 impl Format for JsxAnyAttributeName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsxAnyAttributeValue;
 impl Format for JsxAnyAttributeValue {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/any/child.rs
+++ b/crates/rome_js_formatter/src/jsx/any/child.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsxAnyChild;
 impl Format for JsxAnyChild {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/any/element_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/element_name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsxAnyElementName;
 impl Format for JsxAnyElementName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/any/name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsxAnyName;
 impl Format for JsxAnyName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/any/object_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/object_name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsxAnyObjectName;
 impl Format for JsxAnyObjectName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/any/tag.rs
+++ b/crates/rome_js_formatter/src/jsx/any/tag.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::JsxAnyTag;
 impl Format for JsxAnyTag {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/attribute/attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/attribute.rs
@@ -1,5 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsxAttribute, JsxAttributeFields};
 
 impl FormatNode for JsxAttribute {

--- a/crates/rome_js_formatter/src/jsx/attribute/attribute_initializer_clause.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/attribute_initializer_clause.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsxAttributeInitializerClause, JsxAttributeInitializerClauseFields};
 
 impl FormatNode for JsxAttributeInitializerClause {

--- a/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
@@ -1,7 +1,5 @@
-use crate::{
-    format_elements, soft_block_indent, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
-use rome_formatter::group_elements;
+use crate::{format_elements, soft_block_indent, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::{group_elements, FormatResult};
 use rome_js_syntax::{
     JsAnyExpression, JsxExpressionAttributeValue, JsxExpressionAttributeValueFields,
 };

--- a/crates/rome_js_formatter/src/jsx/attribute/spread_attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/spread_attribute.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxSpreadAttribute;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxExpressionChild;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/auxiliary/name.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/name.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxName;
 
 impl FormatNode for JsxName {

--- a/crates/rome_js_formatter/src/jsx/auxiliary/namespace_name.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/namespace_name.rs
@@ -1,5 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
-use rome_formatter::format_elements;
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::{format_elements, FormatResult};
 use rome_js_syntax::{JsxNamespaceName, JsxNamespaceNameFields};
 
 impl FormatNode for JsxNamespaceName {

--- a/crates/rome_js_formatter/src/jsx/auxiliary/reference_identifier.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/reference_identifier.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxReferenceIdentifier;
 
 impl FormatNode for JsxReferenceIdentifier {

--- a/crates/rome_js_formatter/src/jsx/auxiliary/spread_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/spread_child.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxSpreadChild;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/auxiliary/string.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/string.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxString;
 
 impl FormatNode for JsxString {

--- a/crates/rome_js_formatter/src/jsx/auxiliary/text.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/text.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxText;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/expressions/tag_expression.rs
+++ b/crates/rome_js_formatter/src/jsx/expressions/tag_expression.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxTagExpression;
 
 impl FormatNode for JsxTagExpression {

--- a/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxAttributeList;
 impl Format for JsxAttributeList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/lists/child_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/child_list.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxChildList;
 impl Format for JsxChildList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/jsx/objects/member_name.rs
+++ b/crates/rome_js_formatter/src/jsx/objects/member_name.rs
@@ -1,5 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
-use rome_formatter::format_elements;
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::{format_elements, FormatResult};
 use rome_js_syntax::{JsxMemberName, JsxMemberNameFields};
 
 impl FormatNode for JsxMemberName {

--- a/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxClosingElement;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/tag/closing_fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/closing_fragment.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxClosingFragment;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/tag/element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/element.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxElement;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/tag/fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/fragment.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxFragment;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxOpeningElement;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/tag/opening_fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/opening_fragment.rs
@@ -1,4 +1,5 @@
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsxOpeningFragment;
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/jsx/tag/self_closing_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/self_closing_element.rs
@@ -2,9 +2,9 @@ use crate::format_traits::FormatOptional;
 use crate::group_elements;
 use crate::{
     format_elements, soft_block_indent, soft_line_break_or_space, space_token, Format,
-    FormatElement, FormatNode, FormatResult, Formatter,
+    FormatElement, FormatNode, Formatter,
 };
-use rome_formatter::join_elements;
+use rome_formatter::{join_elements, FormatResult};
 use rome_js_syntax::JsxSelfClosingElement;
 
 impl FormatNode for JsxSelfClosingElement {

--- a/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
+++ b/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyExternalModuleDeclarationBody;
 impl Format for TsAnyExternalModuleDeclarationBody {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyIndexSignatureModifier;
 impl Format for TsAnyIndexSignatureModifier {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyMethodSignatureModifier;
 impl Format for TsAnyMethodSignatureModifier {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/module_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyModuleName;
 impl Format for TsAnyModuleName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/module_reference.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_reference.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyModuleReference;
 impl Format for TsAnyModuleReference {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/name.rs
+++ b/crates/rome_js_formatter/src/ts/any/name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyName;
 impl Format for TsAnyName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_annotation.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyPropertyAnnotation;
 impl Format for TsAnyPropertyAnnotation {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyPropertyParameterModifier;
 impl Format for TsAnyPropertyParameterModifier {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyPropertySignatureAnnotation;
 impl Format for TsAnyPropertySignatureAnnotation {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyPropertySignatureModifier;
 impl Format for TsAnyPropertySignatureModifier {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/return_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/return_type.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyReturnType;
 impl Format for TsAnyReturnType {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/template_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/template_element.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyTemplateElement;
 impl Format for TsAnyTemplateElement {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/ts_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/ts_type.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsType;
 impl Format for TsType {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyTupleTypeElement;
 impl Format for TsAnyTupleTypeElement {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/type_member.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_member.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyTypeMember;
 impl Format for TsAnyTypeMember {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyTypePredicateParameterName;
 impl Format for TsAnyTypePredicateParameterName {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
@@ -1,6 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::{Format, FormatElement, FormatResult, Formatter};
+use crate::{Format, Formatter};
+use rome_formatter::{FormatElement, FormatResult};
 use rome_js_syntax::TsAnyVariableAnnotation;
 impl Format for TsAnyVariableAnnotation {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {

--- a/crates/rome_js_formatter/src/ts/assignments/as_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/as_assignment.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsAsAssignment;
 use rome_js_syntax::TsAsAssignmentFields;
 

--- a/crates/rome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsNonNullAssertionAssignment;
 use rome_js_syntax::TsNonNullAssertionAssignmentFields;
 

--- a/crates/rome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeAssertionAssignmentFields;
 
 use rome_js_syntax::TsTypeAssertionAssignment;

--- a/crates/rome_js_formatter/src/ts/auxiliary/abstract_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/abstract_modifier.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsAbstractModifier;
 use rome_js_syntax::TsAbstractModifierFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/accessibility_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/accessibility_modifier.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsAccessibilityModifier;
 use rome_js_syntax::TsAccessibilityModifierFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/asserts_condition.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/asserts_condition.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsAssertsCondition;
 use rome_js_syntax::TsAssertsConditionFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/call_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/call_signature_type_member.rs
@@ -1,6 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_type_member_separator;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsCallSignatureTypeMember;
 
 impl FormatNode for TsCallSignatureTypeMember {

--- a/crates/rome_js_formatter/src/ts/auxiliary/construct_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/construct_signature_type_member.rs
@@ -1,6 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_type_member_separator;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsConstructSignatureTypeMember, TsConstructSignatureTypeMemberFields};
 
 impl FormatNode for TsConstructSignatureTypeMember {

--- a/crates/rome_js_formatter/src/ts/auxiliary/declare_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/declare_modifier.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsDeclareModifier;
 use rome_js_syntax::TsDeclareModifierFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/default_type_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/default_type_clause.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsDefaultTypeClause;
 
 impl FormatNode for TsDefaultTypeClause {

--- a/crates/rome_js_formatter/src/ts/auxiliary/definite_property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/definite_property_annotation.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsDefinitePropertyAnnotation;
 use rome_js_syntax::TsDefinitePropertyAnnotationFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/definite_variable_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/definite_variable_annotation.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsDefiniteVariableAnnotation;
 use rome_js_syntax::TsDefiniteVariableAnnotationFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/empty_external_module_declaration_body.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/empty_external_module_declaration_body.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsEmptyExternalModuleDeclarationBody;
 use rome_js_syntax::TsEmptyExternalModuleDeclarationBodyFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/enum_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/enum_member.rs
@@ -1,5 +1,6 @@
 use crate::utils::format_initializer_clause;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsEnumMember;
 
 impl FormatNode for TsEnumMember {

--- a/crates/rome_js_formatter/src/ts/auxiliary/external_module_reference.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/external_module_reference.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsExternalModuleReference;
 use rome_js_syntax::TsExternalModuleReferenceFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/getter_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/getter_signature_type_member.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_type_member_separator;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsGetterSignatureTypeMember;
 
 impl FormatNode for TsGetterSignatureTypeMember {

--- a/crates/rome_js_formatter/src/ts/auxiliary/implements_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/implements_clause.rs
@@ -1,7 +1,8 @@
 use crate::{
     block_indent, format_elements, group_elements, if_group_breaks, if_group_fits_on_single_line,
-    soft_block_indent, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
+    soft_block_indent, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsImplementsClause;
 use rome_js_syntax::TsImplementsClauseFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/index_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/index_signature_type_member.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_type_member_separator;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsIndexSignatureTypeMember;
 
 impl FormatNode for TsIndexSignatureTypeMember {

--- a/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_as_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_as_clause.rs
@@ -1,7 +1,6 @@
 use crate::format_traits::FormatWith;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsMappedTypeAsClause;
 
 impl FormatNode for TsMappedTypeAsClause {

--- a/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_optional_modifier_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_optional_modifier_clause.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsMappedTypeOptionalModifierClause;
 use rome_js_syntax::TsMappedTypeOptionalModifierClauseFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_readonly_modifier_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_readonly_modifier_clause.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsMappedTypeReadonlyModifierClause;
 use rome_js_syntax::TsMappedTypeReadonlyModifierClauseFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/method_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/method_signature_type_member.rs
@@ -1,6 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_type_member_separator;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsMethodSignatureTypeMember;
 
 impl FormatNode for TsMethodSignatureTypeMember {

--- a/crates/rome_js_formatter/src/ts/auxiliary/module_block.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/module_block.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsModuleBlock;
 use rome_js_syntax::TsModuleBlockFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/named_tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/named_tuple_type_element.rs
@@ -1,7 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsNamedTupleTypeElement, TsNamedTupleTypeElementFields};
 
 impl FormatNode for TsNamedTupleTypeElement {

--- a/crates/rome_js_formatter/src/ts/auxiliary/optional_property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/optional_property_annotation.rs
@@ -1,5 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsOptionalPropertyAnnotation;
 use rome_js_syntax::TsOptionalPropertyAnnotationFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/optional_tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/optional_tuple_type_element.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsOptionalTupleTypeElement, TsOptionalTupleTypeElementFields};
 
 impl FormatNode for TsOptionalTupleTypeElement {

--- a/crates/rome_js_formatter/src/ts/auxiliary/override_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/override_modifier.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsOverrideModifier;
 use rome_js_syntax::TsOverrideModifierFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_type_member_separator;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsPropertySignatureTypeMember;
 
 impl FormatNode for TsPropertySignatureTypeMember {

--- a/crates/rome_js_formatter/src/ts/auxiliary/qualified_module_name.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/qualified_module_name.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsQualifiedModuleName;
 use rome_js_syntax::TsQualifiedModuleNameFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/qualified_name.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/qualified_name.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsQualifiedName;
 use rome_js_syntax::TsQualifiedNameFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/readonly_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/readonly_modifier.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsReadonlyModifier;
 use rome_js_syntax::TsReadonlyModifierFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/rest_tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/rest_tuple_type_element.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsRestTupleTypeElement, TsRestTupleTypeElementFields};
 
 impl FormatNode for TsRestTupleTypeElement {

--- a/crates/rome_js_formatter/src/ts/auxiliary/return_type_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/return_type_annotation.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsReturnTypeAnnotation;
 use rome_js_syntax::TsReturnTypeAnnotationFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/setter_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/setter_signature_type_member.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_type_member_separator;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsSetterSignatureTypeMember;
 
 impl FormatNode for TsSetterSignatureTypeMember {

--- a/crates/rome_js_formatter/src/ts/auxiliary/type_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/type_annotation.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeAnnotation;
 
 impl FormatNode for TsTypeAnnotation {

--- a/crates/rome_js_formatter/src/ts/auxiliary/type_constraint_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/type_constraint_clause.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeConstraintClause;
 
 impl FormatNode for TsTypeConstraintClause {

--- a/crates/rome_js_formatter/src/ts/auxiliary/type_parameter_name.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/type_parameter_name.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeParameterName;
 
 impl FormatNode for TsTypeParameterName {

--- a/crates/rome_js_formatter/src/ts/bindings/identifier_binding.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/identifier_binding.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsIdentifierBinding;
 
 impl FormatNode for TsIdentifierBinding {

--- a/crates/rome_js_formatter/src/ts/bindings/index_signature_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/index_signature_parameter.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsIndexSignatureParameter;
 
 impl FormatNode for TsIndexSignatureParameter {

--- a/crates/rome_js_formatter/src/ts/bindings/property_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/property_parameter.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsPropertyParameter, TsPropertyParameterFields};
 
 impl FormatNode for TsPropertyParameter {

--- a/crates/rome_js_formatter/src/ts/bindings/this_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/this_parameter.rs
@@ -1,5 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsThisParameter;
 
 impl FormatNode for TsThisParameter {

--- a/crates/rome_js_formatter/src/ts/bindings/type_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/type_parameter.rs
@@ -1,7 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeParameter;
 
 impl FormatNode for TsTypeParameter {

--- a/crates/rome_js_formatter/src/ts/bindings/type_parameters.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/type_parameters.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsTypeParameters, TsTypeParametersFields};
 
 impl FormatNode for TsTypeParameters {

--- a/crates/rome_js_formatter/src/ts/classes/constructor_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/constructor_signature_class_member.rs
@@ -1,8 +1,8 @@
 use crate::utils::format_with_semicolon;
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsConstructorSignatureClassMember;
 use rome_js_syntax::TsConstructorSignatureClassMemberFields;
 

--- a/crates/rome_js_formatter/src/ts/classes/extends_clause.rs
+++ b/crates/rome_js_formatter/src/ts/classes/extends_clause.rs
@@ -1,7 +1,8 @@
 use crate::{
     block_indent, format_elements, group_elements, if_group_breaks, if_group_fits_on_single_line,
-    soft_block_indent, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
+    soft_block_indent, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsExtendsClause, TsExtendsClauseFields};
 
 impl FormatNode for TsExtendsClause {

--- a/crates/rome_js_formatter/src/ts/classes/getter_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/getter_signature_class_member.rs
@@ -1,8 +1,9 @@
 use crate::utils::format_with_semicolon;
 use crate::{
     format_elements, format_traits::FormatOptional, hard_group_elements, space_token, Format,
-    FormatElement, FormatNode, FormatResult, Formatter,
+    FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsGetterSignatureClassMember, TsGetterSignatureClassMemberFields};
 
 impl FormatNode for TsGetterSignatureClassMember {

--- a/crates/rome_js_formatter/src/ts/classes/index_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/index_signature_class_member.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsIndexSignatureClassMember;
 use rome_js_syntax::TsIndexSignatureClassMemberFields;
 

--- a/crates/rome_js_formatter/src/ts/classes/method_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/method_signature_class_member.rs
@@ -1,8 +1,9 @@
 use crate::utils::format_with_semicolon;
 use crate::{
     format_elements, format_traits::FormatOptional, hard_group_elements, space_token, Format,
-    FormatElement, FormatNode, FormatResult, Formatter,
+    FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsMethodSignatureClassMember, TsMethodSignatureClassMemberFields};
 
 impl FormatNode for TsMethodSignatureClassMember {

--- a/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
@@ -1,8 +1,9 @@
 use crate::utils::format_with_semicolon;
 use crate::{
     format_elements, format_traits::FormatOptional, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsPropertySignatureClassMember, TsPropertySignatureClassMemberFields};
 
 impl FormatNode for TsPropertySignatureClassMember {

--- a/crates/rome_js_formatter/src/ts/classes/setter_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/setter_signature_class_member.rs
@@ -1,8 +1,8 @@
 use crate::utils::format_with_semicolon;
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsSetterSignatureClassMember, TsSetterSignatureClassMemberFields};
 
 impl FormatNode for TsSetterSignatureClassMember {

--- a/crates/rome_js_formatter/src/ts/declarations/declare_function_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/declare_function_declaration.rs
@@ -1,9 +1,9 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_with_semicolon;
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsDeclareFunctionDeclaration;
 use rome_js_syntax::TsDeclareFunctionDeclarationFields;
 

--- a/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
@@ -2,8 +2,9 @@ use crate::format_traits::{FormatOptional, FormatWith};
 use crate::formatter::TrailingSeparator;
 use crate::{
     format_elements, join_elements, soft_line_break_or_space, space_token, token, FormatElement,
-    FormatNode, FormatResult, Formatter,
+    FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsEnumDeclaration, TsEnumDeclarationFields};
 
 impl FormatNode for TsEnumDeclaration {

--- a/crates/rome_js_formatter/src/ts/declarations/external_module_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/external_module_declaration.rs
@@ -1,7 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsExternalModuleDeclaration;
 use rome_js_syntax::TsExternalModuleDeclarationFields;
 

--- a/crates/rome_js_formatter/src/ts/declarations/global_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/global_declaration.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsGlobalDeclaration;
 use rome_js_syntax::TsGlobalDeclarationFields;
 

--- a/crates/rome_js_formatter/src/ts/declarations/import_equals_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/import_equals_declaration.rs
@@ -1,7 +1,8 @@
 use crate::format_traits::FormatOptional;
 use crate::space_token;
 use crate::utils::format_with_semicolon;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsImportEqualsDeclaration;
 use rome_js_syntax::TsImportEqualsDeclarationFields;
 

--- a/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
@@ -1,8 +1,8 @@
 use crate::format_traits::FormatOptional;
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsInterfaceDeclaration, TsInterfaceDeclarationFields};
 
 impl FormatNode for TsInterfaceDeclaration {

--- a/crates/rome_js_formatter/src/ts/declarations/module_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/module_declaration.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsModuleDeclaration;
 use rome_js_syntax::TsModuleDeclarationFields;
 

--- a/crates/rome_js_formatter/src/ts/declarations/type_alias_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/type_alias_declaration.rs
@@ -1,9 +1,9 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_with_semicolon;
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsTypeAliasDeclaration, TsTypeAliasDeclarationFields};
 
 impl FormatNode for TsTypeAliasDeclaration {

--- a/crates/rome_js_formatter/src/ts/expressions/as_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/as_expression.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsAsExpression;
 use rome_js_syntax::TsAsExpressionFields;
 

--- a/crates/rome_js_formatter/src/ts/expressions/name_with_type_arguments.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/name_with_type_arguments.rs
@@ -1,5 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsNameWithTypeArguments, TsNameWithTypeArgumentsFields};
 
 impl FormatNode for TsNameWithTypeArguments {

--- a/crates/rome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsNonNullAssertionExpression;
 use rome_js_syntax::TsNonNullAssertionExpressionFields;
 

--- a/crates/rome_js_formatter/src/ts/expressions/template_chunk_element.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/template_chunk_element.rs
@@ -1,5 +1,6 @@
 use crate::utils::format_template_chunk;
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsTemplateChunkElement, TsTemplateChunkElementFields};
 
 impl FormatNode for TsTemplateChunkElement {

--- a/crates/rome_js_formatter/src/ts/expressions/template_element.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/template_element.rs
@@ -1,5 +1,6 @@
 use crate::utils::{format_template_literal, TemplateElement};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTemplateElement;
 
 impl FormatNode for TsTemplateElement {

--- a/crates/rome_js_formatter/src/ts/expressions/template_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/template_literal_type.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTemplateLiteralType;
 use rome_js_syntax::TsTemplateLiteralTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/expressions/type_arguments.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/type_arguments.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsTypeArguments, TsTypeArgumentsFields};
 
 impl FormatNode for TsTypeArguments {

--- a/crates/rome_js_formatter/src/ts/expressions/type_assertion_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/type_assertion_expression.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeAssertionExpression;
 use rome_js_syntax::TsTypeAssertionExpressionFields;
 

--- a/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsEnumMemberList;
 
 impl Format for TsEnumMemberList {

--- a/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
@@ -1,5 +1,6 @@
 use crate::utils::sort_modifiers_by_precedence;
-use crate::{join_elements, space_token, Format, FormatElement, FormatResult, Formatter};
+use crate::{join_elements, space_token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsIndexSignatureModifierList;
 
 impl Format for TsIndexSignatureModifierList {

--- a/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
@@ -1,7 +1,8 @@
 use crate::{
     concat_elements, empty_element, format_elements, soft_line_break_or_space, space_token, token,
-    Format, FormatElement, FormatResult, Formatter,
+    Format, FormatElement, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsIntersectionTypeElementList;
 use rome_rowan::AstSeparatedList;
 

--- a/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
@@ -1,5 +1,6 @@
 use crate::utils::sort_modifiers_by_precedence;
-use crate::{join_elements, space_token, Format, FormatElement, FormatResult, Formatter};
+use crate::{join_elements, space_token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsMethodSignatureModifierList;
 
 impl Format for TsMethodSignatureModifierList {

--- a/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
@@ -1,5 +1,6 @@
 use crate::utils::sort_modifiers_by_precedence;
-use crate::{join_elements, space_token, Format, FormatElement, FormatResult, Formatter};
+use crate::{join_elements, space_token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsPropertyParameterModifierList;
 
 impl Format for TsPropertyParameterModifierList {

--- a/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
@@ -1,5 +1,6 @@
 use crate::utils::sort_modifiers_by_precedence;
-use crate::{join_elements, space_token, Format, FormatElement, FormatResult, Formatter};
+use crate::{join_elements, space_token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsPropertySignatureModifierList;
 
 impl Format for TsPropertySignatureModifierList {

--- a/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
@@ -1,4 +1,5 @@
-use crate::{concat_elements, Format, FormatElement, FormatResult, Formatter};
+use crate::{concat_elements, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTemplateElementList;
 use rome_rowan::AstNodeList;
 

--- a/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTupleTypeElementList;
 
 impl Format for TsTupleTypeElementList {

--- a/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeArgumentList;
 
 impl Format for TsTypeArgumentList {

--- a/crates/rome_js_formatter/src/ts/lists/type_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeList;
 
 impl Format for TsTypeList {

--- a/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
@@ -1,7 +1,8 @@
 use crate::{
     empty_element, format_elements, if_group_breaks, join_elements, soft_line_break_or_space,
-    token, Format, FormatElement, FormatResult, Formatter,
+    token, Format, FormatElement, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeMemberList;
 use rome_rowan::AstNodeList;
 

--- a/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
@@ -1,7 +1,6 @@
 use crate::formatter::TrailingSeparator;
-use crate::{
-    join_elements, soft_line_break_or_space, token, Format, FormatElement, FormatResult, Formatter,
-};
+use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeParameterList;
 use rome_rowan::AstSeparatedList;
 

--- a/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
@@ -1,7 +1,8 @@
 use crate::{
     concat_elements, empty_element, format_elements, soft_line_break_or_space, space_token, token,
-    Format, FormatElement, FormatResult, Formatter,
+    Format, FormatElement, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsUnionTypeVariantList;
 use rome_rowan::AstSeparatedList;
 

--- a/crates/rome_js_formatter/src/ts/module/export_as_namespace_clause.rs
+++ b/crates/rome_js_formatter/src/ts/module/export_as_namespace_clause.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsExportAsNamespaceClause;
 use rome_js_syntax::TsExportAsNamespaceClauseFields;
 

--- a/crates/rome_js_formatter/src/ts/module/export_assignment_clause.rs
+++ b/crates/rome_js_formatter/src/ts/module/export_assignment_clause.rs
@@ -1,7 +1,6 @@
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsExportAssignmentClause;
 use rome_js_syntax::TsExportAssignmentClauseFields;
 

--- a/crates/rome_js_formatter/src/ts/module/export_declare_clause.rs
+++ b/crates/rome_js_formatter/src/ts/module/export_declare_clause.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsExportDeclareClause;
 use rome_js_syntax::TsExportDeclareClauseFields;
 

--- a/crates/rome_js_formatter/src/ts/module/import_type.rs
+++ b/crates/rome_js_formatter/src/ts/module/import_type.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_string_literal_token;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsImportType;
 use rome_js_syntax::TsImportTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/module/import_type_qualifier.rs
+++ b/crates/rome_js_formatter/src/ts/module/import_type_qualifier.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsImportTypeQualifier;
 use rome_js_syntax::TsImportTypeQualifierFields;
 

--- a/crates/rome_js_formatter/src/ts/statements/declare_statement.rs
+++ b/crates/rome_js_formatter/src/ts/statements/declare_statement.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsDeclareStatement;
 use rome_js_syntax::TsDeclareStatementFields;
 

--- a/crates/rome_js_formatter/src/ts/types/any_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/any_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsAnyType;
 
 impl FormatNode for TsAnyType {

--- a/crates/rome_js_formatter/src/ts/types/array_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/array_type.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsArrayType, TsArrayTypeFields};
 
 impl FormatNode for TsArrayType {

--- a/crates/rome_js_formatter/src/ts/types/asserts_return_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/asserts_return_type.rs
@@ -1,7 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsAssertsReturnType;
 use rome_js_syntax::TsAssertsReturnTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/types/big_int_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/big_int_literal_type.rs
@@ -1,5 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsBigIntLiteralType;
 
 impl FormatNode for TsBigIntLiteralType {

--- a/crates/rome_js_formatter/src/ts/types/bigint_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/bigint_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsBigintType;
 
 impl FormatNode for TsBigintType {

--- a/crates/rome_js_formatter/src/ts/types/boolean_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/boolean_literal_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsBooleanLiteralType;
 
 impl FormatNode for TsBooleanLiteralType {

--- a/crates/rome_js_formatter/src/ts/types/boolean_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/boolean_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsBooleanType;
 
 impl FormatNode for TsBooleanType {

--- a/crates/rome_js_formatter/src/ts/types/conditional_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/conditional_type.rs
@@ -1,5 +1,6 @@
 use crate::utils::{format_conditional, Conditional};
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsConditionalType;
 
 impl FormatNode for TsConditionalType {

--- a/crates/rome_js_formatter/src/ts/types/constructor_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/constructor_type.rs
@@ -1,7 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsConstructorType;
 use rome_js_syntax::TsConstructorTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/types/function_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/function_type.rs
@@ -1,8 +1,8 @@
 use crate::format_traits::FormatOptional;
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
-    FormatResult, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsFunctionType;
 use rome_js_syntax::TsFunctionTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/types/indexed_access_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/indexed_access_type.rs
@@ -1,4 +1,5 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsIndexedAccessType;
 use rome_js_syntax::TsIndexedAccessTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/types/infer_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/infer_type.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsInferType;
 
 impl FormatNode for TsInferType {

--- a/crates/rome_js_formatter/src/ts/types/intersection_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/intersection_type.rs
@@ -1,7 +1,8 @@
 use crate::{
     format_elements, group_elements, if_group_breaks, indent, soft_line_break, space_token, token,
-    Format, FormatElement, FormatNode, FormatResult, Formatter, Token,
+    Format, FormatElement, FormatNode, Formatter, Token,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsIntersectionType;
 use rome_js_syntax::TsIntersectionTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/types/mapped_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/mapped_type.rs
@@ -1,8 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_with_semicolon;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::{TsMappedType, TsMappedTypeFields};
 
 impl FormatNode for TsMappedType {

--- a/crates/rome_js_formatter/src/ts/types/never_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/never_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsNeverType;
 
 impl FormatNode for TsNeverType {

--- a/crates/rome_js_formatter/src/ts/types/non_primitive_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/non_primitive_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsNonPrimitiveType;
 
 impl FormatNode for TsNonPrimitiveType {

--- a/crates/rome_js_formatter/src/ts/types/null_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/null_literal_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsNullLiteralType;
 
 impl FormatNode for TsNullLiteralType {

--- a/crates/rome_js_formatter/src/ts/types/number_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/number_literal_type.rs
@@ -1,5 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsNumberLiteralType;
 
 impl FormatNode for TsNumberLiteralType {

--- a/crates/rome_js_formatter/src/ts/types/number_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/number_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsNumberType;
 
 impl FormatNode for TsNumberType {

--- a/crates/rome_js_formatter/src/ts/types/object_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/object_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsObjectType;
 
 impl FormatNode for TsObjectType {

--- a/crates/rome_js_formatter/src/ts/types/parenthesized_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/parenthesized_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsParenthesizedType;
 use rome_js_syntax::TsParenthesizedTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/types/predicate_return_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/predicate_return_type.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsPredicateReturnType;
 use rome_js_syntax::TsPredicateReturnTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/types/reference_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/reference_type.rs
@@ -1,5 +1,6 @@
 use crate::format_traits::FormatOptional;
-use crate::{format_elements, Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsReferenceType;
 
 impl FormatNode for TsReferenceType {

--- a/crates/rome_js_formatter/src/ts/types/string_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/string_literal_type.rs
@@ -1,5 +1,6 @@
 use crate::utils::format_string_literal_token;
-use crate::{FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsStringLiteralType;
 
 impl FormatNode for TsStringLiteralType {

--- a/crates/rome_js_formatter/src/ts/types/string_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/string_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsStringType;
 
 impl FormatNode for TsStringType {

--- a/crates/rome_js_formatter/src/ts/types/symbol_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/symbol_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsSymbolType;
 
 impl FormatNode for TsSymbolType {

--- a/crates/rome_js_formatter/src/ts/types/this_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/this_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsThisType;
 
 impl FormatNode for TsThisType {

--- a/crates/rome_js_formatter/src/ts/types/tuple_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/tuple_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTupleType;
 
 impl FormatNode for TsTupleType {

--- a/crates/rome_js_formatter/src/ts/types/type_operator_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/type_operator_type.rs
@@ -1,7 +1,6 @@
 use crate::format_traits::FormatWith;
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeOperatorType;
 
 impl FormatNode for TsTypeOperatorType {

--- a/crates/rome_js_formatter/src/ts/types/typeof_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/typeof_type.rs
@@ -1,6 +1,5 @@
-use crate::{
-    format_elements, space_token, Format, FormatElement, FormatNode, FormatResult, Formatter,
-};
+use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeofType;
 
 impl FormatNode for TsTypeofType {

--- a/crates/rome_js_formatter/src/ts/types/undefined_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/undefined_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsUndefinedType;
 
 impl FormatNode for TsUndefinedType {

--- a/crates/rome_js_formatter/src/ts/types/union_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/union_type.rs
@@ -1,7 +1,8 @@
 use crate::{
     format_elements, group_elements, if_group_breaks, indent, soft_line_break, space_token, token,
-    Format, FormatElement, FormatNode, FormatResult, Formatter, Token,
+    Format, FormatElement, FormatNode, Formatter, Token,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsUnionType;
 use rome_js_syntax::TsUnionTypeFields;
 

--- a/crates/rome_js_formatter/src/ts/types/unknown_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/unknown_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsUnknownType;
 
 impl FormatNode for TsUnknownType {

--- a/crates/rome_js_formatter/src/ts/types/void_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/void_type.rs
@@ -1,4 +1,5 @@
-use crate::{Format, FormatElement, FormatNode, FormatResult, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatResult;
 use rome_js_syntax::TsVoidType;
 
 impl FormatNode for TsVoidType {

--- a/crates/rome_js_formatter/src/utils/array.rs
+++ b/crates/rome_js_formatter/src/utils/array.rs
@@ -1,3 +1,4 @@
+use rome_formatter::FormatResult;
 use rome_js_syntax::{
     JsAnyArrayAssignmentPatternElement, JsAnyArrayBindingPatternElement, JsAnyArrayElement,
     JsLanguage,
@@ -6,7 +7,7 @@ use rome_rowan::{AstNode, AstSeparatedList};
 
 use crate::{
     empty_element, format_elements, format_traits::FormatOptional, if_group_breaks,
-    join_elements_soft_line, token, Format, FormatElement, FormatResult, Formatter,
+    join_elements_soft_line, token, Format, FormatElement, Formatter,
 };
 
 /// Utility function to print array-like nodes (array expressions, array bindings and assignment patterns)

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -1,9 +1,10 @@
 use crate::{
     empty_element, format_elements, group_elements, hard_group_elements, hard_line_break,
     join_elements, soft_block_indent, soft_line_break_or_space, soft_line_indent_or_space,
-    space_token, token, Format, FormatElement, FormatNode, FormatResult, Formatter,
+    space_token, token, Format, FormatElement, FormatNode, Formatter,
 };
 
+use rome_formatter::FormatResult;
 use rome_js_syntax::{
     JsAnyExpression, JsAnyInProperty, JsBinaryExpression, JsBinaryOperator, JsInExpression,
     JsInstanceofExpression, JsLanguage, JsLogicalExpression, JsLogicalOperator, JsPrivateName,

--- a/crates/rome_js_formatter/src/utils/call_expression.rs
+++ b/crates/rome_js_formatter/src/utils/call_expression.rs
@@ -1,8 +1,9 @@
 use crate::format_traits::FormatOptional;
 use crate::{
     concat_elements, format_elements, group_elements, indent, join_elements, soft_line_break,
-    Format, FormatElement, FormatResult, Formatter,
+    Format, FormatElement, Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{
     JsCallExpression, JsComputedMemberExpression, JsImportCallExpression, JsStaticMemberExpression,
 };

--- a/crates/rome_js_formatter/src/utils/format_conditional.rs
+++ b/crates/rome_js_formatter/src/utils/format_conditional.rs
@@ -1,7 +1,8 @@
 use crate::{
     format_elements, group_elements, hard_line_break, indent, space_token, Format, FormatElement,
-    FormatResult, Formatter,
+    Formatter,
 };
+use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyExpression, JsConditionalExpression, TsConditionalType, TsType};
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -11,12 +11,12 @@ mod quickcheck_utils;
 use crate::format_traits::FormatOptional;
 use crate::{
     empty_element, empty_line, format_elements, hard_group_elements, space_token, token, Format,
-    FormatElement, FormatResult, Formatter, QuoteStyle, Token,
+    FormatElement, Formatter, QuoteStyle, Token,
 };
 pub(crate) use binary_like_expression::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 pub(crate) use call_expression::format_call_expression;
 pub(crate) use format_conditional::{format_conditional, Conditional};
-use rome_formatter::normalize_newlines;
+use rome_formatter::{normalize_newlines, FormatResult};
 use rome_js_syntax::{
     JsAnyExpression, JsAnyFunction, JsAnyRoot, JsAnyStatement, JsInitializerClause, JsLanguage,
     JsTemplateElement, JsTemplateElementFields, Modifiers, TsTemplateElement,

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -73,7 +73,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
                 ),
             )
         }
-        _ => rome_js_formatter::format(options, &syntax),
+        _ => rome_js_formatter::format_node(options, &syntax).map(|formatted| formatted.print()),
     };
 
     let formatted = result.expect("formatting failed");

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -91,7 +91,9 @@ pub(crate) fn format(params: FormatParams) -> Result<Option<Vec<TextEdit>>> {
         return Ok(None);
     }
 
-    let new_text = rome_js_formatter::format(format_options, &parse_result.syntax())?.into_code();
+    let new_text = rome_js_formatter::format_node(format_options, &parse_result.syntax())?
+        .print()
+        .into_code();
 
     let num_lines: u32 = line_index::LineIndex::new(text).newlines.len().try_into()?;
 
@@ -216,7 +218,7 @@ pub(crate) fn format_on_type(params: FormatOnTypeParams) -> Result<Option<Vec<Te
         None => bail!("found a token with no parent"),
     };
 
-    let formatted = rome_js_formatter::format_node(params.format_options, &root_node)?;
+    let formatted = rome_js_formatter::format_sub_tree(params.format_options, &root_node)?;
 
     // Recalculate the actual range that was reformatted from the formatter result
     let formatted_range = match formatted.range() {

--- a/website/playground/src/lib.rs
+++ b/website/playground/src/lib.rs
@@ -3,7 +3,7 @@
 use rome_diagnostics::file::SimpleFiles;
 use rome_diagnostics::termcolor::{ColorSpec, WriteColor};
 use rome_diagnostics::Emitter;
-use rome_js_formatter::{format as format_code, to_format_element, FormatOptions, IndentStyle};
+use rome_js_formatter::{format_node, FormatOptions, IndentStyle};
 use rome_js_parser::{parse, LanguageVariant, SourceType};
 use std::io;
 use wasm_bindgen::prelude::*;
@@ -117,12 +117,10 @@ pub fn run(
 
     let cst = format!("{:#?}", syntax);
     let ast = format!("{:#?}", parse.tree());
-    let formatted_code = format_code(options, &syntax)
-        // TODO: impl Error for FormatError
-        .unwrap()
-        .into_code();
+    let formatted = format_node(options, &syntax).unwrap();
+    let formatted_code = formatted.print().into_code();
 
-    let root_element = to_format_element(options, &syntax).unwrap();
+    let root_element = formatted.into_format_element();
     let formatter_ir = format!("{:#?}", root_element);
 
     let mut errors = ErrorOutput(Vec::new());

--- a/xtask/bench/src/features/formatter.rs
+++ b/xtask/bench/src/features/formatter.rs
@@ -1,5 +1,5 @@
 use crate::BenchmarkSummary;
-use rome_js_formatter::{format, FormatOptions, Formatted};
+use rome_js_formatter::{format_node, FormatOptions, Printed};
 use rome_js_syntax::JsSyntaxNode;
 use std::fmt::{Display, Formatter};
 use std::time::Duration;
@@ -20,8 +20,8 @@ pub fn benchmark_format_lib(id: &str, root: &JsSyntaxNode) -> BenchmarkSummary {
     })
 }
 
-pub fn run_format(root: &JsSyntaxNode) -> Formatted {
-    format(FormatOptions::default(), root).unwrap()
+pub fn run_format(root: &JsSyntaxNode) -> Printed {
+    format_node(FormatOptions::default(), root).unwrap().print()
 }
 
 impl FormatterMeasurement {

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -302,7 +302,8 @@ pub fn generate_formatter() {
         // format_verbatim for all the other nodes
         let tokens = match kind {
             NodeKind::List { separated: false } => quote! {
-                use crate::{FormatElement, FormatResult, Formatter, Format};
+                use rome_formatter::{FormatResult, FormatElement};
+                use crate::{Formatter, Format};
                 use rome_js_syntax::#id;
 
                 impl Format for #id {
@@ -313,8 +314,9 @@ pub fn generate_formatter() {
             },
             NodeKind::Node | NodeKind::List { separated: true } => {
                 quote! {
-                    use crate::{FormatElement, FormatResult, Formatter, FormatNode};
+                    use crate::{Formatter, FormatNode};
                     use rome_rowan::AstNode;
+                    use rome_formatter::{FormatResult, FormatElement};
                     use rome_js_syntax::{#id};
 
                     impl FormatNode for #id {
@@ -326,8 +328,9 @@ pub fn generate_formatter() {
             }
             NodeKind::Unknown => {
                 quote! {
-                    use crate::{FormatElement, FormatResult, Formatter, FormatNode};
+                    use crate::{Formatter, FormatNode};
                     use rome_rowan::AstNode;
+                    use rome_formatter::{FormatResult, FormatElement};
                     use rome_js_syntax::{#id};
 
                     impl FormatNode for #id {
@@ -348,7 +351,8 @@ pub fn generate_formatter() {
                     .collect();
 
                 quote! {
-                    use crate::{FormatElement, FormatResult, Formatter, Format};
+                    use crate::{Formatter, Format};
+                    use rome_formatter::{FormatResult, FormatElement};
                     use rome_js_syntax::#id;
 
                     impl Format for #id {
@@ -410,7 +414,8 @@ impl FormatImpls {
         let impls = self.impls;
 
         let tokens = quote! {
-            use crate::{FormatElement, FormatResult, Formatter, Format, FormatNode};
+            use crate::{FormatElement, Formatter, Format, FormatNode};
+            use rome_formatter::FormatResult;
 
             #( #impls )*
         };


### PR DESCRIPTION
This PR removes the `format_root` method from the `Formatter` so that it can be used to format any value implementing `Format`.

* Rename existing `format_node` method to `format_sub_tree`
* Move `FormatError` and `FormatResult` to `rome_formatter`
* Rename `Formatted` to `Printed`
* `format_node` to reduce `Formatted` which is the formatted IR that hasn't been printed. Can be printed by calling `print`
* `Formatted` replaces `to_format_element`
* Introduce new `format` method to format any type implementing `Format`
