### PR TITLE
chore: Upgrade to Rust 1.61.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.60.0"
+channel = "1.61.0"


### PR DESCRIPTION
Release blog: https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html
tldr: https://twitter.com/m_ou_se/status/1527413077632765965