### PR TITLE
fix(rome_js_formatter): number with trailing whitespace

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -28,8 +28,7 @@ impl FormatNode for JsStaticMemberExpression {
         let formatted_object = object?.format(formatter)?;
 
         if is_object_number_literal && (has_object_trailing_trivia || has_operator_leading_trivia) {
-            let (object_leading, object_content, object_trailing) =
-                formatted_object.clone().split_trivia();
+            let (object_leading, object_content, object_trailing) = formatted_object.split_trivia();
 
             Ok(group_elements(format_elements![
                 object_leading,

--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -20,21 +20,23 @@ impl FormatNode for JsStaticMemberExpression {
         let is_object_number_literal =
             object_syntax.kind() == JsSyntaxKind::JS_NUMBER_LITERAL_EXPRESSION;
 
-        let has_object_trailing_whitespace = object_syntax
-            .text()
-            .to_string()
-            .chars()
-            .last()
-            .unwrap()
-            .is_whitespace();
+        let has_object_trailing_trivia =
+            object_syntax.last_trailing_trivia().unwrap().pieces().len() > 0;
+        let has_operator_leading_trivia =
+            operator_token.clone()?.leading_trivia().pieces().len() > 0;
 
         let formatted_object = object?.format(formatter)?;
 
-        if is_object_number_literal && has_object_trailing_whitespace {
+        if is_object_number_literal && (has_object_trailing_trivia || has_operator_leading_trivia) {
+            let (object_leading, object_content, object_trailing) =
+                formatted_object.clone().split_trivia();
+
             Ok(group_elements(format_elements![
+                object_leading,
                 token("("),
-                formatted_object,
+                object_content,
                 token(")"),
+                object_trailing,
                 operator_token.format(formatter)?,
                 member.format(formatter)?,
             ]))

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number-with-space.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number-with-space.js
@@ -1,1 +1,6 @@
 123 .toString
+123
+/****/.toString
+123/**/.toString
+123
+.toString

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number-with-space.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number-with-space.js
@@ -1,0 +1,1 @@
+123 .toString

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number-with-space.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number-with-space.js.snap
@@ -4,6 +4,12 @@ expression: number-with-space.js
 ---
 # Input
 123 .toString
+123
+/****/.toString
+123/**/.toString
+123
+.toString
+
 =============================
 # Outputs
 ## Output 1
@@ -12,5 +18,9 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 -----
+(123).toString;
+(123)
+/****/ .toString;
+(123) /**/ .toString;
 (123).toString;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number-with-space.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number-with-space.js.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: number-with-space.js
+---
+# Input
+123 .toString
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+-----
+(123).toString;
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #2501.

This PR adds conditional to `JsStaticMemberExpression` that checks if its value is a number literal expression that has trailing whitespace.

## Test Plan

Added new test that covers the case.
