### PR TITLE
feat(rome_rowan): cast and parent to help SyntaxNode and AstNode navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "extension-trait"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5129068fe3183546eaa0529af88ab0afbcddec2a373db69e94a20b8d5f6c4d74"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1529,7 @@ name = "rome_rowan"
 version = "0.0.0"
 dependencies = [
  "countme",
+ "extension-trait",
  "hashbrown",
  "memoffset",
  "quickcheck",

--- a/crates/rome_rowan/Cargo.toml
+++ b/crates/rome_rowan/Cargo.toml
@@ -15,8 +15,8 @@ hashbrown = { version = "0.11.2", features = [
 text-size = "1.1.0"
 memoffset = "0.6.5"
 countme = "3.0.0"
-
 serde_crate = { package = "serde", version = "1.0.133", optional = true, default-features = false }
+extension-trait = "1.0.1"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -4,6 +4,7 @@
 //! from any error and produce an ast from any source code. If you don't want to account for
 //! optionals for everything, you can use ...
 
+use extension_trait::extension_trait;
 #[cfg(feature = "serde")]
 use serde_crate::Serialize;
 use std::error::Error;
@@ -75,6 +76,17 @@ pub trait AstNode {
         Self: Sized,
     {
         Self::cast(self.syntax().clone_subtree()).unwrap()
+    }
+
+    fn parent<T: AstNode<Language = Self::Language>>(&self) -> Option<T> {
+        self.syntax().parent().and_then(T::cast)
+    }
+}
+
+#[extension_trait]
+impl<L: Language> SyntaxNodeCast<L> for SyntaxNode<L> {
+    fn cast<T: AstNode<Language = L>>(self) -> Option<T> {
+        T::cast(self)
     }
 }
 
@@ -641,5 +653,51 @@ mod tests {
             list.elements(),
             vec![(Some(1.), None), (Some(2.), Some(","))],
         );
+    }
+
+    #[test]
+    fn ok_typed_parent_navigation() {
+        use crate::ast::SyntaxNodeCast;
+        use crate::raw_language::{RawLanguage, RawLanguageKind, RawSyntaxTreeBuilder};
+        use crate::*;
+
+        // This test creates the following tree
+        // Root
+        //     Condition
+        //         Let
+        // then selects the CONDITION node, cast it,
+        // then navigate upwards to its parent.
+        // All casts are fake and implemented below
+
+        let tree = RawSyntaxTreeBuilder::wrap_with_node(RawLanguageKind::ROOT, |builder| {
+            builder.start_node(RawLanguageKind::CONDITION);
+            builder.token(RawLanguageKind::LET_TOKEN, "let");
+            builder.finish_node();
+        });
+        let typed = tree.first_child().unwrap().cast::<RawRoot>().unwrap();
+        let _ = typed.parent::<RawRoot>().unwrap();
+
+        struct RawRoot(SyntaxNode<RawLanguage>);
+        impl AstNode for RawRoot {
+            type Language = RawLanguage;
+            fn can_cast(_: <Self::Language as Language>::Kind) -> bool {
+                todo!()
+            }
+
+            fn cast(syntax: SyntaxNode<Self::Language>) -> Option<Self>
+            where
+                Self: Sized,
+            {
+                Some(Self(syntax))
+            }
+
+            fn syntax(&self) -> &SyntaxNode<Self::Language> {
+                &self.0
+            }
+
+            fn into_syntax(self) -> SyntaxNode<Self::Language> {
+                todo!()
+            }
+        }
     }
 }


### PR DESCRIPTION
this PR is about this discussion: https://github.com/rome/tools/discussions/2586

I avoided the lifted ```parent``` method because is more unconventional.