### PR TITLE
feat(rome_diagnostic): refactor diagnostics to use markup

### DIFF
--- a/crates/rome_analyze/src/analyzers/no_delete.rs
+++ b/crates/rome_analyze/src/analyzers/no_delete.rs
@@ -1,5 +1,5 @@
 use rome_console::markup;
-use rome_diagnostics::Severity;
+use rome_diagnostics::{Applicability, Severity};
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyAssignment, JsAnyAssignmentPattern, JsAnyExpression, JsAnyRoot,
@@ -9,7 +9,7 @@ use rome_js_syntax::{
 use rome_rowan::{AstNode, AstNodeExt};
 
 use crate::registry::{Rule, RuleAction, RuleDiagnostic};
-use crate::{ActionCategories, RuleCategory};
+use crate::{ActionCategory, RuleCategory};
 
 pub(crate) enum NoDelete {}
 
@@ -54,7 +54,8 @@ impl Rule for NoDelete {
         )?;
 
         Some(RuleAction {
-            category: ActionCategories::SUGGESTION,
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::MaybeIncorrect,
             message: markup! { "Replace with undefined assignment" }.to_owned(),
             root,
         })

--- a/crates/rome_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_analyze/src/analyzers/no_double_equals.rs
@@ -1,12 +1,12 @@
 use rome_console::markup;
-use rome_diagnostics::Severity;
+use rome_diagnostics::{Applicability, Severity};
 use rome_js_factory::make;
 use rome_js_syntax::{JsAnyExpression, JsAnyLiteralExpression, JsAnyRoot, JsBinaryExpression, T};
 use rome_js_syntax::{JsSyntaxKind::*, JsSyntaxToken};
 use rome_rowan::{AstNodeExt, SyntaxResult};
 
 use crate::registry::{Rule, RuleAction, RuleDiagnostic};
-use crate::{ActionCategories, RuleCategory};
+use crate::{ActionCategory, RuleCategory};
 
 pub(crate) enum NoDoubleEquals {}
 
@@ -50,7 +50,8 @@ impl Rule for NoDoubleEquals {
         )?;
 
         Some(RuleAction {
-            category: ActionCategories::SUGGESTION,
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::MaybeIncorrect,
             message: markup! { "Replace with strict equality" }.to_owned(),
             root,
         })

--- a/crates/rome_analyze/src/analyzers/use_single_var_declarator.rs
+++ b/crates/rome_analyze/src/analyzers/use_single_var_declarator.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use rome_console::markup;
-use rome_diagnostics::Severity;
+use rome_diagnostics::{Applicability, Severity};
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyRoot, JsAnyStatement, JsStatementList, JsSyntaxToken, JsVariableDeclarationFields,
@@ -9,7 +9,7 @@ use rome_js_syntax::{
 };
 use rome_rowan::{AstNode, AstNodeExt, AstNodeList, AstNodeListExt, AstSeparatedList};
 
-use crate::{ActionCategories, RuleCategory};
+use crate::{ActionCategory, RuleCategory};
 
 use crate::registry::{Rule, RuleAction, RuleDiagnostic};
 
@@ -91,7 +91,8 @@ impl Rule for UseSingleVarDeclarator {
         );
 
         Some(RuleAction {
-            category: ActionCategories::SUGGESTION,
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::MaybeIncorrect,
             message: markup! { "Break out into multiple declarations" }.to_owned(),
             root: root.replace_node_discard_trivia(prev_parent, next_parent)?,
         })

--- a/crates/rome_analyze/src/analyzers/use_while.rs
+++ b/crates/rome_analyze/src/analyzers/use_while.rs
@@ -1,12 +1,12 @@
 use rome_console::markup;
-use rome_diagnostics::Severity;
+use rome_diagnostics::{Applicability, Severity};
 use rome_js_factory::make;
 use rome_js_syntax::{JsAnyRoot, JsAnyStatement, JsForStatement, JsForStatementFields, T};
 use rome_rowan::{AstNode, AstNodeExt};
 
 use crate::{
     registry::{Rule, RuleAction, RuleDiagnostic},
-    ActionCategories, RuleCategory,
+    ActionCategory, RuleCategory,
 };
 
 pub(crate) enum UseWhile {}
@@ -80,7 +80,8 @@ impl Rule for UseWhile {
         )?;
 
         Some(RuleAction {
-            category: ActionCategories::SUGGESTION,
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::MaybeIncorrect,
             message: markup! { "Use a while loop" }.to_owned(),
             root,
         })

--- a/crates/rome_analyze/src/assists/flip_bin_exp.rs
+++ b/crates/rome_analyze/src/assists/flip_bin_exp.rs
@@ -1,4 +1,5 @@
 use rome_console::markup;
+use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyRoot, JsBinaryExpression, JsBinaryExpressionFields, JsBinaryOperator, JsSyntaxKind, T,
@@ -6,9 +7,8 @@ use rome_js_syntax::{
 use rome_rowan::AstNodeExt;
 
 use crate::{
-    categories::RuleCategory,
     registry::{Rule, RuleAction},
-    ActionCategories,
+    ActionCategory, RuleCategory,
 };
 
 pub(crate) enum FlipBinExp {}
@@ -48,7 +48,8 @@ impl Rule for FlipBinExp {
         let new_node = new_node.replace_node(prev_right, new_right)?;
 
         Some(RuleAction {
-            category: ActionCategories::REFACTOR,
+            category: ActionCategory::Refactor,
+            applicability: Applicability::Always,
             message: markup! { "Flip Binary Expression" }.to_owned(),
             root: root.replace_node(node.clone(), new_node)?,
         })

--- a/crates/rome_analyze/src/categories.rs
+++ b/crates/rome_analyze/src/categories.rs
@@ -14,17 +14,19 @@ pub enum RuleCategory {
     Action,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ActionCategory {
+    /// This action provides a fix to the diagnostic emitted by the same signal
+    QuickFix,
+    /// This action provides an optional refactor opportunity
+    Refactor,
+}
+
 bitflags! {
     pub struct RuleCategories: u8 {
         const SYNTAX = 1 << RuleCategory::Syntax as u8;
         const LINT = 1 << RuleCategory::Lint as u8;
         const ACTION = 1 << RuleCategory::Action as u8;
-    }
-
-    pub struct ActionCategories: u8 {
-        const SAFE_FIX = 1 << 0;
-        const SUGGESTION = 1 << 1;
-        const REFACTOR = 1 << 2;
     }
 }
 

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -1,40 +1,60 @@
 use std::marker::PhantomData;
 
 use rome_console::MarkupBuf;
-use rome_diagnostics::Severity;
+use rome_diagnostics::{
+    file::{FileId, FileSpan},
+    Applicability, CodeSuggestion, Diagnostic, SubDiagnostic, SuggestionChange, SuggestionStyle,
+};
 use rome_js_syntax::{JsAnyRoot, TextRange};
+use rome_rowan::AstNode;
 
-use crate::{registry::Rule, ActionCategories};
+use crate::{categories::ActionCategory, registry::Rule};
 
-/// Event raised by the analyzer when a [Rule](crate::analysis_server::Rule)
+/// Event raised by the analyzer when a [Rule](crate::registry::Rule)
 /// emits a diagnostic, a code action, or both
 pub trait AnalyzerSignal {
-    fn diagnostic(&self) -> Option<AnalyzerDiagnostic>;
+    fn diagnostic(&self) -> Option<Diagnostic>;
     fn action(&self) -> Option<AnalyzerAction>;
 }
 
-/// Diagnostic object returned by the analyzer, generated from a [RuleDiagnostic](crate::analysis_server::RuleDiagnostic)
+/// Code Action object returned by the analyzer, generated from a [RuleAction](crate::registry::RuleAction)
 /// with additional informations about the rule injected by the analyzer
-#[derive(Debug, PartialEq, Eq)]
-pub struct AnalyzerDiagnostic {
-    pub rule_name: &'static str,
-    pub severity: Severity,
-    pub range: TextRange,
-    pub message: MarkupBuf,
-}
-
-/// Code Action object returned by the analyzer, generated from a [RuleAction](crate::analysis_server::RuleAction)
-/// with additional informations about the rule injected by the analyzer
+///
+/// This struct can be converted into a [CodeSuggestion] and injected into
+/// a diagnostic emitted by the same signal
 #[derive(Debug, PartialEq, Eq)]
 pub struct AnalyzerAction {
     pub rule_name: &'static str,
-    pub category: ActionCategories,
+    pub file_id: FileId,
+    pub category: ActionCategory,
+    pub applicability: Applicability,
     pub message: MarkupBuf,
+    /// Range of the original document being modified by this action
+    ///
+    /// By default this is conservatively set to cover the entire document
+    pub range: TextRange,
     pub root: JsAnyRoot,
 }
 
-/// Analyzer-internal implementation of [AnalyzerSignal] for a specific [Rule](crate::analysis_server::Rule)
+impl From<AnalyzerAction> for CodeSuggestion {
+    fn from(action: AnalyzerAction) -> Self {
+        CodeSuggestion {
+            substitution: SuggestionChange::String(action.root.to_string()),
+            span: FileSpan {
+                file: action.file_id,
+                range: action.range,
+            },
+            applicability: action.applicability,
+            msg: action.message,
+            style: SuggestionStyle::Full,
+            labels: Vec::new(),
+        }
+    }
+}
+
+/// Analyzer-internal implementation of [AnalyzerSignal] for a specific [Rule](crate::registry::Rule)
 pub(crate) struct RuleSignal<'a, R: Rule> {
+    file_id: FileId,
     root: &'a JsAnyRoot,
     node: R::Query,
     state: R::State,
@@ -43,11 +63,13 @@ pub(crate) struct RuleSignal<'a, R: Rule> {
 
 impl<'a, R: Rule + 'static> RuleSignal<'a, R> {
     pub(crate) fn new_boxed(
+        file_id: FileId,
         root: &'a JsAnyRoot,
         node: R::Query,
         state: R::State,
     ) -> Box<dyn AnalyzerSignal + 'a> {
         Box::new(Self {
+            file_id,
             root,
             node,
             state,
@@ -57,20 +79,35 @@ impl<'a, R: Rule + 'static> RuleSignal<'a, R> {
 }
 
 impl<'a, R: Rule> AnalyzerSignal for RuleSignal<'a, R> {
-    fn diagnostic(&self) -> Option<AnalyzerDiagnostic> {
-        R::diagnostic(&self.node, &self.state).map(|diag| AnalyzerDiagnostic {
-            rule_name: R::NAME,
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        R::diagnostic(&self.node, &self.state).map(|diag| Diagnostic {
+            file_id: self.file_id,
             severity: diag.severity,
-            range: diag.range,
-            message: diag.message,
+            code: Some(R::NAME.into()),
+            title: diag.message.clone(),
+            tag: None,
+            primary: Some(SubDiagnostic {
+                severity: diag.severity,
+                msg: diag.message,
+                span: FileSpan {
+                    file: self.file_id,
+                    range: diag.range,
+                },
+            }),
+            children: Vec::new(),
+            suggestions: Vec::new(),
+            footers: Vec::new(),
         })
     }
 
     fn action(&self) -> Option<AnalyzerAction> {
         R::action(self.root.clone(), &self.node, &self.state).map(|action| AnalyzerAction {
             rule_name: R::NAME,
+            file_id: self.file_id,
             category: action.category,
+            applicability: action.applicability,
             message: action.message,
+            range: self.root.syntax().text_range(),
             root: action.root,
         })
     }

--- a/crates/rome_analyze/tests/specs/noDelete.js.snap
+++ b/crates/rome_analyze/tests/specs/noDelete.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_analyze/tests/spec_tests.rs
-assertion_line: 92
 expression: noDelete.js
-
 ---
 # Input
 ```js
@@ -16,31 +14,13 @@ delete a?.["b"];
 
 # Diagnostics
 ```
+warning[noDelete]: This is an unexpected use of the delete operator.
   ┌─ noDelete.js:2:1
   │
 2 │ delete a.b;
-  │ ^^^^^^^^^^ This is an unexpected use of the delete operator.
+  │ ---------- This is an unexpected use of the delete operator.
 
-```
-
-```
-  ┌─ noDelete.js:3:1
-  │
-3 │ delete a?.b;
-  │ ^^^^^^^^^^^ This is an unexpected use of the delete operator.
-
-```
-
-```
-  ┌─ noDelete.js:4:1
-  │
-4 │ delete a["b"];
-  │ ^^^^^^^^^^^^^ This is an unexpected use of the delete operator.
-
-```
-
-# Actions
-```
+Replace with undefined assignment
     | @@ -1,5 +1,5 @@
 0 0 |   delete a;
 1   | - delete a.b;
@@ -49,9 +29,17 @@ delete a?.["b"];
 3 3 |   delete a["b"];
 4 4 |   delete a?.["b"];
 
+
 ```
 
 ```
+warning[noDelete]: This is an unexpected use of the delete operator.
+  ┌─ noDelete.js:3:1
+  │
+3 │ delete a?.b;
+  │ ----------- This is an unexpected use of the delete operator.
+
+Replace with undefined assignment
     | @@ -1,5 +1,5 @@
 0 0 |   delete a;
 1 1 |   delete a.b;
@@ -60,9 +48,17 @@ delete a?.["b"];
 3 3 |   delete a["b"];
 4 4 |   delete a?.["b"];
 
+
 ```
 
 ```
+warning[noDelete]: This is an unexpected use of the delete operator.
+  ┌─ noDelete.js:4:1
+  │
+4 │ delete a["b"];
+  │ ------------- This is an unexpected use of the delete operator.
+
+Replace with undefined assignment
     | @@ -1,5 +1,5 @@
 0 0 |   delete a;
 1 1 |   delete a.b;
@@ -70,6 +66,7 @@ delete a?.["b"];
 3   | - delete a["b"];
   3 | + a["b"] = undefined;
 4 4 |   delete a?.["b"];
+
 
 ```
 

--- a/crates/rome_analyze/tests/specs/noDoubleEquals.js.snap
+++ b/crates/rome_analyze/tests/specs/noDoubleEquals.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_analyze/tests/spec_tests.rs
-assertion_line: 92
 expression: noDoubleEquals.js
-
 ---
 # Input
 ```js
@@ -16,23 +14,13 @@ const isNonNull = a != null;
 
 # Diagnostics
 ```
+error[noDoubleEquals]: Do not use the == operator
   ┌─ noDoubleEquals.js:1:18
   │
 1 │ const isZero = a == 0;
   │                  ^^ Do not use the == operator
 
-```
-
-```
-  ┌─ noDoubleEquals.js:2:21
-  │
-2 │ const isNonZero = a != 0;
-  │                     ^^ Do not use the != operator
-
-```
-
-# Actions
-```
+Replace with strict equality
     | @@ -1,4 +1,4 @@
 0   | - const isZero = a == 0;
   0 | + const isZero = a === 0;
@@ -40,9 +28,17 @@ const isNonNull = a != null;
 2 2 |   
 3 3 |   const isNull = a == null;
 
+
 ```
 
 ```
+error[noDoubleEquals]: Do not use the != operator
+  ┌─ noDoubleEquals.js:2:21
+  │
+2 │ const isNonZero = a != 0;
+  │                     ^^ Do not use the != operator
+
+Replace with strict equality
     | @@ -1,5 +1,5 @@
 0 0 |   const isZero = a == 0;
 1   | - const isNonZero = a != 0;
@@ -50,6 +46,7 @@ const isNonNull = a != null;
 2 2 |   
 3 3 |   const isNull = a == null;
 4 4 |   const isNonNull = a != null;
+
 
 ```
 

--- a/crates/rome_analyze/tests/specs/useSingleVarDeclarator.js.snap
+++ b/crates/rome_analyze/tests/specs/useSingleVarDeclarator.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_analyze/tests/spec_tests.rs
-assertion_line: 92
 expression: useSingleVarDeclarator.js
-
 ---
 # Input
 ```js
@@ -15,15 +13,13 @@ function test() {
 
 # Diagnostics
 ```
+warning[useSingleVarDeclarator]: Declare variables separately.
   ┌─ useSingleVarDeclarator.js:3:2
   │
 3 │     let foo, bar;
-  │     ^^^^^^^^^^^^^ Declare variables separately.
+  │     ------------- Declare variables separately.
 
-```
-
-# Actions
-```
+Break out into multiple declarations
     | @@ -1,4 +1,5 @@
 0 0 |   function test() {
 1 1 |   	// Comment
@@ -31,6 +27,7 @@ function test() {
   2 | + 	let foo;
   3 | + 	let bar;
 3 4 |   }
+
 
 ```
 

--- a/crates/rome_analyze/tests/specs/useWhile.js.snap
+++ b/crates/rome_analyze/tests/specs/useWhile.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_analyze/tests/spec_tests.rs
-assertion_line: 92
 expression: useWhile.js
-
 ---
 # Input
 ```js
@@ -14,20 +12,19 @@ for (; true; ) {}
 
 # Diagnostics
 ```
+error[useWhile]: Use a while loop instead of a for loop
   ┌─ useWhile.js:3:1
   │
 3 │ for (; true; ) {}
   │ ^^^^^^^^^^^^^^^^^ Use a while loop instead of a for loop
 
-```
-
-# Actions
-```
+Use a while loop
     | @@ -1,3 +1,3 @@
 0 0 |   for (let i = 0; i < 16; ++i) {}
 1 1 |   
 2   | - for (; true; ) {}
   2 | + while (true) {}
+
 
 ```
 

--- a/crates/rome_console/src/markup.rs
+++ b/crates/rome_console/src/markup.rs
@@ -4,11 +4,12 @@ use std::{
 };
 
 use termcolor::{Color, ColorSpec};
+use text_size::TextSize;
 
 use crate::fmt::{Display, Formatter, MarkupElements, Write};
 
 /// Enumeration of all the supported markup elements
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum MarkupElement {
     Emphasis,
     Dim,
@@ -70,7 +71,7 @@ pub struct MarkupNode<'fmt> {
     pub content: &'fmt dyn Display,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct MarkupNodeBuf {
     pub elements: Vec<MarkupElement>,
     pub content: String,
@@ -110,12 +111,16 @@ impl<'fmt> Markup<'fmt> {
     }
 }
 
-#[derive(Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
 pub struct MarkupBuf(pub Vec<MarkupNodeBuf>);
 
 impl MarkupBuf {
-    pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+    pub fn is_empty(&self) -> bool {
+        self.0.iter().all(|node| node.content.is_empty())
+    }
+
+    pub fn len(&self) -> TextSize {
+        self.0.iter().map(|node| TextSize::of(&node.content)).sum()
     }
 }
 

--- a/crates/rome_diagnostics/src/emit.rs
+++ b/crates/rome_diagnostics/src/emit.rs
@@ -10,10 +10,10 @@ use rome_console::{
     fmt::{Display, Formatter, Termcolor},
     markup, MarkupBuf,
 };
-use rome_rowan::{TextRange, TextSize};
 use rome_text_edit::apply_indels;
 use std::borrow::Cow;
 use std::io;
+use std::ops::Range;
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 /// The emitter is responsible for emitting
@@ -160,16 +160,12 @@ impl<'a> Display for DiagnosticPrinter<'a> {
                         SuggestionChange::String(string) => Cow::Borrowed(string),
                     };
 
-                    let new = format!(
-                        "{}{}{}",
-                        &old[TextRange::new(TextSize::from(0u32), range.start())],
-                        new,
-                        &old[TextRange::new(range.end(), TextSize::of(old))],
-                    );
+                    let mut buffer = old.to_string();
+                    buffer.replace_range(Range::<usize>::from(range), &new);
 
                     fmt.write_markup(markup! {
                         <Info>{suggestion.msg}</Info>"\n"
-                        {Diff { mode: DiffMode::Unified, left: old, right: &new }}
+                        {Diff { mode: DiffMode::Unified, left: old, right: &buffer }}
                     })?;
                 }
                 SuggestionStyle::Inline => {

--- a/crates/rome_diagnostics/src/suggestion.rs
+++ b/crates/rome_diagnostics/src/suggestion.rs
@@ -1,4 +1,5 @@
 use crate::{file::FileSpan, *};
+use rome_console::MarkupBuf;
 use rome_rowan::TextRange;
 use rome_text_edit::Indel;
 
@@ -12,7 +13,7 @@ pub struct CodeSuggestion {
     pub substitution: SuggestionChange,
     pub span: FileSpan,
     pub applicability: Applicability,
-    pub msg: String,
+    pub msg: MarkupBuf,
     pub style: SuggestionStyle,
     pub labels: Vec<TextRange>,
 }

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -115,9 +115,10 @@ impl Session {
 
         let diagnostics = if workspace_settings.analysis.enable_diagnostics {
             let file_id = doc.file_id();
+            let url = url.clone();
 
             let handle = tokio::task::spawn_blocking(move || {
-                handlers::analysis::diagnostics(file_id, &doc.text)
+                handlers::analysis::diagnostics(file_id, &url, &doc.text)
             });
 
             handle.await??

--- a/xtask/bench/src/features/analyzer.rs
+++ b/xtask/bench/src/features/analyzer.rs
@@ -22,7 +22,7 @@ pub fn benchmark_analyze_lib(id: &str, root: &JsAnyRoot) -> BenchmarkSummary {
 }
 
 pub fn run_analyzer(root: &JsAnyRoot) {
-    analyze(root, AnalysisFilter::default(), |event| {
+    analyze(0, root, AnalysisFilter::default(), |event| {
         black_box(event.diagnostic());
         black_box(event.action());
     });


### PR DESCRIPTION
## Summary

This PR changes the internal representation of title, label and suggestion messages in diagnostics to use markup (`MarkupBuf`) instead of plain strings. This change is mostly transparent to the producers of diagnostics (the trait bounds for messages has been changed to `impl rome_console::fmt::Display` which is a superset of the previous `impl Into<String>`) as well as the consumers (diagnostics are already printed as markup, so whether they use strings or markup internally is an implementation detail).

This change removes the need for the intermediate `AnalyzerDiagnostic` struct (analyzer rules now return a plain diagnostic object), however the `AnalyzerAction` struct is still needed as it contains additional information not present in `CodeSuggestion` (but it's now possible to transparently convert the former to the later with `.into()`)

## Test Plan

The tests snapshots for the analyzer have been updated to use the mainline diagnostic printing. The tests snapshots for the parser are unchanged since these diagnostics are represented as markup too but do not make use of it yet.
