### PR TITLE
fix(formatter): Stack overflow in formatting computed member expressions

### DIFF
--- a/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js
@@ -12,3 +12,5 @@ x["very"]["long"]["chain"]["of"]["computed"]["members"]["that"]["goes"]["on"]["f
 x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever["and"].even.longer.than.that.and["rofefefeeffeme"].doesnt.supportit
 
 x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever[and()].even.longer.than.that.and["rofefefeefefme"].doesnt.supportit
+
+x[b["test"]]

--- a/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 242
 expression: computed_member.js
 ---
 # Input
@@ -18,6 +17,8 @@ x["very"]["long"]["chain"]["of"]["computed"]["members"]["that"]["goes"]["on"]["f
 x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever["and"].even.longer.than.that.and["rofefefeeffeme"].doesnt.supportit
 
 x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever[and()].even.longer.than.that.and["rofefefeefefme"].doesnt.supportit
+
+x[b["test"]]
 
 =============================
 # Outputs
@@ -49,4 +50,6 @@ x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever[
 x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever[
 	and()
 ].even.longer.than.that.and["rofefefeefefme"].doesnt.supportit;
+
+x[b["test"]];
 


### PR DESCRIPTION
## Summary

The formatting stack overflowed in release/printed tokens twice for computed member expressions that have a computed member expression member.

The problem was that the upwards traversal logic didn't check if the `current` node is indeed the `parents.object()` node which is the rule it uses when traversing downwards.

## Test

I added a spec test and verified that it fails without the fix.


Cargo bench completes for all formatter tests

```bash
❯ cargo bench_formatter --criterion=false
   Compiling rome_js_formatter v0.0.0 (/home/micha/git/rome/crates/rome_js_formatter)
   Compiling xtask_bench v0.0.0 (/home/micha/git/rome/xtask/bench)
    Finished release [optimized] target(s) in 7.34s
     Running `target/release/xtask_bench --feature formatter --criterion=false`
[jquery.min.js] - using [/home/micha/git/rome/target/jquery.min.js]
Benchmark: https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js
        Formatting: 30.447799ms
                      ----------
        Total:        30.447799ms

[vue.global.prod.js] - using [/home/micha/git/rome/target/vue.global.prod.js]
Benchmark: https://cdn.jsdelivr.net/npm/vue@3.2.22/dist/vue.global.prod.js
        Formatting: 45.87776ms
                      ----------
        Total:        45.87776ms

[react.production.min.js] - using [/home/micha/git/rome/target/react.production.min.js]
Benchmark: https://cdn.jsdelivr.net/npm/react@17.0.2/cjs/react.production.min.js
        Formatting:  1.73918ms
                      ----------
        Total:         1.73918ms

[react-dom.production.min.js] - using [/home/micha/git/rome/target/react-dom.production.min.js]
Benchmark: https://cdn.jsdelivr.net/npm/react-dom@17.0.2/cjs/react-dom.production.min.js
        Formatting: 34.647134ms
                      ----------
        Total:        34.647134ms

[compiler.js] - using [/home/micha/git/rome/target/compiler.js]
Benchmark: https://cdn.jsdelivr.net/npm/svelte@3.44.2/compiler.js
        Formatting: 140.526416ms
                      ----------
        Total:        140.526416ms

[dojo.js] - using [/home/micha/git/rome/target/dojo.js]
Benchmark: https://cdn.jsdelivr.net/npm/dojo@1.16.4/dojo.js
        Formatting: 7.422777ms
                      ----------
        Total:        7.422777ms

[d3.min.js] - using [/home/micha/git/rome/target/d3.min.js]
Benchmark: https://cdn.jsdelivr.net/npm/d3@7.1.1/dist/d3.min.js
        Formatting: 107.534913ms
                      ----------
        Total:        107.534913ms

[pixi.min.js] - using [/home/micha/git/rome/target/pixi.min.js]
Benchmark: https://cdn.jsdelivr.net/npm/pixi.js@6.2.0/dist/browser/pixi.min.js
        Formatting: 124.745646ms
                      ----------
        Total:        124.745646ms

[three.min.js] - using [/home/micha/git/rome/target/three.min.js]
Benchmark: https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js
        Formatting: 138.823197ms
                      ----------
        Total:        138.823197ms

[tex-chtml-full.js] - using [/home/micha/git/rome/target/tex-chtml-full.js]
Benchmark: https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-chtml-full.js
        Formatting: 281.353651ms
                      ----------
        Total:        281.353651ms

[math.js] - using [/home/micha/git/rome/target/math.js]
Benchmark: https://cdn.jsdelivr.net/npm/mathjs@10.3.0/lib/browser/math.js
        Formatting: 226.704919ms
                      ----------
        Total:        226.704919ms

[typescript.js] - using [/home/micha/git/rome/target/typescript.js]
Benchmark: https://www.unpkg.com/typescript@4.5.5/lib/typescript.js
        Formatting: 942.926405ms
                      ----------
        Total:        942.926405ms

[ios.d.ts] - using [/home/micha/git/rome/target/ios.d.ts]
Benchmark: https://github.com/PanayotCankov/nativescript-big-dts/raw/master/ios.d.ts
        Formatting: 171.669711ms
                      ----------
        Total:        171.669711ms

[checker.ts] - using [/home/micha/git/rome/target/checker.ts]
Benchmark: https://raw.githubusercontent.com/microsoft/TypeScript/2a7eb58589c62529c9045c50cae31ddcca23a6ae/src/compiler/checker.ts
        Formatting: 242.75073ms
                      ----------
        Total:        242.75073ms

[parser.ts] - using [/home/micha/git/rome/target/parser.ts]
Benchmark: https://raw.githubusercontent.com/angular/angular/master/packages/compiler/src/expression_parser/parser.ts
        Formatting:  5.21296ms
                      ----------
        Total:         5.21296ms

[router.ts] - using [/home/micha/git/rome/target/router.ts]
Benchmark: https://raw.githubusercontent.com/angular/angular/master/packages/router/src/router.ts
        Formatting: 3.814558ms
                      ----------
        Total:        3.814558ms

Summary
-------
jquery.min.js, Formatting: 30.447799ms
vue.global.prod.js, Formatting: 45.87776ms
react.production.min.js, Formatting: 1.73918ms
react-dom.production.min.js, Formatting: 34.647134ms
compiler.js, Formatting: 140.526416ms
dojo.js, Formatting: 7.422777ms
d3.min.js, Formatting: 107.534913ms
pixi.min.js, Formatting: 124.745646ms
three.min.js, Formatting: 138.823197ms
tex-chtml-full.js, Formatting: 281.353651ms
math.js, Formatting: 226.704919ms
typescript.js, Formatting: 942.926405ms
ios.d.ts, Formatting: 171.669711ms
checker.ts, Formatting: 242.75073ms
parser.ts, Formatting: 5.21296ms
router.ts, Formatting: 3.814558ms
```
