### PR TITLE
feature(formatter): `LineSuffixBoundary` and `ExpandParent` IR

### DIFF
--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -605,7 +605,7 @@ fn fits_on_line<'a>(
         pending_indent: printer.state.pending_indent,
         pending_space: printer.state.pending_space,
         line_width: printer.state.line_width,
-        has_line_suffix: printer.state.line_suffixes.len() > 0,
+        has_line_suffix: !printer.state.line_suffixes.is_empty(),
     };
 
     let result = loop {
@@ -747,12 +747,6 @@ fn fits_element_on_line<'a, 'rest>(
         }
 
         FormatElement::LineSuffix(_) => {
-            // The current behavior is to return `false` for all line suffixes if trying to print
-            // something in "flat" mode.
-            if args.mode.is_flat() {
-                return Fits::No;
-            }
-
             state.has_line_suffix = true;
         }
 

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -242,6 +242,10 @@ impl<'a> Printer<'a> {
             }
             FormatElement::ExpandParent => {
                 // No-op, only has an effect on `fits`
+                debug_assert!(
+                    !args.mode.is_flat(),
+                    "Fits should always return false for `ExpandParent`"
+                );
             }
         }
     }

--- a/crates/rome_js_formatter/src/formatter.rs
+++ b/crates/rome_js_formatter/src/formatter.rs
@@ -216,7 +216,10 @@ where
                     ]),
                 ]
             } else {
-                line_suffix(format_elements![space_token(), comment, space_token()])
+                format_elements![
+                    line_suffix(format_elements![space_token(), comment]),
+                    expand_parent()
+                ]
             };
 
             elements.push(crate::comment(content));

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -21,6 +21,7 @@ impl FormatNodeFields<JsAssignmentExpression> for FormatNodeRule<JsAssignmentExp
                 left.format(),
                 space_token(),
                 operator_token.format(),
+                line_suffix_boundary(),
                 group_elements(soft_line_indent_or_space(formatted![
                     formatter,
                     [right.format()]

--- a/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
@@ -64,6 +64,7 @@ impl FormatNodeFields<JsxExpressionAttributeValue> for FormatNodeRule<JsxExpress
             [
                 l_curly_token.format(),
                 formatted_expression,
+                line_suffix_boundary(),
                 r_curly_token.format(),
             ]
         ]?))

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: function.js
-
 ---
 # Input
 ```js
@@ -89,15 +87,15 @@ f3 =
     a = b, //comment
   ) => {};
 
-f4 = () => {}; // Comment
+f4 = // Comment
+() => {};
 
 f5 =
   // Comment
 
   () => {};
 
-f6 =
-  /* comment */
+f6 = /* comment */
   // Comment
 
   () => {};

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: number.js
-
 ---
 # Input
 ```js
@@ -70,8 +68,7 @@ fnNumber =
 
 fnNumber = /* comment */ 3;
 
-fnNumber =
-  /* comments0 */
+fnNumber = /* comments0 */
   /* comments1 */
   3;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/string.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: string.js
-
 ---
 # Input
 ```js
@@ -118,12 +116,12 @@ fnString =
     "long" +
     "string";
 
-fnString =
-  // Comment0
+fnString = // Comment0
   // Comment1
   "some" + "long" + "string";
 
-fnString = "some" + "long" + "string"; // Comment
+fnString = // Comment
+"some" + "long" + "string";
 
 fnString =
   // Comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/while.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/while.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 121
 expression: while.js
-
 ---
 # Input
 ```js

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/while.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/while.js.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 121
 expression: while.js
+
 ---
 # Input
 ```js


### PR DESCRIPTION
## Summary

This PR introduces  two new IR elements:

* `LineSuffixBoundary`: Forces the printer to flush any pending `LineSuffix`. For example necessary to avoid a comment inside of a JSX expression accidentally getting pushed into the content of an outer element. 
* `ExpandParent`: Forces the parent group to be printed as expended. E.g. should allow us to remove the `LineSuffix` special case inside of the printer by emitting a `ExpandParent` for each block comment.

Part of #2579 

## Test Plan

I added examples with integration tests for each new IR element