### PR TITLE
feature(formatter): Add `BestFitting` IR element

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -1395,6 +1395,15 @@ pub struct BestFitting {
 }
 
 impl BestFitting {
+    /// Creates a new best fitting IR with the given variants. The method itself isn't unsafe
+    /// but it is to discourage people from using it because the printer will panic if
+    /// the slice doesn't contain at least the least and most expanded variants.
+    ///
+    /// You're looking for a way to create a `BestFitting` object, use the `best_fitting![least_expanded, most_expanded]` macro.
+    ///
+    /// ## Safety
+    /// The slice must contain at least two variants.
+    #[doc(hidden)]
     pub unsafe fn from_slice_unchecked(variants: &[FormatElement]) -> Self {
         debug_assert!(
             variants.len() >= 2,

--- a/crates/rome_formatter/src/prelude.rs
+++ b/crates/rome_formatter/src/prelude.rs
@@ -4,6 +4,6 @@ pub use crate::formatter::Formatter;
 pub use crate::printer::PrinterOptions;
 
 pub use crate::{
-    format_elements, formatted, Format, Format as _, FormatError, FormatResult, FormatRule,
-    FormatWithRule as _, IntoFormatElement as _,
+    best_fitting, format_elements, formatted, Format, Format as _, FormatError, FormatResult,
+    FormatRule, FormatWithRule as _, IntoFormatElement as _,
 };

--- a/crates/rome_formatter/src/printer/printer_options/mod.rs
+++ b/crates/rome_formatter/src/printer/printer_options/mod.rs
@@ -21,8 +21,8 @@ pub struct PrinterOptions {
 }
 
 impl PrinterOptions {
-    pub fn with_print_with(mut self, with: LineWidth) -> Self {
-        self.print_width = with;
+    pub fn with_print_width(mut self, width: LineWidth) -> Self {
+        self.print_width = width;
         self
     }
 

--- a/crates/rome_js_formatter/src/options.rs
+++ b/crates/rome_js_formatter/src/options.rs
@@ -36,7 +36,7 @@ impl FormatOptions for JsFormatOptions {
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions::default()
             .with_indent(self.indent_style)
-            .with_print_with(self.line_width)
+            .with_print_width(self.line_width)
     }
 }
 


### PR DESCRIPTION
This PR introduces the new IR element `BestFitting`. The IR matches Prettier's `ConditionalGroupContent`. This IR can be useful if the best representation depends on the available space. `BestFitting` defers the choice of how to print the element to the printer by providing multiple variants. The printer picks the element that best fits given the circumstances (that's where its name is coming from but I'm open to better names).

The printer picks the first variant that fits on the current line and falls back to print the last variant in expanded mode if no variant fits.

Part of #2579

## Test Plan

I added an integration test as part of the documentation of the `best_fitting` function.