### PR TITLE
refactor(formatter): Extract language specific options

### DIFF
--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -21,16 +21,17 @@ use rome_diagnostics::{
     file::{FileId, Files, SimpleFile},
     Diagnostic, DiagnosticHeader, Severity,
 };
-use rome_formatter::{FormatOptions, IndentStyle};
+use rome_formatter::IndentStyle;
 use rome_fs::{AtomicInterner, FileSystem, PathInterner, RomePath};
 use rome_fs::{TraversalContext, TraversalScope};
+use rome_js_formatter::options::JsFormatOptions;
 use rome_js_parser::{parse, SourceType};
 
 use crate::{CliSession, Termination};
 
 /// Handler for the "format" command of the Rome CLI
 pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
-    let mut options = FormatOptions::default();
+    let mut options = JsFormatOptions::default();
 
     let size = session
         .args
@@ -355,7 +356,7 @@ struct FormatCommandOptions<'ctx, 'app> {
     /// Set of features supported by this instance of the CLI
     features: &'ctx Features,
     /// Options to use for formatting the discovered files
-    options: FormatOptions,
+    options: JsFormatOptions,
     /// Determines how the result of formatting should be handled
     mode: FormatMode,
     /// Whether the formatter should silently skip files with errors
@@ -453,7 +454,7 @@ fn handle_file(ctx: &FormatCommandOptions, path: &Path, file_id: FileId) {
 struct FormatFileParams<'ctx, 'app> {
     fs: &'app dyn FileSystem,
     features: &'ctx Features,
-    options: FormatOptions,
+    options: JsFormatOptions,
     mode: FormatMode,
     ignore_errors: bool,
     path: &'ctx Path,

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -27,15 +27,14 @@ pub fn empty_element() -> FormatElement {
 /// Soft line breaks are omitted if the enclosing `Group` fits on a single line
 ///
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_line_break, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![token("a,"), soft_line_break(), token("b"),]);
 ///
 /// assert_eq!(
 ///     "a,b",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -45,10 +44,8 @@ pub fn empty_element() -> FormatElement {
 ///
 /// Soft line breaks are emitted if the enclosing `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_line_break, token, FormatOptions, Formatted,
-///     LineWidth,
-/// };
+/// use rome_formatter::{Formatted, LineWidth};
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("a long word,"),
@@ -56,9 +53,9 @@ pub fn empty_element() -> FormatElement {
 ///     token("so that the group doesn't fit on a single line"),
 /// ]);
 ///
-/// let options = FormatOptions {
-///     line_width: LineWidth::try_from(10).unwrap(),
-///     ..FormatOptions::default()
+/// let options = PrinterOptions {
+///     print_width: LineWidth::try_from(10).unwrap(),
+///     ..PrinterOptions::default()
 /// };
 ///
 /// assert_eq!(
@@ -78,9 +75,8 @@ pub const fn soft_line_break() -> FormatElement {
 ///
 /// It forces a line break, even if the enclosing `Group` would otherwise fit on a single line.
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, hard_line_break, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::*;
+/// use rome_formatter::prelude::PrinterOptions;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("a,"),
@@ -91,7 +87,7 @@ pub const fn soft_line_break() -> FormatElement {
 ///
 /// assert_eq!(
 ///     "a,\nb\n",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -107,9 +103,8 @@ pub const fn hard_line_break() -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{
-///     empty_line, format_elements, group_elements, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("a,"),
@@ -120,7 +115,7 @@ pub const fn hard_line_break() -> FormatElement {
 ///
 /// assert_eq!(
 ///     "a,\n\nb\n\n",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -136,9 +131,8 @@ pub const fn empty_line() -> FormatElement {
 ///
 /// The line breaks are emitted as spaces if the enclosing `Group` fits on a a single line:
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_line_break_or_space, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("a,"),
@@ -148,7 +142,7 @@ pub const fn empty_line() -> FormatElement {
 ///
 /// assert_eq!(
 ///     "a, b",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -156,10 +150,8 @@ pub const fn empty_line() -> FormatElement {
 ///
 /// The printer breaks the lines if the enclosing `Group` doesn't fit on a single line:
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_line_break_or_space, token, FormatOptions, Formatted,
-///     LineWidth,
-/// };
+/// use rome_formatter::{Formatted, LineWidth};
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("a long word,"),
@@ -167,9 +159,9 @@ pub const fn empty_line() -> FormatElement {
 ///     token("so that the group doesn't fit on a single line"),
 /// ]);
 ///
-/// let options = FormatOptions {
-///     line_width: LineWidth::try_from(10).unwrap(),
-///     ..FormatOptions::default()
+/// let options = PrinterOptions {
+///     print_width: LineWidth::try_from(10).unwrap(),
+///     ..PrinterOptions::default()
 /// };
 ///
 /// assert_eq!(
@@ -192,12 +184,13 @@ pub const fn soft_line_break_or_space() -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{token, FormatOptions, Formatted};
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 /// let elements = token("Hello World");
 ///
 /// assert_eq!(
 ///     "Hello World",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -207,12 +200,13 @@ pub const fn soft_line_break_or_space() -> FormatElement {
 /// enclosed in quotes (depending on the target language).
 ///
 /// ```
-/// use rome_formatter::{FormatOptions, token, Formatted};
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
 /// let elements = token("\"Hello\\tWorld\"");
 ///
-/// assert_eq!(r#""Hello\tWorld""#, Formatted::new(elements, FormatOptions::default()).print().as_code());
+/// assert_eq!(r#""Hello\tWorld""#, Formatted::new(elements, PrinterOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub const fn token(text: &'static str) -> FormatElement {
@@ -228,13 +222,14 @@ pub const fn token(text: &'static str) -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{format_elements, line_suffix, token, FormatOptions, Formatted};
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = format_elements![token("a"), line_suffix(token("c")), token("b")];
 ///
 /// assert_eq!(
 ///     "abc",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -252,10 +247,8 @@ pub fn line_suffix(element: impl Into<FormatElement>) -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{
-///     comment, empty_line, format_elements, group_elements, soft_line_break_or_space, token,
-///     FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     comment(empty_line()),
@@ -266,7 +259,7 @@ pub fn line_suffix(element: impl Into<FormatElement>) -> FormatElement {
 ///
 /// assert_eq!(
 ///     "\na b",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -281,12 +274,13 @@ pub fn comment(element: impl Into<FormatElement>) -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{FormatOptions, token, Formatted, space_token, format_elements};
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
 /// let elements = format_elements![token("a"), space_token(), token("b")];
 ///
-/// assert_eq!("a b", Formatted::new(elements, FormatOptions::default()).print().as_code());
+/// assert_eq!("a b", Formatted::new(elements, PrinterOptions::default()).print().as_code());
 /// ```
 #[inline]
 pub const fn space_token() -> FormatElement {
@@ -298,9 +292,8 @@ pub const fn space_token() -> FormatElement {
 /// ## Examples
 ///
 /// ```rust
-/// use rome_formatter::{
-///     concat_elements, space_token, token, FormatElement, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 /// let expr = concat_elements(vec![
 ///     token("a"),
 ///     space_token(),
@@ -311,7 +304,7 @@ pub const fn space_token() -> FormatElement {
 ///
 /// assert_eq!(
 ///     "a + b",
-///     Formatted::new(expr, FormatOptions::default())
+///     Formatted::new(expr, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// )
@@ -338,10 +331,10 @@ where
 /// ## Examples
 ///
 /// ```rust
-/// use rome_formatter::{
-///     fill_elements, space_token, token, FormatElement, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::prelude::*;
+/// use rome_formatter::Formatted;
 /// use std::str::from_utf8;
+///
 /// let a = from_utf8(&[b'a'; 30]).unwrap();
 /// let b = from_utf8(&[b'b'; 30]).unwrap();
 /// let c = from_utf8(&[b'c'; 30]).unwrap();
@@ -350,7 +343,7 @@ where
 ///
 /// assert_eq!(
 ///     format!("{a} {b}\n{c} {d}"),
-///     Formatted::new(expr, FormatOptions::default())
+///     Formatted::new(expr, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// )
@@ -371,9 +364,8 @@ pub fn fill_elements(elements: impl IntoIterator<Item = FormatElement>) -> Forma
 /// Joining different tokens by separating them with a comma and a space.
 ///
 /// ```
-/// use rome_formatter::{
-///     concat_elements, join_elements, space_token, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let separator = concat_elements(vec![token(","), space_token()]);
 /// let elements = join_elements(
@@ -383,7 +375,7 @@ pub fn fill_elements(elements: impl IntoIterator<Item = FormatElement>) -> Forma
 ///
 /// assert_eq!(
 ///     "1, 2, 3, 4",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -411,9 +403,9 @@ where
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{
-///     block_indent, format_elements, hard_line_break, indent, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
+///
 /// let block = (format_elements![
 ///     token("switch {"),
 ///     block_indent(format_elements![
@@ -429,7 +421,7 @@ where
 ///
 /// assert_eq!(
 ///     "switch {\n\tdefault:\n\t\tbreak;\n}",
-///     Formatted::new(block, FormatOptions::default())
+///     Formatted::new(block, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -455,9 +447,8 @@ pub fn indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{
-///     block_indent, format_elements, hard_line_break, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let block = (format_elements![
 ///     token("{"),
@@ -471,7 +462,7 @@ pub fn indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// assert_eq!(
 ///     "{\n\tlet a = 10;\n\tlet c = a + 5;\n}",
-///     Formatted::new(block, FormatOptions::default())
+///     Formatted::new(block, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -499,10 +490,8 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// Indents the content by one level and puts in new lines if the enclosing `Group` doesn't fit on a single line
 ///
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_block_indent, soft_line_break_or_space, token,
-///     FormatOptions, Formatted, LineWidth,
-/// };
+/// use rome_formatter::{Formatted, LineWidth};
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("["),
@@ -514,9 +503,9 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///     token("]"),
 /// ]);
 ///
-/// let options = FormatOptions {
-///     line_width: LineWidth::try_from(10).unwrap(),
-///     ..FormatOptions::default()
+/// let options = PrinterOptions {
+///     print_width: LineWidth::try_from(10).unwrap(),
+///     ..PrinterOptions::default()
 /// };
 ///
 /// assert_eq!(
@@ -527,10 +516,8 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// Doesn't change the formatting if the enclosing `Group` fits on a single line
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_block_indent, soft_line_break_or_space, token,
-///     FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("["),
@@ -544,7 +531,7 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// assert_eq!(
 ///     "[5, 10]",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -575,10 +562,8 @@ pub fn soft_block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// fit on a single line. Otherwise, just inserts a space.
 ///
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_block_indent, soft_line_indent_or_space, space_token,
-///     token, FormatOptions, Formatted, LineWidth,
-/// };
+/// use rome_formatter::{Formatted, LineWidth};
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("name"),
@@ -593,9 +578,9 @@ pub fn soft_block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///     ]),
 /// ]);
 ///
-/// let options = FormatOptions {
-///     line_width: LineWidth::try_from(10).unwrap(),
-///     ..FormatOptions::default()
+/// let options = PrinterOptions {
+///     print_width: LineWidth::try_from(10).unwrap(),
+///     ..PrinterOptions::default()
 /// };
 ///
 /// assert_eq!(
@@ -606,10 +591,8 @@ pub fn soft_block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// Only adds a space if the enclosing `Group` fits on a single line
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_block_indent, soft_line_indent_or_space, space_token,
-///     token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("a"),
@@ -620,7 +603,7 @@ pub fn soft_block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// assert_eq!(
 ///     "a = 10",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -653,10 +636,8 @@ pub fn soft_line_indent_or_space<T: Into<FormatElement>>(content: T) -> FormatEl
 /// `Group` that fits on a single line
 ///
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_block_indent, soft_line_break_or_space, token,
-///     FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("["),
@@ -672,7 +653,7 @@ pub fn soft_line_indent_or_space<T: Into<FormatElement>>(content: T) -> FormatEl
 ///
 /// assert_eq!(
 ///     "[1, 2, 3]",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -680,10 +661,8 @@ pub fn soft_line_indent_or_space<T: Into<FormatElement>>(content: T) -> FormatEl
 ///
 /// The printer breaks the `Group` over multiple lines if its content doesn't fit on a single line
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, soft_block_indent, soft_line_break_or_space, token,
-///     FormatOptions, Formatted, LineWidth,
-/// };
+/// use rome_formatter::{Formatted, LineWidth};
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("["),
@@ -697,9 +676,9 @@ pub fn soft_line_indent_or_space<T: Into<FormatElement>>(content: T) -> FormatEl
 ///     token("]"),
 /// ]);
 ///
-/// let options = FormatOptions {
-///     line_width: LineWidth::try_from(20).unwrap(),
-///     ..FormatOptions::default()
+/// let options = PrinterOptions {
+///     print_width: LineWidth::try_from(20).unwrap(),
+///     ..PrinterOptions::default()
 /// };
 ///
 /// assert_eq!(
@@ -729,10 +708,8 @@ pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// # Example
 /// ```
-/// use rome_formatter::{
-///     empty_line, format_elements, group_elements, hard_group_elements, if_group_breaks,
-///     if_group_fits_on_single_line, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(hard_group_elements(format_elements![
 ///     if_group_breaks(token("not printed")),
@@ -742,7 +719,7 @@ pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// assert_eq!(
 ///     "\nprinted",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -774,10 +751,8 @@ pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement 
 ///
 /// Omits the trailing comma for the last array element if the `Group` fits on a single line
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, if_group_breaks, soft_block_indent,
-///     soft_line_break_or_space, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("["),
@@ -793,7 +768,7 @@ pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement 
 /// ]);
 /// assert_eq!(
 ///     "[1, 2, 3]",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -801,10 +776,8 @@ pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement 
 ///
 /// Prints the trailing comma for the last array element if the `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, if_group_breaks, soft_block_indent,
-///     soft_line_break_or_space, token, FormatOptions, Formatted, LineWidth,
-/// };
+/// use rome_formatter::{Formatted, LineWidth};
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("["),
@@ -819,9 +792,9 @@ pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement 
 ///     token("]"),
 /// ]);
 ///
-/// let options = FormatOptions {
-///     line_width: LineWidth::try_from(20).unwrap(),
-///     ..FormatOptions::default()
+/// let options = PrinterOptions {
+///     print_width: LineWidth::try_from(20).unwrap(),
+///     ..PrinterOptions::default()
 /// };
 /// assert_eq!(
 ///     "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3,\n]",
@@ -851,10 +824,8 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// Adds the trailing comma for the last array element if the `Group` fits on a single line
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, if_group_fits_on_single_line, soft_block_indent,
-///     soft_line_break_or_space, token, FormatOptions, Formatted,
-/// };
+/// use rome_formatter::Formatted;
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("["),
@@ -870,7 +841,7 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// ]);
 /// assert_eq!(
 ///     "[1, 2, 3,]",
-///     Formatted::new(elements, FormatOptions::default())
+///     Formatted::new(elements, PrinterOptions::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -878,10 +849,8 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// Omits the trailing comma for the last array element if the `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{
-///     format_elements, group_elements, if_group_fits_on_single_line, soft_block_indent,
-///     soft_line_break_or_space, token, FormatOptions, Formatted, LineWidth,
-/// };
+/// use rome_formatter::{Formatted, LineWidth};
+/// use rome_formatter::prelude::*;
 ///
 /// let elements = group_elements(format_elements![
 ///     token("["),
@@ -896,9 +865,9 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///     token("]"),
 /// ]);
 ///
-/// let options = FormatOptions {
-///     line_width: LineWidth::try_from(20).unwrap(),
-///     ..FormatOptions::default()
+/// let options = PrinterOptions {
+///     print_width: LineWidth::try_from(20).unwrap(),
+///     ..PrinterOptions::default()
 /// };
 /// assert_eq!(
 ///     "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3\n]",

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 #[cfg(debug_assertions)]
 use crate::printed_tokens::PrintedTokens;
-use crate::FormatOptions;
 use rome_rowan::{Language, SyntaxNode, SyntaxToken};
 #[cfg(debug_assertions)]
 use std::cell::RefCell;
@@ -10,17 +9,18 @@ use std::cell::RefCell;
 /// The formatter is passed to the [Format] implementation of every node in the CST so that they
 /// can use it to format their children.
 #[derive(Debug, Default)]
-pub struct Formatter {
-    options: FormatOptions,
+pub struct Formatter<Options> {
+    options: Options,
+
     // This is using a RefCell as it only exists in debug mode,
     // the Formatter is still completely immutable in release builds
     #[cfg(debug_assertions)]
     pub printed_tokens: RefCell<PrintedTokens>,
 }
 
-impl Formatter {
+impl<Options> Formatter<Options> {
     /// Creates a new context that uses the given formatter options
-    pub fn new(options: FormatOptions) -> Self {
+    pub fn new(options: Options) -> Self {
         Self {
             options,
             #[cfg(debug_assertions)]
@@ -29,7 +29,7 @@ impl Formatter {
     }
 
     /// Returns the [FormatOptions] specifying how to format the current CST
-    pub fn options(&self) -> &FormatOptions {
+    pub fn options(&self) -> &Options {
         &self.options
     }
 
@@ -60,7 +60,7 @@ impl Formatter {
     ///
     /// Returns the [Err] of the first item that failed to format.
     #[inline]
-    pub fn format_all<T: Format>(
+    pub fn format_all<T: Format<Options = Options>>(
         &self,
         nodes: impl IntoIterator<Item = T>,
     ) -> FormatResult<impl Iterator<Item = FormatElement>> {
@@ -79,7 +79,7 @@ impl Formatter {
     }
 }
 
-impl Formatter {
+impl<Options> Formatter<Options> {
     /// Take a snapshot of the state of the formatter
     #[inline]
     pub fn snapshot(&self) -> FormatterSnapshot {

--- a/crates/rome_formatter/src/prelude.rs
+++ b/crates/rome_formatter/src/prelude.rs
@@ -1,6 +1,7 @@
 pub use crate::format_element::*;
 pub use crate::format_extensions::{FormatOptional as _, FormatWith as _, MemoizeFormat};
 pub use crate::formatter::Formatter;
+pub use crate::printer::PrinterOptions;
 
 pub use crate::{
     format_elements, formatted, Format, Format as _, FormatError, FormatResult, FormatRule,

--- a/crates/rome_formatter/src/printer.rs
+++ b/crates/rome_formatter/src/printer.rs
@@ -3,8 +3,8 @@ use crate::format_element::{
 };
 use crate::intersperse::Intersperse;
 use crate::{
-    hard_line_break, space_token, FormatElement, FormatOptions, IndentStyle, LineWidth, Printed,
-    SourceMarker, TextRange,
+    hard_line_break, space_token, FormatElement, IndentStyle, LineWidth, Printed, SourceMarker,
+    TextRange,
 };
 use rome_rowan::TextSize;
 use std::iter::once;
@@ -29,21 +29,25 @@ pub struct PrinterOptions {
     pub indent_string: String,
 }
 
-impl From<FormatOptions> for PrinterOptions {
-    fn from(options: FormatOptions) -> Self {
-        let tab_width = options.tab_width();
+impl PrinterOptions {
+    pub fn with_print_with(mut self, with: LineWidth) -> Self {
+        self.print_width = with;
+        self
+    }
 
-        let indent_string = match options.indent_style {
-            IndentStyle::Tab => String::from("\t"),
-            IndentStyle::Space(width) => " ".repeat(width as usize),
-        };
-
-        PrinterOptions {
-            indent_string,
-            tab_width,
-            print_width: options.line_width,
-            ..PrinterOptions::default()
+    pub fn with_indent(mut self, style: IndentStyle) -> Self {
+        match style {
+            IndentStyle::Tab => {
+                self.indent_string = String::from("\t");
+                self.tab_width = 2;
+            }
+            IndentStyle::Space(quantity) => {
+                self.indent_string = " ".repeat(quantity as usize);
+                self.tab_width = quantity;
+            }
         }
+
+        self
     }
 }
 

--- a/crates/rome_js_formatter/src/check_reformat.rs
+++ b/crates/rome_js_formatter/src/check_reformat.rs
@@ -1,6 +1,5 @@
-use crate::format_node;
+use crate::{format_node, JsFormatOptions};
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
-use rome_formatter::FormatOptions;
 use rome_js_parser::{parse, SourceType};
 use rome_js_syntax::JsSyntaxNode;
 
@@ -9,7 +8,7 @@ pub struct CheckReformatParams<'a> {
     pub text: &'a str,
     pub source_type: SourceType,
     pub file_name: &'a str,
-    pub format_options: FormatOptions,
+    pub format_options: JsFormatOptions,
 }
 
 /// Perform a second pass of formatting on a file, printing a diff if the

--- a/crates/rome_js_formatter/src/cst.rs
+++ b/crates/rome_js_formatter/src/cst.rs
@@ -1,13 +1,18 @@
 use crate::prelude::*;
 use rome_formatter::{FormatOwnedWithRule, FormatRefWithRule};
 
-use crate::{AsFormat, IntoFormat};
+use crate::{AsFormat, IntoFormat, JsFormatOptions};
 use rome_js_syntax::{map_syntax_node, JsSyntaxNode};
 
 pub struct FormatJsSyntaxNode;
 
 impl rome_formatter::FormatRule<JsSyntaxNode> for FormatJsSyntaxNode {
-    fn format(node: &JsSyntaxNode, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsSyntaxNode,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         map_syntax_node!(node.clone(), node => formatted![formatter, [node.format()]])
     }
 }

--- a/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyArrayAssignmentPatternElement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayAssignmentPatternElement;
 impl FormatRule<JsAnyArrayAssignmentPatternElement> for FormatJsAnyArrayAssignmentPatternElement {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyArrayAssignmentPatternElement,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(node) => {

--- a/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyArrayBindingPatternElement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayBindingPatternElement;
 impl FormatRule<JsAnyArrayBindingPatternElement> for FormatJsAnyArrayBindingPatternElement {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyArrayBindingPatternElement,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyArrayBindingPatternElement::JsArrayHole(node) => {

--- a/crates/rome_js_formatter/src/js/any/array_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_element.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyArrayElement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayElement;
 impl FormatRule<JsAnyArrayElement> for FormatJsAnyArrayElement {
-    fn format(node: &JsAnyArrayElement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyArrayElement,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyArrayElement::JsAnyExpression(node) => formatted![formatter, [node.format()]],
             JsAnyArrayElement::JsSpread(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
+++ b/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyArrowFunctionParameters;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrowFunctionParameters;
 impl FormatRule<JsAnyArrowFunctionParameters> for FormatJsAnyArrowFunctionParameters {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyArrowFunctionParameters,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyArrowFunctionParameters::JsParameters(node) => {

--- a/crates/rome_js_formatter/src/js/any/assignment.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyAssignment;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyAssignment;
 impl FormatRule<JsAnyAssignment> for FormatJsAnyAssignment {
-    fn format(node: &JsAnyAssignment, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyAssignment,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyAssignment::JsIdentifierAssignment(node) => formatted![formatter, [node.format()]],
             JsAnyAssignment::JsStaticMemberAssignment(node) => {

--- a/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyAssignmentPattern;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyAssignmentPattern;
 impl FormatRule<JsAnyAssignmentPattern> for FormatJsAnyAssignmentPattern {
-    fn format(node: &JsAnyAssignmentPattern, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyAssignmentPattern,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyAssignmentPattern::JsAnyAssignment(node) => formatted![formatter, [node.format()]],
             JsAnyAssignmentPattern::JsArrayAssignmentPattern(node) => {

--- a/crates/rome_js_formatter/src/js/any/binding.rs
+++ b/crates/rome_js_formatter/src/js/any/binding.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyBinding;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyBinding;
 impl FormatRule<JsAnyBinding> for FormatJsAnyBinding {
-    fn format(node: &JsAnyBinding, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyBinding,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyBinding::JsIdentifierBinding(node) => formatted![formatter, [node.format()]],
             JsAnyBinding::JsUnknownBinding(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/binding_pattern.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyBindingPattern;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyBindingPattern;
 impl FormatRule<JsAnyBindingPattern> for FormatJsAnyBindingPattern {
-    fn format(node: &JsAnyBindingPattern, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyBindingPattern,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyBindingPattern::JsAnyBinding(node) => formatted![formatter, [node.format()]],
             JsAnyBindingPattern::JsArrayBindingPattern(node) => {

--- a/crates/rome_js_formatter/src/js/any/call_argument.rs
+++ b/crates/rome_js_formatter/src/js/any/call_argument.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyCallArgument;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyCallArgument;
 impl FormatRule<JsAnyCallArgument> for FormatJsAnyCallArgument {
-    fn format(node: &JsAnyCallArgument, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyCallArgument,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyCallArgument::JsAnyExpression(node) => formatted![formatter, [node.format()]],
             JsAnyCallArgument::JsSpread(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/class.rs
+++ b/crates/rome_js_formatter/src/js/any/class.rs
@@ -4,7 +4,12 @@ use rome_js_syntax::JsAnyClass;
 use rome_rowan::AstNode;
 
 impl FormatRule<JsAnyClass> for FormatJsAnyClass {
-    fn format(node: &JsAnyClass, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsAnyClass,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let abstract_token = node.abstract_token();
         let id = node.id();
         let extends = node.extends_clause();

--- a/crates/rome_js_formatter/src/js/any/class_member.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyClassMember;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClassMember;
 impl FormatRule<JsAnyClassMember> for FormatJsAnyClassMember {
-    fn format(node: &JsAnyClassMember, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyClassMember,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyClassMember::JsConstructorClassMember(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/class_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member_name.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyClassMemberName;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClassMemberName;
 impl FormatRule<JsAnyClassMemberName> for FormatJsAnyClassMemberName {
-    fn format(node: &JsAnyClassMemberName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyClassMemberName,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyClassMemberName::JsLiteralMemberName(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyConstructorParameter;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyConstructorParameter;
 impl FormatRule<JsAnyConstructorParameter> for FormatJsAnyConstructorParameter {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyConstructorParameter,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyConstructorParameter::JsAnyFormalParameter(node) => {

--- a/crates/rome_js_formatter/src/js/any/declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyDeclaration;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyDeclaration;
 impl FormatRule<JsAnyDeclaration> for FormatJsAnyDeclaration {
-    fn format(node: &JsAnyDeclaration, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyDeclaration,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyDeclaration::JsClassDeclaration(node) => formatted![formatter, [node.format()]],
             JsAnyDeclaration::JsFunctionDeclaration(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration_clause.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyDeclarationClause;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyDeclarationClause;
 impl FormatRule<JsAnyDeclarationClause> for FormatJsAnyDeclarationClause {
-    fn format(node: &JsAnyDeclarationClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyDeclarationClause,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyDeclarationClause::JsClassDeclaration(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/export_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/export_clause.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyExportClause;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportClause;
 impl FormatRule<JsAnyExportClause> for FormatJsAnyExportClause {
-    fn format(node: &JsAnyExportClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyExportClause,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyExportClause::JsExportDefaultDeclarationClause(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyExportDefaultDeclaration;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportDefaultDeclaration;
 impl FormatRule<JsAnyExportDefaultDeclaration> for FormatJsAnyExportDefaultDeclaration {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyExportDefaultDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyExportDefaultDeclaration::JsClassExportDefaultDeclaration(node) => {

--- a/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyExportNamedSpecifier;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportNamedSpecifier;
 impl FormatRule<JsAnyExportNamedSpecifier> for FormatJsAnyExportNamedSpecifier {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyExportNamedSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyExportNamedSpecifier::JsExportNamedShorthandSpecifier(node) => {

--- a/crates/rome_js_formatter/src/js/any/expression.rs
+++ b/crates/rome_js_formatter/src/js/any/expression.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyExpression;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExpression;
 impl FormatRule<JsAnyExpression> for FormatJsAnyExpression {
-    fn format(node: &JsAnyExpression, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyExpression,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyExpression::JsAnyLiteralExpression(node) => formatted![formatter, [node.format()]],
             JsAnyExpression::ImportMeta(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyForInOrOfInitializer;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyForInOrOfInitializer;
 impl FormatRule<JsAnyForInOrOfInitializer> for FormatJsAnyForInOrOfInitializer {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyForInOrOfInitializer,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyForInOrOfInitializer::JsAnyAssignmentPattern(node) => {

--- a/crates/rome_js_formatter/src/js/any/for_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_initializer.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyForInitializer;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyForInitializer;
 impl FormatRule<JsAnyForInitializer> for FormatJsAnyForInitializer {
-    fn format(node: &JsAnyForInitializer, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyForInitializer,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyForInitializer::JsVariableDeclaration(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/formal_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/formal_parameter.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyFormalParameter;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFormalParameter;
 impl FormatRule<JsAnyFormalParameter> for FormatJsAnyFormalParameter {
-    fn format(node: &JsAnyFormalParameter, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyFormalParameter,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyFormalParameter::JsFormalParameter(node) => formatted![formatter, [node.format()]],
             JsAnyFormalParameter::JsUnknownParameter(node) => {

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -7,7 +7,12 @@ use rome_js_syntax::{
 };
 
 impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
-    fn format(node: &JsAnyFunction, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsAnyFunction,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let mut tokens = vec![];
 
         tokens.push(formatted![

--- a/crates/rome_js_formatter/src/js/any/function_body.rs
+++ b/crates/rome_js_formatter/src/js/any/function_body.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyFunctionBody;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFunctionBody;
 impl FormatRule<JsAnyFunctionBody> for FormatJsAnyFunctionBody {
-    fn format(node: &JsAnyFunctionBody, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyFunctionBody,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyFunctionBody::JsAnyExpression(node) => formatted![formatter, [node.format()]],
             JsAnyFunctionBody::JsFunctionBody(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyImportAssertionEntry;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyImportAssertionEntry;
 impl FormatRule<JsAnyImportAssertionEntry> for FormatJsAnyImportAssertionEntry {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyImportAssertionEntry,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyImportAssertionEntry::JsImportAssertionEntry(node) => {

--- a/crates/rome_js_formatter/src/js/any/import_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/import_clause.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyImportClause;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyImportClause;
 impl FormatRule<JsAnyImportClause> for FormatJsAnyImportClause {
-    fn format(node: &JsAnyImportClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyImportClause,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyImportClause::JsImportBareClause(node) => formatted![formatter, [node.format()]],
             JsAnyImportClause::JsImportNamedClause(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/in_property.rs
+++ b/crates/rome_js_formatter/src/js/any/in_property.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyInProperty;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyInProperty;
 impl FormatRule<JsAnyInProperty> for FormatJsAnyInProperty {
-    fn format(node: &JsAnyInProperty, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyInProperty,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyInProperty::JsPrivateName(node) => formatted![formatter, [node.format()]],
             JsAnyInProperty::JsAnyExpression(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/any/literal_expression.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyLiteralExpression;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyLiteralExpression;
 impl FormatRule<JsAnyLiteralExpression> for FormatJsAnyLiteralExpression {
-    fn format(node: &JsAnyLiteralExpression, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyLiteralExpression,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyLiteralExpression::JsStringLiteralExpression(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/method_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/method_modifier.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyMethodModifier;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyMethodModifier;
 impl FormatRule<JsAnyMethodModifier> for FormatJsAnyMethodModifier {
-    fn format(node: &JsAnyMethodModifier, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyMethodModifier,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyMethodModifier::TsAccessibilityModifier(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/module_item.rs
+++ b/crates/rome_js_formatter/src/js/any/module_item.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyModuleItem;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyModuleItem;
 impl FormatRule<JsAnyModuleItem> for FormatJsAnyModuleItem {
-    fn format(node: &JsAnyModuleItem, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyModuleItem,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyModuleItem::JsAnyStatement(node) => formatted![formatter, [node.format()]],
             JsAnyModuleItem::JsExport(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/name.rs
+++ b/crates/rome_js_formatter/src/js/any/name.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyName;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyName;
 impl FormatRule<JsAnyName> for FormatJsAnyName {
-    fn format(node: &JsAnyName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyName,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyName::JsName(node) => formatted![formatter, [node.format()]],
             JsAnyName::JsPrivateName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/named_import.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyNamedImport;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyNamedImport;
 impl FormatRule<JsAnyNamedImport> for FormatJsAnyNamedImport {
-    fn format(node: &JsAnyNamedImport, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyNamedImport,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyNamedImport::JsNamedImportSpecifiers(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyNamedImportSpecifier;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyNamedImportSpecifier;
 impl FormatRule<JsAnyNamedImportSpecifier> for FormatJsAnyNamedImportSpecifier {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyNamedImportSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyNamedImportSpecifier::JsShorthandNamedImportSpecifier(node) => {

--- a/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyObjectAssignmentPatternMember;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectAssignmentPatternMember;
 impl FormatRule<JsAnyObjectAssignmentPatternMember> for FormatJsAnyObjectAssignmentPatternMember {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyObjectAssignmentPatternMember,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyObjectAssignmentPatternMember::JsObjectAssignmentPatternShorthandProperty(

--- a/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatJsAnyObjectBindingPatternMember;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectBindingPatternMember;
 impl FormatRule<JsAnyObjectBindingPatternMember> for FormatJsAnyObjectBindingPatternMember {
+    type Options = JsFormatOptions;
     fn format(
         node: &JsAnyObjectBindingPatternMember,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyObjectBindingPatternMember::JsObjectBindingPatternProperty(node) => {

--- a/crates/rome_js_formatter/src/js/any/object_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyObjectMember;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectMember;
 impl FormatRule<JsAnyObjectMember> for FormatJsAnyObjectMember {
-    fn format(node: &JsAnyObjectMember, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyObjectMember,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyObjectMember::JsPropertyObjectMember(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/object_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member_name.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyObjectMemberName;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectMemberName;
 impl FormatRule<JsAnyObjectMemberName> for FormatJsAnyObjectMemberName {
-    fn format(node: &JsAnyObjectMemberName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyObjectMemberName,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyObjectMemberName::JsLiteralMemberName(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/parameter.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyParameter;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyParameter;
 impl FormatRule<JsAnyParameter> for FormatJsAnyParameter {
-    fn format(node: &JsAnyParameter, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyParameter,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyParameter::JsAnyFormalParameter(node) => formatted![formatter, [node.format()]],
             JsAnyParameter::JsRestParameter(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/property_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/property_modifier.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyPropertyModifier;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyPropertyModifier;
 impl FormatRule<JsAnyPropertyModifier> for FormatJsAnyPropertyModifier {
-    fn format(node: &JsAnyPropertyModifier, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyPropertyModifier,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyPropertyModifier::TsAccessibilityModifier(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/any/root.rs
+++ b/crates/rome_js_formatter/src/js/any/root.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyRoot;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyRoot;
 impl FormatRule<JsAnyRoot> for FormatJsAnyRoot {
-    fn format(node: &JsAnyRoot, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyRoot,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyRoot::JsScript(node) => formatted![formatter, [node.format()]],
             JsAnyRoot::JsModule(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/statement.rs
+++ b/crates/rome_js_formatter/src/js/any/statement.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyStatement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyStatement;
 impl FormatRule<JsAnyStatement> for FormatJsAnyStatement {
-    fn format(node: &JsAnyStatement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyStatement,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyStatement::JsBlockStatement(node) => formatted![formatter, [node.format()]],
             JsAnyStatement::JsBreakStatement(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/switch_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/switch_clause.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnySwitchClause;
 use crate::prelude::*;
 use rome_js_syntax::JsAnySwitchClause;
 impl FormatRule<JsAnySwitchClause> for FormatJsAnySwitchClause {
-    fn format(node: &JsAnySwitchClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnySwitchClause,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnySwitchClause::JsCaseClause(node) => formatted![formatter, [node.format()]],
             JsAnySwitchClause::JsDefaultClause(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/template_element.rs
+++ b/crates/rome_js_formatter/src/js/any/template_element.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsAnyTemplateElement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyTemplateElement;
 impl FormatRule<JsAnyTemplateElement> for FormatJsAnyTemplateElement {
-    fn format(node: &JsAnyTemplateElement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsAnyTemplateElement,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsAnyTemplateElement::JsTemplateChunkElement(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsArrayAssignmentPatternFields;
 impl FormatNodeFields<JsArrayAssignmentPattern> for FormatNodeRule<JsArrayAssignmentPattern> {
     fn format_fields(
         node: &JsArrayAssignmentPattern,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsArrayAssignmentPatternFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
+++ b/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsArrayAssignmentPatternRestElement>
 {
     fn format_fields(
         node: &JsArrayAssignmentPatternRestElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsArrayAssignmentPatternRestElementFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/assignments/assignment_with_default.rs
+++ b/crates/rome_js_formatter/src/js/assignments/assignment_with_default.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsAssignmentWithDefaultFields;
 impl FormatNodeFields<JsAssignmentWithDefault> for FormatNodeRule<JsAssignmentWithDefault> {
     fn format_fields(
         node: &JsAssignmentWithDefault,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsAssignmentWithDefaultFields {
             pattern,

--- a/crates/rome_js_formatter/src/js/assignments/computed_member_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/computed_member_assignment.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsComputedMemberAssignmentFields;
 impl FormatNodeFields<JsComputedMemberAssignment> for FormatNodeRule<JsComputedMemberAssignment> {
     fn format_fields(
         node: &JsComputedMemberAssignment,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsComputedMemberAssignmentFields {
             object,

--- a/crates/rome_js_formatter/src/js/assignments/identifier_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/identifier_assignment.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsIdentifierAssignmentFields;
 impl FormatNodeFields<JsIdentifierAssignment> for FormatNodeRule<JsIdentifierAssignment> {
     fn format_fields(
         node: &JsIdentifierAssignment,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsIdentifierAssignmentFields { name_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsObjectAssignmentPatternFields;
 impl FormatNodeFields<JsObjectAssignmentPattern> for FormatNodeRule<JsObjectAssignmentPattern> {
     fn format_fields(
         node: &JsObjectAssignmentPattern,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsObjectAssignmentPatternFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_property.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_property.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectAssignmentPatternProperty>
 {
     fn format_fields(
         node: &JsObjectAssignmentPatternProperty,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsObjectAssignmentPatternPropertyFields {
             member,

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_rest.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_rest.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectAssignmentPatternRest>
 {
     fn format_fields(
         node: &JsObjectAssignmentPatternRest,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsObjectAssignmentPatternRestFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectAssignmentPatternShorthandProperty>
 {
     fn format_fields(
         node: &JsObjectAssignmentPatternShorthandProperty,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsObjectAssignmentPatternShorthandPropertyFields { identifier, init } =
             node.as_fields();

--- a/crates/rome_js_formatter/src/js/assignments/parenthesized_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/parenthesized_assignment.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsParenthesizedAssignmentFields;
 impl FormatNodeFields<JsParenthesizedAssignment> for FormatNodeRule<JsParenthesizedAssignment> {
     fn format_fields(
         node: &JsParenthesizedAssignment,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsParenthesizedAssignmentFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/assignments/static_member_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/static_member_assignment.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsStaticMemberAssignmentFields;
 impl FormatNodeFields<JsStaticMemberAssignment> for FormatNodeRule<JsStaticMemberAssignment> {
     fn format_fields(
         node: &JsStaticMemberAssignment,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsStaticMemberAssignmentFields {
             object,

--- a/crates/rome_js_formatter/src/js/auxiliary/array_hole.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/array_hole.rs
@@ -4,7 +4,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::JsArrayHole;
 
 impl FormatNodeFields<JsArrayHole> for FormatNodeRule<JsArrayHole> {
-    fn format_fields(_: &JsArrayHole, _: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        _: &JsArrayHole,
+        _: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(empty_element())
     }
 }

--- a/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
@@ -7,7 +7,10 @@ use rome_js_syntax::JsCaseClause;
 use rome_js_syntax::JsCaseClauseFields;
 
 impl FormatNodeFields<JsCaseClause> for FormatNodeRule<JsCaseClause> {
-    fn format_fields(node: &JsCaseClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsCaseClause,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsCaseClauseFields {
             case_token,
             test,

--- a/crates/rome_js_formatter/src/js/auxiliary/catch_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/catch_clause.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsCatchClause;
 use rome_js_syntax::JsCatchClauseFields;
 
 impl FormatNodeFields<JsCatchClause> for FormatNodeRule<JsCatchClause> {
-    fn format_fields(node: &JsCatchClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsCatchClause,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsCatchClauseFields {
             catch_token,
             declaration,

--- a/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::{JsAnyStatement, JsDefaultClauseFields};
 use rome_rowan::AstNodeList;
 
 impl FormatNodeFields<JsDefaultClause> for FormatNodeRule<JsDefaultClause> {
-    fn format_fields(node: &JsDefaultClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsDefaultClause,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsDefaultClauseFields {
             default_token,
             colon_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/directive.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/directive.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::JsDirective;
 use rome_js_syntax::JsDirectiveFields;
 
 impl FormatNodeFields<JsDirective> for FormatNodeRule<JsDirective> {
-    fn format_fields(node: &JsDirective, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsDirective,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsDirectiveFields {
             value_token,
             semicolon_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/else_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/else_clause.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsElseClause;
 use rome_js_syntax::JsElseClauseFields;
 
 impl FormatNodeFields<JsElseClause> for FormatNodeRule<JsElseClause> {
-    fn format_fields(node: &JsElseClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsElseClause,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsElseClauseFields {
             else_token,
             alternate,

--- a/crates/rome_js_formatter/src/js/auxiliary/expression_snipped.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/expression_snipped.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExpressionSnippedFields;
 impl FormatNodeFields<JsExpressionSnipped> for FormatNodeRule<JsExpressionSnipped> {
     fn format_fields(
         node: &JsExpressionSnipped,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExpressionSnippedFields {
             expression,

--- a/crates/rome_js_formatter/src/js/auxiliary/finally_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/finally_clause.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsFinallyClause;
 use rome_js_syntax::JsFinallyClauseFields;
 
 impl FormatNodeFields<JsFinallyClause> for FormatNodeRule<JsFinallyClause> {
-    fn format_fields(node: &JsFinallyClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsFinallyClause,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsFinallyClauseFields {
             finally_token,
             body,

--- a/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsFunctionBody;
 use rome_js_syntax::JsFunctionBodyFields;
 
 impl FormatNodeFields<JsFunctionBody> for FormatNodeRule<JsFunctionBody> {
-    fn format_fields(node: &JsFunctionBody, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsFunctionBody,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsFunctionBodyFields {
             l_curly_token,
             directives,

--- a/crates/rome_js_formatter/src/js/auxiliary/initializer_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/initializer_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsInitializerClauseFields;
 impl FormatNodeFields<JsInitializerClause> for FormatNodeRule<JsInitializerClause> {
     fn format_fields(
         node: &JsInitializerClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsInitializerClauseFields {
             eq_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/module.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/module.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::JsModule;
 use rome_js_syntax::JsModuleFields;
 
 impl FormatNodeFields<JsModule> for FormatNodeRule<JsModule> {
-    fn format_fields(node: &JsModule, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsModule,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsModuleFields {
             interpreter_token,
             directives,

--- a/crates/rome_js_formatter/src/js/auxiliary/name.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/name.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsName;
 use rome_js_syntax::JsNameFields;
 
 impl FormatNodeFields<JsName> for FormatNodeRule<JsName> {
-    fn format_fields(node: &JsName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsName,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsNameFields { value_token } = node.as_fields();
 
         formatted![formatter, [value_token.format()]]

--- a/crates/rome_js_formatter/src/js/auxiliary/new_target.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/new_target.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::NewTarget;
 use rome_js_syntax::NewTargetFields;
 
 impl FormatNodeFields<NewTarget> for FormatNodeRule<NewTarget> {
-    fn format_fields(node: &NewTarget, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &NewTarget,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let NewTargetFields {
             new_token,
             dot_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/private_name.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/private_name.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsPrivateName;
 use rome_js_syntax::JsPrivateNameFields;
 
 impl FormatNodeFields<JsPrivateName> for FormatNodeRule<JsPrivateName> {
-    fn format_fields(node: &JsPrivateName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsPrivateName,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsPrivateNameFields {
             hash_token,
             value_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/reference_identifier.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/reference_identifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsReferenceIdentifierFields;
 impl FormatNodeFields<JsReferenceIdentifier> for FormatNodeRule<JsReferenceIdentifier> {
     fn format_fields(
         node: &JsReferenceIdentifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsReferenceIdentifierFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/auxiliary/script.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/script.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::JsScript;
 use rome_js_syntax::JsScriptFields;
 
 impl FormatNodeFields<JsScript> for FormatNodeRule<JsScript> {
-    fn format_fields(node: &JsScript, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsScript,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsScriptFields {
             interpreter_token,
             directives,

--- a/crates/rome_js_formatter/src/js/auxiliary/spread.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/spread.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsSpread;
 use rome_js_syntax::JsSpreadFields;
 
 impl FormatNodeFields<JsSpread> for FormatNodeRule<JsSpread> {
-    fn format_fields(node: &JsSpread, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsSpread,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsSpreadFields {
             dotdotdot_token,
             argument,

--- a/crates/rome_js_formatter/src/js/auxiliary/static_modifier.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/static_modifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsStaticModifierFields;
 impl FormatNodeFields<JsStaticModifier> for FormatNodeRule<JsStaticModifier> {
     fn format_fields(
         node: &JsStaticModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsStaticModifierFields { modifier_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/auxiliary/variable_declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/variable_declaration_clause.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsVariableDeclarationClauseFields;
 impl FormatNodeFields<JsVariableDeclarationClause> for FormatNodeRule<JsVariableDeclarationClause> {
     fn format_fields(
         node: &JsVariableDeclarationClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsVariableDeclarationClauseFields {
             declaration,

--- a/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsVariableDeclaratorFields;
 impl FormatNodeFields<JsVariableDeclarator> for FormatNodeRule<JsVariableDeclarator> {
     fn format_fields(
         node: &JsVariableDeclarator,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsVariableDeclaratorFields {
             id,

--- a/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsArrayBindingPatternFields;
 impl FormatNodeFields<JsArrayBindingPattern> for FormatNodeRule<JsArrayBindingPattern> {
     fn format_fields(
         node: &JsArrayBindingPattern,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsArrayBindingPatternFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
+++ b/crates/rome_js_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsArrayBindingPatternRestElement>
 {
     fn format_fields(
         node: &JsArrayBindingPatternRestElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsArrayBindingPatternRestElementFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/bindings/binding_pattern_with_default.rs
+++ b/crates/rome_js_formatter/src/js/bindings/binding_pattern_with_default.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsBindingPatternWithDefaultFields;
 impl FormatNodeFields<JsBindingPatternWithDefault> for FormatNodeRule<JsBindingPatternWithDefault> {
     fn format_fields(
         node: &JsBindingPatternWithDefault,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsBindingPatternWithDefaultFields {
             pattern,

--- a/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsConstructorParametersFields;
 impl FormatNodeFields<JsConstructorParameters> for FormatNodeRule<JsConstructorParameters> {
     fn format_fields(
         node: &JsConstructorParameters,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsConstructorParametersFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/bindings/formal_parameter.rs
+++ b/crates/rome_js_formatter/src/js/bindings/formal_parameter.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsFormalParameterFields;
 impl FormatNodeFields<JsFormalParameter> for FormatNodeRule<JsFormalParameter> {
     fn format_fields(
         node: &JsFormalParameter,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsFormalParameterFields {
             binding,

--- a/crates/rome_js_formatter/src/js/bindings/identifier_binding.rs
+++ b/crates/rome_js_formatter/src/js/bindings/identifier_binding.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsIdentifierBindingFields;
 impl FormatNodeFields<JsIdentifierBinding> for FormatNodeRule<JsIdentifierBinding> {
     fn format_fields(
         node: &JsIdentifierBinding,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsIdentifierBindingFields { name_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsObjectBindingPatternFields;
 impl FormatNodeFields<JsObjectBindingPattern> for FormatNodeRule<JsObjectBindingPattern> {
     fn format_fields(
         node: &JsObjectBindingPattern,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsObjectBindingPatternFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectBindingPatternProperty>
 {
     fn format_fields(
         node: &JsObjectBindingPatternProperty,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsObjectBindingPatternPropertyFields {
             member,

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_rest.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_rest.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsObjectBindingPatternRestFields;
 impl FormatNodeFields<JsObjectBindingPatternRest> for FormatNodeRule<JsObjectBindingPatternRest> {
     fn format_fields(
         node: &JsObjectBindingPatternRest,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsObjectBindingPatternRestFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectBindingPatternShorthandProperty>
 {
     fn format_fields(
         node: &JsObjectBindingPatternShorthandProperty,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsObjectBindingPatternShorthandPropertyFields { identifier, init } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/parameters.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsParameters;
 use rome_js_syntax::JsParametersFields;
 
 impl FormatNodeFields<JsParameters> for FormatNodeRule<JsParameters> {
-    fn format_fields(node: &JsParameters, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsParameters,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsParametersFields {
             l_paren_token,
             items,

--- a/crates/rome_js_formatter/src/js/bindings/rest_parameter.rs
+++ b/crates/rome_js_formatter/src/js/bindings/rest_parameter.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsRestParameter;
 use rome_js_syntax::JsRestParameterFields;
 
 impl FormatNodeFields<JsRestParameter> for FormatNodeRule<JsRestParameter> {
-    fn format_fields(node: &JsRestParameter, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsRestParameter,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsRestParameterFields {
             dotdotdot_token,
             binding,

--- a/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsConstructorClassMemberFields;
 impl FormatNodeFields<JsConstructorClassMember> for FormatNodeRule<JsConstructorClassMember> {
     fn format_fields(
         node: &JsConstructorClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsConstructorClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsEmptyClassMemberFields;
 impl FormatNodeFields<JsEmptyClassMember> for FormatNodeRule<JsEmptyClassMember> {
     fn format_fields(
         node: &JsEmptyClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsEmptyClassMemberFields { semicolon_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/classes/extends_clause.rs
+++ b/crates/rome_js_formatter/src/js/classes/extends_clause.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsExtendsClause;
 use rome_js_syntax::JsExtendsClauseFields;
 
 impl FormatNodeFields<JsExtendsClause> for FormatNodeRule<JsExtendsClause> {
-    fn format_fields(node: &JsExtendsClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsExtendsClause,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsExtendsClauseFields {
             extends_token,
             super_class,

--- a/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsGetterClassMemberFields;
 impl FormatNodeFields<JsGetterClassMember> for FormatNodeRule<JsGetterClassMember> {
     fn format_fields(
         node: &JsGetterClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsGetterClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/method_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/method_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsMethodClassMemberFields;
 impl FormatNodeFields<JsMethodClassMember> for FormatNodeRule<JsMethodClassMember> {
     fn format_fields(
         node: &JsMethodClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsMethodClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/property_class_member.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsPropertyClassMemberFields;
 impl FormatNodeFields<JsPropertyClassMember> for FormatNodeRule<JsPropertyClassMember> {
     fn format_fields(
         node: &JsPropertyClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsPropertyClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsSetterClassMemberFields;
 impl FormatNodeFields<JsSetterClassMember> for FormatNodeRule<JsSetterClassMember> {
     fn format_fields(
         node: &JsSetterClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsSetterClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsStaticInitializationBlockClassMember>
 {
     fn format_fields(
         node: &JsStaticInitializationBlockClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsStaticInitializationBlockClassMemberFields {
             static_token,

--- a/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsCatchDeclarationFields;
 impl FormatNodeFields<JsCatchDeclaration> for FormatNodeRule<JsCatchDeclaration> {
     fn format_fields(
         node: &JsCatchDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsCatchDeclarationFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/declarations/class_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/class_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyClass, JsClassDeclaration};
 impl FormatNodeFields<JsClassDeclaration> for FormatNodeRule<JsClassDeclaration> {
     fn format_fields(
         node: &JsClassDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyClass::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/declarations/class_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/class_export_default_declaration.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsClassExportDefaultDeclaration>
 {
     fn format_fields(
         node: &JsClassExportDefaultDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyClass::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/declarations/for_variable_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/for_variable_declaration.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsForVariableDeclarationFields;
 impl FormatNodeFields<JsForVariableDeclaration> for FormatNodeRule<JsForVariableDeclaration> {
     fn format_fields(
         node: &JsForVariableDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsForVariableDeclarationFields {
             kind_token,

--- a/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyFunction, JsFunctionDeclaration};
 impl FormatNodeFields<JsFunctionDeclaration> for FormatNodeRule<JsFunctionDeclaration> {
     fn format_fields(
         node: &JsFunctionDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyFunction::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsFunctionExportDefaultDeclaration>
 {
     fn format_fields(
         node: &JsFunctionExportDefaultDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyFunction::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/declarations/variable_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/variable_declaration.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsVariableDeclarationFields;
 impl FormatNodeFields<JsVariableDeclaration> for FormatNodeRule<JsVariableDeclaration> {
     fn format_fields(
         node: &JsVariableDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsVariableDeclarationFields { kind, declarators } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/array_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/array_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsArrayExpressionFields;
 impl FormatNodeFields<JsArrayExpression> for FormatNodeRule<JsArrayExpression> {
     fn format_fields(
         node: &JsArrayExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsArrayExpressionFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyFunction, JsArrowFunctionExpression};
 impl FormatNodeFields<JsArrowFunctionExpression> for FormatNodeRule<JsArrowFunctionExpression> {
     fn format_fields(
         node: &JsArrowFunctionExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyFunction::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsAssignmentExpressionFields;
 impl FormatNodeFields<JsAssignmentExpression> for FormatNodeRule<JsAssignmentExpression> {
     fn format_fields(
         node: &JsAssignmentExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsAssignmentExpressionFields {
             left,

--- a/crates/rome_js_formatter/src/js/expressions/await_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/await_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsAwaitExpressionFields;
 impl FormatNodeFields<JsAwaitExpression> for FormatNodeRule<JsAwaitExpression> {
     fn format_fields(
         node: &JsAwaitExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsAwaitExpressionFields {
             await_token,

--- a/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::JsBigIntLiteralExpressionFields;
 impl FormatNodeFields<JsBigIntLiteralExpression> for FormatNodeRule<JsBigIntLiteralExpression> {
     fn format_fields(
         node: &JsBigIntLiteralExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsBigIntLiteralExpressionFields { value_token } = node.as_fields();
         let value_token = value_token?;

--- a/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsBinaryExpression;
 impl FormatNodeFields<JsBinaryExpression> for FormatNodeRule<JsBinaryExpression> {
     fn format_fields(
         node: &JsBinaryExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_binary_like_expression(
             JsAnyBinaryLikeExpression::JsBinaryExpression(node.clone()),

--- a/crates/rome_js_formatter/src/js/expressions/boolean_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/boolean_literal_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsBooleanLiteralExpressionFields;
 impl FormatNodeFields<JsBooleanLiteralExpression> for FormatNodeRule<JsBooleanLiteralExpression> {
     fn format_fields(
         node: &JsBooleanLiteralExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsBooleanLiteralExpressionFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -7,7 +7,10 @@ use rome_js_syntax::{JsAnyCallArgument, JsCallArguments};
 use rome_rowan::{AstSeparatedList, SyntaxResult};
 
 impl FormatNodeFields<JsCallArguments> for FormatNodeRule<JsCallArguments> {
-    fn format_fields(node: &JsCallArguments, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsCallArguments,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsCallArgumentsFields {
             l_paren_token,
             args,

--- a/crates/rome_js_formatter/src/js/expressions/call_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_expression.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsCallExpression> for FormatNodeRule<JsCallExpression> {
     fn format_fields(
         node: &JsCallExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_call_expression(node.syntax(), formatter)
     }

--- a/crates/rome_js_formatter/src/js/expressions/class_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/class_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyClass, JsClassExpression};
 impl FormatNodeFields<JsClassExpression> for FormatNodeRule<JsClassExpression> {
     fn format_fields(
         node: &JsClassExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyClass::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/expressions/computed_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/computed_member_expression.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsComputedMemberExpression> for FormatNodeRule<JsComputedMemberExpression> {
     fn format_fields(
         node: &JsComputedMemberExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let mut current = node.clone();
 

--- a/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsConditionalExpression;
 impl FormatNodeFields<JsConditionalExpression> for FormatNodeRule<JsConditionalExpression> {
     fn format_fields(
         node: &JsConditionalExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_conditional(Conditional::Expression(node.clone()), formatter, false)
     }

--- a/crates/rome_js_formatter/src/js/expressions/function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/function_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyFunction, JsFunctionExpression};
 impl FormatNodeFields<JsFunctionExpression> for FormatNodeRule<JsFunctionExpression> {
     fn format_fields(
         node: &JsFunctionExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyFunction::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/expressions/identifier_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/identifier_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsIdentifierExpressionFields;
 impl FormatNodeFields<JsIdentifierExpression> for FormatNodeRule<JsIdentifierExpression> {
     fn format_fields(
         node: &JsIdentifierExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsIdentifierExpressionFields { name } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/import_call_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/import_call_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportCallExpressionFields;
 impl FormatNodeFields<JsImportCallExpression> for FormatNodeRule<JsImportCallExpression> {
     fn format_fields(
         node: &JsImportCallExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsImportCallExpressionFields {
             import_token,

--- a/crates/rome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/in_expression.rs
@@ -5,7 +5,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::JsInExpression;
 
 impl FormatNodeFields<JsInExpression> for FormatNodeRule<JsInExpression> {
-    fn format_fields(node: &JsInExpression, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsInExpression,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         format_binary_like_expression(
             JsAnyBinaryLikeExpression::JsInExpression(node.clone()),
             formatter,

--- a/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsInstanceofExpression;
 impl FormatNodeFields<JsInstanceofExpression> for FormatNodeRule<JsInstanceofExpression> {
     fn format_fields(
         node: &JsInstanceofExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_binary_like_expression(
             JsAnyBinaryLikeExpression::JsInstanceofExpression(node.clone()),

--- a/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsLogicalExpression;
 impl FormatNodeFields<JsLogicalExpression> for FormatNodeRule<JsLogicalExpression> {
     fn format_fields(
         node: &JsLogicalExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_binary_like_expression(
             JsAnyBinaryLikeExpression::JsLogicalExpression(node.clone()),

--- a/crates/rome_js_formatter/src/js/expressions/new_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/new_expression.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsNewExpression;
 use rome_js_syntax::JsNewExpressionFields;
 
 impl FormatNodeFields<JsNewExpression> for FormatNodeRule<JsNewExpression> {
-    fn format_fields(node: &JsNewExpression, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsNewExpression,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsNewExpressionFields {
             new_token,
             callee,

--- a/crates/rome_js_formatter/src/js/expressions/null_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/null_literal_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNullLiteralExpressionFields;
 impl FormatNodeFields<JsNullLiteralExpression> for FormatNodeRule<JsNullLiteralExpression> {
     fn format_fields(
         node: &JsNullLiteralExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsNullLiteralExpressionFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNumberLiteralExpressionFields;
 impl FormatNodeFields<JsNumberLiteralExpression> for FormatNodeRule<JsNumberLiteralExpression> {
     fn format_fields(
         node: &JsNumberLiteralExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsNumberLiteralExpressionFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/object_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/object_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsObjectExpressionFields;
 impl FormatNodeFields<JsObjectExpression> for FormatNodeRule<JsObjectExpression> {
     fn format_fields(
         node: &JsObjectExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsObjectExpressionFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -11,7 +11,7 @@ use rome_rowan::{AstNode, SyntaxResult};
 impl FormatNodeFields<JsParenthesizedExpression> for FormatNodeRule<JsParenthesizedExpression> {
     fn format_fields(
         node: &JsParenthesizedExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsParenthesizedExpressionFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsPostUpdateExpressionFields;
 impl FormatNodeFields<JsPostUpdateExpression> for FormatNodeRule<JsPostUpdateExpression> {
     fn format_fields(
         node: &JsPostUpdateExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsPostUpdateExpressionFields {
             operand,

--- a/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsPreUpdateExpressionFields;
 impl FormatNodeFields<JsPreUpdateExpression> for FormatNodeRule<JsPreUpdateExpression> {
     fn format_fields(
         node: &JsPreUpdateExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsPreUpdateExpressionFields {
             operator_token,

--- a/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsRegexLiteralExpressionFields;
 impl FormatNodeFields<JsRegexLiteralExpression> for FormatNodeRule<JsRegexLiteralExpression> {
     fn format_fields(
         node: &JsRegexLiteralExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsRegexLiteralExpressionFields { value_token } = node.as_fields();
         let value_token = value_token?;

--- a/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsSequenceExpression> for FormatNodeRule<JsSequenceExpression> {
     fn format_fields(
         node: &JsSequenceExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let mut current = node.clone();
 

--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::JsStaticMemberExpressionFields;
 impl FormatNodeFields<JsStaticMemberExpression> for FormatNodeRule<JsStaticMemberExpression> {
     fn format_fields(
         node: &JsStaticMemberExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsStaticMemberExpressionFields {
             object,

--- a/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -10,7 +10,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsStringLiteralExpression> for FormatNodeRule<JsStringLiteralExpression> {
     fn format_fields(
         node: &JsStringLiteralExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsStringLiteralExpressionFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/super_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/super_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsSuperExpressionFields;
 impl FormatNodeFields<JsSuperExpression> for FormatNodeRule<JsSuperExpression> {
     fn format_fields(
         node: &JsSuperExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsSuperExpressionFields { super_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/template.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsTemplate;
 use rome_js_syntax::JsTemplateFields;
 
 impl FormatNodeFields<JsTemplate> for FormatNodeRule<JsTemplate> {
-    fn format_fields(node: &JsTemplate, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsTemplate,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsTemplateFields {
             tag,
             type_arguments,

--- a/crates/rome_js_formatter/src/js/expressions/template_chunk_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_chunk_element.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{JsTemplateChunkElement, JsTemplateChunkElementFields};
 impl FormatNodeFields<JsTemplateChunkElement> for FormatNodeRule<JsTemplateChunkElement> {
     fn format_fields(
         node: &JsTemplateChunkElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsTemplateChunkElementFields {
             template_chunk_token,

--- a/crates/rome_js_formatter/src/js/expressions/template_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_element.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsTemplateElement;
 impl FormatNodeFields<JsTemplateElement> for FormatNodeRule<JsTemplateElement> {
     fn format_fields(
         node: &JsTemplateElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_template_literal(TemplateElement::Js(node.clone()), formatter)
     }

--- a/crates/rome_js_formatter/src/js/expressions/this_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/this_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsThisExpressionFields;
 impl FormatNodeFields<JsThisExpression> for FormatNodeRule<JsThisExpression> {
     fn format_fields(
         node: &JsThisExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsThisExpressionFields { this_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{JsUnaryExpressionFields, JsUnaryOperator};
 impl FormatNodeFields<JsUnaryExpression> for FormatNodeRule<JsUnaryExpression> {
     fn format_fields(
         node: &JsUnaryExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsUnaryExpressionFields {
             operator_token,

--- a/crates/rome_js_formatter/src/js/expressions/yield_argument.rs
+++ b/crates/rome_js_formatter/src/js/expressions/yield_argument.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsYieldArgument;
 use rome_js_syntax::JsYieldArgumentFields;
 
 impl FormatNodeFields<JsYieldArgument> for FormatNodeRule<JsYieldArgument> {
-    fn format_fields(node: &JsYieldArgument, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsYieldArgument,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsYieldArgumentFields {
             star_token,
             expression,

--- a/crates/rome_js_formatter/src/js/expressions/yield_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/yield_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsYieldExpressionFields;
 impl FormatNodeFields<JsYieldExpression> for FormatNodeRule<JsYieldExpression> {
     fn format_fields(
         node: &JsYieldExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsYieldExpressionFields {
             yield_token,

--- a/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
@@ -4,9 +4,11 @@ use crate::utils::array::format_array_node;
 use rome_js_syntax::JsArrayAssignmentPatternElementList;
 
 impl FormatRule<JsArrayAssignmentPatternElementList> for FormatJsArrayAssignmentPatternElementList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsArrayAssignmentPatternElementList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_array_node(node, formatter)
     }

--- a/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
@@ -4,9 +4,11 @@ use crate::utils::array::format_array_node;
 use rome_js_syntax::JsArrayBindingPatternElementList;
 
 impl FormatRule<JsArrayBindingPatternElementList> for FormatJsArrayBindingPatternElementList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsArrayBindingPatternElementList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_array_node(node, formatter)
     }

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -10,7 +10,12 @@ use rome_js_syntax::{JsAnyExpression, JsArrayElementList};
 use rome_rowan::{AstNode, AstSeparatedList};
 
 impl FormatRule<JsArrayElementList> for FormatJsArrayElementList {
-    fn format(node: &JsArrayElementList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsArrayElementList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         if !has_formatter_trivia(node.syntax()) && can_print_fill(node) {
             return Ok(fill_elements(
                 // Using format_separated is valid in this case as can_print_fill does not allow holes

--- a/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
@@ -4,7 +4,12 @@ use crate::prelude::*;
 use rome_js_syntax::JsCallArgumentList;
 
 impl FormatRule<JsCallArgumentList> for FormatJsCallArgumentList {
-    fn format(node: &JsCallArgumentList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsCallArgumentList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),
             formatter.format_separated(node, || token(","), TrailingSeparator::default())?,

--- a/crates/rome_js_formatter/src/js/lists/class_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/class_member_list.rs
@@ -3,7 +3,12 @@ use crate::prelude::*;
 use rome_js_syntax::JsClassMemberList;
 
 impl FormatRule<JsClassMemberList> for FormatJsClassMemberList {
-    fn format(node: &JsClassMemberList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsClassMemberList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(formatter.format_list(node))
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
@@ -4,9 +4,11 @@ use rome_js_syntax::JsConstructorModifierList;
 use rome_rowan::AstNodeList;
 
 impl FormatRule<JsConstructorModifierList> for FormatJsConstructorModifierList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsConstructorModifierList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
@@ -4,9 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsConstructorParameterList;
 
 impl FormatRule<JsConstructorParameterList> for FormatJsConstructorParameterList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsConstructorParameterList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/directive_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/directive_list.rs
@@ -4,7 +4,12 @@ use rome_js_syntax::JsDirectiveList;
 use rome_rowan::{AstNode, AstNodeList};
 
 impl FormatRule<JsDirectiveList> for FormatJsDirectiveList {
-    fn format(node: &JsDirectiveList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsDirectiveList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         if !node.is_empty() {
             let syntax_node = node.syntax();
             let next_sibling = syntax_node.next_sibling();

--- a/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
@@ -4,9 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsExportNamedFromSpecifierList;
 
 impl FormatRule<JsExportNamedFromSpecifierList> for FormatJsExportNamedFromSpecifierList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsExportNamedFromSpecifierList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
@@ -4,9 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsExportNamedSpecifierList;
 
 impl FormatRule<JsExportNamedSpecifierList> for FormatJsExportNamedSpecifierList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsExportNamedSpecifierList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
@@ -4,9 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsImportAssertionEntryList;
 
 impl FormatRule<JsImportAssertionEntryList> for FormatJsImportAssertionEntryList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsImportAssertionEntryList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
@@ -4,7 +4,12 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::JsMethodModifierList;
 
 impl FormatRule<JsMethodModifierList> for FormatJsMethodModifierList {
-    fn format(node: &JsMethodModifierList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsMethodModifierList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),
             formatter.format_all(sort_modifiers_by_precedence(node).into_iter().formatted())?,

--- a/crates/rome_js_formatter/src/js/lists/module_item_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/module_item_list.rs
@@ -3,7 +3,12 @@ use crate::prelude::*;
 use rome_js_syntax::JsModuleItemList;
 
 impl FormatRule<JsModuleItemList> for FormatJsModuleItemList {
-    fn format(node: &JsModuleItemList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsModuleItemList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(formatter.format_list(node))
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
@@ -4,9 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsNamedImportSpecifierList;
 
 impl FormatRule<JsNamedImportSpecifierList> for FormatJsNamedImportSpecifierList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsNamedImportSpecifierList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
@@ -6,9 +6,11 @@ use rome_js_syntax::{JsAnyObjectAssignmentPatternMember, JsObjectAssignmentPatte
 impl FormatRule<JsObjectAssignmentPatternPropertyList>
     for FormatJsObjectAssignmentPatternPropertyList
 {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsObjectAssignmentPatternPropertyList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         // The trailing separator is disallowed after a rest element
         let has_trailing_rest = match node.into_iter().last() {

--- a/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
@@ -4,9 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::{JsAnyObjectBindingPatternMember, JsObjectBindingPatternPropertyList};
 
 impl FormatRule<JsObjectBindingPatternPropertyList> for FormatJsObjectBindingPatternPropertyList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsObjectBindingPatternPropertyList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         // The trailing separator is disallowed after a rest element
         let has_trailing_rest = match node.into_iter().last() {

--- a/crates/rome_js_formatter/src/js/lists/object_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_member_list.rs
@@ -5,7 +5,12 @@ use rome_js_syntax::JsObjectMemberList;
 use rome_rowan::{AstNode, AstSeparatedList};
 
 impl FormatRule<JsObjectMemberList> for FormatJsObjectMemberList {
-    fn format(node: &JsObjectMemberList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsObjectMemberList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let members =
             formatter.format_separated(node, || token(","), TrailingSeparator::default())?;
 

--- a/crates/rome_js_formatter/src/js/lists/parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/parameter_list.rs
@@ -4,7 +4,12 @@ use crate::prelude::*;
 use rome_js_syntax::{JsAnyParameter, JsParameterList};
 
 impl FormatRule<JsParameterList> for FormatJsParameterList {
-    fn format(node: &JsParameterList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsParameterList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         // The trailing separator is disallowed if the last element in the list is a rest parameter
         let has_trailing_rest = match node.into_iter().last() {
             Some(elem) => matches!(elem?, JsAnyParameter::JsRestParameter(_)),

--- a/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
@@ -4,7 +4,12 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::JsPropertyModifierList;
 
 impl FormatRule<JsPropertyModifierList> for FormatJsPropertyModifierList {
-    fn format(node: &JsPropertyModifierList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsPropertyModifierList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),
             formatter.format_all(sort_modifiers_by_precedence(node).into_iter().formatted())?,

--- a/crates/rome_js_formatter/src/js/lists/statement_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/statement_list.rs
@@ -3,7 +3,12 @@ use crate::prelude::*;
 use rome_js_syntax::JsStatementList;
 
 impl FormatRule<JsStatementList> for FormatJsStatementList {
-    fn format(node: &JsStatementList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsStatementList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(formatter.format_list(node))
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
@@ -3,7 +3,12 @@ use crate::prelude::*;
 use rome_js_syntax::JsSwitchCaseList;
 
 impl FormatRule<JsSwitchCaseList> for FormatJsSwitchCaseList {
-    fn format(node: &JsSwitchCaseList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsSwitchCaseList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(formatter.format_list(node))
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/template_element_list.rs
@@ -3,7 +3,12 @@ use crate::prelude::*;
 use rome_js_syntax::JsTemplateElementList;
 
 impl FormatRule<JsTemplateElementList> for FormatJsTemplateElementList {
-    fn format(node: &JsTemplateElementList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsTemplateElementList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(formatter.format_list(node))
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
@@ -6,9 +6,11 @@ use rome_js_syntax::JsVariableDeclaratorList;
 use rome_rowan::AstSeparatedList;
 
 impl FormatRule<JsVariableDeclaratorList> for FormatJsVariableDeclaratorList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &JsVariableDeclaratorList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let last_index = node.len().saturating_sub(1);
 

--- a/crates/rome_js_formatter/src/js/module/default_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/default_import_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsDefaultImportSpecifierFields;
 impl FormatNodeFields<JsDefaultImportSpecifier> for FormatNodeRule<JsDefaultImportSpecifier> {
     fn format_fields(
         node: &JsDefaultImportSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsDefaultImportSpecifierFields {
             local_name,

--- a/crates/rome_js_formatter/src/js/module/export.rs
+++ b/crates/rome_js_formatter/src/js/module/export.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsExport;
 use rome_js_syntax::JsExportFields;
 
 impl FormatNodeFields<JsExport> for FormatNodeRule<JsExport> {
-    fn format_fields(node: &JsExport, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsExport,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsExportFields {
             export_token,
             export_clause,

--- a/crates/rome_js_formatter/src/js/module/export_as_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_as_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportAsClauseFields;
 impl FormatNodeFields<JsExportAsClause> for FormatNodeRule<JsExportAsClause> {
     fn format_fields(
         node: &JsExportAsClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExportAsClauseFields {
             as_token,

--- a/crates/rome_js_formatter/src/js/module/export_default_declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_default_declaration_clause.rs
@@ -7,7 +7,7 @@ impl FormatNodeFields<JsExportDefaultDeclarationClause>
 {
     fn format_fields(
         node: &JsExportDefaultDeclarationClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExportDefaultDeclarationClauseFields {
             default_token,

--- a/crates/rome_js_formatter/src/js/module/export_default_expression_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_default_expression_clause.rs
@@ -10,7 +10,7 @@ impl FormatNodeFields<JsExportDefaultExpressionClause>
 {
     fn format_fields(
         node: &JsExportDefaultExpressionClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExportDefaultExpressionClauseFields {
             default_token,

--- a/crates/rome_js_formatter/src/js/module/export_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_from_clause.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsExportFromClauseFields;
 impl FormatNodeFields<JsExportFromClause> for FormatNodeRule<JsExportFromClause> {
     fn format_fields(
         node: &JsExportFromClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExportFromClauseFields {
             star_token,

--- a/crates/rome_js_formatter/src/js/module/export_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_clause.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsExportNamedClauseFields;
 impl FormatNodeFields<JsExportNamedClause> for FormatNodeRule<JsExportNamedClause> {
     fn format_fields(
         node: &JsExportNamedClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsExportNamedFromClauseFields;
 impl FormatNodeFields<JsExportNamedFromClause> for FormatNodeRule<JsExportNamedFromClause> {
     fn format_fields(
         node: &JsExportNamedFromClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedFromClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/export_named_from_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportNamedFromSpecifierFields;
 impl FormatNodeFields<JsExportNamedFromSpecifier> for FormatNodeRule<JsExportNamedFromSpecifier> {
     fn format_fields(
         node: &JsExportNamedFromSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedFromSpecifierFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/export_named_shorthand_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_shorthand_specifier.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsExportNamedShorthandSpecifier>
 {
     fn format_fields(
         node: &JsExportNamedShorthandSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedShorthandSpecifierFields { type_token, name } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/module/export_named_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportNamedSpecifierFields;
 impl FormatNodeFields<JsExportNamedSpecifier> for FormatNodeRule<JsExportNamedSpecifier> {
     fn format_fields(
         node: &JsExportNamedSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedSpecifierFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/import.rs
+++ b/crates/rome_js_formatter/src/js/module/import.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::JsImport;
 use rome_js_syntax::JsImportFields;
 
 impl FormatNodeFields<JsImport> for FormatNodeRule<JsImport> {
-    fn format_fields(node: &JsImport, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsImport,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsImportFields {
             import_token,
             import_clause,

--- a/crates/rome_js_formatter/src/js/module/import_assertion.rs
+++ b/crates/rome_js_formatter/src/js/module/import_assertion.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportAssertionFields;
 impl FormatNodeFields<JsImportAssertion> for FormatNodeRule<JsImportAssertion> {
     fn format_fields(
         node: &JsImportAssertion,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsImportAssertionFields {
             assert_token,

--- a/crates/rome_js_formatter/src/js/module/import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/module/import_assertion_entry.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::{JsImportAssertionEntry, JsSyntaxKind};
 impl FormatNodeFields<JsImportAssertionEntry> for FormatNodeRule<JsImportAssertionEntry> {
     fn format_fields(
         node: &JsImportAssertionEntry,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsImportAssertionEntryFields {
             key,

--- a/crates/rome_js_formatter/src/js/module/import_bare_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_bare_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportBareClauseFields;
 impl FormatNodeFields<JsImportBareClause> for FormatNodeRule<JsImportBareClause> {
     fn format_fields(
         node: &JsImportBareClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsImportBareClauseFields { source, assertion } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/module/import_default_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_default_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportDefaultClauseFields;
 impl FormatNodeFields<JsImportDefaultClause> for FormatNodeRule<JsImportDefaultClause> {
     fn format_fields(
         node: &JsImportDefaultClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsImportDefaultClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/import_meta.rs
+++ b/crates/rome_js_formatter/src/js/module/import_meta.rs
@@ -5,7 +5,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::ImportMetaFields;
 
 impl FormatNodeFields<ImportMeta> for FormatNodeRule<ImportMeta> {
-    fn format_fields(node: &ImportMeta, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &ImportMeta,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let ImportMetaFields {
             import_token,
             dot_token,

--- a/crates/rome_js_formatter/src/js/module/import_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_named_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportNamedClauseFields;
 impl FormatNodeFields<JsImportNamedClause> for FormatNodeRule<JsImportNamedClause> {
     fn format_fields(
         node: &JsImportNamedClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsImportNamedClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/import_namespace_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_namespace_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportNamespaceClauseFields;
 impl FormatNodeFields<JsImportNamespaceClause> for FormatNodeRule<JsImportNamespaceClause> {
     fn format_fields(
         node: &JsImportNamespaceClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsImportNamespaceClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/literal_export_name.rs
+++ b/crates/rome_js_formatter/src/js/module/literal_export_name.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsLiteralExportNameFields;
 impl FormatNodeFields<JsLiteralExportName> for FormatNodeRule<JsLiteralExportName> {
     fn format_fields(
         node: &JsLiteralExportName,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsLiteralExportNameFields { value } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/module/module_source.rs
+++ b/crates/rome_js_formatter/src/js/module/module_source.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::JsModuleSource;
 use rome_js_syntax::JsModuleSourceFields;
 
 impl FormatNodeFields<JsModuleSource> for FormatNodeRule<JsModuleSource> {
-    fn format_fields(node: &JsModuleSource, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsModuleSource,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsModuleSourceFields { value_token } = node.as_fields();
 
         Ok(format_string_literal_token(value_token?, formatter))

--- a/crates/rome_js_formatter/src/js/module/named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/named_import_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNamedImportSpecifierFields;
 impl FormatNodeFields<JsNamedImportSpecifier> for FormatNodeRule<JsNamedImportSpecifier> {
     fn format_fields(
         node: &JsNamedImportSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsNamedImportSpecifierFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
+++ b/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNamedImportSpecifiersFields;
 impl FormatNodeFields<JsNamedImportSpecifiers> for FormatNodeRule<JsNamedImportSpecifiers> {
     fn format_fields(
         node: &JsNamedImportSpecifiers,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsNamedImportSpecifiersFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/module/namespace_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/namespace_import_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNamespaceImportSpecifierFields;
 impl FormatNodeFields<JsNamespaceImportSpecifier> for FormatNodeRule<JsNamespaceImportSpecifier> {
     fn format_fields(
         node: &JsNamespaceImportSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsNamespaceImportSpecifierFields {
             star_token,

--- a/crates/rome_js_formatter/src/js/module/shorthand_named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/shorthand_named_import_specifier.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsShorthandNamedImportSpecifier>
 {
     fn format_fields(
         node: &JsShorthandNamedImportSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsShorthandNamedImportSpecifierFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/objects/computed_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/computed_member_name.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsComputedMemberNameFields;
 impl FormatNodeFields<JsComputedMemberName> for FormatNodeRule<JsComputedMemberName> {
     fn format_fields(
         node: &JsComputedMemberName,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsComputedMemberNameFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/js/objects/getter_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/getter_object_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsGetterObjectMemberFields;
 impl FormatNodeFields<JsGetterObjectMember> for FormatNodeRule<JsGetterObjectMember> {
     fn format_fields(
         node: &JsGetterObjectMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsGetterObjectMemberFields {
             get_token,

--- a/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::{JsLiteralMemberName, JsSyntaxKind};
 impl FormatNodeFields<JsLiteralMemberName> for FormatNodeRule<JsLiteralMemberName> {
     fn format_fields(
         node: &JsLiteralMemberName,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsLiteralMemberNameFields { value } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/objects/method_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/method_object_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsMethodObjectMemberFields;
 impl FormatNodeFields<JsMethodObjectMember> for FormatNodeRule<JsMethodObjectMember> {
     fn format_fields(
         node: &JsMethodObjectMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsMethodObjectMemberFields {
             async_token,

--- a/crates/rome_js_formatter/src/js/objects/private_class_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/private_class_member_name.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsPrivateClassMemberNameFields;
 impl FormatNodeFields<JsPrivateClassMemberName> for FormatNodeRule<JsPrivateClassMemberName> {
     fn format_fields(
         node: &JsPrivateClassMemberName,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsPrivateClassMemberNameFields {
             hash_token,

--- a/crates/rome_js_formatter/src/js/objects/property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/property_object_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsPropertyObjectMemberFields;
 impl FormatNodeFields<JsPropertyObjectMember> for FormatNodeRule<JsPropertyObjectMember> {
     fn format_fields(
         node: &JsPropertyObjectMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsPropertyObjectMemberFields {
             name,

--- a/crates/rome_js_formatter/src/js/objects/setter_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/setter_object_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsSetterObjectMemberFields;
 impl FormatNodeFields<JsSetterObjectMember> for FormatNodeRule<JsSetterObjectMember> {
     fn format_fields(
         node: &JsSetterObjectMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsSetterObjectMemberFields {
             set_token,

--- a/crates/rome_js_formatter/src/js/objects/shorthand_property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/shorthand_property_object_member.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsShorthandPropertyObjectMember>
 {
     fn format_fields(
         node: &JsShorthandPropertyObjectMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsShorthandPropertyObjectMemberFields { name } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/statements/block_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/block_statement.rs
@@ -11,7 +11,7 @@ use rome_rowan::{AstNode, AstNodeList};
 impl FormatNodeFields<JsBlockStatement> for FormatNodeRule<JsBlockStatement> {
     fn format_fields(
         node: &JsBlockStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsBlockStatementFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/statements/break_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/break_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsBreakStatementFields;
 impl FormatNodeFields<JsBreakStatement> for FormatNodeRule<JsBreakStatement> {
     fn format_fields(
         node: &JsBreakStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsBreakStatementFields {
             break_token,

--- a/crates/rome_js_formatter/src/js/statements/continue_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/continue_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsContinueStatementFields;
 impl FormatNodeFields<JsContinueStatement> for FormatNodeRule<JsContinueStatement> {
     fn format_fields(
         node: &JsContinueStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsContinueStatementFields {
             continue_token,

--- a/crates/rome_js_formatter/src/js/statements/debugger_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/debugger_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsDebuggerStatementFields;
 impl FormatNodeFields<JsDebuggerStatement> for FormatNodeRule<JsDebuggerStatement> {
     fn format_fields(
         node: &JsDebuggerStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsDebuggerStatementFields {
             debugger_token,

--- a/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{JsAnyStatement, JsDoWhileStatement};
 impl FormatNodeFields<JsDoWhileStatement> for FormatNodeRule<JsDoWhileStatement> {
     fn format_fields(
         node: &JsDoWhileStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsDoWhileStatementFields {
             do_token,

--- a/crates/rome_js_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/empty_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsEmptyStatementFields;
 impl FormatNodeFields<JsEmptyStatement> for FormatNodeRule<JsEmptyStatement> {
     fn format_fields(
         node: &JsEmptyStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsEmptyStatementFields { semicolon_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/statements/expression_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/expression_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsExpressionStatementFields;
 impl FormatNodeFields<JsExpressionStatement> for FormatNodeRule<JsExpressionStatement> {
     fn format_fields(
         node: &JsExpressionStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsExpressionStatementFields {
             expression,

--- a/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsForInStatementFields;
 impl FormatNodeFields<JsForInStatement> for FormatNodeRule<JsForInStatement> {
     fn format_fields(
         node: &JsForInStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsForInStatementFields {
             for_token,

--- a/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsForOfStatementFields;
 impl FormatNodeFields<JsForOfStatement> for FormatNodeRule<JsForOfStatement> {
     fn format_fields(
         node: &JsForOfStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsForOfStatementFields {
             for_token,

--- a/crates/rome_js_formatter/src/js/statements/for_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_statement.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::JsForStatement;
 use rome_js_syntax::JsForStatementFields;
 
 impl FormatNodeFields<JsForStatement> for FormatNodeRule<JsForStatement> {
-    fn format_fields(node: &JsForStatement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsForStatement,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsForStatementFields {
             for_token,
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::{JsAnyStatement, JsElseClauseFields, JsIfStatement};
 use rome_js_syntax::{JsElseClause, JsIfStatementFields};
 
 impl FormatNodeFields<JsIfStatement> for FormatNodeRule<JsIfStatement> {
-    fn format_fields(node: &JsIfStatement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsIfStatement,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let (head, mut else_clause) = format_if_element(formatter, None, node)?;
 
         let mut if_chain = vec![head];
@@ -43,7 +46,7 @@ impl FormatNodeFields<JsIfStatement> for FormatNodeRule<JsIfStatement> {
 
 /// Format a single `else? if(test) consequent` element, returning the next else clause
 fn format_if_element(
-    formatter: &Formatter,
+    formatter: &Formatter<JsFormatOptions>,
     else_token: Option<JsSyntaxToken>,
     stmt: &JsIfStatement,
 ) -> FormatResult<(FormatElement, Option<JsElseClause>)> {
@@ -79,7 +82,10 @@ fn format_if_element(
 }
 
 /// Wraps the statement into a block if its not already a JsBlockStatement
-fn into_block(formatter: &Formatter, stmt: JsAnyStatement) -> FormatResult<FormatElement> {
+fn into_block(
+    formatter: &Formatter<JsFormatOptions>,
+    stmt: JsAnyStatement,
+) -> FormatResult<FormatElement> {
     if matches!(stmt, JsAnyStatement::JsBlockStatement(_)) {
         return formatted![formatter, [stmt.format()]];
     }

--- a/crates/rome_js_formatter/src/js/statements/labeled_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/labeled_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{JsAnyStatement, JsLabeledStatement};
 impl FormatNodeFields<JsLabeledStatement> for FormatNodeRule<JsLabeledStatement> {
     fn format_fields(
         node: &JsLabeledStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsLabeledStatementFields {
             label_token,

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsReturnStatement> for FormatNodeRule<JsReturnStatement> {
     fn format_fields(
         node: &JsReturnStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsReturnStatementFields {
             return_token,

--- a/crates/rome_js_formatter/src/js/statements/switch_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/switch_statement.rs
@@ -6,7 +6,7 @@ use rome_rowan::{AstNode, AstNodeList};
 impl FormatNodeFields<JsSwitchStatement> for FormatNodeRule<JsSwitchStatement> {
     fn format_fields(
         node: &JsSwitchStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsSwitchStatementFields {
             switch_token,

--- a/crates/rome_js_formatter/src/js/statements/throw_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/throw_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsThrowStatementFields;
 impl FormatNodeFields<JsThrowStatement> for FormatNodeRule<JsThrowStatement> {
     fn format_fields(
         node: &JsThrowStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsThrowStatementFields {
             throw_token,

--- a/crates/rome_js_formatter/src/js/statements/try_finally_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/try_finally_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsTryFinallyStatementFields;
 impl FormatNodeFields<JsTryFinallyStatement> for FormatNodeRule<JsTryFinallyStatement> {
     fn format_fields(
         node: &JsTryFinallyStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsTryFinallyStatementFields {
             try_token,

--- a/crates/rome_js_formatter/src/js/statements/try_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/try_statement.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsTryStatement;
 use rome_js_syntax::JsTryStatementFields;
 
 impl FormatNodeFields<JsTryStatement> for FormatNodeRule<JsTryStatement> {
-    fn format_fields(node: &JsTryStatement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsTryStatement,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsTryStatementFields {
             try_token,
             body,

--- a/crates/rome_js_formatter/src/js/statements/variable_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/variable_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsVariableStatementFields;
 impl FormatNodeFields<JsVariableStatement> for FormatNodeRule<JsVariableStatement> {
     fn format_fields(
         node: &JsVariableStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsVariableStatementFields {
             declaration,

--- a/crates/rome_js_formatter/src/js/statements/while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/while_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsWhileStatementFields;
 impl FormatNodeFields<JsWhileStatement> for FormatNodeRule<JsWhileStatement> {
     fn format_fields(
         node: &JsWhileStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsWhileStatementFields {
             while_token,

--- a/crates/rome_js_formatter/src/js/statements/with_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/with_statement.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::JsWithStatement;
 use rome_js_syntax::JsWithStatementFields;
 
 impl FormatNodeFields<JsWithStatement> for FormatNodeRule<JsWithStatement> {
-    fn format_fields(node: &JsWithStatement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsWithStatement,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsWithStatementFields {
             with_token,
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/unknown/unknown.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsUnknown;
 use rome_rowan::AstNode;
 
 impl FormatNodeFields<JsUnknown> for FormatNodeRule<JsUnknown> {
-    fn format_fields(node: &JsUnknown, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsUnknown,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownAssignment> for FormatNodeRule<JsUnknownAssignment> {
     fn format_fields(
         node: &JsUnknownAssignment,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownBinding> for FormatNodeRule<JsUnknownBinding> {
     fn format_fields(
         node: &JsUnknownBinding,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownExpression> for FormatNodeRule<JsUnknownExpression> {
     fn format_fields(
         node: &JsUnknownExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
@@ -10,7 +10,7 @@ impl FormatNodeFields<JsUnknownImportAssertionEntry>
 {
     fn format_fields(
         node: &JsUnknownImportAssertionEntry,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
@@ -6,7 +6,10 @@ use rome_js_syntax::JsUnknownMember;
 use rome_rowan::AstNode;
 
 impl FormatNodeFields<JsUnknownMember> for FormatNodeRule<JsUnknownMember> {
-    fn format_fields(node: &JsUnknownMember, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsUnknownMember,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
@@ -10,7 +10,7 @@ impl FormatNodeFields<JsUnknownNamedImportSpecifier>
 {
     fn format_fields(
         node: &JsUnknownNamedImportSpecifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownParameter> for FormatNodeRule<JsUnknownParameter> {
     fn format_fields(
         node: &JsUnknownParameter,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownStatement> for FormatNodeRule<JsUnknownStatement> {
     fn format_fields(
         node: &JsUnknownStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/any/attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsxAnyAttribute;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttribute;
 impl FormatRule<JsxAnyAttribute> for FormatJsxAnyAttribute {
-    fn format(node: &JsxAnyAttribute, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsxAnyAttribute,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyAttribute::JsxAttribute(node) => formatted![formatter, [node.format()]],
             JsxAnyAttribute::JsxSpreadAttribute(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsxAnyAttributeName;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttributeName;
 impl FormatRule<JsxAnyAttributeName> for FormatJsxAnyAttributeName {
-    fn format(node: &JsxAnyAttributeName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsxAnyAttributeName,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyAttributeName::JsxName(node) => formatted![formatter, [node.format()]],
             JsxAnyAttributeName::JsxNamespaceName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsxAnyAttributeValue;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttributeValue;
 impl FormatRule<JsxAnyAttributeValue> for FormatJsxAnyAttributeValue {
-    fn format(node: &JsxAnyAttributeValue, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsxAnyAttributeValue,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyAttributeValue::JsxAnyTag(node) => formatted![formatter, [node.format()]],
             JsxAnyAttributeValue::JsxString(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/child.rs
+++ b/crates/rome_js_formatter/src/jsx/any/child.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsxAnyChild;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyChild;
 impl FormatRule<JsxAnyChild> for FormatJsxAnyChild {
-    fn format(node: &JsxAnyChild, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsxAnyChild,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyChild::JsxElement(node) => formatted![formatter, [node.format()]],
             JsxAnyChild::JsxSelfClosingElement(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/element_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/element_name.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsxAnyElementName;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyElementName;
 impl FormatRule<JsxAnyElementName> for FormatJsxAnyElementName {
-    fn format(node: &JsxAnyElementName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsxAnyElementName,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyElementName::JsxName(node) => formatted![formatter, [node.format()]],
             JsxAnyElementName::JsxReferenceIdentifier(node) => {

--- a/crates/rome_js_formatter/src/jsx/any/name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/name.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsxAnyName;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyName;
 impl FormatRule<JsxAnyName> for FormatJsxAnyName {
-    fn format(node: &JsxAnyName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsxAnyName,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyName::JsxName(node) => formatted![formatter, [node.format()]],
             JsxAnyName::JsxNamespaceName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/object_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/object_name.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsxAnyObjectName;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyObjectName;
 impl FormatRule<JsxAnyObjectName> for FormatJsxAnyObjectName {
-    fn format(node: &JsxAnyObjectName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsxAnyObjectName,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyObjectName::JsxReferenceIdentifier(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/jsx/any/tag.rs
+++ b/crates/rome_js_formatter/src/jsx/any/tag.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatJsxAnyTag;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyTag;
 impl FormatRule<JsxAnyTag> for FormatJsxAnyTag {
-    fn format(node: &JsxAnyTag, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &JsxAnyTag,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyTag::JsxElement(node) => formatted![formatter, [node.format()]],
             JsxAnyTag::JsxSelfClosingElement(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/attribute/attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/attribute.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{JsxAttribute, JsxAttributeFields};
 
 impl FormatNodeFields<JsxAttribute> for FormatNodeRule<JsxAttribute> {
-    fn format_fields(node: &JsxAttribute, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsxAttribute,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsxAttributeFields { name, initializer } = node.as_fields();
 
         formatted![formatter, [name.format(), initializer.format()]]

--- a/crates/rome_js_formatter/src/jsx/attribute/attribute_initializer_clause.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/attribute_initializer_clause.rs
@@ -7,7 +7,7 @@ impl FormatNodeFields<JsxAttributeInitializerClause>
 {
     fn format_fields(
         node: &JsxAttributeInitializerClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsxAttributeInitializerClauseFields { eq_token, value } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{
 impl FormatNodeFields<JsxExpressionAttributeValue> for FormatNodeRule<JsxExpressionAttributeValue> {
     fn format_fields(
         node: &JsxExpressionAttributeValue,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsxExpressionAttributeValueFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/jsx/attribute/spread_attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/spread_attribute.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxSpreadAttribute, JsxSpreadAttributeFields};
 impl FormatNodeFields<JsxSpreadAttribute> for FormatNodeRule<JsxSpreadAttribute> {
     fn format_fields(
         node: &JsxSpreadAttribute,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsxSpreadAttributeFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsxExpressionChild> for FormatNodeRule<JsxExpressionChild> {
     fn format_fields(
         node: &JsxExpressionChild,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/name.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/name.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{JsxName, JsxNameFields};
 
 impl FormatNodeFields<JsxName> for FormatNodeRule<JsxName> {
-    fn format_fields(node: &JsxName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsxName,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsxNameFields { value_token } = node.as_fields();
 
         formatted![formatter, [value_token.format()]]

--- a/crates/rome_js_formatter/src/jsx/auxiliary/namespace_name.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/namespace_name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxNamespaceName, JsxNamespaceNameFields};
 impl FormatNodeFields<JsxNamespaceName> for FormatNodeRule<JsxNamespaceName> {
     fn format_fields(
         node: &JsxNamespaceName,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsxNamespaceNameFields {
             namespace,

--- a/crates/rome_js_formatter/src/jsx/auxiliary/reference_identifier.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/reference_identifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsxReferenceIdentifier;
 impl FormatNodeFields<JsxReferenceIdentifier> for FormatNodeRule<JsxReferenceIdentifier> {
     fn format_fields(
         node: &JsxReferenceIdentifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [node.value_token().format()]]
     }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/spread_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/spread_child.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsxSpreadChild;
 use rome_rowan::AstNode;
 
 impl FormatNodeFields<JsxSpreadChild> for FormatNodeRule<JsxSpreadChild> {
-    fn format_fields(node: &JsxSpreadChild, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsxSpreadChild,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/string.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/string.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::JsxString;
 
 impl FormatNodeFields<JsxString> for FormatNodeRule<JsxString> {
-    fn format_fields(node: &JsxString, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsxString,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         formatted![formatter, [node.value_token().format()]]
     }
 }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/text.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/text.rs
@@ -6,7 +6,10 @@ use std::ops::Range;
 use std::str::CharIndices;
 
 impl FormatNodeFields<JsxText> for FormatNodeRule<JsxText> {
-    fn format_fields(node: &JsxText, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsxText,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsxTextFields { value_token } = node.as_fields();
         let token = value_token?;
         let new_text = clean_jsx_text(token.text());

--- a/crates/rome_js_formatter/src/jsx/expressions/tag_expression.rs
+++ b/crates/rome_js_formatter/src/jsx/expressions/tag_expression.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsxTagExpression;
 impl FormatNodeFields<JsxTagExpression> for FormatNodeRule<JsxTagExpression> {
     fn format_fields(
         node: &JsxTagExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [node.tag().format()]]
     }

--- a/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
@@ -3,7 +3,12 @@ use crate::prelude::*;
 use rome_js_syntax::JsxAttributeList;
 
 impl FormatRule<JsxAttributeList> for FormatJsxAttributeList {
-    fn format(node: &JsxAttributeList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsxAttributeList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let attributes = join_elements(
             soft_line_break_or_space(),
             formatter.format_all(node.iter().formatted())?,

--- a/crates/rome_js_formatter/src/jsx/lists/child_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/child_list.rs
@@ -5,7 +5,12 @@ use rome_js_syntax::JsxChildList;
 use rome_rowan::AstNode;
 
 impl FormatRule<JsxChildList> for FormatJsxChildList {
-    fn format(node: &JsxChildList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &JsxChildList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/objects/member_name.rs
+++ b/crates/rome_js_formatter/src/jsx/objects/member_name.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{JsxMemberName, JsxMemberNameFields};
 
 impl FormatNodeFields<JsxMemberName> for FormatNodeRule<JsxMemberName> {
-    fn format_fields(node: &JsxMemberName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsxMemberName,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsxMemberNameFields {
             object,
             dot_token,

--- a/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsxClosingElement> for FormatNodeRule<JsxClosingElement> {
     fn format_fields(
         node: &JsxClosingElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/tag/closing_fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/closing_fragment.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxClosingFragment, JsxClosingFragmentFields};
 impl FormatNodeFields<JsxClosingFragment> for FormatNodeRule<JsxClosingFragment> {
     fn format_fields(
         node: &JsxClosingFragment,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsxClosingFragmentFields {
             r_angle_token,

--- a/crates/rome_js_formatter/src/jsx/tag/element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/element.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::JsxElement;
 use rome_rowan::AstNode;
 
 impl FormatNodeFields<JsxElement> for FormatNodeRule<JsxElement> {
-    fn format_fields(node: &JsxElement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsxElement,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }
 }

--- a/crates/rome_js_formatter/src/jsx/tag/fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/fragment.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{JsxFragment, JsxFragmentFields};
 
 impl FormatNodeFields<JsxFragment> for FormatNodeRule<JsxFragment> {
-    fn format_fields(node: &JsxFragment, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &JsxFragment,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let JsxFragmentFields {
             opening_fragment,
             children,

--- a/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsxOpeningElement> for FormatNodeRule<JsxOpeningElement> {
     fn format_fields(
         node: &JsxOpeningElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/tag/opening_fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/opening_fragment.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxOpeningFragment, JsxOpeningFragmentFields};
 impl FormatNodeFields<JsxOpeningFragment> for FormatNodeRule<JsxOpeningFragment> {
     fn format_fields(
         node: &JsxOpeningFragment,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsxOpeningFragmentFields {
             r_angle_token,

--- a/crates/rome_js_formatter/src/jsx/tag/self_closing_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/self_closing_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxSelfClosingElement, JsxSelfClosingElementFields};
 impl FormatNodeFields<JsxSelfClosingElement> for FormatNodeRule<JsxSelfClosingElement> {
     fn format_fields(
         node: &JsxSelfClosingElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let JsxSelfClosingElementFields {
             l_angle_token,

--- a/crates/rome_js_formatter/src/options.rs
+++ b/crates/rome_js_formatter/src/options.rs
@@ -1,0 +1,84 @@
+use rome_formatter::printer::PrinterOptions;
+use rome_formatter::{FormatOptions, IndentStyle, LineWidth};
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct JsFormatOptions {
+    /// The indent style.
+    pub indent_style: IndentStyle,
+
+    /// What's the max width of a line. Defaults to 80.
+    pub line_width: LineWidth,
+
+    // The style for quotes. Defaults to double.
+    pub quote_style: QuoteStyle,
+}
+
+impl JsFormatOptions {
+    pub fn tab_width(&self) -> u8 {
+        match self.indent_style {
+            IndentStyle::Tab => 2,
+            IndentStyle::Space(quantities) => quantities,
+        }
+    }
+}
+
+impl FormatOptions for JsFormatOptions {
+    fn indent_style(&self) -> IndentStyle {
+        self.indent_style
+    }
+
+    fn line_with(&self) -> LineWidth {
+        self.line_width
+    }
+
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions::default()
+            .with_indent(self.indent_style)
+            .with_print_with(self.line_width)
+    }
+}
+
+impl fmt::Display for JsFormatOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Indent style: {}", self.indent_style)?;
+        writeln!(f, "Line width: {}", self.line_width.value())?;
+        writeln!(f, "Quote style: {}", self.quote_style)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum QuoteStyle {
+    Double,
+    Single,
+}
+
+impl Default for QuoteStyle {
+    fn default() -> Self {
+        Self::Double
+    }
+}
+
+impl FromStr for QuoteStyle {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "double" | "Double" => Ok(Self::Double),
+            "single" | "Single" => Ok(Self::Single),
+            // TODO: replace this error with a diagnostic
+            _ => Err("Value not supported for QuoteStyle"),
+        }
+    }
+}
+
+impl fmt::Display for QuoteStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QuoteStyle::Double => write!(f, "Double Quotes"),
+            QuoteStyle::Single => write!(f, "Single Quotes"),
+        }
+    }
+}

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -1,6 +1,8 @@
 //! This module provides important and useful traits to help to format tokens and nodes
 //! when implementing the [crate::FormatNode] trait.
 
-pub(crate) use crate::{AsFormat as _, FormatNodeRule, FormattedIterExt, JsFormatter as _};
+pub(crate) use crate::{
+    AsFormat as _, FormatNodeRule, FormattedIterExt, JsFormatOptions, JsFormatter as _,
+};
 pub use rome_formatter::prelude::*;
 pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};

--- a/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
+++ b/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatTsAnyExternalModuleDeclarationBody;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyExternalModuleDeclarationBody;
 impl FormatRule<TsAnyExternalModuleDeclarationBody> for FormatTsAnyExternalModuleDeclarationBody {
+    type Options = JsFormatOptions;
     fn format(
         node: &TsAnyExternalModuleDeclarationBody,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyExternalModuleDeclarationBody::TsEmptyExternalModuleDeclarationBody(node) => {

--- a/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatTsAnyIndexSignatureModifier;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyIndexSignatureModifier;
 impl FormatRule<TsAnyIndexSignatureModifier> for FormatTsAnyIndexSignatureModifier {
+    type Options = JsFormatOptions;
     fn format(
         node: &TsAnyIndexSignatureModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyIndexSignatureModifier::JsStaticModifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatTsAnyMethodSignatureModifier;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyMethodSignatureModifier;
 impl FormatRule<TsAnyMethodSignatureModifier> for FormatTsAnyMethodSignatureModifier {
+    type Options = JsFormatOptions;
     fn format(
         node: &TsAnyMethodSignatureModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyMethodSignatureModifier::TsAccessibilityModifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/module_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_name.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatTsAnyModuleName;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyModuleName;
 impl FormatRule<TsAnyModuleName> for FormatTsAnyModuleName {
-    fn format(node: &TsAnyModuleName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &TsAnyModuleName,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             TsAnyModuleName::TsIdentifierBinding(node) => formatted![formatter, [node.format()]],
             TsAnyModuleName::TsQualifiedModuleName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/ts/any/module_reference.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_reference.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatTsAnyModuleReference;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyModuleReference;
 impl FormatRule<TsAnyModuleReference> for FormatTsAnyModuleReference {
-    fn format(node: &TsAnyModuleReference, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &TsAnyModuleReference,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             TsAnyModuleReference::TsAnyName(node) => formatted![formatter, [node.format()]],
             TsAnyModuleReference::TsExternalModuleReference(node) => {

--- a/crates/rome_js_formatter/src/ts/any/name.rs
+++ b/crates/rome_js_formatter/src/ts/any/name.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatTsAnyName;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyName;
 impl FormatRule<TsAnyName> for FormatTsAnyName {
-    fn format(node: &TsAnyName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &TsAnyName,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             TsAnyName::JsReferenceIdentifier(node) => formatted![formatter, [node.format()]],
             TsAnyName::TsQualifiedName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/ts/any/property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_annotation.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatTsAnyPropertyAnnotation;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertyAnnotation;
 impl FormatRule<TsAnyPropertyAnnotation> for FormatTsAnyPropertyAnnotation {
+    type Options = JsFormatOptions;
     fn format(
         node: &TsAnyPropertyAnnotation,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyPropertyAnnotation::TsTypeAnnotation(node) => {

--- a/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatTsAnyPropertyParameterModifier;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertyParameterModifier;
 impl FormatRule<TsAnyPropertyParameterModifier> for FormatTsAnyPropertyParameterModifier {
+    type Options = JsFormatOptions;
     fn format(
         node: &TsAnyPropertyParameterModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyPropertyParameterModifier::TsAccessibilityModifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatTsAnyPropertySignatureAnnotation;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertySignatureAnnotation;
 impl FormatRule<TsAnyPropertySignatureAnnotation> for FormatTsAnyPropertySignatureAnnotation {
+    type Options = JsFormatOptions;
     fn format(
         node: &TsAnyPropertySignatureAnnotation,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyPropertySignatureAnnotation::TsTypeAnnotation(node) => {

--- a/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatTsAnyPropertySignatureModifier;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertySignatureModifier;
 impl FormatRule<TsAnyPropertySignatureModifier> for FormatTsAnyPropertySignatureModifier {
+    type Options = JsFormatOptions;
     fn format(
         node: &TsAnyPropertySignatureModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyPropertySignatureModifier::TsDeclareModifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/return_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/return_type.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatTsAnyReturnType;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyReturnType;
 impl FormatRule<TsAnyReturnType> for FormatTsAnyReturnType {
-    fn format(node: &TsAnyReturnType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &TsAnyReturnType,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             TsAnyReturnType::TsType(node) => formatted![formatter, [node.format()]],
             TsAnyReturnType::TsPredicateReturnType(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/ts/any/template_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/template_element.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatTsAnyTemplateElement;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTemplateElement;
 impl FormatRule<TsAnyTemplateElement> for FormatTsAnyTemplateElement {
-    fn format(node: &TsAnyTemplateElement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &TsAnyTemplateElement,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             TsAnyTemplateElement::TsTemplateChunkElement(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/ts/any/ts_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/ts_type.rs
@@ -4,7 +4,8 @@ use crate::generated::FormatTsType;
 use crate::prelude::*;
 use rome_js_syntax::TsType;
 impl FormatRule<TsType> for FormatTsType {
-    fn format(node: &TsType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(node: &TsType, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
         match node {
             TsType::TsAnyType(node) => formatted![formatter, [node.format()]],
             TsType::TsUnknownType(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatTsAnyTupleTypeElement;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTupleTypeElement;
 impl FormatRule<TsAnyTupleTypeElement> for FormatTsAnyTupleTypeElement {
-    fn format(node: &TsAnyTupleTypeElement, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &TsAnyTupleTypeElement,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             TsAnyTupleTypeElement::TsNamedTupleTypeElement(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/ts/any/type_member.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_member.rs
@@ -4,7 +4,11 @@ use crate::generated::FormatTsAnyTypeMember;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTypeMember;
 impl FormatRule<TsAnyTypeMember> for FormatTsAnyTypeMember {
-    fn format(node: &TsAnyTypeMember, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+    fn format(
+        node: &TsAnyTypeMember,
+        formatter: &Formatter<Self::Options>,
+    ) -> FormatResult<FormatElement> {
         match node {
             TsAnyTypeMember::TsCallSignatureTypeMember(node) => {
                 formatted![formatter, [node.format()]]

--- a/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatTsAnyTypePredicateParameterName;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTypePredicateParameterName;
 impl FormatRule<TsAnyTypePredicateParameterName> for FormatTsAnyTypePredicateParameterName {
+    type Options = JsFormatOptions;
     fn format(
         node: &TsAnyTypePredicateParameterName,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyTypePredicateParameterName::JsReferenceIdentifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
@@ -4,9 +4,10 @@ use crate::generated::FormatTsAnyVariableAnnotation;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyVariableAnnotation;
 impl FormatRule<TsAnyVariableAnnotation> for FormatTsAnyVariableAnnotation {
+    type Options = JsFormatOptions;
     fn format(
         node: &TsAnyVariableAnnotation,
-        formatter: &Formatter,
+        formatter: &Formatter<Self::Options>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyVariableAnnotation::TsTypeAnnotation(node) => {

--- a/crates/rome_js_formatter/src/ts/assignments/as_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/as_assignment.rs
@@ -4,7 +4,10 @@ use rome_js_syntax::TsAsAssignment;
 use rome_js_syntax::TsAsAssignmentFields;
 
 impl FormatNodeFields<TsAsAssignment> for FormatNodeRule<TsAsAssignment> {
-    fn format_fields(node: &TsAsAssignment, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsAsAssignment,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsAsAssignmentFields {
             assignment,
             as_token,

--- a/crates/rome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsNonNullAssertionAssignment>
 {
     fn format_fields(
         node: &TsNonNullAssertionAssignment,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsNonNullAssertionAssignmentFields {
             assignment,

--- a/crates/rome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsTypeAssertionAssignment;
 impl FormatNodeFields<TsTypeAssertionAssignment> for FormatNodeRule<TsTypeAssertionAssignment> {
     fn format_fields(
         node: &TsTypeAssertionAssignment,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTypeAssertionAssignmentFields {
             l_angle_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/abstract_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/abstract_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAbstractModifierFields;
 impl FormatNodeFields<TsAbstractModifier> for FormatNodeRule<TsAbstractModifier> {
     fn format_fields(
         node: &TsAbstractModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsAbstractModifierFields { modifier_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/accessibility_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/accessibility_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAccessibilityModifierFields;
 impl FormatNodeFields<TsAccessibilityModifier> for FormatNodeRule<TsAccessibilityModifier> {
     fn format_fields(
         node: &TsAccessibilityModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsAccessibilityModifierFields { modifier_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/asserts_condition.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/asserts_condition.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAssertsConditionFields;
 impl FormatNodeFields<TsAssertsCondition> for FormatNodeRule<TsAssertsCondition> {
     fn format_fields(
         node: &TsAssertsCondition,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsAssertsConditionFields { is_token, ty } = node.as_fields();
         formatted![formatter, [is_token.format(), space_token(), ty.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/call_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/call_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsCallSignatureTypeMember, TsCallSignatureTypeMemberFields}
 impl FormatNodeFields<TsCallSignatureTypeMember> for FormatNodeRule<TsCallSignatureTypeMember> {
     fn format_fields(
         node: &TsCallSignatureTypeMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsCallSignatureTypeMemberFields {
             type_parameters,

--- a/crates/rome_js_formatter/src/ts/auxiliary/construct_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/construct_signature_type_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsConstructSignatureTypeMember>
 {
     fn format_fields(
         node: &TsConstructSignatureTypeMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsConstructSignatureTypeMemberFields {
             new_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/declare_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/declare_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsDeclareModifierFields;
 impl FormatNodeFields<TsDeclareModifier> for FormatNodeRule<TsDeclareModifier> {
     fn format_fields(
         node: &TsDeclareModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsDeclareModifierFields { modifier_token } = node.as_fields();
         formatted![formatter, [modifier_token.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/default_type_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/default_type_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsDefaultTypeClause, TsDefaultTypeClauseFields};
 impl FormatNodeFields<TsDefaultTypeClause> for FormatNodeRule<TsDefaultTypeClause> {
     fn format_fields(
         node: &TsDefaultTypeClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsDefaultTypeClauseFields { eq_token, ty } = node.as_fields();
         formatted![formatter, [eq_token.format(), space_token(), ty.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/definite_property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/definite_property_annotation.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsDefinitePropertyAnnotation>
 {
     fn format_fields(
         node: &TsDefinitePropertyAnnotation,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsDefinitePropertyAnnotationFields {
             excl_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/definite_variable_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/definite_variable_annotation.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsDefiniteVariableAnnotation>
 {
     fn format_fields(
         node: &TsDefiniteVariableAnnotation,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsDefiniteVariableAnnotationFields {
             excl_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/empty_external_module_declaration_body.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/empty_external_module_declaration_body.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsEmptyExternalModuleDeclarationBody>
 {
     fn format_fields(
         node: &TsEmptyExternalModuleDeclarationBody,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsEmptyExternalModuleDeclarationBodyFields { semicolon_token } = node.as_fields();
         formatted![formatter, [semicolon_token.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/enum_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/enum_member.rs
@@ -4,7 +4,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsEnumMember, TsEnumMemberFields};
 
 impl FormatNodeFields<TsEnumMember> for FormatNodeRule<TsEnumMember> {
-    fn format_fields(node: &TsEnumMember, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsEnumMember,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsEnumMemberFields { name, initializer } = node.as_fields();
 
         let name = name.format();

--- a/crates/rome_js_formatter/src/ts/auxiliary/external_module_reference.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/external_module_reference.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsExternalModuleReferenceFields;
 impl FormatNodeFields<TsExternalModuleReference> for FormatNodeRule<TsExternalModuleReference> {
     fn format_fields(
         node: &TsExternalModuleReference,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsExternalModuleReferenceFields {
             require_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/getter_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/getter_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsGetterSignatureTypeMember, TsGetterSignatureTypeMemberFie
 impl FormatNodeFields<TsGetterSignatureTypeMember> for FormatNodeRule<TsGetterSignatureTypeMember> {
     fn format_fields(
         node: &TsGetterSignatureTypeMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsGetterSignatureTypeMemberFields {
             get_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/implements_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/implements_clause.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsImplementsClauseFields;
 impl FormatNodeFields<TsImplementsClause> for FormatNodeRule<TsImplementsClause> {
     fn format_fields(
         node: &TsImplementsClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsImplementsClauseFields {
             implements_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/index_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/index_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsIndexSignatureTypeMember, TsIndexSignatureTypeMemberField
 impl FormatNodeFields<TsIndexSignatureTypeMember> for FormatNodeRule<TsIndexSignatureTypeMember> {
     fn format_fields(
         node: &TsIndexSignatureTypeMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsIndexSignatureTypeMemberFields {
             readonly_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_as_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_as_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsMappedTypeAsClause, TsMappedTypeAsClauseFields};
 impl FormatNodeFields<TsMappedTypeAsClause> for FormatNodeRule<TsMappedTypeAsClause> {
     fn format_fields(
         node: &TsMappedTypeAsClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsMappedTypeAsClauseFields { as_token, ty } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_optional_modifier_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_optional_modifier_clause.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsMappedTypeOptionalModifierClause>
 {
     fn format_fields(
         node: &TsMappedTypeOptionalModifierClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsMappedTypeOptionalModifierClauseFields {
             operator_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_readonly_modifier_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_readonly_modifier_clause.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsMappedTypeReadonlyModifierClause>
 {
     fn format_fields(
         node: &TsMappedTypeReadonlyModifierClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsMappedTypeReadonlyModifierClauseFields {
             operator_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/method_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/method_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsMethodSignatureTypeMember, TsMethodSignatureTypeMemberFie
 impl FormatNodeFields<TsMethodSignatureTypeMember> for FormatNodeRule<TsMethodSignatureTypeMember> {
     fn format_fields(
         node: &TsMethodSignatureTypeMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsMethodSignatureTypeMemberFields {
             name,

--- a/crates/rome_js_formatter/src/ts/auxiliary/module_block.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/module_block.rs
@@ -4,7 +4,10 @@ use rome_js_syntax::TsModuleBlock;
 use rome_js_syntax::TsModuleBlockFields;
 
 impl FormatNodeFields<TsModuleBlock> for FormatNodeRule<TsModuleBlock> {
-    fn format_fields(node: &TsModuleBlock, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsModuleBlock,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsModuleBlockFields {
             l_curly_token,
             items,

--- a/crates/rome_js_formatter/src/ts/auxiliary/named_tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/named_tuple_type_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNamedTupleTypeElement, TsNamedTupleTypeElementFields};
 impl FormatNodeFields<TsNamedTupleTypeElement> for FormatNodeRule<TsNamedTupleTypeElement> {
     fn format_fields(
         node: &TsNamedTupleTypeElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsNamedTupleTypeElementFields {
             ty,

--- a/crates/rome_js_formatter/src/ts/auxiliary/optional_property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/optional_property_annotation.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsOptionalPropertyAnnotation>
 {
     fn format_fields(
         node: &TsOptionalPropertyAnnotation,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsOptionalPropertyAnnotationFields {
             question_mark_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/optional_tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/optional_tuple_type_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsOptionalTupleTypeElement, TsOptionalTupleTypeElementField
 impl FormatNodeFields<TsOptionalTupleTypeElement> for FormatNodeRule<TsOptionalTupleTypeElement> {
     fn format_fields(
         node: &TsOptionalTupleTypeElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsOptionalTupleTypeElementFields {
             ty,

--- a/crates/rome_js_formatter/src/ts/auxiliary/override_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/override_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsOverrideModifierFields;
 impl FormatNodeFields<TsOverrideModifier> for FormatNodeRule<TsOverrideModifier> {
     fn format_fields(
         node: &TsOverrideModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsOverrideModifierFields { modifier_token } = node.as_fields();
         formatted![formatter, [modifier_token.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsPropertySignatureTypeMember>
 {
     fn format_fields(
         node: &TsPropertySignatureTypeMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsPropertySignatureTypeMemberFields {
             readonly_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/qualified_module_name.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/qualified_module_name.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsQualifiedModuleNameFields;
 impl FormatNodeFields<TsQualifiedModuleName> for FormatNodeRule<TsQualifiedModuleName> {
     fn format_fields(
         node: &TsQualifiedModuleName,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsQualifiedModuleNameFields {
             left,

--- a/crates/rome_js_formatter/src/ts/auxiliary/qualified_name.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/qualified_name.rs
@@ -4,7 +4,10 @@ use rome_js_syntax::TsQualifiedName;
 use rome_js_syntax::TsQualifiedNameFields;
 
 impl FormatNodeFields<TsQualifiedName> for FormatNodeRule<TsQualifiedName> {
-    fn format_fields(node: &TsQualifiedName, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsQualifiedName,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsQualifiedNameFields {
             left,
             dot_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/readonly_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/readonly_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsReadonlyModifierFields;
 impl FormatNodeFields<TsReadonlyModifier> for FormatNodeRule<TsReadonlyModifier> {
     fn format_fields(
         node: &TsReadonlyModifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsReadonlyModifierFields { modifier_token } = node.as_fields();
         formatted![formatter, [modifier_token.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/rest_tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/rest_tuple_type_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsRestTupleTypeElement, TsRestTupleTypeElementFields};
 impl FormatNodeFields<TsRestTupleTypeElement> for FormatNodeRule<TsRestTupleTypeElement> {
     fn format_fields(
         node: &TsRestTupleTypeElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsRestTupleTypeElementFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/return_type_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/return_type_annotation.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsReturnTypeAnnotationFields;
 impl FormatNodeFields<TsReturnTypeAnnotation> for FormatNodeRule<TsReturnTypeAnnotation> {
     fn format_fields(
         node: &TsReturnTypeAnnotation,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsReturnTypeAnnotationFields { colon_token, ty } = node.as_fields();
         formatted![

--- a/crates/rome_js_formatter/src/ts/auxiliary/setter_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/setter_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsSetterSignatureTypeMember, TsSetterSignatureTypeMemberFie
 impl FormatNodeFields<TsSetterSignatureTypeMember> for FormatNodeRule<TsSetterSignatureTypeMember> {
     fn format_fields(
         node: &TsSetterSignatureTypeMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsSetterSignatureTypeMemberFields {
             set_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/type_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/type_annotation.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeAnnotation, TsTypeAnnotationFields};
 impl FormatNodeFields<TsTypeAnnotation> for FormatNodeRule<TsTypeAnnotation> {
     fn format_fields(
         node: &TsTypeAnnotation,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTypeAnnotationFields { colon_token, ty } = node.as_fields();
         let colon = colon_token.format();

--- a/crates/rome_js_formatter/src/ts/auxiliary/type_constraint_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/type_constraint_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeConstraintClause, TsTypeConstraintClauseFields};
 impl FormatNodeFields<TsTypeConstraintClause> for FormatNodeRule<TsTypeConstraintClause> {
     fn format_fields(
         node: &TsTypeConstraintClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTypeConstraintClauseFields { extends_token, ty } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/type_parameter_name.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/type_parameter_name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeParameterName, TsTypeParameterNameFields};
 impl FormatNodeFields<TsTypeParameterName> for FormatNodeRule<TsTypeParameterName> {
     fn format_fields(
         node: &TsTypeParameterName,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTypeParameterNameFields { ident_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/bindings/identifier_binding.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/identifier_binding.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsIdentifierBinding, TsIdentifierBindingFields};
 impl FormatNodeFields<TsIdentifierBinding> for FormatNodeRule<TsIdentifierBinding> {
     fn format_fields(
         node: &TsIdentifierBinding,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsIdentifierBindingFields { name_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/bindings/index_signature_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/index_signature_parameter.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsIndexSignatureParameter, TsIndexSignatureParameterFields}
 impl FormatNodeFields<TsIndexSignatureParameter> for FormatNodeRule<TsIndexSignatureParameter> {
     fn format_fields(
         node: &TsIndexSignatureParameter,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsIndexSignatureParameterFields {
             binding,

--- a/crates/rome_js_formatter/src/ts/bindings/property_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/property_parameter.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsPropertyParameter, TsPropertyParameterFields};
 impl FormatNodeFields<TsPropertyParameter> for FormatNodeRule<TsPropertyParameter> {
     fn format_fields(
         node: &TsPropertyParameter,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsPropertyParameterFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/bindings/this_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/this_parameter.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsThisParameter, TsThisParameterFields};
 
 impl FormatNodeFields<TsThisParameter> for FormatNodeRule<TsThisParameter> {
-    fn format_fields(node: &TsThisParameter, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsThisParameter,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsThisParameterFields {
             this_token,
             type_annotation,

--- a/crates/rome_js_formatter/src/ts/bindings/type_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/type_parameter.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsTypeParameter, TsTypeParameterFields};
 
 impl FormatNodeFields<TsTypeParameter> for FormatNodeRule<TsTypeParameter> {
-    fn format_fields(node: &TsTypeParameter, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsTypeParameter,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsTypeParameterFields {
             name,
             constraint,

--- a/crates/rome_js_formatter/src/ts/bindings/type_parameters.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/type_parameters.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeParameters, TsTypeParametersFields};
 impl FormatNodeFields<TsTypeParameters> for FormatNodeRule<TsTypeParameters> {
     fn format_fields(
         node: &TsTypeParameters,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTypeParametersFields {
             items,

--- a/crates/rome_js_formatter/src/ts/classes/constructor_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/constructor_signature_class_member.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<TsConstructorSignatureClassMember>
 {
     fn format_fields(
         node: &TsConstructorSignatureClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsConstructorSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/extends_clause.rs
+++ b/crates/rome_js_formatter/src/ts/classes/extends_clause.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsExtendsClause, TsExtendsClauseFields};
 
 impl FormatNodeFields<TsExtendsClause> for FormatNodeRule<TsExtendsClause> {
-    fn format_fields(node: &TsExtendsClause, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsExtendsClause,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsExtendsClauseFields {
             extends_token,
             types,

--- a/crates/rome_js_formatter/src/ts/classes/getter_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/getter_signature_class_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsGetterSignatureClassMember>
 {
     fn format_fields(
         node: &TsGetterSignatureClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsGetterSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/index_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/index_signature_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsIndexSignatureClassMemberFields;
 impl FormatNodeFields<TsIndexSignatureClassMember> for FormatNodeRule<TsIndexSignatureClassMember> {
     fn format_fields(
         node: &TsIndexSignatureClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsIndexSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/method_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/method_signature_class_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsMethodSignatureClassMember>
 {
     fn format_fields(
         node: &TsMethodSignatureClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsMethodSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsPropertySignatureClassMember>
 {
     fn format_fields(
         node: &TsPropertySignatureClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsPropertySignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/setter_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/setter_signature_class_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsSetterSignatureClassMember>
 {
     fn format_fields(
         node: &TsSetterSignatureClassMember,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsSetterSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/declarations/declare_function_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/declare_function_declaration.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<TsDeclareFunctionDeclaration>
 {
     fn format_fields(
         node: &TsDeclareFunctionDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsDeclareFunctionDeclarationFields {
             async_token,

--- a/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsEnumDeclaration, TsEnumDeclarationFields};
 impl FormatNodeFields<TsEnumDeclaration> for FormatNodeRule<TsEnumDeclaration> {
     fn format_fields(
         node: &TsEnumDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsEnumDeclarationFields {
             const_token,

--- a/crates/rome_js_formatter/src/ts/declarations/external_module_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/external_module_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsExternalModuleDeclarationFields;
 impl FormatNodeFields<TsExternalModuleDeclaration> for FormatNodeRule<TsExternalModuleDeclaration> {
     fn format_fields(
         node: &TsExternalModuleDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsExternalModuleDeclarationFields {
             body,

--- a/crates/rome_js_formatter/src/ts/declarations/global_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/global_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsGlobalDeclarationFields;
 impl FormatNodeFields<TsGlobalDeclaration> for FormatNodeRule<TsGlobalDeclaration> {
     fn format_fields(
         node: &TsGlobalDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsGlobalDeclarationFields { global_token, body } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/declarations/import_equals_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/import_equals_declaration.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsImportEqualsDeclarationFields;
 impl FormatNodeFields<TsImportEqualsDeclaration> for FormatNodeRule<TsImportEqualsDeclaration> {
     fn format_fields(
         node: &TsImportEqualsDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsImportEqualsDeclarationFields {
             import_token,

--- a/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsInterfaceDeclaration, TsInterfaceDeclarationFields};
 impl FormatNodeFields<TsInterfaceDeclaration> for FormatNodeRule<TsInterfaceDeclaration> {
     fn format_fields(
         node: &TsInterfaceDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsInterfaceDeclarationFields {
             interface_token,

--- a/crates/rome_js_formatter/src/ts/declarations/module_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/module_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsModuleDeclarationFields;
 impl FormatNodeFields<TsModuleDeclaration> for FormatNodeRule<TsModuleDeclaration> {
     fn format_fields(
         node: &TsModuleDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsModuleDeclarationFields {
             module_or_namespace,

--- a/crates/rome_js_formatter/src/ts/declarations/type_alias_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/type_alias_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsTypeAliasDeclaration, TsTypeAliasDeclarationFields};
 impl FormatNodeFields<TsTypeAliasDeclaration> for FormatNodeRule<TsTypeAliasDeclaration> {
     fn format_fields(
         node: &TsTypeAliasDeclaration,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTypeAliasDeclarationFields {
             type_token,

--- a/crates/rome_js_formatter/src/ts/expressions/as_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/as_expression.rs
@@ -4,7 +4,10 @@ use rome_js_syntax::TsAsExpression;
 use rome_js_syntax::TsAsExpressionFields;
 
 impl FormatNodeFields<TsAsExpression> for FormatNodeRule<TsAsExpression> {
-    fn format_fields(node: &TsAsExpression, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsAsExpression,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsAsExpressionFields {
             ty,
             as_token,

--- a/crates/rome_js_formatter/src/ts/expressions/name_with_type_arguments.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/name_with_type_arguments.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNameWithTypeArguments, TsNameWithTypeArgumentsFields};
 impl FormatNodeFields<TsNameWithTypeArguments> for FormatNodeRule<TsNameWithTypeArguments> {
     fn format_fields(
         node: &TsNameWithTypeArguments,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsNameWithTypeArgumentsFields {
             name,

--- a/crates/rome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsNonNullAssertionExpression>
 {
     fn format_fields(
         node: &TsNonNullAssertionExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsNonNullAssertionExpressionFields {
             expression,

--- a/crates/rome_js_formatter/src/ts/expressions/template_chunk_element.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/template_chunk_element.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsTemplateChunkElement, TsTemplateChunkElementFields};
 impl FormatNodeFields<TsTemplateChunkElement> for FormatNodeRule<TsTemplateChunkElement> {
     fn format_fields(
         node: &TsTemplateChunkElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTemplateChunkElementFields {
             template_chunk_token,

--- a/crates/rome_js_formatter/src/ts/expressions/template_element.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/template_element.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsTemplateElement;
 impl FormatNodeFields<TsTemplateElement> for FormatNodeRule<TsTemplateElement> {
     fn format_fields(
         node: &TsTemplateElement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_template_literal(TemplateElement::Ts(node.clone()), formatter)
     }

--- a/crates/rome_js_formatter/src/ts/expressions/template_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/template_literal_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsTemplateLiteralTypeFields;
 impl FormatNodeFields<TsTemplateLiteralType> for FormatNodeRule<TsTemplateLiteralType> {
     fn format_fields(
         node: &TsTemplateLiteralType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTemplateLiteralTypeFields {
             l_tick_token,

--- a/crates/rome_js_formatter/src/ts/expressions/type_arguments.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/type_arguments.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsTypeArguments, TsTypeArgumentsFields};
 
 impl FormatNodeFields<TsTypeArguments> for FormatNodeRule<TsTypeArguments> {
-    fn format_fields(node: &TsTypeArguments, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsTypeArguments,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsTypeArgumentsFields {
             l_angle_token,
             ts_type_argument_list,

--- a/crates/rome_js_formatter/src/ts/expressions/type_assertion_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/type_assertion_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsTypeAssertionExpressionFields;
 impl FormatNodeFields<TsTypeAssertionExpression> for FormatNodeRule<TsTypeAssertionExpression> {
     fn format_fields(
         node: &TsTypeAssertionExpression,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTypeAssertionExpressionFields {
             l_angle_token,

--- a/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
@@ -4,7 +4,12 @@ use crate::prelude::*;
 use rome_js_syntax::TsEnumMemberList;
 
 impl FormatRule<TsEnumMemberList> for FormatTsEnumMemberList {
-    fn format(node: &TsEnumMemberList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &TsEnumMemberList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),
             formatter.format_separated(node, || token(","), TrailingSeparator::default())?,

--- a/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
@@ -4,9 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::TsIndexSignatureModifierList;
 
 impl FormatRule<TsIndexSignatureModifierList> for FormatTsIndexSignatureModifierList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &TsIndexSignatureModifierList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
@@ -4,9 +4,11 @@ use rome_js_syntax::TsIntersectionTypeElementList;
 use rome_rowan::AstSeparatedList;
 
 impl FormatRule<TsIntersectionTypeElementList> for FormatTsIntersectionTypeElementList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &TsIntersectionTypeElementList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let mut elements = Vec::with_capacity(node.len());
         let last_index = node.len().saturating_sub(1);

--- a/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
@@ -4,9 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::TsMethodSignatureModifierList;
 
 impl FormatRule<TsMethodSignatureModifierList> for FormatTsMethodSignatureModifierList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &TsMethodSignatureModifierList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
@@ -4,9 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::TsPropertyParameterModifierList;
 
 impl FormatRule<TsPropertyParameterModifierList> for FormatTsPropertyParameterModifierList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &TsPropertyParameterModifierList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
@@ -4,9 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::TsPropertySignatureModifierList;
 
 impl FormatRule<TsPropertySignatureModifierList> for FormatTsPropertySignatureModifierList {
+    type Options = JsFormatOptions;
+
     fn format(
         node: &TsPropertySignatureModifierList,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
@@ -4,7 +4,12 @@ use rome_js_syntax::TsTemplateElementList;
 use rome_rowan::AstNodeList;
 
 impl FormatRule<TsTemplateElementList> for FormatTsTemplateElementList {
-    fn format(node: &TsTemplateElementList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &TsTemplateElementList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(concat_elements(
             formatter.format_all(node.iter().formatted())?,
         ))

--- a/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
@@ -4,7 +4,12 @@ use crate::prelude::*;
 use rome_js_syntax::TsTupleTypeElementList;
 
 impl FormatRule<TsTupleTypeElementList> for FormatTsTupleTypeElementList {
-    fn format(node: &TsTupleTypeElementList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &TsTupleTypeElementList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),
             formatter.format_separated(node, || token(","), TrailingSeparator::default())?,

--- a/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
@@ -4,7 +4,12 @@ use crate::prelude::*;
 use rome_js_syntax::TsTypeArgumentList;
 
 impl FormatRule<TsTypeArgumentList> for FormatTsTypeArgumentList {
-    fn format(node: &TsTypeArgumentList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &TsTypeArgumentList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),
             formatter.format_separated(node, || token(","), TrailingSeparator::Disallowed)?,

--- a/crates/rome_js_formatter/src/ts/lists/type_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_list.rs
@@ -4,7 +4,12 @@ use crate::prelude::*;
 use rome_js_syntax::TsTypeList;
 
 impl FormatRule<TsTypeList> for FormatTsTypeList {
-    fn format(node: &TsTypeList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &TsTypeList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         // the grouping will be applied by the parent
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
@@ -4,7 +4,12 @@ use rome_js_syntax::TsTypeMemberList;
 use rome_rowan::AstNodeList;
 
 impl FormatRule<TsTypeMemberList> for FormatTsTypeMemberList {
-    fn format(node: &TsTypeMemberList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &TsTypeMemberList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let items = node.iter();
         let last_index = items.len().saturating_sub(1);
 

--- a/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
@@ -5,7 +5,12 @@ use rome_js_syntax::TsTypeParameterList;
 use rome_rowan::AstSeparatedList;
 
 impl FormatRule<TsTypeParameterList> for FormatTsTypeParameterList {
-    fn format(node: &TsTypeParameterList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &TsTypeParameterList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         // nodes and formatter are not aware of the source type (TSX vs TS), which means we can't
         // exactly pin point the exact case.
         //

--- a/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
@@ -4,7 +4,12 @@ use rome_js_syntax::TsUnionTypeVariantList;
 use rome_rowan::AstSeparatedList;
 
 impl FormatRule<TsUnionTypeVariantList> for FormatTsUnionTypeVariantList {
-    fn format(node: &TsUnionTypeVariantList, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(
+        node: &TsUnionTypeVariantList,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let mut elements = Vec::with_capacity(node.len());
         let last_index = node.len().saturating_sub(1);
 

--- a/crates/rome_js_formatter/src/ts/module/export_as_namespace_clause.rs
+++ b/crates/rome_js_formatter/src/ts/module/export_as_namespace_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsExportAsNamespaceClauseFields;
 impl FormatNodeFields<TsExportAsNamespaceClause> for FormatNodeRule<TsExportAsNamespaceClause> {
     fn format_fields(
         node: &TsExportAsNamespaceClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsExportAsNamespaceClauseFields {
             as_token,

--- a/crates/rome_js_formatter/src/ts/module/export_assignment_clause.rs
+++ b/crates/rome_js_formatter/src/ts/module/export_assignment_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsExportAssignmentClauseFields;
 impl FormatNodeFields<TsExportAssignmentClause> for FormatNodeRule<TsExportAssignmentClause> {
     fn format_fields(
         node: &TsExportAssignmentClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsExportAssignmentClauseFields {
             eq_token,

--- a/crates/rome_js_formatter/src/ts/module/export_declare_clause.rs
+++ b/crates/rome_js_formatter/src/ts/module/export_declare_clause.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsExportDeclareClauseFields;
 impl FormatNodeFields<TsExportDeclareClause> for FormatNodeRule<TsExportDeclareClause> {
     fn format_fields(
         node: &TsExportDeclareClause,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsExportDeclareClauseFields {
             declare_token,

--- a/crates/rome_js_formatter/src/ts/module/import_type.rs
+++ b/crates/rome_js_formatter/src/ts/module/import_type.rs
@@ -5,7 +5,10 @@ use rome_js_syntax::TsImportType;
 use rome_js_syntax::TsImportTypeFields;
 
 impl FormatNodeFields<TsImportType> for FormatNodeRule<TsImportType> {
-    fn format_fields(node: &TsImportType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsImportType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsImportTypeFields {
             typeof_token,
             import_token,

--- a/crates/rome_js_formatter/src/ts/module/import_type_qualifier.rs
+++ b/crates/rome_js_formatter/src/ts/module/import_type_qualifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsImportTypeQualifierFields;
 impl FormatNodeFields<TsImportTypeQualifier> for FormatNodeRule<TsImportTypeQualifier> {
     fn format_fields(
         node: &TsImportTypeQualifier,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsImportTypeQualifierFields { dot_token, right } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/statements/declare_statement.rs
+++ b/crates/rome_js_formatter/src/ts/statements/declare_statement.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsDeclareStatementFields;
 impl FormatNodeFields<TsDeclareStatement> for FormatNodeRule<TsDeclareStatement> {
     fn format_fields(
         node: &TsDeclareStatement,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsDeclareStatementFields {
             declaration,

--- a/crates/rome_js_formatter/src/ts/types/any_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/any_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsAnyType, TsAnyTypeFields};
 
 impl FormatNodeFields<TsAnyType> for FormatNodeRule<TsAnyType> {
-    fn format_fields(node: &TsAnyType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsAnyType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsAnyTypeFields { any_token } = node.as_fields();
 
         formatted![formatter, [any_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/array_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/array_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsArrayType, TsArrayTypeFields};
 
 impl FormatNodeFields<TsArrayType> for FormatNodeRule<TsArrayType> {
-    fn format_fields(node: &TsArrayType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsArrayType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsArrayTypeFields {
             l_brack_token,
             element_type,

--- a/crates/rome_js_formatter/src/ts/types/asserts_return_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/asserts_return_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAssertsReturnTypeFields;
 impl FormatNodeFields<TsAssertsReturnType> for FormatNodeRule<TsAssertsReturnType> {
     fn format_fields(
         node: &TsAssertsReturnType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsAssertsReturnTypeFields {
             parameter_name,

--- a/crates/rome_js_formatter/src/ts/types/big_int_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/big_int_literal_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsBigIntLiteralType, TsBigIntLiteralTypeFields};
 impl FormatNodeFields<TsBigIntLiteralType> for FormatNodeRule<TsBigIntLiteralType> {
     fn format_fields(
         node: &TsBigIntLiteralType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsBigIntLiteralTypeFields {
             minus_token,

--- a/crates/rome_js_formatter/src/ts/types/bigint_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/bigint_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsBigintType, TsBigintTypeFields};
 
 impl FormatNodeFields<TsBigintType> for FormatNodeRule<TsBigintType> {
-    fn format_fields(node: &TsBigintType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsBigintType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsBigintTypeFields { bigint_token } = node.as_fields();
 
         formatted![formatter, [bigint_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/boolean_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/boolean_literal_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsBooleanLiteralType, TsBooleanLiteralTypeFields};
 impl FormatNodeFields<TsBooleanLiteralType> for FormatNodeRule<TsBooleanLiteralType> {
     fn format_fields(
         node: &TsBooleanLiteralType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsBooleanLiteralTypeFields { literal } = node.as_fields();
         formatted![formatter, [literal.format()]]

--- a/crates/rome_js_formatter/src/ts/types/boolean_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/boolean_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsBooleanType, TsBooleanTypeFields};
 
 impl FormatNodeFields<TsBooleanType> for FormatNodeRule<TsBooleanType> {
-    fn format_fields(node: &TsBooleanType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsBooleanType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsBooleanTypeFields { boolean_token } = node.as_fields();
 
         formatted![formatter, [boolean_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/conditional_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/conditional_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsConditionalType;
 impl FormatNodeFields<TsConditionalType> for FormatNodeRule<TsConditionalType> {
     fn format_fields(
         node: &TsConditionalType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         format_conditional(Conditional::Type(node.clone()), formatter, false)
     }

--- a/crates/rome_js_formatter/src/ts/types/constructor_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/constructor_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsConstructorTypeFields;
 impl FormatNodeFields<TsConstructorType> for FormatNodeRule<TsConstructorType> {
     fn format_fields(
         node: &TsConstructorType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsConstructorTypeFields {
             abstract_token,

--- a/crates/rome_js_formatter/src/ts/types/function_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/function_type.rs
@@ -4,7 +4,10 @@ use rome_js_syntax::TsFunctionType;
 use rome_js_syntax::TsFunctionTypeFields;
 
 impl FormatNodeFields<TsFunctionType> for FormatNodeRule<TsFunctionType> {
-    fn format_fields(node: &TsFunctionType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsFunctionType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsFunctionTypeFields {
             parameters,
             fat_arrow_token,

--- a/crates/rome_js_formatter/src/ts/types/indexed_access_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/indexed_access_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsIndexedAccessTypeFields;
 impl FormatNodeFields<TsIndexedAccessType> for FormatNodeRule<TsIndexedAccessType> {
     fn format_fields(
         node: &TsIndexedAccessType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsIndexedAccessTypeFields {
             object_type,

--- a/crates/rome_js_formatter/src/ts/types/infer_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/infer_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsInferType, TsInferTypeFields};
 
 impl FormatNodeFields<TsInferType> for FormatNodeRule<TsInferType> {
-    fn format_fields(node: &TsInferType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsInferType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsInferTypeFields {
             infer_token,
             type_parameter,

--- a/crates/rome_js_formatter/src/ts/types/intersection_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/intersection_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsIntersectionTypeFields;
 impl FormatNodeFields<TsIntersectionType> for FormatNodeRule<TsIntersectionType> {
     fn format_fields(
         node: &TsIntersectionType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsIntersectionTypeFields {
             leading_separator_token,

--- a/crates/rome_js_formatter/src/ts/types/mapped_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/mapped_type.rs
@@ -4,7 +4,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsMappedType, TsMappedTypeFields};
 
 impl FormatNodeFields<TsMappedType> for FormatNodeRule<TsMappedType> {
-    fn format_fields(node: &TsMappedType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsMappedType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsMappedTypeFields {
             l_curly_token,
             readonly_modifier,

--- a/crates/rome_js_formatter/src/ts/types/never_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/never_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsNeverType, TsNeverTypeFields};
 
 impl FormatNodeFields<TsNeverType> for FormatNodeRule<TsNeverType> {
-    fn format_fields(node: &TsNeverType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsNeverType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsNeverTypeFields { never_token } = node.as_fields();
         formatted![formatter, [never_token.format()]]
     }

--- a/crates/rome_js_formatter/src/ts/types/non_primitive_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/non_primitive_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNonPrimitiveType, TsNonPrimitiveTypeFields};
 impl FormatNodeFields<TsNonPrimitiveType> for FormatNodeRule<TsNonPrimitiveType> {
     fn format_fields(
         node: &TsNonPrimitiveType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsNonPrimitiveTypeFields { object_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/null_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/null_literal_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNullLiteralType, TsNullLiteralTypeFields};
 impl FormatNodeFields<TsNullLiteralType> for FormatNodeRule<TsNullLiteralType> {
     fn format_fields(
         node: &TsNullLiteralType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsNullLiteralTypeFields { literal_token } = node.as_fields();
         formatted![formatter, [literal_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/number_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/number_literal_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNumberLiteralType, TsNumberLiteralTypeFields};
 impl FormatNodeFields<TsNumberLiteralType> for FormatNodeRule<TsNumberLiteralType> {
     fn format_fields(
         node: &TsNumberLiteralType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsNumberLiteralTypeFields {
             minus_token,

--- a/crates/rome_js_formatter/src/ts/types/number_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/number_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsNumberType, TsNumberTypeFields};
 
 impl FormatNodeFields<TsNumberType> for FormatNodeRule<TsNumberType> {
-    fn format_fields(node: &TsNumberType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsNumberType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsNumberTypeFields { number_token } = node.as_fields();
 
         formatted![formatter, [number_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/object_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/object_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsObjectType, TsObjectTypeFields};
 
 impl FormatNodeFields<TsObjectType> for FormatNodeRule<TsObjectType> {
-    fn format_fields(node: &TsObjectType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsObjectType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsObjectTypeFields {
             l_curly_token,
             members,

--- a/crates/rome_js_formatter/src/ts/types/parenthesized_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/parenthesized_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsParenthesizedTypeFields;
 impl FormatNodeFields<TsParenthesizedType> for FormatNodeRule<TsParenthesizedType> {
     fn format_fields(
         node: &TsParenthesizedType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsParenthesizedTypeFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/ts/types/predicate_return_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/predicate_return_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsPredicateReturnTypeFields;
 impl FormatNodeFields<TsPredicateReturnType> for FormatNodeRule<TsPredicateReturnType> {
     fn format_fields(
         node: &TsPredicateReturnType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsPredicateReturnTypeFields {
             parameter_name,

--- a/crates/rome_js_formatter/src/ts/types/reference_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/reference_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsReferenceType, TsReferenceTypeFields};
 
 impl FormatNodeFields<TsReferenceType> for FormatNodeRule<TsReferenceType> {
-    fn format_fields(node: &TsReferenceType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsReferenceType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsReferenceTypeFields {
             name,
             type_arguments,

--- a/crates/rome_js_formatter/src/ts/types/string_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/string_literal_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsStringLiteralType, TsStringLiteralTypeFields};
 impl FormatNodeFields<TsStringLiteralType> for FormatNodeRule<TsStringLiteralType> {
     fn format_fields(
         node: &TsStringLiteralType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsStringLiteralTypeFields { literal_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/string_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/string_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsStringType, TsStringTypeFields};
 
 impl FormatNodeFields<TsStringType> for FormatNodeRule<TsStringType> {
-    fn format_fields(node: &TsStringType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsStringType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsStringTypeFields { string_token } = node.as_fields();
 
         formatted![formatter, [string_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/symbol_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/symbol_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsSymbolType, TsSymbolTypeFields};
 
 impl FormatNodeFields<TsSymbolType> for FormatNodeRule<TsSymbolType> {
-    fn format_fields(node: &TsSymbolType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsSymbolType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsSymbolTypeFields { symbol_token } = node.as_fields();
 
         formatted![formatter, [symbol_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/this_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/this_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsThisType, TsThisTypeFields};
 
 impl FormatNodeFields<TsThisType> for FormatNodeRule<TsThisType> {
-    fn format_fields(node: &TsThisType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsThisType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsThisTypeFields { this_token } = node.as_fields();
 
         formatted![formatter, [this_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/tuple_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/tuple_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsTupleType, TsTupleTypeFields};
 
 impl FormatNodeFields<TsTupleType> for FormatNodeRule<TsTupleType> {
-    fn format_fields(node: &TsTupleType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsTupleType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsTupleTypeFields {
             l_brack_token,
             elements,

--- a/crates/rome_js_formatter/src/ts/types/type_operator_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/type_operator_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeOperatorType, TsTypeOperatorTypeFields};
 impl FormatNodeFields<TsTypeOperatorType> for FormatNodeRule<TsTypeOperatorType> {
     fn format_fields(
         node: &TsTypeOperatorType,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let TsTypeOperatorTypeFields { operator_token, ty } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/typeof_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/typeof_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsTypeofType, TsTypeofTypeFields};
 
 impl FormatNodeFields<TsTypeofType> for FormatNodeRule<TsTypeofType> {
-    fn format_fields(node: &TsTypeofType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsTypeofType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsTypeofTypeFields {
             typeof_token,
             expression_name,

--- a/crates/rome_js_formatter/src/ts/types/undefined_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/undefined_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsUndefinedType, TsUndefinedTypeFields};
 
 impl FormatNodeFields<TsUndefinedType> for FormatNodeRule<TsUndefinedType> {
-    fn format_fields(node: &TsUndefinedType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsUndefinedType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsUndefinedTypeFields { undefined_token } = node.as_fields();
 
         formatted![formatter, [undefined_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/union_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/union_type.rs
@@ -4,7 +4,10 @@ use rome_js_syntax::TsUnionType;
 use rome_js_syntax::TsUnionTypeFields;
 
 impl FormatNodeFields<TsUnionType> for FormatNodeRule<TsUnionType> {
-    fn format_fields(node: &TsUnionType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsUnionType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsUnionTypeFields {
             leading_separator_token,
             types,

--- a/crates/rome_js_formatter/src/ts/types/unknown_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/unknown_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsUnknownType, TsUnknownTypeFields};
 
 impl FormatNodeFields<TsUnknownType> for FormatNodeRule<TsUnknownType> {
-    fn format_fields(node: &TsUnknownType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsUnknownType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsUnknownTypeFields { unknown_token } = node.as_fields();
         formatted![formatter, [unknown_token.format()]]
     }

--- a/crates/rome_js_formatter/src/ts/types/void_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/void_type.rs
@@ -3,7 +3,10 @@ use crate::FormatNodeFields;
 use rome_js_syntax::{TsVoidType, TsVoidTypeFields};
 
 impl FormatNodeFields<TsVoidType> for FormatNodeRule<TsVoidType> {
-    fn format_fields(node: &TsVoidType, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_fields(
+        node: &TsVoidType,
+        formatter: &Formatter<JsFormatOptions>,
+    ) -> FormatResult<FormatElement> {
         let TsVoidTypeFields { void_token } = node.as_fields();
 
         formatted![formatter, [void_token.format()]]

--- a/crates/rome_js_formatter/src/utils/array.rs
+++ b/crates/rome_js_formatter/src/utils/array.rs
@@ -10,7 +10,7 @@ use rome_rowan::{AstNode, AstSeparatedList};
 /// Utility function to print array-like nodes (array expressions, array bindings and assignment patterns)
 pub(crate) fn format_array_node<N, I>(
     node: &N,
-    formatter: &Formatter,
+    formatter: &Formatter<JsFormatOptions>,
 ) -> FormatResult<FormatElement>
 where
     N: AstSeparatedList<Language = JsLanguage, Node = I>,

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -95,7 +95,7 @@ use std::iter::FusedIterator;
 /// which is what we wanted since the beginning!
 pub(crate) fn format_binary_like_expression(
     expression: JsAnyBinaryLikeExpression,
-    formatter: &Formatter,
+    formatter: &Formatter<JsFormatOptions>,
 ) -> FormatResult<FormatElement> {
     let mut flatten_items = FlattenItems::default();
     let current_node = expression.syntax().clone();
@@ -169,7 +169,7 @@ fn format_with_or_without_parenthesis(
     parent_operator: BinaryLikeOperator,
     node: &JsSyntaxNode,
     formatted_node: FormatElement,
-    formatter: &Formatter,
+    formatter: &Formatter<JsFormatOptions>,
 ) -> FormatResult<(FormatElement, bool)> {
     let compare_to = match JsAnyExpression::cast(node.clone()) {
         Some(JsAnyExpression::JsLogicalExpression(logical)) => {
@@ -297,7 +297,7 @@ impl FlattenItems {
         &mut self,
         expression: JsAnyBinaryLikeExpression,
         parent_operator: Option<JsSyntaxToken>,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<()> {
         let should_flatten = expression.can_flatten()?;
 
@@ -313,7 +313,7 @@ impl FlattenItems {
         &mut self,
         binary_like_expression: JsAnyBinaryLikeExpression,
         parent_operator: Option<JsSyntaxToken>,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<()> {
         let right = binary_like_expression.right()?;
         let has_comments = right.syntax().has_comments_direct();
@@ -340,7 +340,7 @@ impl FlattenItems {
         &mut self,
         binary_like_expression: JsAnyBinaryLikeExpression,
         parent_operator: Option<JsSyntaxToken>,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<()> {
         if let Some(last) = self.items.last_mut() {
             // Remove any line breaks and the trailing operator so that the operator/trailing aren't part
@@ -415,7 +415,7 @@ impl FlattenItems {
     fn take_format_element(
         &mut self,
         current_node: &JsSyntaxNode,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         let can_hard_group = can_hard_group(&self.items);
         let len = self.items.len();
@@ -870,7 +870,9 @@ impl AstNode for JsAnyBinaryLikeLeftExpression {
 }
 
 impl Format for JsAnyBinaryLikeLeftExpression {
-    fn format(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+    type Options = JsFormatOptions;
+
+    fn format(&self, formatter: &Formatter<JsFormatOptions>) -> FormatResult<FormatElement> {
         match self {
             JsAnyBinaryLikeLeftExpression::JsAnyExpression(expression) => {
                 formatted![formatter, [expression.format()]]

--- a/crates/rome_js_formatter/src/utils/format_conditional.rs
+++ b/crates/rome_js_formatter/src/utils/format_conditional.rs
@@ -29,7 +29,7 @@ impl Conditional {
 
     fn into_format_element(
         self,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
         parent_is_conditional: bool,
     ) -> FormatResult<FormatElement> {
         let (head, body) = match self {
@@ -46,7 +46,7 @@ impl Conditional {
         formatted![formatter, [head, body]]
     }
 
-    fn format_head(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+    fn format_head(&self, formatter: &Formatter<JsFormatOptions>) -> FormatResult<FormatElement> {
         match self {
             Conditional::Expression(expr) => {
                 formatted![formatter, [expr.test()?.format(), space_token(),]]
@@ -88,7 +88,7 @@ impl Conditional {
 
     fn format_body(
         &self,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
         parent_is_conditional: bool,
     ) -> FormatResult<FormatElement> {
         let mut left_or_right_is_conditional = false;
@@ -127,7 +127,7 @@ impl Conditional {
 
     fn format_with_consequent(
         &self,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
         consequent: Option<FormatElement>,
     ) -> FormatResult<FormatElement> {
         match self {
@@ -174,7 +174,7 @@ impl Conditional {
 
     fn format_with_alternate(
         &self,
-        formatter: &Formatter,
+        formatter: &Formatter<JsFormatOptions>,
         alternate: Option<FormatElement>,
     ) -> FormatResult<FormatElement> {
         match self {
@@ -225,7 +225,7 @@ impl Conditional {
 /// - [rome_js_syntax::JsConditionalExpression]
 pub fn format_conditional(
     conditional: Conditional,
-    formatter: &Formatter,
+    formatter: &Formatter<JsFormatOptions>,
     parent_is_conditional: bool,
 ) -> FormatResult<FormatElement> {
     conditional.into_format_element(formatter, parent_is_conditional)

--- a/crates/rome_js_formatter/src/utils/member_chain/groups.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/groups.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use crate::utils::member_chain::flatten_item::FlattenItem;
 use crate::utils::member_chain::simple_argument::SimpleArgument;
 
+use crate::options::JsFormatOptions;
 use rome_js_syntax::{JsAnyCallArgument, JsAnyExpression, JsCallExpression};
 use rome_rowan::{AstSeparatedList, SyntaxResult};
 use std::mem;
@@ -19,7 +20,7 @@ pub(crate) struct Groups<'f> {
     current_group: Vec<FlattenItem>,
 
     /// instance of the formatter
-    formatter: &'f Formatter,
+    formatter: &'f Formatter<JsFormatOptions>,
 
     /// This is a threshold of when we should start breaking the groups
     ///
@@ -28,7 +29,7 @@ pub(crate) struct Groups<'f> {
 }
 
 impl<'f> Groups<'f> {
-    pub fn new(formatter: &'f Formatter, in_expression_statement: bool) -> Self {
+    pub fn new(formatter: &'f Formatter<JsFormatOptions>, in_expression_statement: bool) -> Self {
         Self {
             formatter,
             in_expression_statement,

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -119,7 +119,7 @@ use rome_rowan::AstNode;
 /// [Prettier applies]: https://github.com/prettier/prettier/blob/main/src/language-js/print/member-chain.js
 pub fn format_call_expression(
     syntax_node: &JsSyntaxNode,
-    formatter: &Formatter,
+    formatter: &Formatter<JsFormatOptions>,
 ) -> FormatResult<FormatElement> {
     let mut flattened_items = vec![];
     let parent_is_expression_statement = syntax_node.parent().map_or(false, |parent| {
@@ -234,7 +234,7 @@ fn compute_first_group_index(flatten_items: &[FlattenItem]) -> usize {
 fn compute_groups(
     flatten_items: impl Iterator<Item = FlattenItem>,
     in_expression_statement: bool,
-    formatter: &Formatter,
+    formatter: &Formatter<JsFormatOptions>,
 ) -> FormatResult<Groups> {
     let mut has_seen_call_expression = false;
     let mut groups = Groups::new(formatter, in_expression_statement);
@@ -313,7 +313,7 @@ fn format_groups(
 fn flatten_call_expression(
     queue: &mut Vec<FlattenItem>,
     node: JsSyntaxNode,
-    formatter: &Formatter,
+    formatter: &Formatter<JsFormatOptions>,
 ) -> FormatResult<()> {
     match node.kind() {
         JsSyntaxKind::JS_CALL_EXPRESSION => {

--- a/crates/rome_js_formatter/tests/check_reformat.rs
+++ b/crates/rome_js_formatter/tests/check_reformat.rs
@@ -1,7 +1,7 @@
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
-use rome_formatter::FormatOptions;
 
 use rome_js_formatter::format_node;
+use rome_js_formatter::options::JsFormatOptions;
 use rome_js_parser::{parse, SourceType};
 use rome_js_syntax::JsSyntaxNode;
 
@@ -10,7 +10,7 @@ pub struct CheckReformatParams<'a> {
     pub text: &'a str,
     pub source_type: SourceType,
     pub file_name: &'a str,
-    pub format_options: FormatOptions,
+    pub format_options: JsFormatOptions,
 }
 
 /// Perform a second pass of formatting on a file, printing a diff if the

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -13,7 +13,8 @@ use std::{
 };
 
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
-use rome_formatter::{FormatOptions, IndentStyle};
+use rome_formatter::IndentStyle;
+use rome_js_formatter::options::JsFormatOptions;
 use rome_js_parser::{parse, SourceType};
 
 use crate::check_reformat::CheckReformatParams;
@@ -56,7 +57,10 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
     let has_errors = parsed.has_errors();
     let syntax = parsed.syntax();
 
-    let options = FormatOptions::new(IndentStyle::Space(2));
+    let options = JsFormatOptions {
+        indent_style: IndentStyle::Space(2),
+        ..JsFormatOptions::default()
+    };
 
     let result = match (range_start_index, range_end_index) {
         (Some(start), Some(end)) => {

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -2,7 +2,8 @@ use crate::config::{FormatterWorkspaceSettings, WorkspaceSettings};
 use crate::line_index::{self, LineCol};
 use anyhow::{bail, Result};
 use rome_diagnostics::file::FileId;
-use rome_formatter::{FormatOptions, IndentStyle, QuoteStyle};
+use rome_formatter::IndentStyle;
+use rome_js_formatter::options::{JsFormatOptions, QuoteStyle};
 use rome_js_parser::{parse, SourceType};
 use rome_js_syntax::{TextRange, TokenAtOffset};
 use std::str::FromStr;
@@ -17,15 +18,15 @@ use tracing::info;
 pub(crate) fn to_format_options(
     params: &FormattingOptions,
     workspace_settings: &FormatterWorkspaceSettings,
-) -> FormatOptions {
+) -> JsFormatOptions {
     let indent_style = if params.insert_spaces {
         IndentStyle::Space(params.tab_size as u8)
     } else {
         IndentStyle::Tab
     };
-    let mut default_options = FormatOptions {
+    let mut default_options = JsFormatOptions {
         indent_style,
-        ..FormatOptions::default()
+        ..JsFormatOptions::default()
     };
 
     let custom_ident_style =
@@ -70,7 +71,7 @@ pub(crate) fn to_format_options(
 pub(crate) struct FormatParams<'input> {
     pub(crate) text: &'input str,
     pub(crate) file_id: usize,
-    pub(crate) format_options: FormatOptions,
+    pub(crate) format_options: JsFormatOptions,
     pub(crate) workspace_settings: WorkspaceSettings,
     pub(crate) source_type: SourceType,
 }
@@ -114,7 +115,7 @@ pub(crate) struct FormatRangeParams<'input> {
     pub(crate) file_id: FileId,
     pub(crate) range: Range,
     /// Options to pass to [rome_js_formatter]
-    pub(crate) format_options: FormatOptions,
+    pub(crate) format_options: JsFormatOptions,
     pub(crate) workspace_settings: WorkspaceSettings,
     pub(crate) source_type: SourceType,
 }
@@ -181,7 +182,7 @@ pub(crate) struct FormatOnTypeParams<'input> {
     pub(crate) file_id: FileId,
     pub(crate) position: Position,
     /// Options to pass to [rome_js_formatter]
-    pub(crate) format_options: FormatOptions,
+    pub(crate) format_options: JsFormatOptions,
     pub(crate) workspace_settings: WorkspaceSettings,
     pub(crate) source_type: SourceType,
 }

--- a/website/playground/src/lib.rs
+++ b/website/playground/src/lib.rs
@@ -8,8 +8,9 @@ use rome_console::markup;
 use rome_diagnostics::file::{Files, SimpleFiles};
 use rome_diagnostics::termcolor::{ColorSpec, WriteColor};
 use rome_diagnostics::{DiagnosticHeader, Emitter};
-use rome_formatter::{FormatOptions, IndentStyle};
+use rome_formatter::IndentStyle;
 use rome_js_formatter::format_node;
+use rome_js_formatter::options::JsFormatOptions;
 use rome_js_parser::{parse, LanguageVariant, SourceType};
 use serde_json::json;
 use std::io;
@@ -154,7 +155,7 @@ pub fn run(
         IndentStyle::Tab
     };
 
-    let options = FormatOptions {
+    let options = JsFormatOptions {
         indent_style,
         line_width: line_width.try_into().unwrap_or_default(),
         quote_style: quote_style.parse().unwrap_or_default(),

--- a/xtask/bench/src/features/formatter.rs
+++ b/xtask/bench/src/features/formatter.rs
@@ -1,6 +1,7 @@
 use crate::BenchmarkSummary;
-use rome_formatter::{FormatOptions, Printed};
+use rome_formatter::Printed;
 use rome_js_formatter::format_node;
+use rome_js_formatter::options::JsFormatOptions;
 use rome_js_syntax::JsSyntaxNode;
 use std::fmt::{Display, Formatter};
 use std::time::Duration;
@@ -22,7 +23,9 @@ pub fn benchmark_format_lib(id: &str, root: &JsSyntaxNode) -> BenchmarkSummary {
 }
 
 pub fn run_format(root: &JsSyntaxNode) -> Printed {
-    format_node(FormatOptions::default(), root).unwrap().print()
+    format_node(JsFormatOptions::default(), root)
+        .unwrap()
+        .print()
 }
 
 impl FormatterMeasurement {

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -309,7 +309,9 @@ pub fn generate_formatter() {
                 use rome_js_syntax::#node_id;
 
                 impl FormatRule<#node_id> for #format_id {
-                    fn format(node: &#node_id, formatter: &Formatter) -> FormatResult<FormatElement> {
+                    type Options = JsFormatOptions;
+
+                    fn format(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
                         Ok(formatter.format_list(node))
                     }
                 }
@@ -321,7 +323,9 @@ pub fn generate_formatter() {
                 use rome_js_syntax::#node_id;
 
                 impl FormatRule<#node_id> for #format_id {
-                    fn format(node: &#node_id, formatter: &Formatter) -> FormatResult<FormatElement> {
+                    type Options = JsFormatOptions;
+
+                    fn format(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
                         verbatim_node(node.syntax()).format(formatter)
                     }
                 }
@@ -334,7 +338,7 @@ pub fn generate_formatter() {
                     use rome_js_syntax::#node_id;
 
                     impl FormatNodeFields<#node_id> for FormatNodeRule<#node_id> {
-                        fn format_fields(node: &#node_id, formatter: &Formatter) -> FormatResult<FormatElement> {
+                        fn format_fields(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
                             verbatim_node(node.syntax()).format(formatter)
                         }
                     }
@@ -348,7 +352,7 @@ pub fn generate_formatter() {
                     use rome_js_syntax::#node_id;
 
                     impl FormatNodeFields<#node_id> for FormatNodeRule<#node_id> {
-                        fn format_fields(node: &#node_id, formatter: &Formatter) -> FormatResult<FormatElement> {
+                        fn format_fields(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
                             unknown_node(node.syntax()).format(formatter)
                         }
                     }
@@ -370,7 +374,9 @@ pub fn generate_formatter() {
                     use rome_js_syntax::#node_id;
 
                     impl FormatRule<#node_id> for #format_id {
-                        fn format(node: &#node_id, formatter: &Formatter) -> FormatResult<FormatElement> {
+                        type Options = JsFormatOptions;
+
+                        fn format(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
                             match node {
                                 #( #match_arms )*
                             }


### PR DESCRIPTION
This PR extracts the language specific `quote_style` option out of `rome_formatter` and moves it into `rome_js_formatter`.

This is done by adding a new associated type `Options` to `Format` that specifies the options passed to the formatter. I also changed the `Formatter` type to have one generic `Options` parameter.

This PR introduces a new `FormatOptions` trait that must be implemented by all option types that are used in conjunction with any `format` function.

This PR isn't addressing the fact that the CLI/LSP are still constructing `JsFormatOptions`. It's only concerned about removing the dependency from `rome_formatter`.


## Other Options that I explored

* Using an `enum` for `FormatOptions` and use it with `as_js_options` or something like that. Has the downside that we don't get any compile-time guarantee that the `Formatter` provides the options that the consumer needs.
* Thread local options: No guarantee that the options have been initialized or get correctly cleared. But might be a possible alternative considering that most `Format` implementations are option independent. 

## Test Plan

`cargo test`
