### PR TITLE
fix(rome_js_formatter): empty statements in `if/else` and `do/while`

### DIFF
--- a/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
@@ -19,7 +19,7 @@ impl FormatNodeFields<JsDoWhileStatement> for FormatNodeRule<JsDoWhileStatement>
             semicolon_token,
         } = node.as_fields();
 
-        let head = formatted![formatter, [do_token.format(), space_token(),]]?;
+        let head = formatted![formatter, [do_token.format()]]?;
 
         let tail = formatted![
             formatter,
@@ -40,5 +40,26 @@ impl FormatNodeFields<JsDoWhileStatement> for FormatNodeRule<JsDoWhileStatement>
         ]?;
 
         formatted![formatter, [head, body.format(), tail,]]
+        let body = body?;
+        if matches!(body, JsAnyStatement::JsBlockStatement(_)) {
+            Ok(hard_group_elements(format_elements![
+                head,
+                space_token(),
+                body.format(formatter)?,
+                tail,
+            ]))
+        } else if matches!(body, JsAnyStatement::JsEmptyStatement(_)) {
+            Ok(format_elements![
+                hard_group_elements(format_elements![head, body.format(formatter)?,]),
+                hard_line_break(),
+                tail,
+            ])
+        } else {
+            Ok(format_elements![
+                hard_group_elements(format_elements![head, space_token()]),
+                body.format(formatter)?,
+                hard_group_elements(tail),
+            ])
+        }
     }
 }

--- a/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 
 use crate::FormatNodeFields;
-use rome_js_syntax::JsDoWhileStatement;
 use rome_js_syntax::JsDoWhileStatementFields;
+use rome_js_syntax::{JsAnyStatement, JsDoWhileStatement};
 
 impl FormatNodeFields<JsDoWhileStatement> for FormatNodeRule<JsDoWhileStatement> {
     fn format_fields(
@@ -39,27 +39,11 @@ impl FormatNodeFields<JsDoWhileStatement> for FormatNodeRule<JsDoWhileStatement>
             ]
         ]?;
 
-        formatted![formatter, [head, body.format(), tail,]]
         let body = body?;
-        if matches!(body, JsAnyStatement::JsBlockStatement(_)) {
-            Ok(hard_group_elements(format_elements![
-                head,
-                space_token(),
-                body.format(formatter)?,
-                tail,
-            ]))
-        } else if matches!(body, JsAnyStatement::JsEmptyStatement(_)) {
-            Ok(format_elements![
-                hard_group_elements(format_elements![head, body.format(formatter)?,]),
-                hard_line_break(),
-                tail,
-            ])
+        if matches!(body, JsAnyStatement::JsEmptyStatement(_)) {
+            formatted![formatter, [head, body.format(), hard_line_break(), tail,]]
         } else {
-            Ok(format_elements![
-                hard_group_elements(format_elements![head, space_token()]),
-                body.format(formatter)?,
-                hard_group_elements(tail),
-            ])
+            formatted![formatter, [head, space_token(), body.format(), tail,]]
         }
     }
 }

--- a/crates/rome_js_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/empty_statement.rs
@@ -1,9 +1,7 @@
 use crate::prelude::*;
 
 use crate::FormatNodeFields;
-use rome_js_syntax::JsEmptyStatement;
-use rome_js_syntax::JsEmptyStatementFields;
-use rome_js_syntax::{JsEmptyStatement, JsSyntaxKind};
+use rome_js_syntax::{JsEmptyStatement, JsEmptyStatementFields, JsSyntaxKind};
 use rome_rowan::AstNode;
 
 impl FormatNodeFields<JsEmptyStatement> for FormatNodeRule<JsEmptyStatement> {
@@ -12,14 +10,14 @@ impl FormatNodeFields<JsEmptyStatement> for FormatNodeRule<JsEmptyStatement> {
         formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsEmptyStatementFields { semicolon_token } = node.as_fields();
-        let parent_kind = self.syntax().parent().map(|p| p.kind());
+        let parent_kind = node.syntax().parent().map(|p| p.kind());
         if matches!(
             parent_kind,
             Some(JsSyntaxKind::JS_DO_WHILE_STATEMENT)
                 | Some(JsSyntaxKind::JS_IF_STATEMENT)
                 | Some(JsSyntaxKind::JS_ELSE_CLAUSE)
         ) {
-            semicolon_token.format(formatter)
+            formatted![formatter, [semicolon_token.format()]]
         } else {
             Ok(formatter.format_replaced(&semicolon_token?, empty_element()))
         }

--- a/crates/rome_js_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/empty_statement.rs
@@ -3,6 +3,8 @@ use crate::prelude::*;
 use crate::FormatNodeFields;
 use rome_js_syntax::JsEmptyStatement;
 use rome_js_syntax::JsEmptyStatementFields;
+use rome_js_syntax::{JsEmptyStatement, JsSyntaxKind};
+use rome_rowan::AstNode;
 
 impl FormatNodeFields<JsEmptyStatement> for FormatNodeRule<JsEmptyStatement> {
     fn format_fields(
@@ -10,7 +12,16 @@ impl FormatNodeFields<JsEmptyStatement> for FormatNodeRule<JsEmptyStatement> {
         formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsEmptyStatementFields { semicolon_token } = node.as_fields();
-
-        Ok(formatter.format_replaced(&semicolon_token?, empty_element()))
+        let parent_kind = self.syntax().parent().map(|p| p.kind());
+        if matches!(
+            parent_kind,
+            Some(JsSyntaxKind::JS_DO_WHILE_STATEMENT)
+                | Some(JsSyntaxKind::JS_IF_STATEMENT)
+                | Some(JsSyntaxKind::JS_ELSE_CLAUSE)
+        ) {
+            semicolon_token.format(formatter)
+        } else {
+            Ok(formatter.format_replaced(&semicolon_token?, empty_element()))
+        }
     }
 }

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -75,7 +75,6 @@ fn format_if_element(
                 )
                 .soft_block_indent()
                 .finish()?,
-            space_token(),
             into_block(formatter, consequent?)?,
         ]
     ]?;
@@ -88,22 +87,25 @@ fn into_block(
     formatter: &Formatter<JsFormatOptions>,
     stmt: JsAnyStatement,
 ) -> FormatResult<FormatElement> {
+    let formatted_statement = stmt.format();
+
     if matches!(stmt, JsAnyStatement::JsBlockStatement(_)) {
-        return Ok(format_elements![space_token(), stmt.format(formatter)?]);
+        return formatted![formatter, [space_token(), formatted_statement]];
     }
 
     // If the body is an empty statement, force a line break to ensure behavior
     // is coherent with `is_non_collapsable_empty_block`
     if matches!(stmt, JsAnyStatement::JsEmptyStatement(_)) {
-        return Ok(format_elements![stmt.format(formatter)?, hard_line_break()]);
+        return formatted![formatter, [formatted_statement, hard_line_break()]];
     }
 
-    Ok(format_elements![
-        space_token(),
-        group_elements(format_elements![
+    formatted![
+        formatter,
+        [
+            space_token(),
             token("{"),
-            block_indent(stmt.format(formatter)?),
+            block_indent(formatted![formatter, [stmt.format()]]?),
             token("}"),
-        ])
-    ])
+        ]
+    ]
 }

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -32,7 +32,6 @@ impl FormatNodeFields<JsIfStatement> for FormatNodeRule<JsIfStatement> {
                         [
                             space_token(),
                             else_token.format(),
-                            space_token(),
                             into_block(formatter, alternate)?,
                         ]
                     ]?);
@@ -90,24 +89,21 @@ fn into_block(
     stmt: JsAnyStatement,
 ) -> FormatResult<FormatElement> {
     if matches!(stmt, JsAnyStatement::JsBlockStatement(_)) {
-        return formatted![formatter, [stmt.format()]];
+        return Ok(format_elements![space_token(), stmt.format(formatter)?]);
     }
 
     // If the body is an empty statement, force a line break to ensure behavior
     // is coherent with `is_non_collapsable_empty_block`
     if matches!(stmt, JsAnyStatement::JsEmptyStatement(_)) {
-        return formatted![
-            formatter,
-            [token("{"), stmt.format(), hard_line_break(), token("}")]
-        ];
+        return Ok(format_elements![stmt.format(formatter)?, hard_line_break()]);
     }
 
-    formatted![
-        formatter,
-        [
+    Ok(format_elements![
+        space_token(),
+        group_elements(format_elements![
             token("{"),
-            block_indent(formatted![formatter, [stmt.format()]]?),
+            block_indent(stmt.format(formatter)?),
             token("}"),
-        ]
-    ]
+        ])
+    ])
 }

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -87,16 +87,14 @@ fn into_block(
     formatter: &Formatter<JsFormatOptions>,
     stmt: JsAnyStatement,
 ) -> FormatResult<FormatElement> {
-    let formatted_statement = stmt.format();
-
     if matches!(stmt, JsAnyStatement::JsBlockStatement(_)) {
-        return formatted![formatter, [space_token(), formatted_statement]];
+        return formatted![formatter, [space_token(), stmt.format()]];
     }
 
     // If the body is an empty statement, force a line break to ensure behavior
     // is coherent with `is_non_collapsable_empty_block`
     if matches!(stmt, JsAnyStatement::JsEmptyStatement(_)) {
-        return formatted![formatter, [formatted_statement, hard_line_break()]];
+        return formatted![formatter, [stmt.format(), hard_line_break()]];
     }
 
     formatted![

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js
@@ -10,3 +10,6 @@ do { // trailing
 }
 
 while (something)
+
+
+do; while(true);

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 242
 expression: do_while.js
+
 ---
 # Input
 do {
@@ -15,6 +17,9 @@ do { // trailing
 }
 
 while (something)
+
+
+do; while(true);
 =============================
 # Outputs
 ## Output 1
@@ -31,4 +36,7 @@ do {
 	// trailing
 	var foo = 4;
 } while (something);
+
+do;
+while (true);
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js
@@ -1,3 +1,6 @@
+if(a);
+if(a); else ;
+
 if (Math.random() > 0.5) {
 	console.log(1)
 } else if (Math.random() > 0.5) {

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -1,8 +1,13 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 242
 expression: if_else.js
+
 ---
 # Input
+if(a);
+if(a); else ;
+
 if (Math.random() > 0.5) {
 	console.log(1)
 } else if (Math.random() > 0.5) {
@@ -71,6 +76,10 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 -----
+if (a);
+if (a);
+else;
+
 if (Math.random() > 0.5) {
 	console.log(1);
 } else if (Math.random() > 0.5) {
@@ -122,6 +131,5 @@ if (true) {
 
 if (true) {
 	that();
-} else {
-}
+} else;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/empty-statement/body.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/empty-statement/body.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 175
 expression: body.js
 
 ---
@@ -19,15 +19,15 @@ do; while(1);
 # Output
 ```js
 with (a);
-if (1) {
-} else if (2) {
-} else {
-}
+if (1);
+else if (2);
+else;
 for (;;);
 while (1);
 for (var i in o);
 for (var i of o);
-do while (1);
+do;
+while (1);
 
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #2448

I cherry-picked the implementation of the former PR, which aligns its behaviour to prettier. 


The PR changes how `if/else` and `do/while` statements are formatted where the body is an empty statement, by matching Prettier's behaviour:

```js
// before
if(a); else ;

// now
if (a);
else;
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

New tests to cover the case

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
