### PR TITLE
Update github actions version to v3

### DIFF
--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -24,7 +24,7 @@ jobs:
           version: preview
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Rome Format
         run: rome format --ci editors website


### PR DESCRIPTION
## Summary

same as #2461. Change the GitHub Actions Version for Node16

## Test Plan

Pass GitHub Actions workflows
