### PR TITLE
chore(rome_lsp):  migration to tower_lsp crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,12 +384,13 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "4.0.2"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
 dependencies = [
  "cfg-if",
  "num_cpus",
+ "parking_lot",
 ]
 
 [[package]]
@@ -596,7 +597,7 @@ checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -668,15 +669,6 @@ checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
 dependencies = [
  "byteorder",
  "num-traits",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -776,15 +768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,9 +814,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "libgit2-sys"
@@ -885,52 +868,15 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.91.1"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2368312c59425dd133cb9a327afee65be0a633a8ce471d248e2202a48f8f68ae"
+checksum = "70c74e2173b2b31f8655d33724b4b45ac13f439386f66290f539c22b144c2212"
 dependencies = [
  "bitflags",
  "serde",
  "serde_json",
  "serde_repr",
  "url",
-]
-
-[[package]]
-name = "lspower"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2242d4cb4071c7b9ae53001c8c658402b55bb8c3669a70d3ce9565f1144b30"
-dependencies = [
- "anyhow",
- "async-trait",
- "auto_impl",
- "bytes",
- "dashmap",
- "futures",
- "httparse",
- "log",
- "lsp-types",
- "lspower-macros",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-util",
- "tower-service",
- "twoway",
-]
-
-[[package]]
-name = "lspower-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1d48da0e4a6100b4afd52fae99f36d47964a209624021280ad9ffdd410e83d"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -966,14 +912,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1043,37 +990,12 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1100,6 +1022,26 @@ name = "pico-args"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+
+[[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1329,7 +1271,7 @@ dependencies = [
  "crossbeam",
  "hdrhistogram",
  "lazy_static",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pico-args",
  "rayon",
  "rome_console",
@@ -1399,7 +1341,7 @@ version = "0.0.0"
 dependencies = [
  "crossbeam",
  "indexmap",
- "parking_lot 0.12.0",
+ "parking_lot",
  "rayon",
  "tracing",
 ]
@@ -1412,7 +1354,7 @@ dependencies = [
  "ctor",
  "iai",
  "insta",
- "parking_lot 0.12.0",
+ "parking_lot",
  "quickcheck",
  "quickcheck_macros",
  "rome_core",
@@ -1471,8 +1413,7 @@ dependencies = [
  "anyhow",
  "futures",
  "indexmap",
- "lspower",
- "parking_lot 0.12.0",
+ "parking_lot",
  "rome_analyze",
  "rome_diagnostics",
  "rome_fs",
@@ -1482,6 +1423,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower-lsp",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -1713,6 +1655,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,9 +1807,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
@@ -1865,9 +1817,10 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -1885,16 +1838,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1904,6 +1857,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-lsp"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e094780b4447366c59f79acfd65b1375ecaa84e61dddbde1421aa506334024"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "log",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebd99eec668d0a450c177acbc4d05e0d0d13b1f8d3db13cd706c52cbec4ac04"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1920,7 +1927,19 @@ checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1984,22 +2003,6 @@ dependencies = [
  "termcolor",
  "toml",
 ]
-
-[[package]]
-name = "twoway"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57ffb460d7c24cd6eda43694110189030a3d1dfe418416d9468fd1c1d290b47"
-dependencies = [
- "memchr",
- "unchecked-index",
-]
-
-[[package]]
-name = "unchecked-index"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "ungrammar"
@@ -2110,6 +2113,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -16,7 +16,6 @@ rome_analyze = { path = "../rome_analyze" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 rome_js_parser = { path = "../rome_js_parser" }
 rome_js_syntax = { path = "../rome_js_syntax" }
-# lspower = "1.5"
 tower-lsp = { version = "0.17.0"}
 tokio = { version = "1.15.0", features = ["full" ] }
 tracing = { version = "0.1.31", default-features = false, features = ["std", "max_level_trace", "release_max_level_warn"] }

--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -16,7 +16,8 @@ rome_analyze = { path = "../rome_analyze" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 rome_js_parser = { path = "../rome_js_parser" }
 rome_js_syntax = { path = "../rome_js_syntax" }
-lspower = "1.5"
+# lspower = "1.5"
+tower-lsp = { version = "0.17.0"}
 tokio = { version = "1.15.0", features = ["full" ] }
 tracing = { version = "0.1.31", default-features = false, features = ["std", "max_level_trace", "release_max_level_warn"] }
 tracing-tree = "0.2.0"

--- a/crates/rome_lsp/src/capabilities.rs
+++ b/crates/rome_lsp/src/capabilities.rs
@@ -1,4 +1,9 @@
-use lspower::lsp::{
+// use tower_lsp::lsp::{
+//     CodeActionProviderCapability, DocumentOnTypeFormattingOptions, OneOf, ServerCapabilities,
+//     TextDocumentSyncCapability, TextDocumentSyncKind,
+// };
+
+use tower_lsp::lsp_types::{
     CodeActionProviderCapability, DocumentOnTypeFormattingOptions, OneOf, ServerCapabilities,
     TextDocumentSyncCapability, TextDocumentSyncKind,
 };

--- a/crates/rome_lsp/src/capabilities.rs
+++ b/crates/rome_lsp/src/capabilities.rs
@@ -1,8 +1,3 @@
-// use tower_lsp::lsp::{
-//     CodeActionProviderCapability, DocumentOnTypeFormattingOptions, OneOf, ServerCapabilities,
-//     TextDocumentSyncCapability, TextDocumentSyncKind,
-// };
-
 use tower_lsp::lsp_types::{
     CodeActionProviderCapability, DocumentOnTypeFormattingOptions, OneOf, ServerCapabilities,
     TextDocumentSyncCapability, TextDocumentSyncKind,

--- a/crates/rome_lsp/src/handlers/analysis.rs
+++ b/crates/rome_lsp/src/handlers/analysis.rs
@@ -1,7 +1,7 @@
-use lspower::lsp::CodeActionOrCommand;
-use lspower::{jsonrpc, lsp};
 use rome_analyze::{AnalysisServer, FileId};
 use rome_js_syntax::TextRange;
+use tower_lsp::lsp_types::CodeActionOrCommand;
+use tower_lsp::{jsonrpc, lsp_types};
 
 use crate::line_index::LineIndex;
 use crate::utils;
@@ -12,7 +12,7 @@ use crate::utils;
 pub(crate) fn diagnostics(
     analysis_server: AnalysisServer,
     file_id: FileId,
-) -> jsonrpc::Result<Vec<lsp::Diagnostic>> {
+) -> jsonrpc::Result<Vec<lsp_types::Diagnostic>> {
     let text = analysis_server
         .get_file_text(file_id)
         .ok_or_else(jsonrpc::Error::internal_error)?;
@@ -31,9 +31,9 @@ pub(crate) fn diagnostics(
 pub(crate) fn code_actions(
     analysis_server: AnalysisServer,
     file_id: FileId,
-    url: lsp::Url,
+    url: lsp_types::Url,
     cursor_range: TextRange,
-) -> jsonrpc::Result<Vec<lsp::CodeActionOrCommand>> {
+) -> jsonrpc::Result<Vec<lsp_types::CodeActionOrCommand>> {
     let text = analysis_server
         .get_file_text(file_id)
         .ok_or_else(jsonrpc::Error::internal_error)?;

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -1,12 +1,12 @@
 use crate::config::{FormatterWorkspaceSettings, WorkspaceSettings};
 use crate::line_index::{self, LineCol};
 use anyhow::{bail, Result};
-use lspower::lsp::*;
 use rome_analyze::FileId;
 use rome_js_formatter::{FormatOptions, IndentStyle, QuoteStyle};
 use rome_js_parser::{parse, SourceType};
 use rome_js_syntax::{TextRange, TokenAtOffset};
 use std::str::FromStr;
+use tower_lsp::lsp_types::*;
 use tracing::info;
 
 /// Utility function that takes formatting options from [LSP](lspower::lsp::FormattingOptions)

--- a/crates/rome_lsp/src/handlers/text_document.rs
+++ b/crates/rome_lsp/src/handlers/text_document.rs
@@ -1,12 +1,12 @@
-use lspower::lsp;
 use rome_fs::RomePath;
 use std::sync::Arc;
+use tower_lsp::lsp_types;
 use tracing::error;
 
 use crate::{documents::Document, session::Session};
 
 /// Handler for `textDocument/didOpen` LSP notification
-pub(crate) async fn did_open(session: Arc<Session>, params: lsp::DidOpenTextDocumentParams) {
+pub(crate) async fn did_open(session: Arc<Session>, params: lsp_types::DidOpenTextDocumentParams) {
     let url = params.text_document.uri.clone();
     let file_id = session.file_id(url.clone());
     let version = params.text_document.version;
@@ -25,7 +25,10 @@ pub(crate) async fn did_open(session: Arc<Session>, params: lsp::DidOpenTextDocu
 }
 
 /// Handler for `textDocument/didChange` LSP notification
-pub(crate) async fn did_change(session: Arc<Session>, params: lsp::DidChangeTextDocumentParams) {
+pub(crate) async fn did_change(
+    session: Arc<Session>,
+    params: lsp_types::DidChangeTextDocumentParams,
+) {
     let url = params.text_document.uri;
     let version = params.text_document.version;
 
@@ -50,7 +53,10 @@ pub(crate) async fn did_change(session: Arc<Session>, params: lsp::DidChangeText
 }
 
 /// Handler for `textDocument/didClose` LSP notification
-pub(crate) async fn did_close(session: Arc<Session>, params: lsp::DidCloseTextDocumentParams) {
+pub(crate) async fn did_close(
+    session: Arc<Session>,
+    params: lsp_types::DidCloseTextDocumentParams,
+) {
     let url = params.text_document.uri;
     session.remove_document(&url);
     let diagnostics = vec![];

--- a/crates/rome_lsp/src/requests/syntax_tree.rs
+++ b/crates/rome_lsp/src/requests/syntax_tree.rs
@@ -1,8 +1,8 @@
 use crate::documents::Document;
 use anyhow::Result;
-use lspower::lsp::TextDocumentIdentifier;
 use rome_js_parser::parse;
 use serde::{Deserialize, Serialize};
+use tower_lsp::lsp_types::TextDocumentIdentifier;
 use tracing::{info, trace};
 
 pub const SYNTAX_TREE_REQUEST: &str = "rome/syntaxTree";

--- a/crates/rome_lsp/src/url_interner.rs
+++ b/crates/rome_lsp/src/url_interner.rs
@@ -3,8 +3,8 @@
 //! Based on `path_interner` from `rust-analyzer`
 
 use indexmap::IndexSet;
-use lspower::lsp::Url;
 use rome_analyze::FileId;
+use tower_lsp::lsp_types::Url;
 
 /// Structure to map between [`Url`] and [`FileId`].
 #[derive(Default)]

--- a/crates/rome_rowan/src/serde_impls.rs
+++ b/crates/rome_rowan/src/serde_impls.rs
@@ -2,7 +2,7 @@ use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::fmt;
 
 use crate::{
-    syntax::{Language, RawLanguage, SyntaxNode, SyntaxToken},
+    syntax::{Language, SyntaxNode, SyntaxToken},
     NodeOrToken,
 };
 
@@ -71,13 +71,13 @@ impl<L: Language> Serialize for Children<&'_ SyntaxNode<L>> {
     }
 }
 
-#[test]
-pub fn serialization() {
-    let mut builder: crate::TreeBuilder<crate::syntax::RawLanguage> = crate::TreeBuilder::new();
-    builder.start_node(crate::RawSyntaxKind(0));
-    builder.token(crate::RawSyntaxKind(0), "\n\tlet ");
-    builder.finish_node();
-    let root = builder.finish();
+// #[test]
+// pub fn serialization() {
+//     let mut builder: crate::TreeBuilder<crate::syntax::RawLanguage> = crate::TreeBuilder::new();
+//     builder.start_node(crate::RawSyntaxKind(0));
+//     builder.token(crate::RawSyntaxKind(0), "\n\tlet ");
+//     builder.finish_node();
+//     let root = builder.finish();
 
-    assert!(serde_json::to_string(&root).is_ok());
-}
+//     assert!(serde_json::to_string(&root).is_ok());
+// }

--- a/crates/rome_rowan/src/serde_impls.rs
+++ b/crates/rome_rowan/src/serde_impls.rs
@@ -2,7 +2,7 @@ use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::fmt;
 
 use crate::{
-    syntax::{Language, SyntaxNode, SyntaxToken},
+    syntax::{Language, RawLanguage, SyntaxNode, SyntaxToken},
     NodeOrToken,
 };
 
@@ -71,13 +71,13 @@ impl<L: Language> Serialize for Children<&'_ SyntaxNode<L>> {
     }
 }
 
-// #[test]
-// pub fn serialization() {
-//     let mut builder: crate::TreeBuilder<crate::syntax::RawLanguage> = crate::TreeBuilder::new();
-//     builder.start_node(crate::RawSyntaxKind(0));
-//     builder.token(crate::RawSyntaxKind(0), "\n\tlet ");
-//     builder.finish_node();
-//     let root = builder.finish();
+#[test]
+pub fn serialization() {
+    let mut builder: crate::TreeBuilder<crate::syntax::RawLanguage> = crate::TreeBuilder::new();
+    builder.start_node(crate::RawSyntaxKind(0));
+    builder.token(crate::RawSyntaxKind(0), "\n\tlet ");
+    builder.finish_node();
+    let root = builder.finish();
 
-//     assert!(serde_json::to_string(&root).is_ok());
-// }
+    assert!(serde_json::to_string(&root).is_ok());
+}

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -1,5 +1,5 @@
-import { ExtensionContext, Uri, window, workspace } from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
+import { ExtensionContext, Uri, window, workspace } from "vscode";
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from "vscode-languageclient/node";
 import { setContextValue } from "./utils";
 import { Session } from "./session";
 import { syntaxTree } from "./commands/syntaxTree";
@@ -10,7 +10,9 @@ let client: LanguageClient;
 const IN_ROME_PROJECT = "inRomeProject";
 
 export async function activate(context: ExtensionContext) {
-	const command = process.env.DEBUG_SERVER_PATH || (await getServerPath(context));
+	const command = process.env.DEBUG_SERVER_PATH || (
+		await getServerPath(context)
+	);
 	if (!command) {
 		await window.showErrorMessage(
 			"The Rome extensions doesn't ship with prebuilt binaries for your platform yet. " +
@@ -28,11 +30,7 @@ export async function activate(context: ExtensionContext) {
 	// only override serverOptions.options when developing extension,
 	// this is convenient for debugging
 	if (process.env.DEBUG_SERVER_PATH) {
-		serverOptions.options = {
-			env: {
-				...process.env
-			},
-		};
+		serverOptions.options = { env: { ...process.env } };
 	}
 
 	const clientOptions: LanguageClientOptions = {
@@ -54,7 +52,7 @@ export async function activate(context: ExtensionContext) {
 	client.start();
 }
 
-type Architecture = 'x64' | 'arm64';
+type Architecture = "x64" | "arm64";
 
 type PlatformTriplets = {
 	[P in NodeJS.Platform]?: {

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -29,6 +29,8 @@ export async function activate(context: ExtensionContext) {
 
 	// only override serverOptions.options when developing extension,
 	// this is convenient for debugging
+	// Before, every time we modify the client package, we need to rebuild vscode extension and install, for now, we could use Launching Client or press F5 to open a separate debug window and doing some check, finally we could bundle the vscode and do some final check.
+	// Passing such variable via `Launch.json`, you need not to add an extra environment variable or change the setting.json `rome.lspBin`,
 	if (process.env.DEBUG_SERVER_PATH) {
 		serverOptions.options = { env: { ...process.env } };
 	}

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -10,7 +10,7 @@ let client: LanguageClient;
 const IN_ROME_PROJECT = "inRomeProject";
 
 export async function activate(context: ExtensionContext) {
-	const command = await getServerPath(context);
+	const command = process.env.DEBUG_SERVER_PATH || (await getServerPath(context));
 	if (!command) {
 		await window.showErrorMessage(
 			"The Rome extensions doesn't ship with prebuilt binaries for your platform yet. " +
@@ -24,6 +24,16 @@ export async function activate(context: ExtensionContext) {
 		command,
 		transport: TransportKind.stdio,
 	};
+
+	// only override serverOptions.options when developing extension,
+	// this is convenient for debugging
+	if (process.env.DEBUG_SERVER_PATH) {
+		serverOptions.options = {
+			env: {
+				...process.env
+			},
+		};
+	}
 
 	const clientOptions: LanguageClientOptions = {
 		documentSelector: [


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
1. migrate lsp server crate `lspower` to `tower_lsp`
2. add launch.json which is convenient for debugging, unlike before we need to compile and reinstall `.vsix` every modify,
we could now use `Launch Client` 
![image](https://user-images.githubusercontent.com/17974631/164732555-507905e7-5f96-4a87-bdf9-ed7a1f4d5f43.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. run `cargo build --package rome_lsp`, build our `rome_lsp` server   
2. cd `editors/code`, and ` code .` open this directory as workspace root
3. switch to this pannel, and click `Launch Cilent` 
![image](https://user-images.githubusercontent.com/17974631/164985078-c7c6b056-d568-4a52-a46a-808a4ca7635c.png)
4. open any js,  ts, file, use `Format document` command and choose `rome`, your file should be formatted correctly
5. Using `Rome: show Syntax tree` command, you  should see syntax tree on another split window
![image](https://user-images.githubusercontent.com/17974631/164985367-1a36813b-986b-4d96-9dc1-cf81dd20ba94.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
