### PR TITLE
chore(ci): split the release workflow between the vscode extension and CLI package

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -1,0 +1,180 @@
+name: Release CLI
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 0 * * 2-6'
+  push:
+    branches:
+      - main
+    paths:
+      - npm/rome/package.json
+
+jobs:
+  check:
+    name: Check version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ env.version }}
+      prerelease: ${{ env.prerelease }}
+      nightly: ${{ env.nightly }}
+      version_changed: ${{ steps.version.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check nightly status
+        id: nightly
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: echo "nightly=true" >> $GITHUB_ENV
+
+      - name: Check version changes
+        uses: EndBug/version-check@v1
+        if: env.nightly != 'true'
+        id: version
+        with:
+          diff-search: true
+          file-name: npm/rome/package.json
+
+      - name: Set version name
+        run: echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
+
+      - name: Check prerelease status
+        id: prerelease
+        if: env.nightly == 'true' || steps.version.outputs.type == 'prerelease' || steps.version.outputs.type == 'prepatch' || steps.version.outputs.type == 'premajor' || steps.version.outputs.type == 'preminor'
+        run: echo "prerelease=true" >> $GITHUB_ENV
+
+      - name: Check version status
+        if: steps.version.outputs.changed == 'true'
+        run: 'echo "Version change found! New version: ${{ steps.version.outputs.version }} (${{ steps.version.outputs.version_type }})"'
+
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: windows-2022
+            target: x86_64-pc-windows-msvc
+            code-target: win32-x64
+          - os: windows-2022
+            target: aarch64-pc-windows-msvc
+            code-target: win32-arm64
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            code-target: linux-x64
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            code-target: linux-arm64
+          - os: macos-11
+            target: x86_64-apple-darwin
+            code-target: darwin-x64
+          - os: macos-11
+            target: aarch64-apple-darwin
+            code-target: darwin-arm64
+
+    name: Package ${{ matrix.code-target }}
+    runs-on: ${{ matrix.os }}
+
+    needs: check
+    if: needs.check.outputs.version_changed == 'true' || needs.check.outputs.nightly == 'true'
+    outputs:
+      version: ${{ env.version }}
+      prerelease: ${{ env.prerelease }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust toolchain
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install arm64 toolchain
+        if: matrix.code-target == 'linux-arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Audit crates.io dependencies
+        if: matrix.code-target == 'linux-x64'
+        run: cargo audit
+
+      # Build the CLI binary
+      - name: Build binaries
+        run: cargo build -p rome_cli --release --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          # Perform full Link-Time Optimizations
+          CARGO_PROFILE_RELEASE_LTO: "true"
+          # Strip all debug symbols from the resulting binaries
+          RUSTFLAGS: "-C strip=symbols"
+
+      # Copy the CLI binary and rename it to include the name of the target platform
+      - name: Copy CLI binary
+        if: matrix.os == 'windows-2022'
+        run: |
+          mkdir dist
+          cp target/${{ matrix.target }}/release/rome.exe ./dist/rome-${{ matrix.code-target }}.exe
+      - name: Copy CLI binary
+        if: matrix.os != 'windows-2022'
+        run: |
+          mkdir dist
+          cp target/${{ matrix.target }}/release/rome ./dist/rome-${{ matrix.code-target }}
+
+      # Upload the CLI binary as a build artifact
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: cli
+          path: ./dist/rome-*
+          if-no-files-found: error
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+
+      - name: Set release infos
+        run: |
+          echo "version=${{ needs.check.outputs.version }}" >> $GITHUB_ENV
+          echo "prerelease=${{ needs.check.outputs.prerelease }}" >> $GITHUB_ENV
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
+    environment: marketplace
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: cli
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Generate npm packages
+        run: node npm/rome/scripts/generate-packages.mjs
+
+      - name: Publish npm packages
+        # For now always publish the CLI to the "next" tag
+        run: for package in npm/*; do npm publish $package --tag next --access public; done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+      - name: Create GitHub release and tag
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: CLI v${{ needs.build.outputs.version }}
+          tag_name: cli/v${{ needs.build.outputs.version }}
+          draft: false
+          prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
+          files: |
+            rome-*
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -106,6 +106,8 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: "true"
           # Strip all debug symbols from the resulting binaries
           RUSTFLAGS: "-C strip=symbols"
+          # Inline the version of the npm package in the CLI binary
+          ROME_VERSION: ${{ env.version }}
 
       # Copy the CLI binary and rename it to include the name of the target platform
       - name: Copy CLI binary

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release LSP
 on:
   workflow_dispatch:
   # schedule:
@@ -100,35 +100,15 @@ jobs:
         if: matrix.code-target == 'linux-x64'
         run: cargo audit
 
-      # Build the LSP and CLI binaries
+      # Build the LSP binary
       - name: Build binaries
-        run: cargo build -p rome_lsp -p rome_cli --release --target ${{ matrix.target }}
+        run: cargo build -p rome_lsp --release --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
           # Perform full Link-Time Optimizations
           CARGO_PROFILE_RELEASE_LTO: "true"
           # Strip all debug symbols from the resulting binaries
           RUSTFLAGS: "-C strip=symbols"
-
-      # Copy the CLI binary and rename it to include the name of the target platform
-      - name: Copy CLI binary
-        if: matrix.os == 'windows-2022'
-        run: |
-          mkdir dist
-          cp target/${{ matrix.target }}/release/rome.exe ./dist/rome-${{ matrix.code-target }}.exe
-      - name: Copy CLI binary
-        if: matrix.os != 'windows-2022'
-        run: |
-          mkdir dist
-          cp target/${{ matrix.target }}/release/rome ./dist/rome-${{ matrix.code-target }}
-
-      # Upload the CLI binary as a build artifact
-      - name: Upload CLI artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: cli
-          path: ./dist/rome-*
-          if-no-files-found: error
 
       - name: Copy LSP binary
         if: matrix.os == 'windows-2022'
@@ -188,10 +168,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Download CLI artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: cli
       - name: Download extension artifacts
         uses: actions/download-artifact@v3
         with:
@@ -202,15 +178,6 @@ jobs:
         with:
           node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Generate npm packages
-        run: node npm/rome/scripts/generate-packages.mjs
-
-      - name: Publish npm packages
-        # For now always publish the CLI to the "next" tag
-        run: for package in npm/*; do npm publish $package --tag next --access public; done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
       - name: Publish extension (pre-release)
         run: npx vsce publish --pre-release --packagePath rome_lsp-*.vsix
@@ -228,12 +195,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: v${{ needs.build.outputs.version }}
-          tag_name: v${{ needs.build.outputs.version }}
+          name: VSCode Extension v${{ needs.build.outputs.version }}
+          tag_name: lsp/v${{ needs.build.outputs.version }}
           draft: false
           prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
           files: |
             rome_lsp-*.vsix
-            rome-*
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -1,14 +1,11 @@
 use crate::Termination;
 
-const MAIN: &str = concat!(
-    "Rome v",
-    env!("CARGO_PKG_VERSION"),
-    "
+const MAIN_HEAD: &str = "Rome v";
+const MAIN_BODY: &str = "
 Available commands:
 - format
 - help
-",
-);
+";
 
 const FORMAT: &str = "Rome Formatter
 
@@ -30,7 +27,10 @@ OPTIONS:
 pub(crate) fn help(command: Option<&str>) -> Result<(), Termination> {
     match command {
         Some("help") | None => {
-            print!("{MAIN}");
+            print!(
+                "{MAIN_HEAD}{}{MAIN_BODY}",
+                option_env!("ROME_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
+            );
             Ok(())
         }
         Some("format") => {

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rome",
-    "version": "0.4.2-next",
+    "version": "0.5.0-next",
     "bin": "bin/rome",
     "scripts": {
         "postinstall": "node scripts/postinstall.js"


### PR DESCRIPTION
## Summary

This change allows the VSCode Extension to be versioned independently from the npm wrapper package for the CLI. The releases are still triggered by a change to `editors/vscode/package.json` for the extension (and `npm/rome/package.json` for the CLI), and will be published indepently to either the Visual Studio Marketplace or npm, along with creating a GitHub Release tagged with `lsp/vx.y.z` for the LSP and `cli/vx.y.z` for the CLI

## Test Plan

Once we've merged in everything we want to include in the `0.5.0` release I'll edit this PR to also bump the version number of the packages, and dispatch the workflow manually a few times until I get it to work