### PR TITLE
 feat(rome_formatter): multi group and conditional

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -625,9 +625,9 @@ pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// The first element can be printed one single line
 ///
 /// ```
-/// use rome_formatter::{conditional_group, Formatted, format_elements, space_token, token, soft_line_break_or_space, FormatOptions, soft_block_indent, group_elements};
+/// use rome_formatter::{format_alternatives, Formatted, format_elements, space_token, token, soft_line_break_or_space, FormatOptions, soft_block_indent, group_elements};
 ///
-/// let elements = conditional_group(vec![
+/// let elements = format_alternatives(vec![
 ///     format_elements![token("summer"), token(","), space_token(), token("spring")],
 ///     format_elements![
 ///         group_elements(
@@ -644,9 +644,9 @@ pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// width, there are line suffix, etc.), so the last one is used
 ///
 /// ```
-/// use rome_formatter::{conditional_group, Formatted, space_token, LineWidth, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, group_elements};
+/// use rome_formatter::{format_alternatives, Formatted, space_token, LineWidth, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, group_elements};
 ///
-/// let elements = conditional_group(vec![
+/// let elements = format_alternatives(vec![
 ///     format_elements![token("summer"), token(","), space_token(), token("spring")],
 ///     format_elements![
 ///         group_elements(
@@ -666,7 +666,7 @@ pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// ```
 ///
 #[inline]
-pub fn conditional_group<Tries>(elements: Tries) -> FormatElement
+pub fn format_alternatives<Tries>(elements: Tries) -> FormatElement
 where
     Tries: IntoIterator<Item = FormatElement>,
 {
@@ -692,7 +692,6 @@ where
 /// ```
 /// use rome_formatter::{
 ///   group_elements, Formatted, format_elements, token, hard_group_elements,
-///
 ///   FormatOptions, empty_line, if_group_breaks, if_group_fits_on_single_line
 /// };
 ///
@@ -1425,7 +1424,8 @@ impl FormatElement {
             FormatElement::Indent(indent) => indent.content.has_hard_line_breaks(),
             FormatElement::Group(Group { mode, content, .. }) => match mode {
                 GroupMode::NeverBreak => content.has_hard_line_breaks(),
-                // TODO: review when there's an expanded state
+                // TODO: #2533 this will likely change when the `expanded` state will be removed and baked
+                // inside the actual content
                 GroupMode::MaybeBreak => content.has_hard_line_breaks(),
             },
             FormatElement::ConditionalContentInGroup(group) => group.content.has_hard_line_breaks(),
@@ -1496,7 +1496,7 @@ impl FormatElement {
                     };
                     (leading, content, trailing)
                 } else {
-                    // TODO: implement the pick of trivias on conditional groups
+                    // TODO: #2533 implement the pick of trivia on conditional groups
                     let (_leading, content, _trailing) = content.split_trivia();
 
                     (empty_element(), group_elements(content), empty_element())
@@ -1519,6 +1519,7 @@ impl FormatElement {
             FormatElement::Empty | FormatElement::Line(_) | FormatElement::Comment(_) => None,
 
             FormatElement::Indent(indent) => indent.content.last_element(),
+            // TODO: #2533 figure out the alternative that will be printed inside conditional groups
             FormatElement::Group(group) => group.content.last_element(),
 
             _ => Some(self),

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -4,8 +4,8 @@ pub mod intersperse;
 pub mod printer;
 use crate::printer::Printer;
 pub use format_element::{
-    block_indent, comment, concat_elements, conditional_group, empty_element, empty_line,
-    fill_elements, group_elements, hard_group_elements, hard_line_break, if_group_breaks,
+    block_indent, comment, concat_elements, empty_element, empty_line, fill_elements,
+    format_alternatives, group_elements, hard_group_elements, hard_line_break, if_group_breaks,
     if_group_fits_on_single_line, indent, join_elements, join_elements_hard_line,
     join_elements_soft_line, join_elements_with, line_suffix, normalize_newlines,
     soft_block_indent, soft_line_break, soft_line_break_or_space, soft_line_indent_or_space,

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -4,8 +4,8 @@ pub mod intersperse;
 pub mod printer;
 use crate::printer::Printer;
 pub use format_element::{
-    block_indent, comment, concat_elements, empty_element, empty_line, fill_elements,
-    group_elements, hard_group_elements, hard_line_break, if_group_breaks,
+    block_indent, comment, concat_elements, conditional_group, empty_element, empty_line,
+    fill_elements, group_elements, hard_group_elements, hard_line_break, if_group_breaks,
     if_group_fits_on_single_line, indent, join_elements, join_elements_hard_line,
     join_elements_soft_line, join_elements_with, line_suffix, normalize_newlines,
     soft_block_indent, soft_line_break, soft_line_break_or_space, soft_line_indent_or_space,

--- a/crates/rome_formatter/src/printer.rs
+++ b/crates/rome_formatter/src/printer.rs
@@ -720,7 +720,7 @@ mod tests {
     use crate::format_element::join_elements;
     use crate::printer::{LineEnding, Printer, PrinterOptions};
     use crate::{
-        block_indent, conditional_group, empty_line, format_elements, group_elements,
+        block_indent, empty_line, format_alternatives, format_elements, group_elements,
         hard_group_elements, hard_line_break, if_group_breaks, if_group_fits_on_single_line,
         soft_block_indent, soft_line_break, soft_line_break_or_space, space_token, token,
         FormatElement, LineWidth, Printed,
@@ -935,7 +935,7 @@ two lines`,
 
     #[test]
     fn it_prints_conditional_groups() {
-        let result = print_element(conditional_group(vec![
+        let result = print_element(format_alternatives(vec![
             format_elements![token("summer"), token(","), space_token(), token("spring")],
             format_elements![group_elements(format_elements![
                 token("summer"),
@@ -953,7 +953,7 @@ two lines`,
             ..PrinterOptions::default()
         };
         let result = print_element_with_options(
-            conditional_group(vec![
+            format_alternatives(vec![
                 format_elements![token("summer"), token(","), space_token(), token("spring")],
                 format_elements![group_elements(format_elements![
                     token("summer"),

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -2,7 +2,6 @@ use crate::utils::{is_simple_expression, token_has_comments};
 use crate::{format_elements, hard_group_elements, Format};
 use crate::{FormatElement, FormatNode, Formatter};
 use rome_formatter::FormatResult;
-
 use rome_js_syntax::JsCallArgumentsFields;
 use rome_js_syntax::{JsAnyCallArgument, JsCallArguments};
 use rome_rowan::{AstSeparatedList, SyntaxResult};

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -156,7 +156,7 @@ pub fn format_node(options: FormatOptions, root: &JsSyntaxNode) -> FormatResult<
         let formatter = Formatter::new(options);
         let element = root.format(&formatter)?;
 
-        dbg!(&element);
+        // dbg!(&element);
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
                 let printed_tokens = formatter.printed_tokens.into_inner();

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -485,8 +485,7 @@ mod test {
     #[ignore]
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
-        let src = r#"xyz.a(b!).a(b!).a(b!)
-
+        let src = r#"method().then((x) => x)["abc"]((x) => x)[abc]((x) => x);
 "#;
         let syntax = SourceType::tsx();
         let tree = parse(src, 0, syntax.clone());
@@ -502,7 +501,7 @@ mod test {
         });
         assert_eq!(
             result.as_code(),
-            r#"(a + (b * c)) > (65 + 5);
+            r#"let a = [1, 3];
 "#
         );
     }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -156,7 +156,7 @@ pub fn format_node(options: FormatOptions, root: &JsSyntaxNode) -> FormatResult<
         let formatter = Formatter::new(options);
         let element = root.format(&formatter)?;
 
-        // dbg!(&element);
+        dbg!(&element);
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
                 let printed_tokens = formatter.printed_tokens.into_inner();

--- a/crates/rome_js_formatter/src/utils/member_chain/flatten_item.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/flatten_item.rs
@@ -89,6 +89,13 @@ impl FlattenItem {
         }
     }
 
+    pub(crate) fn should_insert_empty_line_after(&self) -> bool {
+        // TODO: prettier does a text based search to figure out the first newline?
+        // Need to figure out this logic first before implementing it
+        // https://github.com/prettier/prettier/blob/a9de2a128cc8eea84ddd90efdc210378a894ab6b/src/language-js/print/member-chain.js#L71-L90
+        true
+    }
+
     /// There are cases like Object.keys(), Observable.of(), _.values() where
     /// they are the subject of all the chained calls and therefore should
     /// be kept on the same line:
@@ -140,6 +147,7 @@ impl FlattenItem {
         }
     }
 
+    /// A short name is whether the identifier has a length that is smaller than the actual tab width
     pub(crate) fn has_short_name(&self, tab_width: u8) -> SyntaxResult<bool> {
         if let FlattenItem::StaticMember(static_member, ..) = self {
             if let JsAnyExpression::JsIdentifierExpression(identifier_expression) =

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -154,7 +154,7 @@ pub fn format_call_expression(
     // If so, then we extract it and concatenate it together with the head.
     if let Some(group_to_merge) = rest_of_groups.should_merge_with_first_group(&head_group) {
         let group_to_merge = group_to_merge.into_iter().flatten().collect();
-        head_group.expand_group(group_to_merge);
+        head_group.extend_group(group_to_merge);
     }
 
     format_groups(calls_count, head_group, rest_of_groups)
@@ -299,7 +299,7 @@ fn format_groups(
         let head_formatted = head_group.as_format_element();
         let body = groups.one_line_element();
 
-        // TODO: this is not the definitive solution, as there are few restrictions due to how the printer works:
+        // TODO: #2421 this is not the definitive solution, as there are few restrictions due to how the printer works:
         // - groups that contains other groups with hard lines break all the groups
         // - conditionally print one single line is subject to how the printer works (by default, multiline)
         // let body = groups.into_format_elements(&head_group);

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -5,10 +5,7 @@ mod simple_argument;
 use crate::format_traits::FormatOptional;
 use crate::utils::member_chain::flatten_item::FlattenItem;
 use crate::utils::member_chain::groups::{Groups, HeadGroup};
-use crate::{
-    format_elements, group_elements, hard_line_break, indent, Format, FormatElement, FormatResult,
-    Formatter,
-};
+use crate::{format_elements, Format, FormatElement, FormatResult, Formatter};
 use rome_js_syntax::{
     JsCallExpression, JsComputedMemberExpression, JsExpressionStatement, JsStaticMemberExpression,
 };
@@ -295,20 +292,18 @@ fn format_groups(
 ) -> FormatResult<FormatElement> {
     if groups.groups_should_break(calls_count, &head_group)? {
         Ok(format_elements![
-            head_group.into_format_element(),
-            group_elements(indent(format_elements![
-                hard_line_break(),
-                groups.into_joined_hard_line_groups()
-            ]),)
+            head_group.as_format_element(),
+            groups.multi_line_element(&head_group)
         ])
     } else {
-        let head_formatted = head_group.into_format_element();
-        let (one_line, _) = groups.into_format_elements();
+        let head_formatted = head_group.as_format_element();
+        let body = groups.one_line_element();
 
         // TODO: this is not the definitive solution, as there are few restrictions due to how the printer works:
         // - groups that contains other groups with hard lines break all the groups
         // - conditionally print one single line is subject to how the printer works (by default, multiline)
-        Ok(format_elements![head_formatted, one_line])
+        // let body = groups.into_format_elements(&head_group);
+        Ok(format_elements![head_formatted, body])
     }
 }
 

--- a/crates/rome_js_formatter/src/utils/member_chain/simple_argument.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/simple_argument.rs
@@ -193,7 +193,7 @@ impl SimpleArgument {
                         | JsAnyExpression::JsSuperExpression(_)
                 )
             }
-            SimpleArgument::Name(JsAnyName::JsPrivateName(_)) => true,
+            SimpleArgument::Name(JsAnyName::JsPrivateName(_) | JsAnyName::JsName(_)) => true,
             _ => false,
         }
     }

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
@@ -2,7 +2,6 @@
 source: crates/rome_js_formatter/tests/spec_test.rs
 assertion_line: 242
 expression: complex_arguments.js
-
 ---
 # Input
 client.execute(
@@ -20,8 +19,6 @@ Line width: 80
 Quote style: Double Quotes
 -----
 client.execute(
-	Post.selectAll()
-		.where(Post.id.eq(42))
-		.where(Post.published.eq(true)),
+	Post.selectAll().where(Post.id.eq(42)).where(Post.published.eq(true)),
 );
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
@@ -2,7 +2,6 @@
 source: crates/rome_js_formatter/tests/spec_test.rs
 assertion_line: 242
 expression: inline-merge.js
-
 ---
 # Input
 _.flatMap(this.visibilityHandlers, fn => fn())
@@ -26,9 +25,9 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 -----
-_.flatMap(this.visibilityHandlers, (fn) => fn())
-	.concat(this.record.resolved_legacy_visrules)
-	.filter(Boolean);
+_.flatMap(this.visibilityHandlers, (fn) => fn()).concat(
+	this.record.resolved_legacy_visrules,
+).filter(Boolean);
 
 Object.keys(availableLocales({ test: true }))
 	.forEach(

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/complex-args.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/complex-args.js.snap
@@ -16,9 +16,7 @@ client.execute(
 # Output
 ```js
 client.execute(
-  Post.selectAll()
-    .where(Post.id.eq(42))
-    .where(Post.published.eq(true)),
+  Post.selectAll().where(Post.id.eq(42)).where(Post.published.eq(true)),
 );
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/inline_merge.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/inline_merge.js.snap
@@ -37,9 +37,9 @@ Object.keys(availableLocales({ test: true }))
 
 this.layoutPartsToHide =
   this.utils.hashset(
-    _.flatMap(this.visibilityHandlers, (fn) => fn())
-      .concat(this.record.resolved_legacy_visrules)
-      .filter(Boolean),
+    _.flatMap(this.visibilityHandlers, (fn) => fn()).concat(
+      this.record.resolved_legacy_visrules,
+    ).filter(Boolean),
   );
 
 var jqxhr = $.ajax("example.php").done(doneFn).fail(failFn);

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-3594.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-3594.js.snap
@@ -23,9 +23,7 @@ fetched.then((response) => response.json()).then(
   (json) => processThings(json.data.things),
 );
 
-let column = new Column(null, conn)
-  .table(data.table)
-  .json(data.column);
+let column = new Column(null, conn).table(data.table).json(data.column);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
@@ -317,12 +317,7 @@ const a4 = x
   .m([n, o]);
 class X {
   y() {
-    const j = x
-      .a(this)
-      .b(super.cde())
-      .f(/g/)
-      .h(new i())
-      .j();
+    const j = x.a(this).b(super.cde()).f(/g/).h(new i()).j();
   }
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/square_0.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/square_0.js.snap
@@ -21,9 +21,9 @@ const component = find('.org-lclp-edit-copy-url-banner__link')[0]
 ```js
 const version = someLongString.split("jest version =").pop().split(EOL)[0].trim();
 
-const component = find(".org-lclp-edit-copy-url-banner__link")[0]
-  .getAttribute("href")
-  .indexOf(this.landingPageLink);
+const component = find(".org-lclp-edit-copy-url-banner__link")[0].getAttribute(
+  "href",
+).indexOf(this.landingPageLink);
 
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR is going to the first part of many.

This PR closes #2529 

Conditional groups are different from utilities like `if_breaks`. Conditional groups hold different states where the printer tries to print all of them in flat mode, from the first to the last one. If none fits, the last one is chosen and printed in multi line mode.

Conditional group will solve various issue, such as member chains and call expression arguments.

The functionality hasn't been used yet because it will break various things inside the member chain call, causing lot of things not match prettier, especially because the member chain lacks many other features and logic before making everything right.


The plan is also to use just `Group` in the long run. It makes sense having `hard_group_elements`, `group_elements`, etc. but they all generate the same data structure `Group` with different `mode`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Created new tests inside the printer

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
