### PR TITLE
fix(rome_js_formatter): print empty statements as empty blocks

### DIFF
--- a/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
@@ -1,5 +1,5 @@
 use crate::format_traits::FormatOptional;
-use rome_formatter::FormatResult;
+use rome_formatter::{hard_line_break, FormatResult};
 
 use crate::{
     format_elements, hard_group_elements, space_token, token, Format, FormatElement, FormatNode,
@@ -21,7 +21,7 @@ impl FormatNode for JsDoWhileStatement {
             semicolon_token,
         } = self.as_fields();
 
-        let head = format_elements![do_token.format(formatter)?, space_token(),];
+        let head = do_token.format(formatter)?;
 
         let tail = format_elements![
             space_token(),
@@ -39,12 +39,19 @@ impl FormatNode for JsDoWhileStatement {
         if matches!(body, JsAnyStatement::JsBlockStatement(_)) {
             Ok(hard_group_elements(format_elements![
                 head,
+                space_token(),
                 body.format(formatter)?,
                 tail,
             ]))
+        } else if matches!(body, JsAnyStatement::JsEmptyStatement(_)) {
+            Ok(format_elements![
+                hard_group_elements(format_elements![head, body.format(formatter)?,]),
+                hard_line_break(),
+                tail,
+            ])
         } else {
             Ok(format_elements![
-                hard_group_elements(head),
+                hard_group_elements(format_elements![head, space_token()]),
                 body.format(formatter)?,
                 hard_group_elements(tail),
             ])

--- a/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
@@ -1,5 +1,5 @@
-use crate::format_traits::FormatOptional;
-use rome_formatter::{hard_line_break, FormatResult};
+use crate::format_traits::{FormatOptional, FormatWith};
+use rome_formatter::FormatResult;
 
 use crate::{
     format_elements, hard_group_elements, space_token, token, Format, FormatElement, FormatNode,
@@ -21,7 +21,7 @@ impl FormatNode for JsDoWhileStatement {
             semicolon_token,
         } = self.as_fields();
 
-        let head = do_token.format(formatter)?;
+        let head = do_token.format_with(formatter, |e| format_elements![e, space_token()])?;
 
         let tail = format_elements![
             space_token(),
@@ -39,19 +39,17 @@ impl FormatNode for JsDoWhileStatement {
         if matches!(body, JsAnyStatement::JsBlockStatement(_)) {
             Ok(hard_group_elements(format_elements![
                 head,
-                space_token(),
                 body.format(formatter)?,
                 tail,
             ]))
         } else if matches!(body, JsAnyStatement::JsEmptyStatement(_)) {
             Ok(format_elements![
                 hard_group_elements(format_elements![head, body.format(formatter)?,]),
-                hard_line_break(),
                 tail,
             ])
         } else {
             Ok(format_elements![
-                hard_group_elements(format_elements![head, space_token()]),
+                hard_group_elements(head),
                 body.format(formatter)?,
                 hard_group_elements(tail),
             ])

--- a/crates/rome_js_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/empty_statement.rs
@@ -1,13 +1,22 @@
-use crate::{empty_element, FormatElement, FormatNode, Formatter};
+use crate::{empty_element, Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
-
-use rome_js_syntax::JsEmptyStatement;
 use rome_js_syntax::JsEmptyStatementFields;
+use rome_js_syntax::{JsEmptyStatement, JsSyntaxKind};
+use rome_rowan::AstNode;
 
 impl FormatNode for JsEmptyStatement {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let JsEmptyStatementFields { semicolon_token } = self.as_fields();
-
-        Ok(formatter.format_replaced(&semicolon_token?, empty_element()))
+        let parent_kind = self.syntax().parent().map(|p| p.kind());
+        if matches!(
+            parent_kind,
+            Some(JsSyntaxKind::JS_DO_WHILE_STATEMENT)
+                | Some(JsSyntaxKind::JS_IF_STATEMENT)
+                | Some(JsSyntaxKind::JS_ELSE_CLAUSE)
+        ) {
+            semicolon_token.format(formatter)
+        } else {
+            Ok(formatter.format_replaced(&semicolon_token?, empty_element()))
+        }
     }
 }

--- a/crates/rome_js_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/empty_statement.rs
@@ -1,5 +1,5 @@
-use crate::{empty_element, Format, FormatElement, FormatNode, Formatter};
-use rome_formatter::FormatResult;
+use crate::{empty_element, FormatElement, FormatNode, Formatter};
+use rome_formatter::{format_elements, hard_line_break, token, FormatResult};
 use rome_js_syntax::JsEmptyStatementFields;
 use rome_js_syntax::{JsEmptyStatement, JsSyntaxKind};
 use rome_rowan::AstNode;
@@ -14,7 +14,8 @@ impl FormatNode for JsEmptyStatement {
                 | Some(JsSyntaxKind::JS_IF_STATEMENT)
                 | Some(JsSyntaxKind::JS_ELSE_CLAUSE)
         ) {
-            semicolon_token.format(formatter)
+            let new_body = format_elements![token("{"), hard_line_break(), token("}")];
+            Ok(formatter.format_replaced(&semicolon_token?, new_body))
         } else {
             Ok(formatter.format_replaced(&semicolon_token?, empty_element()))
         }

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -1,9 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::{block_indent, concat_elements, group_elements, hard_group_elements, token, Format};
-use rome_formatter::{hard_line_break, FormatResult};
-
 use crate::{format_elements, space_token, FormatElement, FormatNode, Formatter};
-
+use rome_formatter::FormatResult;
 use rome_js_syntax::JsSyntaxToken;
 use rome_js_syntax::{JsAnyStatement, JsElseClauseFields, JsIfStatement};
 use rome_js_syntax::{JsElseClause, JsIfStatementFields};
@@ -30,6 +28,7 @@ impl FormatNode for JsIfStatement {
                     if_chain.push(format_elements![
                         space_token(),
                         else_token.format(formatter)?,
+                        space_token(),
                         into_block(formatter, alternate)?,
                     ]);
                 }
@@ -68,6 +67,7 @@ fn format_if_element(
             test.format(formatter)?,
             &r_paren_token?,
         )?,
+        space_token(),
         into_block(formatter, consequent?)?,
     ];
 
@@ -77,21 +77,18 @@ fn format_if_element(
 /// Wraps the statement into a block if its not already a JsBlockStatement
 fn into_block(formatter: &Formatter, stmt: JsAnyStatement) -> FormatResult<FormatElement> {
     if matches!(stmt, JsAnyStatement::JsBlockStatement(_)) {
-        return Ok(format_elements![space_token(), stmt.format(formatter)?]);
+        return stmt.format(formatter);
     }
 
     // If the body is an empty statement, force a line break to ensure behavior
     // is coherent with `is_non_collapsable_empty_block`
     if matches!(stmt, JsAnyStatement::JsEmptyStatement(_)) {
-        return Ok(format_elements![stmt.format(formatter)?, hard_line_break()]);
+        return Ok(format_elements![stmt.format(formatter)?]);
     }
 
-    Ok(format_elements![
-        space_token(),
-        group_elements(format_elements![
-            token("{"),
-            block_indent(stmt.format(formatter)?),
-            token("}"),
-        ])
-    ])
+    Ok(group_elements(format_elements![
+        token("{"),
+        block_indent(stmt.format(formatter)?),
+        token("}"),
+    ]))
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js
@@ -10,3 +10,6 @@ do { // trailing
 }
 
 while (something)
+
+
+do; while(true);

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 242
 expression: do_while.js
+
 ---
 # Input
 do {
@@ -15,6 +17,9 @@ do { // trailing
 }
 
 while (something)
+
+
+do; while(true);
 =============================
 # Outputs
 ## Output 1
@@ -31,4 +36,7 @@ do {
 	// trailing
 	var foo = 4;
 } while (something);
+
+do;
+while (true);
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js
@@ -1,3 +1,6 @@
+if(a);
+if(a); else ;
+
 if (Math.random() > 0.5) {
 	console.log(1)
 } else if (Math.random() > 0.5) {

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -1,8 +1,13 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 242
 expression: if_else.js
+
 ---
 # Input
+if(a);
+if(a); else ;
+
 if (Math.random() > 0.5) {
 	console.log(1)
 } else if (Math.random() > 0.5) {
@@ -71,6 +76,10 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 -----
+if (a);
+if (a);
+else;
+
 if (Math.random() > 0.5) {
 	console.log(1);
 } else if (Math.random() > 0.5) {
@@ -122,6 +131,5 @@ if (true) {
 
 if (true) {
 	that();
-} else {
-}
+} else;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -76,9 +76,11 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 -----
-if (a);
-if (a);
-else;
+if (a) {
+}
+if (a) {
+} else {
+}
 
 if (Math.random() > 0.5) {
 	console.log(1);
@@ -131,5 +133,6 @@ if (true) {
 
 if (true) {
 	that();
-} else;
+} else {
+}
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/empty-statement/body.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/empty-statement/body.js.snap
@@ -19,15 +19,16 @@ do; while(1);
 # Output
 ```js
 with (a);
-if (1);
-else if (2);
-else;
+if (1) {
+} else if (2) {
+} else {
+}
 for (;;);
 while (1);
 for (var i in o);
 for (var i of o);
-do;
-while (1);
+do {
+} while (1);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/empty-statement/body.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/empty-statement/body.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 175
 expression: body.js
 
 ---
@@ -19,15 +19,15 @@ do; while(1);
 # Output
 ```js
 with (a);
-if (1) {
-} else if (2) {
-} else {
-}
+if (1);
+else if (2);
+else;
 for (;;);
 while (1);
 for (var i in o);
 for (var i of o);
-do while (1);
+do;
+while (1);
 
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #2448

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new cases, one for the `if` and one for `do while`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
