### PR TITLE
Fix(rome_js_formatter):regex flag order

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -2,37 +2,38 @@ use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatError;
 use rome_formatter::FormatResult;
 
-use rome_formatter::concat_elements;
-use rome_formatter::format_elements;
-use rome_formatter::token;
 use rome_formatter::Token;
 use rome_js_syntax::JsRegexLiteralExpression;
 use rome_js_syntax::JsRegexLiteralExpressionFields;
-use rome_js_syntax::TextRange;
-use rome_js_syntax::TextSize;
 
 impl FormatNode for JsRegexLiteralExpression {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let JsRegexLiteralExpressionFields { value_token } = self.as_fields();
         let value_token = value_token?;
         let raw_string = value_token.text();
-        let range = value_token.text_range();
+        // find end slash, so we could split our regex literal to two part `body`: raw_string[0..end_slash_pos + 1] and `flags`: raw_string[end_slash_pos + 1..]
+        // reference https://tc39.es/ecma262/#prod-RegularExpressionLiteral
         let end_slash_pos = raw_string
             .rfind('/')
-            .ok_or_else(|| FormatError::MissingRequiredChild)?;
+            .ok_or(FormatError::MissingRequiredChild)?;
+        // this means that we have a regex literal with no flags
         if end_slash_pos == raw_string.len() - 1 {
             return value_token.format(formatter);
         }
-        let mut flag = raw_string[end_slash_pos + 1..].chars().collect::<Vec<_>>();
-        flag.sort();
-        let flag = flag.iter().collect::<String>();
-        // formatter.format_replaced(current_token, content_to_replace_with);
-        let flag_token = Token::from_syntax_token_cow_slice(
-            std::borrow::Cow::Owned(format!("{}{}", &raw_string[0..end_slash_pos + 1], flag)),
+        let regex_literal_range = value_token.text_range();
+        let mut flag_char_vec = raw_string[end_slash_pos + 1..].chars().collect::<Vec<_>>();
+        flag_char_vec.sort_unstable();
+        let sorted_flag_string = flag_char_vec.iter().collect::<String>();
+
+        let sorted_regex_literal = Token::from_syntax_token_cow_slice(
+            std::borrow::Cow::Owned(format!(
+                "{}{}",
+                &raw_string[0..end_slash_pos + 1],
+                sorted_flag_string
+            )),
             &value_token,
-            range.start(),
+            regex_literal_range.start(),
         );
-        Ok(formatter.format_replaced(&value_token, FormatElement::Token(flag_token)))
-        // value_token.format(formatter)
+        Ok(formatter.format_replaced(&value_token, FormatElement::Token(sorted_regex_literal)))
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -20,7 +20,6 @@ impl FormatNode for JsRegexLiteralExpression {
         if end_slash_pos == trimmed_raw_string.len() - 1 {
             return value_token.format(formatter);
         }
-        // let regex_literal_range = value_token.text_range();
         let mut flag_char_vec = trimmed_raw_string[end_slash_pos + 1..]
             .chars()
             .collect::<Vec<_>>();

--- a/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -1,13 +1,38 @@
 use crate::{Format, FormatElement, FormatNode, Formatter};
+use rome_formatter::FormatError;
 use rome_formatter::FormatResult;
 
+use rome_formatter::concat_elements;
+use rome_formatter::format_elements;
+use rome_formatter::token;
+use rome_formatter::Token;
 use rome_js_syntax::JsRegexLiteralExpression;
 use rome_js_syntax::JsRegexLiteralExpressionFields;
+use rome_js_syntax::TextRange;
+use rome_js_syntax::TextSize;
 
 impl FormatNode for JsRegexLiteralExpression {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let JsRegexLiteralExpressionFields { value_token } = self.as_fields();
-
-        value_token.format(formatter)
+        let value_token = value_token?;
+        let raw_string = value_token.text();
+        let range = value_token.text_range();
+        let end_slash_pos = raw_string
+            .rfind('/')
+            .ok_or_else(|| FormatError::MissingRequiredChild)?;
+        if end_slash_pos == raw_string.len() - 1 {
+            return value_token.format(formatter);
+        }
+        let mut flag = raw_string[end_slash_pos + 1..].chars().collect::<Vec<_>>();
+        flag.sort();
+        let flag = flag.iter().collect::<String>();
+        // formatter.format_replaced(current_token, content_to_replace_with);
+        let flag_token = Token::from_syntax_token_cow_slice(
+            std::borrow::Cow::Owned(format!("{}{}", &raw_string[0..end_slash_pos + 1], flag)),
+            &value_token,
+            range.start(),
+        );
+        Ok(formatter.format_replaced(&value_token, FormatElement::Token(flag_token)))
+        // value_token.format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -1,5 +1,4 @@
 use crate::{Format, FormatElement, FormatNode, Formatter};
-use rome_formatter::FormatError;
 use rome_formatter::FormatResult;
 
 use rome_formatter::Token;
@@ -13,13 +12,13 @@ impl FormatNode for JsRegexLiteralExpression {
         let trimmed_raw_string = value_token.text_trimmed();
         // find end slash, so we could split our regex literal to two part `body`: raw_string[0..end_slash_pos + 1] and `flags`: raw_string[end_slash_pos + 1..]
         // reference https://tc39.es/ecma262/#prod-RegularExpressionLiteral
-        let end_slash_pos = trimmed_raw_string
-            .rfind('/')
-            .ok_or(FormatError::MissingRequiredChild)?;
+        let ends_with_slash = trimmed_raw_string.ends_with('/');
         // this means that we have a regex literal with no flags
-        if end_slash_pos == trimmed_raw_string.len() - 1 {
+        if ends_with_slash {
             return value_token.format(formatter);
         }
+        // SAFETY: a valid regex literal must have a end slash
+        let end_slash_pos = trimmed_raw_string.rfind('/').unwrap();
         let mut flag_char_vec = trimmed_raw_string[end_slash_pos + 1..]
             .chars()
             .collect::<Vec<_>>();

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js
@@ -4,3 +4,4 @@
 true
 false
 null
+;/[/]\/\u0aBc/mgi;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 242
 expression: literal_expression.js
+
 ---
 # Input
 "a"
@@ -9,7 +11,7 @@ expression: literal_expression.js
 true
 false
 null
-
+;/[/]\/\u0aBc/mgi;
 =============================
 # Outputs
 ## Output 1
@@ -24,4 +26,5 @@ Quote style: Double Quotes
 true;
 false;
 null;
+/[/]\/\u0aBc/gim;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/regex/test.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/regex/test.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 175
 expression: test.js
 
 ---
@@ -12,7 +12,7 @@ expression: test.js
 
 # Output
 ```js
-/[/]\/\u0aBc/mgi;
+/[/]\/\u0aBc/gim;
 
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
Resolve #2445
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
Snapshot test result has been aligned to related issue, 
now regex literal flags should be sorted correctly