### PR TITLE
Fix(rome_js_formatter):🐛 fix parenthesis expression bad case

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -99,24 +99,35 @@ fn is_simple_parenthesized_expression(node: &JsParenthesizedExpression) -> Synta
 fn parenthesis_can_be_omitted(node: &JsParenthesizedExpression) -> SyntaxResult<bool> {
     let expression = node.expression()?;
     let parent = node.syntax().parent();
-    let parent_precedence = FormatPrecedence::with_precedence_for_parenthesis(parent.as_ref());
-    let node_precedence = FormatPrecedence::with_precedence_for_parenthesis(Some(node.syntax()));
 
-    // if expression is a StringLiteralExpression, we could not just return false, here is once case:
+    // if expression is a StringLiteralExpression, we need to check it before precedence comparison, here is an example:
     // ```js
     // a[("test")]
     // ```
+    // if we use precedence comparison, we will get:
     // parent_precedence should be `High` due to the parenthesized_expression's parent is ComputedMemberExpression,
-    // and node_precedence should be `Low` due to expression is StringLiteralExpression.
-    // the parenthesis should be omitted.
-    if parent_precedence > node_precedence
-        && !matches!(
-            expression,
-            JsAnyExpression::JsAnyLiteralExpression(
-                JsAnyLiteralExpression::JsStringLiteralExpression(_)
-            )
-        )
-    {
+    // and node_precedence should be `Low` due to expression is StringLiteralExpression. `parent_precedence > node_precedence` will return false,
+    // the parenthesis will not be omitted.
+    // But the expected behavior is that the parenthesis will be omitted. The code above should be formatted as:
+    // ```js
+    // a["test"]
+    // ```
+    // So we need to add extra branch to handle this case.
+    if matches!(
+        expression,
+        JsAnyExpression::JsAnyLiteralExpression(JsAnyLiteralExpression::JsStringLiteralExpression(
+            _
+        ))
+    ) {
+        return Ok(!matches!(
+            parent.map(|p| p.kind()),
+            Some(JsSyntaxKind::JS_EXPRESSION_STATEMENT)
+        ));
+    }
+    let parent_precedence = FormatPrecedence::with_precedence_for_parenthesis(parent.as_ref());
+    let node_precedence = FormatPrecedence::with_precedence_for_parenthesis(Some(node.syntax()));
+
+    if parent_precedence > node_precedence {
         return Ok(false);
     }
     // Here we handle cases where we have binary/logical expressions.
@@ -139,12 +150,6 @@ fn parenthesis_can_be_omitted(node: &JsParenthesizedExpression) -> SyntaxResult<
 
             Ok(not_binaryish_expression(left.syntax()) && not_binaryish_expression(right.syntax()))
         }
-        JsAnyExpression::JsAnyLiteralExpression(
-            JsAnyLiteralExpression::JsStringLiteralExpression(_),
-        ) => Ok(!matches!(
-            parent.map(|p| p.kind()),
-            Some(JsSyntaxKind::JS_EXPRESSION_STATEMENT)
-        )),
         _ => Ok(false),
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -117,9 +117,10 @@ fn parenthesis_can_be_omitted(node: &JsParenthesizedExpression) -> SyntaxResult<
         ) if matches!(
             parent.map(|p| p.kind()),
             Some(JsSyntaxKind::JS_COMPUTED_MEMBER_EXPRESSION)
-        ) => {
-			Ok(true)
-		}
+        ) =>
+        {
+            Ok(true)
+        }
         _ => Ok(false),
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -141,13 +141,10 @@ fn parenthesis_can_be_omitted(node: &JsParenthesizedExpression) -> SyntaxResult<
         }
         JsAnyExpression::JsAnyLiteralExpression(
             JsAnyLiteralExpression::JsStringLiteralExpression(_),
-        ) if matches!(
+        ) => Ok(!matches!(
             parent.map(|p| p.kind()),
-            Some(JsSyntaxKind::JS_COMPUTED_MEMBER_EXPRESSION)
-        ) =>
-        {
-            Ok(true)
-        }
+            Some(JsSyntaxKind::JS_EXPRESSION_STATEMENT)
+        )),
         _ => Ok(false),
     }
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js
@@ -4,5 +4,3 @@ nock(/test/)
   .reply(200, {
     foo: 'bar',
   });
-
-a[("test")]

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
@@ -10,8 +10,6 @@ nock(/test/)
   .reply(200, {
     foo: 'bar',
   });
-
-a[("test")]
 =============================
 # Outputs
 ## Output 1
@@ -23,6 +21,4 @@ Quote style: Double Quotes
 nock(/test/)
 	.matchHeader("Accept", "application/json")[httpMethodNock(method)]("/foo")
 	.reply(200, { foo: "bar" });
-
-a[("test")];
 

--- a/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js
@@ -14,3 +14,6 @@ x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever["an
 x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever[and()].even.longer.than.that.and["rofefefeefefme"].doesnt.supportit
 
 x[b["test"]]
+
+
+a[("test")]

--- a/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 242
 expression: computed_member.js
 ---
 # Input
@@ -19,6 +20,9 @@ x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever["an
 x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever[and()].even.longer.than.that.and["rofefefeefefme"].doesnt.supportit
 
 x[b["test"]]
+
+
+a[("test")]
 
 =============================
 # Outputs
@@ -52,4 +56,6 @@ x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever[
 ].even.longer.than.that.and["rofefefeefefme"].doesnt.supportit;
 
 x[b["test"]];
+
+a["test"];
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
Fix #2558 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
fix the bad case 
```js
a[("test")]
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
