### PR TITLE
feature(formatter): Group list elements

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -728,11 +728,15 @@ pub fn group_elements_with_options(
     content: FormatElement,
     options: GroupElementsOptions,
 ) -> FormatElement {
-    let (leading, content, trailing) = content.split_trivia();
+    if content.is_empty() {
+        content
+    } else {
+        let (leading, content, trailing) = content.split_trivia();
 
-    let group = Group::new(content).with_id(options.group_id);
+        let group = Group::new(content).with_id(options.group_id);
 
-    format_elements![leading, group, trailing]
+        format_elements![leading, group, trailing]
+    }
 }
 
 /// IR element that forces the parent group to print in expanded mode.
@@ -1630,8 +1634,8 @@ impl FormatElement {
 
     /// Splits off the leading and trailing trivias (comments) from this [FormatElement]
     ///
-    /// For [FormatElement::HardGroup] and [FormatElement::Group], the trailing and leading trivias
-    /// are automatically moved  outside of the group. The group itself is then recreated around the
+    /// For [FormatElement::HardGroup], the trailing trivia
+    /// is automatically moved  outside of the group. The group itself is then recreated around the
     /// content itself.
     pub fn split_trivia(self) -> (FormatElement, FormatElement, FormatElement) {
         match self {

--- a/crates/rome_js_formatter/src/formatter.rs
+++ b/crates/rome_js_formatter/src/formatter.rs
@@ -567,7 +567,7 @@ pub(crate) trait JsFormatter {
                 separator_factory()
             };
 
-            result.push(formatted![formatter, [node, separator]]?);
+            result.push(format_elements![group_elements(node), separator]);
         }
 
         Ok(result.into_iter())

--- a/crates/rome_js_formatter/src/js/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/template_element_list.rs
@@ -9,6 +9,10 @@ impl FormatRule<JsTemplateElementList> for FormatJsTemplateElementList {
         node: &JsTemplateElementList,
         formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
-        Ok(formatter.format_list(node))
+        Ok(concat_elements(
+            formatter
+                .format_all(node.iter().formatted())?
+                .map(group_elements),
+        ))
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
@@ -36,7 +36,7 @@ impl FormatRule<JsVariableDeclaratorList> for FormatJsVariableDeclaratorList {
                     }
                 };
 
-                formatted![formatter, [node, separator]]
+                Ok(format_elements![group_elements(node), separator])
             })
             .collect::<FormatResult<Vec<_>>>()?;
 

--- a/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
@@ -14,7 +14,7 @@ impl FormatRule<TsIntersectionTypeElementList> for FormatTsIntersectionTypeEleme
         let last_index = node.len().saturating_sub(1);
 
         for (index, item) in node.elements().enumerate() {
-            let ty = item.node()?;
+            let ty = formatted![formatter, [item.node().format()]]?;
             let separator = item.trailing_separator()?;
 
             let separator = match separator {
@@ -40,7 +40,7 @@ impl FormatRule<TsIntersectionTypeElementList> for FormatTsIntersectionTypeEleme
                 }
             };
 
-            elements.push(formatted![formatter, [ty.format(), separator]]?)
+            elements.push(format_elements![group_elements(ty), separator]);
         }
 
         Ok(concat_elements(elements))

--- a/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
@@ -11,7 +11,9 @@ impl FormatRule<TsTemplateElementList> for FormatTsTemplateElementList {
         formatter: &Formatter<JsFormatOptions>,
     ) -> FormatResult<FormatElement> {
         Ok(concat_elements(
-            formatter.format_all(node.iter().formatted())?,
+            formatter
+                .format_all(node.iter().formatted())?
+                .map(group_elements),
         ))
     }
 }

--- a/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
@@ -35,7 +35,10 @@ impl FormatRule<TsTypeMemberList> for FormatTsTypeMemberList {
                     empty_element()
                 };
 
-                formatted![formatter, [formatted_element, separator]]
+                Ok(format_elements![
+                    group_elements(formatted_element),
+                    separator
+                ])
             })
             .collect::<FormatResult<Vec<_>>>()?;
 

--- a/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
@@ -14,7 +14,7 @@ impl FormatRule<TsUnionTypeVariantList> for FormatTsUnionTypeVariantList {
         let last_index = node.len().saturating_sub(1);
 
         for (index, item) in node.elements().enumerate() {
-            let ty = item.node()?;
+            let ty = formatted![formatter, [item.node().format()]]?;
             let separator = item.trailing_separator()?;
 
             let separator = match separator {
@@ -40,7 +40,7 @@ impl FormatRule<TsUnionTypeVariantList> for FormatTsUnionTypeVariantList {
                 }
             };
 
-            elements.push(formatted![formatter, [ty.format(), separator]]?)
+            elements.push(format_elements![group_elements(ty), separator]);
         }
 
         Ok(concat_elements(elements))

--- a/crates/rome_js_formatter/src/utils/array.rs
+++ b/crates/rome_js_formatter/src/utils/array.rs
@@ -30,7 +30,7 @@ where
             let is_disallow = matches!(separator_mode, TrailingSeparatorMode::Disallow);
             let is_force = matches!(separator_mode, TrailingSeparatorMode::Force);
 
-            let elem = node.format();
+            let formatted_element = formatted![formatter, [node.format()]]?;
             let separator = if is_disallow {
                 // Trailing separators are disallowed, replace it with an empty element
                 if let Some(separator) = element.trailing_separator()? {
@@ -55,7 +55,7 @@ where
 
             Ok((
                 node.syntax().clone(),
-                formatted![formatter, [elem, separator]]?,
+                format_elements![group_elements(formatted_element), separator],
             ))
         })
         .collect::<FormatResult<Vec<_>>>()?;

--- a/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
@@ -39,15 +39,15 @@ import "short" assert { type: "json" };
 
 import "very_long_import_very_long_import_very" assert {
 	// something good is here
-	"type": "json", /****/
+	"type": /****/ "json",
 };
 
 import "very_long_import_very_long_import_very" assert {
 	// something good is here
-	"type": "json", /****/
-	"type2": "json", /****/
-	"type3": "json", /****/
-	"type4": "json", /****/
+	"type": /****/ "json",
+	"type2": /****/ "json",
+	"type3": /****/ "json",
+	"type4": /****/ "json",
 	"typetypetypetypetypetypetypetypetypetypetype": "typetypetypetypetypetypetypetypetypetypetypetypetypetype", /****/
 };
 

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -33,18 +33,12 @@ import { hey } from "hey";
 import { test } from "foo.json" assert { for: "for" };
 import {
 	// some funky comment
-	loooooooooooooooooooong
-	as
-	moreeeeeeloooooooooooooooooooong,
-	loooooooooooooooooooong2
-	as
-	moreeeeeeloooooooooooooooooooong2,
+	loooooooooooooooooooong as moreeeeeeloooooooooooooooooooong,
+	loooooooooooooooooooong2 as moreeeeeeloooooooooooooooooooong2,
 	// some other comment
 } from "test";
 import {
-	loooooooooooooooooooong3
-	as
-	moreeeeeeloooooooooooooooooooong3,
+	loooooooooooooooooooong3 as moreeeeeeloooooooooooooooooooong3,
 	// some funky comment
 } from "test";
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-negative-comment-after-minus.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-negative-comment-after-minus.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
 expression: numbers-negative-comment-after-minus.js
-
 ---
 # Input
 ```js
@@ -68,7 +66,7 @@ const numbers = [
 
 c =
   [
-    -66, /**/
+    - /**/ 66,
     66,
     57,
     45,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/closure-compiler-type-cast.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/closure-compiler-type-cast.js.snap
@@ -75,7 +75,7 @@ let inlineComment = /* some comment */ (
 );
 
 let object = {
-  key: (someReallyLongFunctionCall(withLots, ofArguments)), /* some comment */
+  key: /* some comment */ (someReallyLongFunctionCall(withLots, ofArguments)),
 };
 
 // preserve parens only for type casts

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/method_types.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/method_types.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: method_types.ts
 ---
 # Input
@@ -50,29 +49,29 @@ abstract class Test {
 # Output
 ```js
 interface foo1 {
-  bar3( /* baz */ ); /* foo */ // bat
-  bar?( /* baz */ ); /* foo */ /* bar */ /* bat */
-  bar2( /* baz */ ); /* foo */ /* bat */
+  bar3 /* foo */ ( /* baz */ ); // bat
+  bar /* foo */ ? /* bar */ ( /* baz */ ); /* bat */
+  bar2 /* foo */ ( /* baz */ ); /* bat */
 }
 
 interface foo2 {
-  bar?(bar: /* baz */ string): string; /* foo */ /* bar */ /* bat */
+  bar /* foo */ ? /* bar */ (bar: /* baz */ string): /* bat */ string;
 }
 
 interface foo3 {
-  /* foo */ ( /* bar */ ): string; /* baz */
+  /* foo */ ( /* bar */ ): /* baz */ string;
 }
 
 interface foo4 {
-  /* foo */ (bar: /* bar */ string): string; /* baz */
+  /* foo */ (bar: /* bar */ string): /* baz */ string;
 }
 
 interface foo5 {
-  /* foo */ new (a: /* baz */ string): string; /* bar */ /* bat */
+  /* foo */ new /* bar */ (a: /* baz */ string): /* bat */ string;
 }
 
 interface foo6 {
-  /* foo */ new ( /* baz */ ): string; /* bar */ /* bat */
+  /* foo */ new /* bar */ ( /* baz */ ): /* bat */ string;
 }
 
 type foo7 = /* foo */ ( /* bar */ ) /* baz */ => void;


### PR DESCRIPTION
I noticed that Rome doesn't group the items of list. This is problematic
because the printer then breaks the whole list if one element doesn't fit on a single line.

Before:

```js
import {
	// some funky comment
	loooooooooooooooooooong
	as
	moreeeeeeloooooooooooooooooooong,
	loooooooooooooooooooong2
	as
	moreeeeeeloooooooooooooooooooong2,
	// some other comment
} from "test";
```

After:

```
import {
	// some funky comment
	loooooooooooooooooooong as moreeeeeeloooooooooooooooooooong,
	loooooooooooooooooooong2 as moreeeeeeloooooooooooooooooooong2,
	// some other comment
} from "test";
import {
	loooooooooooooooooooong3 as moreeeeeeloooooooooooooooooooong3,
	// some funky comment
} from "test";
```

This PR wraps the formatted element inside of `format_separated` and
  in some other places where Rome does manual list formatting. There may be more places but this should be a good start.

## Test Plan

`cargo test`

I'm a bit surprised that not more files are changing but noticed that there are plenty of cases when I applied these changes to my local PR that changes how our printer determines if some content "fits". 