### PR TITLE
(npm/rome): remove `node:` prefix for builtin module

### DIFF
--- a/npm/rome/bin/rome
+++ b/npm/rome/bin/rome
@@ -18,7 +18,7 @@ const PLATFORMS = {
 
 const binPath = PLATFORMS?.[platform]?.[arch];
 if (binPath) {
-	const result = require("node:child_process").spawnSync(
+	const result = require("child_process").spawnSync(
 		require.resolve(binPath),
 		process.argv.slice(2),
 		{ shell: false, stdio: "inherit" },

--- a/npm/rome/scripts/generate-packages.mjs
+++ b/npm/rome/scripts/generate-packages.mjs
@@ -1,6 +1,6 @@
-import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import * as fs from "node:fs";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
+import * as fs from "fs";
 
 const ROMECLI_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const PACKAGES_ROOT = resolve(ROMECLI_ROOT, "..");

--- a/npm/rome/scripts/postinstall.js
+++ b/npm/rome/scripts/postinstall.js
@@ -28,7 +28,7 @@ if (binName) {
 
 	if (binPath) {
 		try {
-			require("node:fs").chmodSync(binPath, 0o755);
+			require("fs").chmodSync(binPath, 0o755);
 		} catch (err) {
 			console.warn(
 				"The Rome CLI postinstall script failed to set execution permissions to the native binary. " + "Running Rome from the npm package will probably not work correctly.",

--- a/npm/rome/scripts/update-nightly-version.mjs
+++ b/npm/rome/scripts/update-nightly-version.mjs
@@ -1,6 +1,6 @@
-import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import * as fs from "node:fs";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
+import * as fs from "fs";
 
 const ROMECLI_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const MANIFEST_PATH = resolve(ROMECLI_ROOT, "package.json");


### PR DESCRIPTION
remove node prefix for compatibility

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
Fix #2606 
remove `node:` prefix for better compatibility under Nodejs `14.18.0`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
