### PR TITLE
release(vscode): 0.6.0

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rome",
-	"version": "0.4.2",
+	"version": "0.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rome",
-			"version": "0.4.2",
+			"version": "0.6.0",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-languageclient": "^8.0.0-next.13"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
 	"publisher": "rome",
 	"displayName": "Rome",
 	"description": "Rome LSP VS Code Extension",
-	"version": "0.4.2",
+	"version": "0.6.0",
 	"icon": "icon.png",
 	"activationEvents": [
 		"onLanguage:javascript",


### PR DESCRIPTION
## Summary

This is the same change as #2513 rebased on the latest main (with the fixed release workflow)
