### PR TITLE
fix(repo): Update .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ npm/cli-*
 
 # https://github.com/nnethercote/dhat-rs output file
 dhat-heap.json
+
+crates/rome_js_formatter/report.md

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,6 +1,7 @@
-node_modules
-build
 .env
+build
+node_modules
+package-lock.json
 
 # Auto generated
 src/_includes/styles


### PR DESCRIPTION
## Summary
https://github.com/rome/tools/pull/2596 removed a `package-lock.json` file from the website folder which caused confusion, and https://github.com/rome/tools/pull/2574 added a `report.md` file which shouldn't be committed. This PR adds both of those files to `.gitignore` to make sure they do not get added to the repo accidentally.

## Test Plan
Verified that these two files don't show up in git any longer.