### PR TITLE
fix: Countme overflow in tests

### DIFF
--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -26,6 +26,8 @@ const PRETTIER_IGNORE: &str = "prettier-ignore";
 const ROME_IGNORE: &str = "rome-ignore format: prettier ignore";
 
 fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
+    countme::enable(true);
+
     if input.contains("flow") || input.contains("prepare_tests") {
         return;
     }
@@ -276,8 +278,6 @@ impl DiffReport {
             extern "C" fn print_report() {
                 REPORTER.print();
             }
-
-            countme::enable(true);
 
             // Register the print_report function to be called when the process exits
             unsafe {


### PR DESCRIPTION
Incrementing the `Countme` counter overflowed when running the tests with more than 4 threads.

@leops narrowed the issue down that this is happening because
`countme` only starts counting after calling `countme::enable` and
the counter overflows (underflows) if `Drop` is called for any counted object crated before that point in time.

The issue is inside the `prettier_tests` setup where `countme::enable` was called in the `DiffReporter`. That's too late, because some test running in another thread may have created `Syntax*` or `Green*` objects.

The fix is to move the `countme::enable` at the top of the `test_snapshot` function. That ensures that `Countme` gets enabled before any snapshot test runs (by just making sure that it's still enabled in every snapshot test)

## Test Plan

```
cargo test
```

no longer panics when running with 16 threads