### PR TITLE
refactor: Split out `JsFormatter`

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod format_element;
 pub mod format_elements;
 pub mod intersperse;
+#[cfg(debug_assertions)]
+pub mod printed_tokens;
 pub mod printer;
+
 use crate::printer::Printer;
 pub use format_element::{
     block_indent, comment, concat_elements, empty_element, empty_line, fill_elements,

--- a/crates/rome_formatter/src/printed_tokens.rs
+++ b/crates/rome_formatter/src/printed_tokens.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 /// This implementation uses the fact that no two tokens can have an overlapping range to avoid the need for an interval tree.
 /// Thus, testing if a token has already been formatted only requires testing if a token starting at the same offset has been formatted.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct PrintedTokens {
+pub struct PrintedTokens {
     /// Key: Start of a token's range
     offsets: BTreeSet<TextSize>,
 }
@@ -16,7 +16,7 @@ impl PrintedTokens {
     ///
     /// ## Panics
     /// If this token has been formatted before.
-    pub(crate) fn track_token<L: Language>(&mut self, token: &SyntaxToken<L>) {
+    pub fn track_token<L: Language>(&mut self, token: &SyntaxToken<L>) {
         let range = token.text_trimmed_range();
 
         if !self.offsets.insert(range.start()) {
@@ -28,7 +28,7 @@ impl PrintedTokens {
     ///
     /// ## Panics
     /// If any descendant token of `root` hasn't been tracked
-    pub(crate) fn assert_all_tracked<L: Language>(&self, root: &SyntaxNode<L>) {
+    pub fn assert_all_tracked<L: Language>(&self, root: &SyntaxNode<L>) {
         let mut descendants = root.descendants_tokens();
         let mut offsets = self.offsets.iter();
 

--- a/crates/rome_js_formatter/src/formatter.rs
+++ b/crates/rome_js_formatter/src/formatter.rs
@@ -529,7 +529,7 @@ enum DelimitedContent {
 
 /// JS specific formatter extensions
 pub(crate) trait JsFormatter {
-    fn formatter(&self) -> &Formatter;
+    fn as_formatter(&self) -> &Formatter;
 
     /// Formats a group delimited by an opening and closing token, placing the
     /// content in a [block_indent] group
@@ -540,7 +540,7 @@ pub(crate) trait JsFormatter {
         close_token: &JsSyntaxToken,
     ) -> FormatResult<FormatElement> {
         format_delimited(
-            self.formatter(),
+            self.as_formatter(),
             open_token,
             DelimitedContent::BlockIndent(content),
             close_token,
@@ -556,7 +556,7 @@ pub(crate) trait JsFormatter {
         close_token: &JsSyntaxToken,
     ) -> FormatResult<FormatElement> {
         format_delimited(
-            self.formatter(),
+            self.as_formatter(),
             open_token,
             DelimitedContent::SoftBlockIndent(content),
             close_token,
@@ -573,7 +573,7 @@ pub(crate) trait JsFormatter {
         close_token: &JsSyntaxToken,
     ) -> FormatResult<FormatElement> {
         format_delimited(
-            self.formatter(),
+            self.as_formatter(),
             open_token,
             DelimitedContent::SoftBlockSpaces(content),
             close_token,
@@ -589,7 +589,7 @@ pub(crate) trait JsFormatter {
         current_token: &JsSyntaxToken,
         content_to_replace_with: FormatElement,
     ) -> FormatElement {
-        self.formatter().track_token(current_token);
+        self.as_formatter().track_token(current_token);
 
         format_elements![
             format_leading_trivia(current_token, TriviaPrintMode::Full),
@@ -617,7 +617,7 @@ pub(crate) trait JsFormatter {
     {
         let mut result = Vec::with_capacity(list.len());
         let last_index = list.len().saturating_sub(1);
-        let formatter = self.formatter();
+        let formatter = self.as_formatter();
 
         for (index, element) in list.elements().enumerate() {
             let node = element.node()?.format(formatter)?;
@@ -671,7 +671,7 @@ pub(crate) trait JsFormatter {
     where
         List: AstNodeList<Language = JsLanguage, Node = Node>,
     {
-        let formatter = self.formatter();
+        let formatter = self.as_formatter();
         let formatted_list = list.iter().map(|module_item| {
             let snapshot = formatter.snapshot();
             let elem = match module_item.format(formatter) {
@@ -695,7 +695,7 @@ pub(crate) trait JsFormatter {
 }
 
 impl JsFormatter for Formatter {
-    fn formatter(&self) -> &Formatter {
+    fn as_formatter(&self) -> &Formatter {
         self
     }
 }

--- a/crates/rome_js_formatter/src/formatter.rs
+++ b/crates/rome_js_formatter/src/formatter.rs
@@ -83,9 +83,9 @@ impl Formatter {
         }
     }
 
-    /// Formats all elements and returns the formatted result
+    /// Formats all items of the iterator and returns the formatted result
     ///
-    /// Returns [Err] if any child couldn't be formatted.
+    /// Returns the [Err] of the first item that failed to format.
     pub fn format_all<T: Format>(
         &self,
         nodes: impl IntoIterator<Item = T>,

--- a/crates/rome_js_formatter/src/formatter.rs
+++ b/crates/rome_js_formatter/src/formatter.rs
@@ -66,7 +66,8 @@ impl Formatter {
     }
 
     /// Tracks the given token as formatted
-    pub fn track_token<L: Language>(&self, token: &SyntaxToken<L>) {
+
+    pub fn track_token<L: Language>(&self, #[allow(unused_variables)] token: &SyntaxToken<L>) {
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
                 self.printed_tokens.borrow_mut().track_token(token);
@@ -74,7 +75,10 @@ impl Formatter {
         }
     }
 
-    pub fn assert_formatted_all_tokens<L: Language>(&self, root: &SyntaxNode<L>) {
+    pub fn assert_formatted_all_tokens<L: Language>(
+        &self,
+        #[allow(unused_variables)] root: &SyntaxNode<L>,
+    ) {
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
                 let printed_tokens = self.printed_tokens.borrow();

--- a/crates/rome_js_formatter/src/js/any/class.rs
+++ b/crates/rome_js_formatter/src/js/any/class.rs
@@ -43,7 +43,7 @@ impl Format for JsAnyClass {
                     self.members()
                         .into_iter()
                         .map(|node| node.syntax().clone())
-                        .zip(formatter.format_nodes(self.members())?)
+                        .zip(formatter.format_all(self.members())?)
                 ),
                 &self.r_curly_token()?
             )?

--- a/crates/rome_js_formatter/src/js/any/class.rs
+++ b/crates/rome_js_formatter/src/js/any/class.rs
@@ -1,5 +1,7 @@
 use crate::format_traits::FormatOptional;
-use crate::{format_elements, join_elements_hard_line, space_token, FormatElement, Formatter};
+use crate::{
+    format_elements, join_elements_hard_line, space_token, FormatElement, Formatter, JsFormatter,
+};
 use crate::{hard_group_elements, Format};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsAnyClass;

--- a/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsArrayAssignmentPattern;

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectAssignmentPattern;

--- a/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
@@ -2,7 +2,7 @@ use rome_formatter::FormatResult;
 
 use crate::{
     format_elements, hard_line_break, indent, space_token, Format, FormatElement, FormatNode,
-    Formatter,
+    Formatter, JsFormatter,
 };
 
 use rome_js_syntax::JsCaseClause;

--- a/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
@@ -1,7 +1,7 @@
-use crate::Format;
 use crate::{
     format_elements, hard_line_break, indent, space_token, FormatElement, FormatNode, Formatter,
 };
+use crate::{Format, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsDefaultClause;

--- a/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
@@ -1,4 +1,4 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsFunctionBody;

--- a/crates/rome_js_formatter/src/js/auxiliary/module.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/module.rs
@@ -1,5 +1,7 @@
 use crate::utils::format_interpreter;
-use crate::{format_elements, hard_line_break, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, hard_line_break, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsModule;
 use rome_js_syntax::JsModuleFields;

--- a/crates/rome_js_formatter/src/js/auxiliary/script.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/script.rs
@@ -1,5 +1,7 @@
 use crate::utils::format_interpreter;
-use crate::{format_elements, hard_line_break, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, hard_line_break, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsScript;

--- a/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsArrayBindingPattern;

--- a/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsConstructorParameters;

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectBindingPattern;

--- a/crates/rome_js_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/parameters.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsParameters;

--- a/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
@@ -1,4 +1,4 @@
-use crate::{empty_element, FormatElement, FormatNode, Formatter};
+use crate::{empty_element, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsEmptyClassMember;

--- a/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
@@ -1,4 +1,6 @@
-use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, space_token, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsStaticInitializationBlockClassMember;

--- a/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
@@ -1,7 +1,7 @@
 use crate::format_traits::FormatOptional;
 use rome_formatter::FormatResult;
 
-use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter, JsFormatter};
 
 use rome_js_syntax::JsCatchDeclaration;
 use rome_js_syntax::JsCatchDeclarationFields;

--- a/crates/rome_js_formatter/src/js/expressions/array_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/array_expression.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsArrayExpression;

--- a/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::utils::string_utils::ToAsciiLowercaseCow;
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 
 use rome_formatter::{FormatResult, Token};
 use rome_js_syntax::JsBigIntLiteralExpression;

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -1,5 +1,5 @@
 use crate::utils::{is_simple_expression, token_has_comments};
-use crate::{format_elements, hard_group_elements, Format};
+use crate::{format_elements, hard_group_elements, Format, JsFormatter};
 use crate::{FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 

--- a/crates/rome_js_formatter/src/js/expressions/object_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/object_expression.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectExpression;

--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -1,7 +1,7 @@
 use crate::utils::{is_simple_expression, FormatPrecedence};
 use crate::{
     empty_element, format_elements, group_elements, hard_group_elements, Format, FormatElement,
-    FormatNode, Formatter,
+    FormatNode, Formatter, JsFormatter,
 };
 use rome_formatter::FormatResult;
 use rome_js_syntax::{

--- a/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_formatter::Token;

--- a/crates/rome_js_formatter/src/js/expressions/template.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template.rs
@@ -25,7 +25,7 @@ impl FormatNode for JsTemplate {
             tag,
             type_arguments,
             l_tick,
-            concat_elements(formatter.format_nodes(elements)?),
+            concat_elements(formatter.format_all(elements)?),
             r_tick
         ]))
     }

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -3,7 +3,10 @@ use std::convert::Infallible;
 
 use crate::formatter::TrailingSeparator;
 use crate::utils::array::format_array_node;
-use crate::{fill_elements, token, utils::has_formatter_trivia, Format, FormatElement, Formatter};
+use crate::{
+    fill_elements, token, utils::has_formatter_trivia, Format, FormatElement, Formatter,
+    JsFormatter,
+};
 
 use rome_js_syntax::{JsAnyExpression, JsArrayElementList};
 use rome_rowan::{AstNode, AstSeparatedList};

--- a/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsCallArgumentList;
 

--- a/crates/rome_js_formatter/src/js/lists/class_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/class_member_list.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, Formatter};
+use crate::{Format, FormatElement, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsClassMemberList;
 impl Format for JsClassMemberList {

--- a/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
@@ -7,7 +7,7 @@ impl Format for JsConstructorModifierList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),
-            formatter.format_nodes(self.iter())?,
+            formatter.format_all(self.iter())?,
         ))
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsConstructorParameterList;
 

--- a/crates/rome_js_formatter/src/js/lists/directive_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/directive_list.rs
@@ -1,4 +1,6 @@
-use crate::{empty_element, format_elements, hard_line_break, Format, FormatElement, Formatter};
+use crate::{
+    empty_element, format_elements, hard_line_break, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::{empty_line, format_element::get_lines_before, FormatResult};
 use rome_js_syntax::JsDirectiveList;
 use rome_rowan::{AstNode, AstNodeList};

--- a/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsExportNamedFromSpecifierList;
 

--- a/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsExportNamedSpecifierList;
 

--- a/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsImportAssertionEntryList;
 

--- a/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
@@ -7,7 +7,7 @@ impl Format for JsMethodModifierList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),
-            formatter.format_nodes(sort_modifiers_by_precedence(self))?,
+            formatter.format_all(sort_modifiers_by_precedence(self))?,
         ))
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/module_item_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/module_item_list.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, Formatter};
+use crate::{Format, FormatElement, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsModuleItemList;
 impl Format for JsModuleItemList {

--- a/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsNamedImportSpecifierList;
 

--- a/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyObjectAssignmentPatternMember, JsObjectAssignmentPatternPropertyList};
 

--- a/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyObjectBindingPatternMember, JsObjectBindingPatternPropertyList};
 

--- a/crates/rome_js_formatter/src/js/lists/object_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_member_list.rs
@@ -1,5 +1,5 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements_soft_line, token, Format, FormatElement, Formatter};
+use crate::{join_elements_soft_line, token, Format, FormatElement, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsObjectMemberList;

--- a/crates/rome_js_formatter/src/js/lists/parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/parameter_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::{JsAnyParameter, JsParameterList};
 

--- a/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
@@ -7,7 +7,7 @@ impl Format for JsPropertyModifierList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),
-            formatter.format_nodes(sort_modifiers_by_precedence(self))?,
+            formatter.format_all(sort_modifiers_by_precedence(self))?,
         ))
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/statement_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/statement_list.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, Formatter};
+use crate::{Format, FormatElement, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsStatementList;
 impl Format for JsStatementList {

--- a/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, Formatter};
+use crate::{Format, FormatElement, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsSwitchCaseList;
 impl Format for JsSwitchCaseList {

--- a/crates/rome_js_formatter/src/js/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/template_element_list.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, Formatter};
+use crate::{Format, FormatElement, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsTemplateElementList;
 impl Format for JsTemplateElementList {

--- a/crates/rome_js_formatter/src/js/module/export_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_clause.rs
@@ -2,7 +2,9 @@ use crate::format_traits::FormatOptional;
 use rome_formatter::FormatResult;
 
 use crate::utils::format_with_semicolon;
-use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, space_token, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 
 use rome_js_syntax::JsExportNamedClause;
 use rome_js_syntax::JsExportNamedClauseFields;

--- a/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
@@ -2,7 +2,9 @@ use crate::format_traits::FormatOptional;
 use rome_formatter::FormatResult;
 
 use crate::utils::format_with_semicolon;
-use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, space_token, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 
 use rome_js_syntax::JsExportNamedFromClause;
 use rome_js_syntax::JsExportNamedFromClauseFields;

--- a/crates/rome_js_formatter/src/js/module/import_assertion.rs
+++ b/crates/rome_js_formatter/src/js/module/import_assertion.rs
@@ -1,4 +1,6 @@
-use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, space_token, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsImportAssertion;

--- a/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
+++ b/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsNamedImportSpecifiers;

--- a/crates/rome_js_formatter/src/js/statements/block_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/block_statement.rs
@@ -1,4 +1,6 @@
-use crate::{format_elements, hard_line_break, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, hard_line_break, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsBlockStatement;

--- a/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
@@ -3,7 +3,7 @@ use rome_formatter::FormatResult;
 
 use crate::{
     format_elements, hard_group_elements, space_token, token, Format, FormatElement, FormatNode,
-    Formatter,
+    Formatter, JsFormatter,
 };
 
 use rome_js_syntax::JsDoWhileStatementFields;

--- a/crates/rome_js_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/empty_statement.rs
@@ -1,4 +1,4 @@
-use crate::{empty_element, FormatElement, FormatNode, Formatter};
+use crate::{empty_element, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsEmptyStatement;

--- a/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
@@ -4,7 +4,7 @@ use rome_js_syntax::JsForInStatement;
 use crate::utils::format_head_body_statement;
 use crate::{
     format_elements, soft_line_break_or_space, space_token, Format, FormatElement, FormatNode,
-    Formatter,
+    Formatter, JsFormatter,
 };
 use rome_js_syntax::JsForInStatementFields;
 

--- a/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
@@ -6,7 +6,7 @@ use crate::format_traits::FormatOptional;
 use crate::utils::format_head_body_statement;
 use crate::{
     format_elements, soft_line_break_or_space, space_token, Format, FormatElement, FormatNode,
-    Formatter,
+    Formatter, JsFormatter,
 };
 use rome_js_syntax::JsForOfStatementFields;
 

--- a/crates/rome_js_formatter/src/js/statements/for_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_statement.rs
@@ -3,7 +3,7 @@ use rome_formatter::FormatResult;
 
 use crate::{
     format_elements, group_elements, soft_line_break_or_space, space_token, token, Format,
-    FormatElement, FormatNode, Formatter,
+    FormatElement, FormatNode, Formatter, JsFormatter,
 };
 
 use rome_js_syntax::JsAnyStatement;

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -1,7 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::{
     block_indent, concat_elements, group_elements, hard_group_elements, hard_line_break, token,
-    Format,
+    Format, JsFormatter,
 };
 use rome_formatter::FormatResult;
 

--- a/crates/rome_js_formatter/src/js/statements/switch_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/switch_statement.rs
@@ -35,7 +35,7 @@ impl FormatNode for JsSwitchStatement {
                         .clone()
                         .into_iter()
                         .map(|node| node.syntax().clone())
-                        .zip(formatter.format_nodes(cases)?)
+                        .zip(formatter.format_all(cases)?)
                 ),
                 &r_curly_token?
             )?

--- a/crates/rome_js_formatter/src/js/statements/switch_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/switch_statement.rs
@@ -1,7 +1,7 @@
 use crate::hard_group_elements;
 use crate::{
     format_elements, join_elements_hard_line, space_token, Format, FormatElement, FormatNode,
-    Formatter,
+    Formatter, JsFormatter,
 };
 use rome_formatter::FormatResult;
 use rome_js_syntax::{JsSwitchStatement, JsSwitchStatementFields};

--- a/crates/rome_js_formatter/src/js/statements/while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/while_statement.rs
@@ -1,5 +1,7 @@
 use crate::utils::format_head_body_statement;
-use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, space_token, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsWhileStatement;

--- a/crates/rome_js_formatter/src/js/statements/with_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/with_statement.rs
@@ -1,5 +1,7 @@
 use crate::utils::format_head_body_statement;
-use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, space_token, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 
 use rome_js_syntax::JsWithStatement;

--- a/crates/rome_js_formatter/src/js/unknown/unknown.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::unknown_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsUnknown;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsUnknown {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_unknown(self.syntax()))
+        unknown_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
@@ -1,9 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsUnknownAssignment;
 use rome_rowan::AstNode;
+
 impl FormatNode for JsUnknownAssignment {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
@@ -1,11 +1,12 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 
+use crate::formatter::unknown_node;
 use rome_js_syntax::JsUnknownBinding;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsUnknownBinding {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_unknown(self.syntax()))
+        unknown_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
@@ -1,11 +1,12 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 
+use crate::formatter::unknown_node;
 use rome_js_syntax::JsUnknownExpression;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsUnknownExpression {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_unknown(self.syntax()))
+        unknown_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
@@ -1,11 +1,12 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 
+use crate::formatter::unknown_node;
 use rome_js_syntax::JsUnknownImportAssertionEntry;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsUnknownImportAssertionEntry {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_unknown(self.syntax()))
+        unknown_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
@@ -1,11 +1,12 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 
+use crate::formatter::unknown_node;
 use rome_js_syntax::JsUnknownMember;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsUnknownMember {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_unknown(self.syntax()))
+        unknown_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
@@ -1,11 +1,12 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 
+use crate::formatter::unknown_node;
 use rome_js_syntax::JsUnknownNamedImportSpecifier;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsUnknownNamedImportSpecifier {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_unknown(self.syntax()))
+        unknown_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
@@ -1,11 +1,12 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 
+use crate::formatter::unknown_node;
 use rome_js_syntax::JsUnknownParameter;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsUnknownParameter {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_unknown(self.syntax()))
+        unknown_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
@@ -1,11 +1,12 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 
+use crate::formatter::unknown_node;
 use rome_js_syntax::JsUnknownStatement;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsUnknownStatement {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_unknown(self.syntax()))
+        unknown_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxExpressionChild;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsxExpressionChild {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/spread_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/spread_child.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxSpreadChild;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsxSpreadChild {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/text.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/text.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxText;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsxText {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, Formatter};
+use crate::{Format, FormatElement, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxAttributeList;
 impl Format for JsxAttributeList {

--- a/crates/rome_js_formatter/src/jsx/lists/child_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/child_list.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, Formatter};
+use crate::{Format, FormatElement, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxChildList;
 impl Format for JsxChildList {

--- a/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxClosingElement;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsxClosingElement {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/tag/closing_fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/closing_fragment.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxClosingFragment;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsxClosingFragment {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/tag/element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/element.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxElement;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsxElement {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/tag/fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/fragment.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxFragment;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsxFragment {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxOpeningElement;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsxOpeningElement {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/tag/opening_fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/opening_fragment.rs
@@ -1,10 +1,11 @@
-use crate::{FormatElement, FormatNode, Formatter};
+use crate::formatter::verbatim_node;
+use crate::{Format, FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::JsxOpeningFragment;
 use rome_rowan::AstNode;
 
 impl FormatNode for JsxOpeningFragment {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        verbatim_node(self.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/tag/self_closing_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/self_closing_element.rs
@@ -11,7 +11,7 @@ impl FormatNode for JsxSelfClosingElement {
     fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let attributes = join_elements(
             soft_line_break_or_space(),
-            formatter.format_nodes(self.attributes())?,
+            formatter.format_all(self.attributes())?,
         );
 
         let type_arguments = self.type_arguments().format_or_empty(formatter)?;

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -12,15 +12,16 @@ pub mod utils;
 use crate::formatter::suppressed_node;
 use crate::utils::has_formatter_suppressions;
 pub use formatter::Formatter;
+pub(crate) use formatter::{format_leading_trivia, format_trailing_trivia};
 pub use rome_formatter::{
     block_indent, comment, concat_elements, empty_element, empty_line, fill_elements,
     format_element, format_elements, group_elements, hard_group_elements, hard_line_break,
     if_group_breaks, if_group_fits_on_single_line, indent, join_elements, join_elements_hard_line,
     join_elements_soft_line, join_elements_with, line_suffix, soft_block_indent, soft_line_break,
     soft_line_break_or_space, soft_line_indent_or_space, space_token, token, FormatElement,
-    FormatOptions, IndentStyle, Printed, QuoteStyle, Token, Verbatim, LINE_TERMINATORS,
+    FormatOptions, FormatResult, Formatted, IndentStyle, Printed, QuoteStyle, Token, Verbatim,
+    LINE_TERMINATORS,
 };
-use rome_formatter::{FormatResult, Formatted};
 use rome_js_syntax::{JsLanguage, JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::TextRange;
 use rome_rowan::{AstNode, TextSize};
@@ -131,9 +132,9 @@ impl Format for JsSyntaxToken {
         }
 
         Ok(format_elements![
-            formatter.print_leading_trivia(self, formatter::TriviaPrintMode::Full),
+            format_leading_trivia(self, formatter::TriviaPrintMode::Full),
             Token::from(self),
-            formatter.print_trailing_trivia(self),
+            format_trailing_trivia(self),
         ])
     }
 }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -9,6 +9,7 @@ pub mod prelude;
 mod ts;
 pub mod utils;
 
+use crate::formatter::suppressed_node;
 use crate::utils::has_formatter_suppressions;
 pub use formatter::Formatter;
 pub use rome_formatter::{
@@ -108,7 +109,7 @@ pub trait FormatNode: AstNode<Language = JsLanguage> {
     fn format_node(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let node = self.syntax();
         let element = if has_formatter_suppressions(node) {
-            formatter.format_suppressed(node)
+            suppressed_node(node).format(formatter)?
         } else {
             self.format_fields(formatter)?
         };

--- a/crates/rome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
@@ -1,4 +1,4 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeAssertionAssignmentFields;
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/module_block.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/module_block.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsModuleBlock;
 use rome_js_syntax::TsModuleBlockFields;

--- a/crates/rome_js_formatter/src/ts/bindings/type_parameters.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/type_parameters.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::{TsTypeParameters, TsTypeParametersFields};
 

--- a/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
@@ -2,7 +2,7 @@ use crate::format_traits::{FormatOptional, FormatWith};
 use crate::formatter::TrailingSeparator;
 use crate::{
     format_elements, join_elements, soft_line_break_or_space, space_token, token, FormatElement,
-    FormatNode, Formatter,
+    FormatNode, Formatter, JsFormatter,
 };
 use rome_formatter::FormatResult;
 use rome_js_syntax::{TsEnumDeclaration, TsEnumDeclarationFields};

--- a/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
@@ -1,6 +1,7 @@
 use crate::format_traits::FormatOptional;
 use crate::{
-    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode, Formatter,
+    format_elements, hard_group_elements, space_token, Format, FormatElement, FormatNode,
+    Formatter, JsFormatter,
 };
 use rome_formatter::FormatResult;
 use rome_js_syntax::{TsInterfaceDeclaration, TsInterfaceDeclarationFields};

--- a/crates/rome_js_formatter/src/ts/expressions/type_arguments.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/type_arguments.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::{TsTypeArguments, TsTypeArgumentsFields};
 

--- a/crates/rome_js_formatter/src/ts/expressions/type_assertion_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/type_assertion_expression.rs
@@ -1,4 +1,4 @@
-use crate::{format_elements, Format, FormatElement, FormatNode, Formatter};
+use crate::{format_elements, Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeAssertionExpression;
 use rome_js_syntax::TsTypeAssertionExpressionFields;

--- a/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsEnumMemberList;
 

--- a/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
@@ -7,7 +7,7 @@ impl Format for TsIndexSignatureModifierList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),
-            formatter.format_nodes(sort_modifiers_by_precedence(self))?,
+            formatter.format_all(sort_modifiers_by_precedence(self))?,
         ))
     }
 }

--- a/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
@@ -1,6 +1,6 @@
 use crate::{
     concat_elements, empty_element, format_elements, soft_line_break_or_space, space_token, token,
-    Format, FormatElement, Formatter,
+    Format, FormatElement, Formatter, JsFormatter,
 };
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsIntersectionTypeElementList;
@@ -18,7 +18,7 @@ impl Format for TsIntersectionTypeElementList {
             let separator = match separator {
                 Some(token) => {
                     if index == last_index {
-                        formatter.format_replaced(&token, empty_element())
+                        formatter.format_replaced(token, empty_element())
                     } else {
                         format_elements![
                             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
@@ -7,7 +7,7 @@ impl Format for TsMethodSignatureModifierList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),
-            formatter.format_nodes(sort_modifiers_by_precedence(self))?,
+            formatter.format_all(sort_modifiers_by_precedence(self))?,
         ))
     }
 }

--- a/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
@@ -7,7 +7,7 @@ impl Format for TsPropertyParameterModifierList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),
-            formatter.format_nodes(sort_modifiers_by_precedence(self))?,
+            formatter.format_all(sort_modifiers_by_precedence(self))?,
         ))
     }
 }

--- a/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
@@ -7,7 +7,7 @@ impl Format for TsPropertySignatureModifierList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),
-            formatter.format_nodes(sort_modifiers_by_precedence(self))?,
+            formatter.format_all(sort_modifiers_by_precedence(self))?,
         ))
     }
 }

--- a/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
@@ -5,6 +5,6 @@ use rome_rowan::AstNodeList;
 
 impl Format for TsTemplateElementList {
     fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(concat_elements(formatter.format_nodes(self.iter())?))
+        Ok(concat_elements(formatter.format_all(self.iter())?))
     }
 }

--- a/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsTupleTypeElementList;
 

--- a/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeArgumentList;
 

--- a/crates/rome_js_formatter/src/ts/lists/type_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeList;
 

--- a/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
@@ -1,5 +1,7 @@
 use crate::formatter::TrailingSeparator;
-use crate::{join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter};
+use crate::{
+    join_elements, soft_line_break_or_space, token, Format, FormatElement, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsTypeParameterList;
 use rome_rowan::AstSeparatedList;

--- a/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
@@ -1,6 +1,6 @@
 use crate::{
     concat_elements, empty_element, format_elements, soft_line_break_or_space, space_token, token,
-    Format, FormatElement, Formatter,
+    Format, FormatElement, Formatter, JsFormatter,
 };
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsUnionTypeVariantList;
@@ -18,7 +18,7 @@ impl Format for TsUnionTypeVariantList {
             let separator = match separator {
                 Some(token) => {
                     if index == last_index {
-                        formatter.format_replaced(&token, empty_element())
+                        formatter.format_replaced(token, empty_element())
                     } else {
                         format_elements![
                             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/ts/types/intersection_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/intersection_type.rs
@@ -1,6 +1,6 @@
 use crate::{
     format_elements, group_elements, if_group_breaks, indent, soft_line_break, space_token, token,
-    Format, FormatElement, FormatNode, Formatter, Token,
+    Format, FormatElement, FormatNode, Formatter, JsFormatter, Token,
 };
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsIntersectionType;

--- a/crates/rome_js_formatter/src/ts/types/mapped_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/mapped_type.rs
@@ -1,6 +1,8 @@
 use crate::format_traits::FormatOptional;
 use crate::utils::format_with_semicolon;
-use crate::{format_elements, space_token, Format, FormatElement, FormatNode, Formatter};
+use crate::{
+    format_elements, space_token, Format, FormatElement, FormatNode, Formatter, JsFormatter,
+};
 use rome_formatter::FormatResult;
 use rome_js_syntax::{TsMappedType, TsMappedTypeFields};
 

--- a/crates/rome_js_formatter/src/ts/types/object_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/object_type.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsObjectType;
 

--- a/crates/rome_js_formatter/src/ts/types/parenthesized_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/parenthesized_type.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsParenthesizedType;
 use rome_js_syntax::TsParenthesizedTypeFields;

--- a/crates/rome_js_formatter/src/ts/types/tuple_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/tuple_type.rs
@@ -1,4 +1,4 @@
-use crate::{Format, FormatElement, FormatNode, Formatter};
+use crate::{Format, FormatElement, FormatNode, Formatter, JsFormatter};
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsTupleType;
 

--- a/crates/rome_js_formatter/src/ts/types/union_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/union_type.rs
@@ -1,6 +1,6 @@
 use crate::{
     format_elements, group_elements, if_group_breaks, indent, soft_line_break, space_token, token,
-    Format, FormatElement, FormatNode, Formatter, Token,
+    Format, FormatElement, FormatNode, Formatter, JsFormatter, Token,
 };
 use rome_formatter::FormatResult;
 use rome_js_syntax::TsUnionType;

--- a/crates/rome_js_formatter/src/utils/array.rs
+++ b/crates/rome_js_formatter/src/utils/array.rs
@@ -7,7 +7,7 @@ use rome_rowan::{AstNode, AstSeparatedList};
 
 use crate::{
     empty_element, format_elements, format_traits::FormatOptional, if_group_breaks,
-    join_elements_soft_line, token, Format, FormatElement, Formatter,
+    join_elements_soft_line, token, Format, FormatElement, Formatter, JsFormatter,
 };
 
 /// Utility function to print array-like nodes (array expressions, array bindings and assignment patterns)
@@ -37,7 +37,7 @@ where
             let separator = if is_disallow {
                 // Trailing separators are disallowed, replace it with an empty element
                 if let Some(separator) = element.trailing_separator()? {
-                    formatter.format_replaced(&separator, empty_element())
+                    formatter.format_replaced(separator, empty_element())
                 } else {
                     empty_element()
                 }
@@ -47,7 +47,7 @@ where
                     .trailing_separator()
                     .format_or(formatter, || token(","))?
             } else if let Some(separator) = element.trailing_separator()? {
-                formatter.format_replaced(&separator, if_group_breaks(token(",")))
+                formatter.format_replaced(separator, if_group_breaks(token(",")))
             } else {
                 if_group_breaks(token(","))
             };

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -11,7 +11,7 @@ mod quickcheck_utils;
 use crate::format_traits::FormatOptional;
 use crate::{
     empty_element, empty_line, format_elements, hard_group_elements, space_token, token, Format,
-    FormatElement, Formatter, QuoteStyle, Token,
+    FormatElement, Formatter, JsFormatter, QuoteStyle, Token,
 };
 pub(crate) use binary_like_expression::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 pub(crate) use format_conditional::{format_conditional, Conditional};

--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -163,13 +163,20 @@ pub struct AstSeparatedElement<L: Language, N> {
     trailing_separator: SyntaxResult<Option<SyntaxToken<L>>>,
 }
 
-impl<L: Language, N: AstNode<Language = L> + Clone> AstSeparatedElement<L, N> {
-    pub fn node(&self) -> SyntaxResult<N> {
-        self.node.clone()
+impl<L: Language, N: AstNode<Language = L>> AstSeparatedElement<L, N> {
+    pub fn node(&self) -> SyntaxResult<&N> {
+        match &self.node {
+            Ok(node) => Ok(&node),
+            Err(err) => Err(*err),
+        }
     }
 
-    pub fn trailing_separator(&self) -> SyntaxResult<Option<SyntaxToken<L>>> {
-        self.trailing_separator.clone()
+    pub fn trailing_separator(&self) -> SyntaxResult<Option<&SyntaxToken<L>>> {
+        match &self.trailing_separator {
+            Ok(Some(sep)) => Ok(Some(sep)),
+            Ok(_) => Ok(None),
+            Err(err) => Err(*err),
+        }
     }
 }
 
@@ -331,7 +338,7 @@ impl<L: Language, N: AstNode<Language = L>> FusedIterator for AstSeparatedListNo
 /// Specific result used when navigating nodes using AST APIs
 pub type SyntaxResult<ResultType> = Result<ResultType, SyntaxError>;
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum SyntaxError {
     /// Error thrown when a mandatory node is not found
     MissingRequiredChild,

--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -166,7 +166,7 @@ pub struct AstSeparatedElement<L: Language, N> {
 impl<L: Language, N: AstNode<Language = L>> AstSeparatedElement<L, N> {
     pub fn node(&self) -> SyntaxResult<&N> {
         match &self.node {
-            Ok(node) => Ok(&node),
+            Ok(node) => Ok(node),
             Err(err) => Err(*err),
         }
     }

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -314,28 +314,28 @@ pub fn generate_formatter() {
             },
             NodeKind::Node | NodeKind::List { separated: true } => {
                 quote! {
-                    use crate::{Formatter, FormatNode};
+                    use crate::{Formatter, FormatNode, verbatim_node, Format};
                     use rome_rowan::AstNode;
                     use rome_formatter::{FormatResult, FormatElement};
                     use rome_js_syntax::{#id};
 
                     impl FormatNode for #id {
                         fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-                            Ok(formatter.format_verbatim(self.syntax()))
+                            verbatim_node(self.syntax()).format(formatter)
                         }
                     }
                 }
             }
             NodeKind::Unknown => {
                 quote! {
-                    use crate::{Formatter, FormatNode};
+                    use crate::{Formatter, FormatNode, unknown_node, Format};
                     use rome_rowan::AstNode;
                     use rome_formatter::{FormatResult, FormatElement};
                     use rome_js_syntax::{#id};
 
                     impl FormatNode for #id {
                         fn format_fields(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-                            Ok(formatter.format_unknown(self.syntax()))
+                            unknown_node(self.syntax()).format(formatter)
                         }
                     }
                 }


### PR DESCRIPTION
This PR extracts many of the methods defined on `Formatter` into standalone utiltiy functions
or the `JsFormatter` trait. This is a first step to make the `Formatter` trait language agnostic. 

It isn't possible yet to move the `Formatter` and `Format` traits to `rome_formatter` because
it then becomes impossible to implement `Format` for any `AstNode` inside of `rome_js_formatter`. 
This is likely going to be a larger change and I outlined some ideas in https://github.com/rome/tools/discussions/2525
