### PR TITLE
fix(formatter): Tighten `has_line_breaks` method

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -1449,25 +1449,30 @@ impl FormatElement {
         matches!(self, FormatElement::Empty)
     }
 
-    /// Returns true if this [FormatElement] recursively contains any hard line break
-    /// ([hard_line_break], [empty_line], [Token] containing the '\n' character)
-    pub fn has_hard_line_breaks(&self) -> bool {
+    /// Returns true if this [FormatElement] is guaranteed to break across multiple lines by the printer.
+    /// This is the case if this format element recursively contains a:
+    /// * [empty_line] or [hard_line_break]
+    /// * A token containing '\n'
+    ///
+    /// Use this with caution, this is only a heuristic and the printer may print the element over multiple
+    /// lines if this element is part of a group and the group doesn't fit on a single line.
+    pub fn will_break(&self) -> bool {
         match self {
             FormatElement::Empty => false,
             FormatElement::Space => false,
             FormatElement::Line(line) => matches!(line.mode, LineMode::Hard | LineMode::Empty),
-            FormatElement::Indent(indent) => indent.content.has_hard_line_breaks(),
+            FormatElement::Indent(indent) => indent.content.will_break(),
             FormatElement::Group(group) | FormatElement::HardGroup(group) => {
-                group.content.has_hard_line_breaks()
+                group.content.will_break()
             }
-            FormatElement::ConditionalGroupContent(group) => group.content.has_hard_line_breaks(),
+            FormatElement::ConditionalGroupContent(group) => group.content.will_break(),
             FormatElement::List(list) | FormatElement::Fill(list) => {
-                list.content.iter().any(FormatElement::has_hard_line_breaks)
+                list.content.iter().any(FormatElement::will_break)
             }
             FormatElement::Token(token) => token.contains('\n'),
-            FormatElement::LineSuffix(_) => true,
-            FormatElement::Comment(content) => content.has_hard_line_breaks(),
-            FormatElement::Verbatim(verbatim) => verbatim.element.has_hard_line_breaks(),
+            FormatElement::LineSuffix(_) => false,
+            FormatElement::Comment(content) => content.will_break(),
+            FormatElement::Verbatim(verbatim) => verbatim.element.will_break(),
         }
     }
 

--- a/crates/rome_js_formatter/src/utils/member_chain/groups.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/groups.rs
@@ -112,7 +112,7 @@ impl<'f> Groups<'f> {
             .iter()
             .flat_map(|group| group.iter())
             .flat_map(|item| item.as_format_elements())
-            .any(|element| element.has_hard_line_breaks());
+            .any(|element| element.will_break());
 
         let should_break = has_line_breaks
             || node_has_comments
@@ -219,7 +219,7 @@ impl<'f> Groups<'f> {
 
         if let Some(last_group) = last_group {
             let element = last_group.as_format_elements().last();
-            let group_will_break = element.map_or(false, |element| element.has_hard_line_breaks());
+            let group_will_break = element.map_or(false, |element| element.will_break());
 
             let is_call_expression = last_group.is_loose_call_expression();
 


### PR DESCRIPTION
The `has_line_breaks` method is a heuristic for determining if a `FormatElement` will break for certain, similar to Prettier's `willBreak` function. 

This PR changes the function to return `false` for `LineSuffix` because a line suffix by itself doesn't introduce a line break. It only delays printing its content until the printer reaches the end of the line. A `LineSuffix` forces a group to expand but that only applies if the element is used inside of a `Group`, similar to `soft_line_break` that only expands to a line break outside of a group. That's why this PR changes the semantic to have `soft_line_break` and `LineSuffix` aligned. 
