### PR TITLE
fix(rome_js_parser): jsx vs type assertions

### DIFF
--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/html-like/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/html-like/comment.js.snap
@@ -21,7 +21,7 @@ alert(1)
 
 # Errors
 ```
-error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
+error[SyntaxError]: type assertions are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ comment.js:1:1
   │  
 1 │ ┌ <!--

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/html-like/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/html-like/comment.js.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 175
 expression: comment.js
+
 ---
 # Input
 ```js
@@ -19,17 +21,12 @@ alert(1)
 
 # Errors
 ```
-error[SyntaxError]: Expected an expression for the left hand side of the `<` operator.
+error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ comment.js:1:1
-  │
-1 │ <!--
-  │ ^ This operator requires a left hand side value
-
-error[SyntaxError]: Invalid assignment to `alert(1)`
-  ┌─ comment.js:2:1
-  │
-2 │ alert(1)
-  │ ^^^^^^^^ This expression cannot be assigned to
+  │  
+1 │ ┌ <!--
+2 │ │ alert(1)
+  │ └────────^ TypeScript only syntax
 
 error[SyntaxError]: expected an identifier, or a member expression but instead found '>'
   ┌─ comment.js:3:3

--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -3,6 +3,7 @@
 //!
 //! See the [ECMAScript spec](https://www.ecma-international.org/ecma-262/5.1/#sec-11).
 
+use super::jsx::jsx_parse_errors::jsx_only_syntax_error;
 use super::typescript::*;
 use super::util::*;
 use crate::event::rewrite_events;
@@ -1290,7 +1291,7 @@ fn parse_primary_expression(p: &mut Parser, context: ExpressionContext) -> Parse
         T![<] => {
             let checkpoint = p.checkpoint();
             Jsx.parse_exclusive_syntax(p, parse_jsx_tag_expression, |p, assertion| {
-                ts_only_syntax_error(p, "JSX", assertion.range(p))
+                jsx_only_syntax_error(p, "JSX tags", assertion.range(p))
             })
             .or_else(|| {
                 p.rewind(checkpoint);

--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -118,7 +118,9 @@ impl ExpressionContext {
 impl Default for ExpressionContext {
     fn default() -> Self {
         ExpressionContext(
-            ExpressionContextFlags::INCLUDE_IN | ExpressionContextFlags::ALLOW_OBJECT_EXPRESSION,
+            ExpressionContextFlags::INCLUDE_IN
+                | ExpressionContextFlags::ALLOW_OBJECT_EXPRESSION
+                | ExpressionContextFlags::ALLOW_TS_TYPE_ASSERTION,
         )
     }
 }

--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -4,6 +4,7 @@
 //! See the [ECMAScript spec](https://www.ecma-international.org/ecma-262/5.1/#sec-11).
 
 use super::jsx::jsx_parse_errors::jsx_only_syntax_error;
+use super::typescript::ts_parse_error::ts_type_assertion_on_new_expr;
 use super::typescript::*;
 use super::util::*;
 use crate::event::rewrite_events;
@@ -60,6 +61,10 @@ bitflags! {
         /// If `true` then, don't parse computed member expressions because they can as well indicate
         /// the start of a computed class member.
         const IN_TS_DECORATOR = 1 << 2;
+
+        /// If `true` allows a typescript type assertion.
+        /// Currently disabled on "new" expressions.
+        const ALLOW_TS_TYPE_ASSERTION = 1 << 3;
     }
 }
 
@@ -76,6 +81,10 @@ impl ExpressionContext {
         self.and(ExpressionContextFlags::IN_TS_DECORATOR, in_decorator)
     }
 
+    pub(crate) fn and_ts_type_assertion_allowed(self, allowed: bool) -> Self {
+        self.and(ExpressionContextFlags::ALLOW_TS_TYPE_ASSERTION, allowed)
+    }
+
     /// Returns true if object expressions or object patterns are valid in this context
     pub(crate) const fn is_object_expression_allowed(&self) -> bool {
         self.0
@@ -90,6 +99,12 @@ impl ExpressionContext {
     /// Returns `true` if currently parsing a decorator expression `@<expr>`.
     pub(crate) const fn is_in_ts_decorator(&self) -> bool {
         self.0.contains(ExpressionContextFlags::IN_TS_DECORATOR)
+    }
+
+    /// Returns true if typescript type assertion are valid in this context
+    pub(crate) const fn is_ts_type_assertion_allowed(&self) -> bool {
+        self.0
+            .contains(ExpressionContextFlags::ALLOW_TS_TYPE_ASSERTION)
     }
 
     /// Adds the `flag` if `set` is `true`, otherwise removes the `flag`
@@ -729,7 +744,8 @@ fn parse_new_expr(p: &mut Parser, context: ExpressionContext) -> ParsedSyntax {
         return Present(m.complete(p, NEW_TARGET));
     }
 
-    let expression = parse_primary_expression(p, context).or_add_diagnostic(p, expected_expression);
+    let expression = parse_primary_expression(p, context.and_ts_type_assertion_allowed(false))
+        .or_add_diagnostic(p, expected_expression);
 
     if let Some(lhs) = expression {
         parse_member_expression_rest(p, lhs, context, false, &mut false);
@@ -1289,17 +1305,33 @@ fn parse_primary_expression(p: &mut Parser, context: ExpressionContext) -> Parse
         // test ts type_assertion_primary_expression
         // let a = <number>undefined;
         T![<] => {
+            // Checkpoint in case we are not at a JSX tag
             let checkpoint = p.checkpoint();
             Jsx.parse_exclusive_syntax(p, parse_jsx_tag_expression, |p, assertion| {
                 jsx_only_syntax_error(p, "JSX tags", assertion.range(p))
             })
             .or_else(|| {
+                // Try to parse typescript type assertions
                 p.rewind(checkpoint);
-                TypeScript.parse_exclusive_syntax(
-                    p,
-                    |p| parse_ts_type_assertion_expression(p, context),
-                    |p, assertion| ts_only_syntax_error(p, "type assertion", assertion.range(p)),
-                )
+                TypeScript
+                    .parse_exclusive_syntax(
+                        p,
+                        |p| parse_ts_type_assertion_expression(p, context),
+                        |p, assertion| {
+                            ts_only_syntax_error(p, "type assertions", assertion.range(p))
+                        },
+                    )
+                    .map(|m| {
+                        // we parsed a type assertion, but we need an error
+                        // if type assertions are not allowed
+
+                        // test_err ts ts_type_assertions_not_valid_at_new_expr
+                        // var test2 = new <any>Test2();
+                        if !context.is_ts_type_assertion_allowed() {
+                            p.error(ts_type_assertion_on_new_expr(p, &m))
+                        }
+                        m
+                    })
             })
             .unwrap()
         }

--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -1289,11 +1289,9 @@ fn parse_primary_expression(p: &mut Parser, context: ExpressionContext) -> Parse
         // let a = <number>undefined;
         T![<] => {
             let checkpoint = p.checkpoint();
-            Jsx.parse_exclusive_syntax(
-                p,
-                |p| parse_jsx_tag_expression(p),
-                |p, assertion| ts_only_syntax_error(p, "JSX", assertion.range(p)),
-            )
+            Jsx.parse_exclusive_syntax(p, parse_jsx_tag_expression, |p, assertion| {
+                ts_only_syntax_error(p, "JSX", assertion.range(p))
+            })
             .or_else(|| {
                 p.rewind(checkpoint);
                 TypeScript.parse_exclusive_syntax(

--- a/crates/rome_js_parser/src/syntax/jsx/jsx_parse_errors.rs
+++ b/crates/rome_js_parser/src/syntax/jsx/jsx_parse_errors.rs
@@ -5,6 +5,14 @@ use crate::{
 use rome_diagnostics::Diagnostic;
 use rome_js_syntax::TextRange;
 
+pub(crate) fn jsx_only_syntax_error(p: &Parser, syntax: &str, range: TextRange) -> Diagnostic {
+    p.err_builder(&format!(
+        "{} are a JSX only feature. Convert your file to a JSX file or remove the syntax.",
+        syntax
+    ))
+    .primary(range, "JSX only syntax")
+}
+
 pub(crate) fn jsx_expected_attribute(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("JSX attribute", range).to_diagnostic(p)
 }

--- a/crates/rome_js_parser/src/syntax/typescript/ts_parse_error.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/ts_parse_error.rs
@@ -89,6 +89,11 @@ pub(crate) fn ts_set_accessor_return_type_error(
         .primary(type_annotation.range(p), "")
 }
 
+pub(crate) fn ts_type_assertion_on_new_expr(p: &Parser, type_expr: &CompletedMarker) -> Diagnostic {
+    p.err_builder("Type assertions cannot be used at 'new' expressions.")
+        .primary(type_expr.range(p), "")
+}
+
 pub(crate) fn expected_ts_type(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("type", range).to_diagnostic(p)
 }

--- a/crates/rome_js_parser/test_data/inline/err/ts_type_assertions_not_valid_at_new_expr.rast
+++ b/crates/rome_js_parser/test_data/inline/err/ts_type_assertions_not_valid_at_new_expr.rast
@@ -1,0 +1,95 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                kind: VAR_KW@0..4 "var" [] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@4..10 "test2" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@10..12 "=" [] [Whitespace(" ")],
+                            expression: JsNewExpression {
+                                new_token: NEW_KW@12..16 "new" [] [Whitespace(" ")],
+                                callee: TsTypeAssertionExpression {
+                                    l_angle_token: L_ANGLE@16..17 "<" [] [],
+                                    ty: TsAnyType {
+                                        any_token: ANY_KW@17..20 "any" [] [],
+                                    },
+                                    r_angle_token: R_ANGLE@20..21 ">" [] [],
+                                    expression: JsCallExpression {
+                                        callee: JsIdentifierExpression {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@21..26 "Test2" [] [],
+                                            },
+                                        },
+                                        optional_chain_token: missing (optional),
+                                        type_arguments: missing (optional),
+                                        arguments: JsCallArguments {
+                                            l_paren_token: L_PAREN@26..27 "(" [] [],
+                                            args: JsCallArgumentList [],
+                                            r_paren_token: R_PAREN@27..28 ")" [] [],
+                                        },
+                                    },
+                                },
+                                type_arguments: missing (optional),
+                                arguments: missing (optional),
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@28..29 ";" [] [],
+        },
+    ],
+    eof_token: EOF@29..30 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..30
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..29
+    0: JS_VARIABLE_STATEMENT@0..29
+      0: JS_VARIABLE_DECLARATION@0..28
+        0: VAR_KW@0..4 "var" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATOR_LIST@4..28
+          0: JS_VARIABLE_DECLARATOR@4..28
+            0: JS_IDENTIFIER_BINDING@4..10
+              0: IDENT@4..10 "test2" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@10..28
+              0: EQ@10..12 "=" [] [Whitespace(" ")]
+              1: JS_NEW_EXPRESSION@12..28
+                0: NEW_KW@12..16 "new" [] [Whitespace(" ")]
+                1: TS_TYPE_ASSERTION_EXPRESSION@16..28
+                  0: L_ANGLE@16..17 "<" [] []
+                  1: TS_ANY_TYPE@17..20
+                    0: ANY_KW@17..20 "any" [] []
+                  2: R_ANGLE@20..21 ">" [] []
+                  3: JS_CALL_EXPRESSION@21..28
+                    0: JS_IDENTIFIER_EXPRESSION@21..26
+                      0: JS_REFERENCE_IDENTIFIER@21..26
+                        0: IDENT@21..26 "Test2" [] []
+                    1: (empty)
+                    2: (empty)
+                    3: JS_CALL_ARGUMENTS@26..28
+                      0: L_PAREN@26..27 "(" [] []
+                      1: JS_CALL_ARGUMENT_LIST@27..27
+                      2: R_PAREN@27..28 ")" [] []
+                2: (empty)
+                3: (empty)
+      1: SEMICOLON@28..29 ";" [] []
+  3: EOF@29..30 "" [Newline("\n")] []
+--
+error[SyntaxError]: Type assertions cannot be used at 'new' expressions.
+  ┌─ ts_type_assertions_not_valid_at_new_expr.ts:1:17
+  │
+1 │ var test2 = new <any>Test2();
+  │                 ^^^^^^^^^^^^
+
+--
+var test2 = new <any>Test2();

--- a/crates/rome_js_parser/test_data/inline/err/ts_type_assertions_not_valid_at_new_expr.ts
+++ b/crates/rome_js_parser/test_data/inline/err/ts_type_assertions_not_valid_at_new_expr.ts
@@ -1,0 +1,1 @@
+var test2 = new <any>Test2();

--- a/crates/rome_js_parser/test_data/inline/ok/type_assertion_primary_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/type_assertion_primary_expression.rast
@@ -1,0 +1,61 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                kind: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: TsTypeAssertionExpression {
+                                l_angle_token: L_ANGLE@8..9 "<" [] [],
+                                ty: TsNumberType {
+                                    number_token: NUMBER_KW@9..15 "number" [] [],
+                                },
+                                r_angle_token: R_ANGLE@15..16 ">" [] [],
+                                expression: JsIdentifierExpression {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@16..25 "undefined" [] [],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@25..26 ";" [] [],
+        },
+    ],
+    eof_token: EOF@26..27 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..27
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..26
+    0: JS_VARIABLE_STATEMENT@0..26
+      0: JS_VARIABLE_DECLARATION@0..25
+        0: LET_KW@0..4 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATOR_LIST@4..25
+          0: JS_VARIABLE_DECLARATOR@4..25
+            0: JS_IDENTIFIER_BINDING@4..6
+              0: IDENT@4..6 "a" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@6..25
+              0: EQ@6..8 "=" [] [Whitespace(" ")]
+              1: TS_TYPE_ASSERTION_EXPRESSION@8..25
+                0: L_ANGLE@8..9 "<" [] []
+                1: TS_NUMBER_TYPE@9..15
+                  0: NUMBER_KW@9..15 "number" [] []
+                2: R_ANGLE@15..16 ">" [] []
+                3: JS_IDENTIFIER_EXPRESSION@16..25
+                  0: JS_REFERENCE_IDENTIFIER@16..25
+                    0: IDENT@16..25 "undefined" [] []
+      1: SEMICOLON@25..26 ";" [] []
+  3: EOF@26..27 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/type_assertion_primary_expression.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/type_assertion_primary_expression.ts
@@ -1,0 +1,1 @@
+let a = <number>undefined;


### PR DESCRIPTION
This PR fixes a problem with jsx versus type assertions at primary expressions.

Currently, something like the code below was failing:

```
let a = <number>b;
```

We would treat ```b``` as ```JSXText``` and later complaint about a missing closing tag.
Now we do our best to parse JSX and type assertions separately and warn appropriately.

This changes an error on an HTML comment test, which does not matter because we still do not support these comments.
If anyone thinks that the current message is worst, I can try something to improve it.