### PR TITLE
chore: Fix deploy playground on main

### DIFF
--- a/.github/workflows/deploy_playground_on_main.yml
+++ b/.github/workflows/deploy_playground_on_main.yml
@@ -32,7 +32,7 @@ jobs:
           version: 7
           run_install: |
             args: [--prefix website/playground]
-      - run: pnpm build --prefix website/playground
+      - run: pnpm --prefix website/playground build
       - name: Publish
         uses: jakejarvis/s3-sync-action@master
         env:


### PR DESCRIPTION
The command worked fine with `pnpm6` but now fails after the upgrade to v7.

```bash
pnpm build --prefix website/playground/
ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND No package.json (or package.yaml, or package.json5) was found in "/home/micha/git/rome".
```

Moving the `--prefix` before the `build` subcommand fixes the issue:

```bash
pnpm --prefix website/playground/ build

> playground@0.0.0 build /home/micha/git/rome/website/playground
> pnpm build:wasm && pnpm build:js
```

## Test Plan

Ran the commands locally to verify that they should work with PNPM7