### PR TITLE
fix(ci): fix the release workflows for the CLI and LSP

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check prerelease status
         id: prerelease
-        if: env.nightly == 'true' || steps.version.outputs.type == 'prerelease' || steps.version.outputs.type == 'prepatch' || steps.version.outputs.type == 'premajor' || steps.version.outputs.type == 'preminor'
+        if: env.nightly == 'true'
         run: echo "prerelease=true" >> $GITHUB_ENV
 
       - name: Check version status
@@ -107,7 +107,7 @@ jobs:
           # Strip all debug symbols from the resulting binaries
           RUSTFLAGS: "-C strip=symbols"
           # Inline the version of the npm package in the CLI binary
-          ROME_VERSION: ${{ env.version }}
+          ROME_VERSION: ${{ needs.check.outputs.version }}
 
       # Copy the CLI binary and rename it to include the name of the target platform
       - name: Copy CLI binary

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -113,11 +113,13 @@ jobs:
       - name: Copy LSP binary
         if: matrix.os == 'windows-2022'
         run: |
+          mkdir dist
           mkdir editors/vscode/server
           cp target/${{ matrix.target }}/release/rome_lsp.exe editors/vscode/server/rome_lsp.exe
       - name: Copy LSP binary
         if: matrix.os != 'windows-2022'
         run: |
+          mkdir dist
           mkdir editors/vscode/server
           cp target/${{ matrix.target }}/release/rome_lsp editors/vscode/server/rome_lsp
 


### PR DESCRIPTION
## Summary

This corrects two outstanding issues in the release workflows following #2495:

- The version number injected into the CLI binary was read from an environment variable set in a later step so the version name ended up being empty, it's now being read from the correct source
- The builds of the VSCode extension were failing as the `dist` directory used as a target location for the compiled bundle did not exist, there's now an explicit `mkdir` to create it beforehand
- All builds of the CLI npm package were being tagged as pre-release since it's using a version tagged with `-next`, the logic for checking this has been disabled so that only manual dispatch of the workflow are tagged as pre-release

## Test Plan

Manually dispatch the workflows and see if it works
