### PR TITLE
refactor(rome_js_formatter): Track token offsets instead of tokens

### DIFF
--- a/crates/rome_js_formatter/src/formatter.rs
+++ b/crates/rome_js_formatter/src/formatter.rs
@@ -77,8 +77,8 @@ impl Formatter {
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
                 let mut printed_tokens = self.printed_tokens.borrow_mut();
-                printed_tokens.track_formatted(open_token);
-                printed_tokens.track_formatted(close_token);
+                printed_tokens.track_token(open_token);
+                printed_tokens.track_token(close_token);
                 drop(printed_tokens);
             }
         }
@@ -182,7 +182,7 @@ impl Formatter {
     ) -> FormatElement {
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
-                self.printed_tokens.borrow_mut().track_replaced(current_token);
+                self.printed_tokens.borrow_mut().track_token(current_token);
             }
         }
 
@@ -602,7 +602,7 @@ impl Formatter {
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
                 for token in node.descendants_tokens() {
-                    self.printed_tokens.borrow_mut().track_verbatim(&token);
+                    self.printed_tokens.borrow_mut().track_token(&token);
                 }
             }
         }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -125,7 +125,7 @@ impl Format for JsSyntaxToken {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
-                assert!(formatter.printed_tokens.borrow_mut().insert(self.clone()), "You tried to print the token '{:?}' twice, and this is not valid.", self);
+                formatter.printed_tokens.borrow_mut().track_formatted(self);
             }
         }
 
@@ -159,13 +159,8 @@ pub fn format_node(options: FormatOptions, root: &JsSyntaxNode) -> FormatResult<
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
                 let printed_tokens = formatter.printed_tokens.into_inner();
-                for token in root.descendants_tokens() {
-                    assert!(
-                        printed_tokens.contains(&token),
-                        "token was not seen by the formatter: {:?}",
-                        token
-                    );
-                }
+
+                printed_tokens.assert_all_tracked(root);
             }
         }
 
@@ -474,6 +469,9 @@ function() {
 #[cfg(test)]
 mod check_reformat;
 mod format;
+
+#[cfg(debug_assertions)]
+mod printed_tokens;
 
 #[cfg(test)]
 mod test {

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -125,7 +125,7 @@ impl Format for JsSyntaxToken {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
-                formatter.printed_tokens.borrow_mut().track_formatted(self);
+                formatter.printed_tokens.borrow_mut().track_token(self);
             }
         }
 

--- a/crates/rome_js_formatter/src/printed_tokens.rs
+++ b/crates/rome_js_formatter/src/printed_tokens.rs
@@ -1,0 +1,85 @@
+use rome_rowan::{Language, SyntaxNode, SyntaxToken, TextSize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum TokenTrackMode {
+    Replaced,
+    Formatted,
+    Verbatim,
+}
+
+/// Tracks the ranges of the formatted (including replaced or tokens formatted as verbatim) tokens.
+///
+/// This implementation uses the fact that no two tokens can have an overlapping range to avoid the need for an interval tree.
+/// Thus, testing if a token has already been formatted only requires testing if a token starting at the same offset has been formatted.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PrintedTokens {
+    /// Key: Start of range, value: whatever this is formatted or replaced
+    offsets: BTreeMap<TextSize, TokenTrackMode>,
+}
+
+impl PrintedTokens {
+    fn track_token<L: Language>(&mut self, token: &SyntaxToken<L>, mode: TokenTrackMode) {
+        let range = token.text_trimmed_range();
+
+        if let Some(previous_mode) = self.offsets.insert(range.start(), mode) {
+            panic!("You tried to print the token '{token:?}' twice, and this is not valid. Printed now as {mode:?}, previously printed as {previous_mode:?}.");
+        }
+    }
+
+    /// Tracks a formatted token
+    ///
+    /// ## Panics
+    /// If this token has been formatted before.
+    pub(crate) fn track_formatted<L: Language>(&mut self, token: &SyntaxToken<L>) {
+        self.track_token(token, TokenTrackMode::Formatted)
+    }
+
+    /// Tracks a token that has been replaced with other content
+    ///
+    /// ## Panics
+    /// If this token has been formatted before.
+    pub(crate) fn track_replaced<L: Language>(&mut self, token: &SyntaxToken<L>) {
+        self.track_token(token, TokenTrackMode::Replaced)
+    }
+
+    /// Tracks a verbatim formatted token
+    ///
+    /// ## Panics
+    /// If this token has been formatted before.
+    pub(crate) fn track_verbatim<L: Language>(&mut self, token: &SyntaxToken<L>) {
+        self.track_token(token, TokenTrackMode::Verbatim)
+    }
+
+    /// Asserts that all tokens of the passed in node have been tracked
+    ///
+    /// ## Panics
+    /// If any descendant token of `root` hasn't been tracked
+    pub(crate) fn assert_all_tracked<L: Language>(&self, root: &SyntaxNode<L>) {
+        let mut descendants = root.descendants_tokens();
+        let mut offsets = self.offsets.iter();
+
+        loop {
+            match (descendants.next(), offsets.next()) {
+                (Some(descendant), Some((offset, mode))) => {
+                    match descendant.text_trimmed_range().start() {
+                        descendant_offset if descendant_offset < *offset => {
+                            panic!("token has not been seen by the formatter: {descendant:#?}")
+                        }
+                        descendant_offset if descendant_offset > *offset => {
+                            panic!("tracked offset {offset:?} formatted with {mode:?} doesn't match any token of {root:#?}");
+                        }
+                        _ => {}
+                    }
+                }
+                (Some(descendant), None) => {
+                    panic!("token has not been seen by the formatter: {descendant:#?}")
+                }
+                (None, Some((offset, mode))) => {
+                    panic!("tracked offset {offset:?} formatted with {mode:?} doesn't match any token of {root:#?}");
+                }
+                (None, None) => break,
+            };
+        }
+    }
+}


### PR DESCRIPTION
The `Formatter` tracks all formatted tokens in debug builds to catch if the same token gets formatted twice or not formatted at all.

The current implementation tracks the `JsSyntaxToken`s. The downside of doing this is that a language-agnostic implementation needs to track `SyntaxToken<L>` which:

* has the consequence that `Formatter` must be generic over `L`
* which in turn has the consequence that `Format` must be generic over `L`

This PR changes the node tracking to instead only track the absolute offsets of the formatted nodes rather than holding on to the node itself. This removes the need for a generic `Language` parameter and provides the same functionality.


A next step is to move out all `format_` functions from the `Formatter` and put them into standalone functions / extension traits. 

## Test

* Commented out the `track_replaced` call in `format_replaced` and verified that some tests now panic with a message that token X wasn't formatted.
* Added one an additional `track_replaced` call to `format_replaced` and verified that tests are now failing with a message saying that the token X was formatted twice.
