### PR TITLE
fix(ci): Disable deploy playground for forks

### DIFF
--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Publish
         uses: jakejarvis/s3-sync-action@master
+        if: github.repository_owner == 'rome'
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -56,12 +57,12 @@ jobs:
           echo "::set-output name=url::$url"
 
       - name: Get the PR number
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.repository_owner == 'rome'
         id: pr-number
         uses: kkak10/pr-number-action@v1.3
 
       - name: Find Previous Comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.repository_owner == 'rome'
         uses: peter-evans/find-comment@v1.3.0
         id: previous-comment
         with:
@@ -69,7 +70,7 @@ jobs:
           body-includes: Playground for commit
 
       - name: Update existing comment
-        if: github.event_name == 'pull_request' && steps.previous-comment.outputs.comment-id
+        if: github.event_name == 'pull_request' && steps.previous-comment.outputs.comment-id && github.repository_owner == 'rome'
         uses: peter-evans/create-or-update-comment@v1.4.5
         continue-on-error: true
         with:
@@ -79,7 +80,7 @@ jobs:
           edit-mode: replace
 
       - name: Write a new comment
-        if: github.event_name == 'pull_request' && !steps.previous-comment.outputs.comment-id
+        if: github.event_name == 'pull_request' && !steps.previous-comment.outputs.comment-id && github.repository_owner == 'rome'
         uses: peter-evans/create-or-update-comment@v1.4.5
         continue-on-error: true
         with:

--- a/website/playground/src/IndentStyleSelect.tsx
+++ b/website/playground/src/IndentStyleSelect.tsx
@@ -1,10 +1,10 @@
 import { IndentStyle } from "./types";
 
 interface Props {
-	setIndentStyle: (indentStyle: IndentStyle) => void,
-	indentStyle: IndentStyle,
-	indentWidth: number,
-	setIndentWidth: (indentWidth: number) => void,
+	setIndentStyle: (indentStyle: IndentStyle) => void;
+	indentStyle: IndentStyle;
+	indentWidth: number;
+	setIndentWidth: (indentWidth: number) => void;
 }
 
 export default function IndentStyleSelect(

--- a/website/playground/src/LineWidthInput.tsx
+++ b/website/playground/src/LineWidthInput.tsx
@@ -1,4 +1,4 @@
-interface Props { lineWidth: number, setLineWidth: (lineWidth: number) => void }
+interface Props { lineWidth: number; setLineWidth: (lineWidth: number) => void }
 
 export default function LineWidthInput({ lineWidth, setLineWidth }: Props) {
 	return (

--- a/website/playground/src/QuoteStyleSelect.tsx
+++ b/website/playground/src/QuoteStyleSelect.tsx
@@ -1,8 +1,8 @@
 import { QuoteStyle } from "./types";
 
 interface Props {
-	setQuoteStyle: (v: QuoteStyle) => void,
-	quoteStyle: QuoteStyle,
+	setQuoteStyle: (v: QuoteStyle) => void;
+	quoteStyle: QuoteStyle;
 }
 
 export default function QuoteStyleSelect({ setQuoteStyle, quoteStyle }: Props) {

--- a/website/playground/src/SourceTypeSelect.tsx
+++ b/website/playground/src/SourceTypeSelect.tsx
@@ -1,12 +1,12 @@
 import { SourceType } from "./types";
 
 interface Props {
-	setIsTypeScript: (b: boolean) => void,
-	isTypeScript: boolean,
-	setIsJsx: (b: boolean) => void,
-	isJsx: boolean,
-	setSourceType: (v: SourceType) => void,
-	sourceType: SourceType,
+	setIsTypeScript: (b: boolean) => void;
+	isTypeScript: boolean;
+	setIsJsx: (b: boolean) => void;
+	isJsx: boolean;
+	setSourceType: (v: SourceType) => void;
+	sourceType: SourceType;
 }
 
 export default function SourceTypeSelect(

--- a/website/playground/src/types.ts
+++ b/website/playground/src/types.ts
@@ -5,28 +5,28 @@ export enum SourceType { Module = "module", Script = "script" }
 export enum QuoteStyle { Double = "double", Single = "single" }
 
 export interface PlaygroundState {
-	code: string,
-	setCode: (code: string) => void,
-	lineWidth: number,
-	setLineWidth: (lineWidth: number) => void,
-	indentStyle: IndentStyle,
-	setIndentStyle: (indentStyle: IndentStyle) => void,
-	indentWidth: number,
-	setIndentWidth: (indentWidth: number) => void,
-	quoteStyle: QuoteStyle,
-	setQuoteStyle: (quoteStyle: QuoteStyle) => void,
-	sourceType: SourceType,
-	setSourceType: (sourceType: SourceType) => void,
-	isTypeScript: boolean,
-	setIsTypeScript: (isTypeScript: boolean) => void,
-	isJsx: boolean,
-	setIsJsx: (isJsx: boolean) => void,
+	code: string;
+	setCode: (code: string) => void;
+	lineWidth: number;
+	setLineWidth: (lineWidth: number) => void;
+	indentStyle: IndentStyle;
+	setIndentStyle: (indentStyle: IndentStyle) => void;
+	indentWidth: number;
+	setIndentWidth: (indentWidth: number) => void;
+	quoteStyle: QuoteStyle;
+	setQuoteStyle: (quoteStyle: QuoteStyle) => void;
+	sourceType: SourceType;
+	setSourceType: (sourceType: SourceType) => void;
+	isTypeScript: boolean;
+	setIsTypeScript: (isTypeScript: boolean) => void;
+	isJsx: boolean;
+	setIsJsx: (isJsx: boolean) => void;
 }
 
 export interface PlaygroundProps {
-	playgroundState: PlaygroundState,
-	prettierOutput: string,
-	romeOutput: RomeOutput,
+	playgroundState: PlaygroundState;
+	prettierOutput: string;
+	romeOutput: RomeOutput;
 }
 
 export type PlaygroundSettings = Pick<

--- a/website/playground/src/utils.ts
+++ b/website/playground/src/utils.ts
@@ -5,7 +5,7 @@ import prettier from "prettier";
 import parserBabel from "prettier/esm/parser-babel";
 import { IndentStyle, PlaygroundState, QuoteStyle, SourceType } from "./types";
 
-interface Size { width: number | undefined, height: number | undefined }
+interface Size { width: number | undefined; height: number | undefined }
 
 // Hook
 export function useWindowSize(): Size {
@@ -104,11 +104,11 @@ export function usePlaygroundState(): PlaygroundState {
 export function formatWithPrettier(
 	code: string,
 	options: {
-		lineWidth: number,
-		indentStyle: IndentStyle,
-		indentWidth: number,
-		language: "js" | "ts",
-		quoteStyle: QuoteStyle,
+		lineWidth: number;
+		indentStyle: IndentStyle;
+		indentWidth: number;
+		language: "js" | "ts";
+		quoteStyle: QuoteStyle;
 	},
 ) {
 	try {


### PR DESCRIPTION

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Forks don't have access to our secrets and therefore deploy playground actions run on forks fail. This is misleading as it makes it look like perfectly good PRs have failing CI jobs.

## Test Plan

Honestly...not sure. Ideas?