### PR TITLE
fix(rome_js_formatter): 🐛 preserve new-lines after directives

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -819,30 +819,30 @@ where
     join_elements_with(elements, hard_line_break)
 }
 
+/// Get the number of line breaks between two consecutive SyntaxNodes in the tree
+pub fn get_lines_before<L: Language>(next_node: &SyntaxNode<L>) -> usize {
+    // Count the newlines in the leading trivia of the next node
+    if let Some(leading_trivia) = next_node.first_leading_trivia() {
+        leading_trivia
+            .pieces()
+            .take_while(|piece| {
+                // Stop at the first comment piece, the comment printer
+                // will handle newlines between the comment and the node
+                !piece.is_comments()
+            })
+            .filter(|piece| piece.is_newline())
+            .count()
+    } else {
+        0
+    }
+}
+
 #[inline]
 pub fn join_elements_with<I, L>(elements: I, separator: fn() -> FormatElement) -> FormatElement
 where
     I: IntoIterator<Item = (SyntaxNode<L>, FormatElement)>,
     L: Language,
 {
-    /// Get the number of line breaks between two consecutive SyntaxNodes in the tree
-    fn get_lines_before<L: Language>(next_node: &SyntaxNode<L>) -> usize {
-        // Count the newlines in the leading trivia of the next node
-        if let Some(leading_trivia) = next_node.first_leading_trivia() {
-            leading_trivia
-                .pieces()
-                .take_while(|piece| {
-                    // Stop at the first comment piece, the comment printer
-                    // will handle newlines between the comment and the node
-                    !piece.is_comments()
-                })
-                .filter(|piece| piece.is_newline())
-                .count()
-        } else {
-            0
-        }
-    }
-
     concat_elements(IntersperseFn::new(
         elements.into_iter(),
         |_, next_node, next_elem| {

--- a/crates/rome_js_formatter/src/js/lists/directive_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/directive_list.rs
@@ -1,14 +1,32 @@
 use crate::{empty_element, format_elements, hard_line_break, Format, FormatElement, Formatter};
-use rome_formatter::FormatResult;
+use rome_formatter::{empty_line, FormatResult};
 use rome_js_syntax::JsDirectiveList;
-use rome_rowan::AstNodeList;
+use rome_rowan::{AstNode, AstNodeList};
 
 impl Format for JsDirectiveList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         if !self.is_empty() {
+            let syntax_node = self.syntax();
+            // let child = match syntax_node.last_child() {
+            //     Some(node) => {
+            //     }
+            //     None => false,
+            // };
+            let token = syntax_node.next_sibling();
+            let child = match token {
+                Some(node_or_token) => {
+                    match node_or_token.first_leading_trivia() {
+                        Some(trivia) => trivia.pieces().filter(|piece| piece.is_newline()).count() > 1,
+                        None => false,
+                    }
+                }
+                None => false,
+            };
+            // child.
             Ok(format_elements![
                 formatter.format_list(self.clone()),
-                hard_line_break()
+                hard_line_break(),
+                if child { empty_line() } else { empty_element() }
             ])
         } else {
             Ok(empty_element())

--- a/crates/rome_js_formatter/src/js/lists/directive_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/directive_list.rs
@@ -7,26 +7,36 @@ impl Format for JsDirectiveList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         if !self.is_empty() {
             let syntax_node = self.syntax();
-            // let child = match syntax_node.last_child() {
-            //     Some(node) => {
-            //     }
-            //     None => false,
-            // };
-            let token = syntax_node.next_sibling();
-            let child = match token {
+            let next_sibling = syntax_node.next_sibling();
+            let need_extra_empty_line = match next_sibling {
                 Some(node_or_token) => {
                     match node_or_token.first_leading_trivia() {
-                        Some(trivia) => trivia.pieces().filter(|piece| piece.is_newline()).count() > 1,
+                        // if next_sibling's first leading_trivia has more than one new_line, we should add an extra empty line at the end of
+                        // JsDirectiveList, for example:
+                        //```js
+                        // "use strict"; <- first leading new_line
+                        //  			 <- second leading new_line
+                        // function foo() {
+
+                        // }
+                        //```
+                        // so we should keep an extra empty line after JsDirectiveList
+                        Some(trivia) => {
+                            trivia.pieces().filter(|piece| piece.is_newline()).count() > 1
+                        }
                         None => false,
                     }
                 }
                 None => false,
             };
-            // child.
             Ok(format_elements![
                 formatter.format_list(self.clone()),
                 hard_line_break(),
-                if child { empty_line() } else { empty_element() }
+                if need_extra_empty_line {
+                    empty_line()
+                } else {
+                    empty_element()
+                }
             ])
         } else {
             Ok(empty_element())

--- a/crates/rome_js_formatter/src/js/lists/directive_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/directive_list.rs
@@ -1,5 +1,5 @@
 use crate::{empty_element, format_elements, hard_line_break, Format, FormatElement, Formatter};
-use rome_formatter::{empty_line, FormatResult};
+use rome_formatter::{empty_line, format_element::get_lines_before, FormatResult};
 use rome_js_syntax::JsDirectiveList;
 use rome_rowan::{AstNode, AstNodeList};
 
@@ -8,26 +8,20 @@ impl Format for JsDirectiveList {
         if !self.is_empty() {
             let syntax_node = self.syntax();
             let next_sibling = syntax_node.next_sibling();
-            let need_extra_empty_line = match next_sibling {
-                Some(node_or_token) => {
-                    match node_or_token.first_leading_trivia() {
-                        // if next_sibling's first leading_trivia has more than one new_line, we should add an extra empty line at the end of
-                        // JsDirectiveList, for example:
-                        //```js
-                        // "use strict"; <- first leading new_line
-                        //  			 <- second leading new_line
-                        // function foo() {
+            // if next_sibling's first leading_trivia has more than one new_line, we should add an extra empty line at the end of
+            // JsDirectiveList, for example:
+            //```js
+            // "use strict"; <- first leading new_line
+            //  			 <- second leading new_line
+            // function foo() {
 
-                        // }
-                        //```
-                        // so we should keep an extra empty line after JsDirectiveList
-                        Some(trivia) => {
-                            trivia.pieces().filter(|piece| piece.is_newline()).count() > 1
-                        }
-                        None => false,
-                    }
-                }
-                None => false,
+            // }
+            //```
+            // so we should keep an extra empty line after JsDirectiveList
+            let need_extra_empty_line = if let Some(next_sibling) = next_sibling {
+                get_lines_before(&next_sibling) > 1
+            } else {
+                false
             };
             Ok(format_elements![
                 formatter.format_list(self.clone()),

--- a/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 242
 expression: newlines.js
+
 ---
 # Input
 "directive";
@@ -97,6 +99,7 @@ Quote style: Double Quotes
 "directive";
 
 "directive";
+
 statement();
 // comment
 statement();

--- a/crates/rome_js_formatter/tests/specs/prettier/js/directives/newline.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/directives/newline.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 175
 expression: newline.js
 
 ---
@@ -21,6 +21,7 @@ a();
 /* @flow */
 
 "use strict";
+
 import a from "a";
 
 a();

--- a/crates/rome_js_formatter/tests/specs/prettier/js/directives/test.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/directives/test.js.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 175
 expression: test.js
+
 ---
 # Input
 ```js
@@ -35,6 +37,7 @@ function f4() {
 # Output
 ```js
 "use strict";
+
 function f1() {
   "use strict";
 }
@@ -46,11 +49,13 @@ function f2() {
 
 function f3() {
   "ngInject";
+
   Object.assign(this, { $log, $uibModal });
 }
 
 function f4() {
   "ngInject";
+
   Object.assign(this, { $log, $uibModal });
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
Fix #2437
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
The updated snapshot should fix related issue #2437, 
you could review the snapshot this pr updated.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
