### PR TITLE
feature(rome_js_parser): coverage test suite for ts symbols file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1245,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -1994,9 +2006,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.31"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if",
  "log",
@@ -2039,14 +2051,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.6"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2416,6 +2432,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
  "xtask",
  "yastl",

--- a/crates/rome_js_parser/src/lib.rs
+++ b/crates/rome_js_parser/src/lib.rs
@@ -69,6 +69,7 @@ mod state;
 #[cfg(test)]
 mod tests;
 
+pub mod symbols;
 pub mod syntax;
 mod token_source;
 

--- a/crates/rome_js_parser/src/symbols.rs
+++ b/crates/rome_js_parser/src/symbols.rs
@@ -1,0 +1,18 @@
+use rome_js_syntax::{JsSyntaxNode, TextRange};
+
+#[derive(Debug)]
+pub struct Symbol {}
+
+impl Symbol {
+    pub fn range(&self) -> TextRange {
+        todo!()
+    }
+
+    pub fn name(&self) -> &str {
+        todo!()
+    }
+}
+
+pub fn symbols(_root: JsSyntaxNode) -> impl IntoIterator<Item = Symbol> {
+    vec![]
+}

--- a/xtask/coverage/Cargo.toml
+++ b/xtask/coverage/Cargo.toml
@@ -23,3 +23,5 @@ once_cell = "1.9.0"
 walkdir = "2.3.2"
 num_cpus = "1.13.1"
 atty = "0.2.14"
+tracing = "0.1.34"
+tracing-subscriber = { version = "0.3.11", features = ["env-filter", "std"] }

--- a/xtask/coverage/src/lib.rs
+++ b/xtask/coverage/src/lib.rs
@@ -4,6 +4,7 @@ pub mod jsx;
 mod reporters;
 pub mod results;
 mod runner;
+pub mod symbols;
 pub mod ts;
 mod util;
 
@@ -19,6 +20,7 @@ use jsx::jsx_babel::BabelJsxTestSuite;
 use rome_js_parser::ParseDiagnostic;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
+use symbols::msts::SymbolsMicrosoftTestSuite;
 use ts::ts_babel::BabelTypescriptTestSuite;
 use ts::ts_microsoft::MicrosoftTypescriptTestSuite;
 use util::decode_maybe_utf16_string;
@@ -156,6 +158,7 @@ const ALL_SUITES: &str = "*";
 const ALL_JS_SUITES: &str = "js";
 const ALL_TS_SUITES: &str = "ts";
 const ALL_JSX_SUITES: &str = "jsx";
+const ALL_SYMBOLS_SUITES: &str = "symbols";
 
 fn get_test_suites(suites: Option<&str>) -> Vec<Box<dyn TestSuite>> {
     let suites = suites.unwrap_or("*").to_lowercase();
@@ -168,12 +171,14 @@ fn get_test_suites(suites: Option<&str>) -> Vec<Box<dyn TestSuite>> {
             ALL_JS_SUITES | "javascript" => ids.extend(["js/262"]),
             ALL_TS_SUITES | "typescript" => ids.extend(["ts/microsoft", "ts/babel"]),
             ALL_JSX_SUITES => ids.extend(["jsx/babel"]),
-            ALL_SUITES => ids.extend(["js", "ts", "jsx"]),
+            ALL_SYMBOLS_SUITES => ids.extend(["symbols/microsoft"]),
+            ALL_SUITES => ids.extend(["js", "ts", "jsx", "symbols"]),
 
             "js/262" => suites.push(Box::new(Test262TestSuite)),
             "ts/microsoft" => suites.push(Box::new(MicrosoftTypescriptTestSuite)),
             "ts/babel" => suites.push(Box::new(BabelTypescriptTestSuite)),
             "jsx/babel" => suites.push(Box::new(BabelJsxTestSuite)),
+            "symbols/microsoft" => suites.push(Box::new(SymbolsMicrosoftTestSuite)),
 
             _ => {}
         }

--- a/xtask/coverage/src/main.rs
+++ b/xtask/coverage/src/main.rs
@@ -4,6 +4,8 @@ use xtask::{project_root, pushd, Result};
 use xtask_coverage::{compare::coverage_compare, run, SummaryDetailLevel};
 
 fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
     let _d = pushd(project_root());
 
     let mut args = Arguments::from_env();

--- a/xtask/coverage/src/symbols/mod.rs
+++ b/xtask/coverage/src/symbols/mod.rs
@@ -1,0 +1,2 @@
+pub mod msts;
+mod utils;

--- a/xtask/coverage/src/symbols/msts.rs
+++ b/xtask/coverage/src/symbols/msts.rs
@@ -55,36 +55,39 @@ impl TestCase for SymbolsMicrosoftTestCase {
             .collect();
         actual.sort_by_key(|x| x.range().start());
 
-        if std::env::var("PRINT_CMP").is_ok() {
-            let mut expecteds = expected.symbols.iter();
-            let mut actuals = actual.iter();
-            loop {
-                let e = expecteds.next();
-                let a = actuals.next();
+        // Print to debug! detailed information
+        // on symbols that are different from the
+        // expected
+        let mut expecteds = expected.symbols.iter();
+        let mut actuals = actual.iter();
+        loop {
+            let expected = expecteds.next();
+            let actual = actuals.next();
 
-                if e.is_none() && a.is_none() {
-                    break;
-                }
-
-                if let Some(s) = e {
-                    print!("{}", s.name);
-                }
-
-                print!(" - ");
-
-                if let Some(s) = a {
-                    print!("{:?}", s);
-                }
-
-                match (e, a) {
-                    (Some(e), Some(a)) if e.name != a.name() => {
-                        println!(" <<<<<<<<<<<<<<<<<<<< Diff here")
-                    }
-                    _ => {}
-                }
-
-                println!();
+            if expected.is_none() && actual.is_none() {
+                break;
             }
+
+            let mut debug_text = String::new();
+
+            if let Some(symbol) = expected {
+                debug_text.push_str(&symbol.name);
+            }
+
+            debug_text.push_str(" - ");
+
+            if let Some(symbol) = actual {
+                debug_text.push_str(&format!("{:?}", symbol));
+            }
+
+            match (expected, actual) {
+                (Some(e), Some(a)) if e.name != a.name() => {
+                    debug_text.push_str(" <<<<<<<<<<<<<<<<<<<< Diff here");
+                }
+                _ => {}
+            }
+
+            tracing::debug!("{}", debug_text);
         }
 
         if expected.symbols.len() != actual.len() {

--- a/xtask/coverage/src/symbols/msts.rs
+++ b/xtask/coverage/src/symbols/msts.rs
@@ -98,11 +98,7 @@ impl TestCase for SymbolsMicrosoftTestCase {
         } else {
             for (expected, actual) in expected.symbols.iter().zip(actual) {
                 let are_names_eq = expected.name == actual.name();
-                // let are_paths_eq = expected.name == actual.name;
-                //TODO check decls
-                if !are_names_eq
-                /*|| !are_paths_eq*/
-                {
+                if !are_names_eq {
                     return TestRunOutcome::IncorrectlyErrored {
                         files: t,
                         errors: vec![],

--- a/xtask/coverage/src/symbols/msts.rs
+++ b/xtask/coverage/src/symbols/msts.rs
@@ -1,0 +1,253 @@
+use crate::check_file_encoding;
+use crate::runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite};
+use rome_js_parser::SourceType;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use super::utils::{parse_separated_list, parse_str, parse_until_chr, parse_whitespace0};
+
+const CASES_PATH: &str = "xtask/coverage/Typescript/tests/baselines/reference";
+const BASE_PATH: &str = "xtask/coverage/Typescript";
+
+#[derive(Debug)]
+struct SymbolsMicrosoftTestCase {
+    path: PathBuf,
+    name: String,
+}
+
+impl SymbolsMicrosoftTestCase {
+    fn new(path: &Path) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            name: path.file_name().unwrap().to_string_lossy().to_string(),
+        }
+    }
+}
+
+impl TestCase for SymbolsMicrosoftTestCase {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn run(&self) -> TestRunOutcome {
+        let code = "".to_string();
+
+        let symbols = check_file_encoding(&self.path).unwrap();
+        let expected = load_symbols_file(&symbols);
+
+        let mut full_path = PathBuf::from_str(BASE_PATH).unwrap();
+        full_path.push(expected.code_file);
+
+        if !full_path.exists() {
+            // We may be able to recover the code from the .symbols file
+            let t = TestCaseFiles::single(self.name.clone(), code, SourceType::tsx());
+            return TestRunOutcome::Passed(t);
+        }
+
+        let code = std::fs::read_to_string(&full_path).unwrap();
+        let t = TestCaseFiles::single(self.name.clone(), code.clone(), SourceType::tsx());
+
+        let r = rome_js_parser::parse(&code, 0, SourceType::tsx());
+        let mut actual: Vec<_> = rome_js_parser::symbols::symbols(r.syntax())
+            .into_iter()
+            .filter(|x| !x.name().contains('\"') && !x.name().contains('\''))
+            .collect();
+        actual.sort_by_key(|x| x.range().start());
+
+        if std::env::var("PRINT_CMP").is_ok() {
+            let mut expecteds = expected.symbols.iter();
+            let mut actuals = actual.iter();
+            loop {
+                let e = expecteds.next();
+                let a = actuals.next();
+
+                if e.is_none() && a.is_none() {
+                    break;
+                }
+
+                if let Some(s) = e {
+                    print!("{}", s.name);
+                }
+
+                print!(" - ");
+
+                if let Some(s) = a {
+                    print!("{:?}", s);
+                }
+
+                match (e, a) {
+                    (Some(e), Some(a)) if e.name != a.name() => {
+                        println!(" <<<<<<<<<<<<<<<<<<<< Diff here")
+                    }
+                    _ => {}
+                }
+
+                println!();
+            }
+        }
+
+        if expected.symbols.len() != actual.len() {
+            TestRunOutcome::IncorrectlyErrored {
+                files: t,
+                errors: vec![],
+            }
+        } else {
+            for (expected, actual) in expected.symbols.iter().zip(actual) {
+                let are_names_eq = expected.name == actual.name();
+                // let are_paths_eq = expected.name == actual.name;
+                //TODO check decls
+                if !are_names_eq
+                /*|| !are_paths_eq*/
+                {
+                    return TestRunOutcome::IncorrectlyErrored {
+                        files: t,
+                        errors: vec![],
+                    };
+                }
+            }
+
+            TestRunOutcome::Passed(t)
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct SymbolsMicrosoftTestSuite;
+
+impl TestSuite for SymbolsMicrosoftTestSuite {
+    fn name(&self) -> &str {
+        "symbols/microsoft"
+    }
+
+    fn base_path(&self) -> &str {
+        CASES_PATH
+    }
+
+    fn is_test(&self, path: &Path) -> bool {
+        match path.extension() {
+            Some(ext) if ext == "symbols" => {
+                // only accepts if there is no *.errors.txt file
+                let fullpath = path.with_extension("errors.txt");
+                std::fs::metadata(fullpath).is_err()
+            }
+            _ => false,
+        }
+    }
+
+    fn load_test(&self, path: &Path) -> Option<Box<dyn TestCase>> {
+        Some(Box::new(SymbolsMicrosoftTestCase::new(path)))
+    }
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Decl {
+    file: String,
+    row_start: Option<usize>,
+    col_start: Option<usize>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct Symbol {
+    name: String,
+    path: String,
+    decls: Vec<Decl>,
+}
+
+struct SymbolsFile {
+    code_file: PathBuf,
+    symbols: Vec<Symbol>,
+}
+
+fn parse_decl(input: &str) -> Option<(&str, Decl)> {
+    let (input, _) = parse_str(input, "Decl")?;
+    let (input, _) = parse_whitespace0(input);
+    let (input, _) = parse_str(input, "(")?;
+    let (input, _) = parse_whitespace0(input);
+    let (input, file) = parse_until_chr(input, |x| x.is_whitespace() || x == ',')?;
+    let (input, _) = parse_whitespace0(input);
+    let (input, _) = parse_str(input, ",")?;
+    let (input, _) = parse_whitespace0(input);
+    let (input, row_start) = parse_until_chr(input, |x| x.is_whitespace() || x == ',')?;
+    let (input, _) = parse_whitespace0(input);
+    let (input, _) = parse_str(input, ",")?;
+    let (input, _) = parse_whitespace0(input);
+    let (input, col_start) = parse_until_chr(input, |x| x.is_whitespace() || x == ')')?;
+    let (input, _) = parse_whitespace0(input);
+    let (input, _) = parse_str(input, ")")?;
+    Some((
+        input,
+        Decl {
+            file: file.to_string(),
+            row_start: row_start.parse().ok(),
+            col_start: col_start.parse().ok(),
+        },
+    ))
+}
+
+/// see xtask\coverage\Typescript\src\harness\typeWriter.ts
+/// to understand how the symbol line is generated
+/// example:
+/// >Cell : Symbol(Cell, Decl(2dArrays.ts, 0, 0))
+fn parse_symbol(input: &str) -> Option<Symbol> {
+    let (input, _) = parse_str(input, ">")?;
+    let (input, name) = parse_until_chr(input, |x| x.is_whitespace() || x == ':')?;
+    if name.contains('.')
+        || name.contains('[')
+        || name.contains('\"')
+        || name.contains('\'')
+        || name == "undefined"
+    {
+        return None;
+    }
+    let (input, _) = parse_whitespace0(input);
+    let (input, _) = parse_str(input, ":")?;
+    let (input, _) = parse_whitespace0(input);
+    let (input, _) = parse_str(input, "Symbol")?;
+    let (input, _) = parse_whitespace0(input);
+    let (input, _) = parse_str(input, "(")?;
+    let (input, path) = parse_until_chr(input, |x| x.is_whitespace() || x == ',' || x == ')')?;
+    let (input, _) = parse_whitespace0(input);
+    let decls = if !input.starts_with(')') {
+        let (input, _) = parse_str(input, ",")?;
+        let (input, _) = parse_whitespace0(input);
+
+        let (_, decls) = parse_separated_list(
+            input,
+            parse_decl,
+            |s| parse_str(s, ",").map(|x| x.0).unwrap_or(s),
+            |s| parse_whitespace0(s).0,
+        );
+        decls
+    } else {
+        vec![]
+    };
+
+    Some(Symbol {
+        name: name.to_string(),
+        path: path.to_string(),
+        decls,
+    })
+}
+
+fn load_symbols_file(txt: &str) -> SymbolsFile {
+    let mut lines = txt.lines();
+
+    // first line example
+    // === tests/cases/compiler/2dArrays.ts ===
+    let code_file = lines.next().unwrap().replace("===", "").trim().to_string();
+
+    let mut symbols = vec![];
+
+    for line in lines {
+        if let Some(symbol) = parse_symbol(line) {
+            symbols.push(symbol);
+        }
+    }
+
+    SymbolsFile {
+        code_file: PathBuf::from(code_file),
+        symbols,
+    }
+}

--- a/xtask/coverage/src/symbols/msts.rs
+++ b/xtask/coverage/src/symbols/msts.rs
@@ -1,6 +1,7 @@
+use rome_js_syntax::SourceType;
+
 use crate::check_file_encoding;
 use crate::runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite};
-use rome_js_parser::SourceType;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 

--- a/xtask/coverage/src/symbols/utils.rs
+++ b/xtask/coverage/src/symbols/utils.rs
@@ -1,0 +1,54 @@
+pub fn parse_str<'a>(input: &'a str, s: &'a str) -> Option<(&'a str, &'a str)> {
+    input
+        .strip_prefix(s)
+        .map(|stripped| (stripped, &input[0..s.len()]))
+}
+
+pub fn parse_until_chr(input: &'_ str, f: impl Fn(char) -> bool) -> Option<(&'_ str, &'_ str)> {
+    let mut qty = 0;
+
+    for chr in input.chars() {
+        if f(chr) {
+            break;
+        }
+
+        qty += chr.len_utf8();
+    }
+
+    if qty > 0 {
+        Some((&input[qty..], &input[0..qty]))
+    } else {
+        None
+    }
+}
+
+pub fn parse_whitespace0(input: &'_ str) -> (&'_ str, &'_ str) {
+    parse_until_chr(input, |x| !x.is_whitespace()).unwrap_or((input, ""))
+}
+
+pub fn parse_separated_list<T>(
+    input: &str,
+    item: impl Fn(&str) -> Option<(&str, T)>,
+    separator: impl Fn(&str) -> &str,
+    trivia: impl Fn(&str) -> &str,
+) -> (&str, Vec<T>) {
+    let mut list = vec![];
+
+    let mut input = input;
+    loop {
+        let s = trivia(input);
+
+        let s = if let Some((s, item)) = item(s) {
+            list.push(item);
+            s
+        } else {
+            break;
+        };
+
+        let s = trivia(s);
+        let s = separator(s);
+        input = s;
+    }
+
+    (input, list)
+}


### PR DESCRIPTION
see https://github.com/rome/tools/issues/2488

This PR parses Microsoft/ts .symbols file;

#### Microsoft ts .symbols file

We are running only files without any errors.

```
symbols/msts: Ran 5946 tests in 19.05s
┌───────────┬────────┬────────┬────────┬──────────┐
│ Tests ran │ Passed │ Failed │ Panics │ Coverage │
├───────────┼────────┼────────┼────────┼──────────┤
│      5946 │   1613 │   4328 │      5 │    27.13 │
└───────────┴────────┴────────┴────────┴──────────┘
```

All ```parse_*``` functions are simplified versions of ```nom```, just to avoid including another crate.

#### Fake Implementation

```Symbol``` and ```symbols``` are fake and only exist to make the coverage test to compile and run.