### PR TITLE
fix(playground): JSX and TypeScript not persisted in URL

### DIFF
--- a/website/playground/src/utils.ts
+++ b/website/playground/src/utils.ts
@@ -65,8 +65,8 @@ export function usePlaygroundState(): [
 			//@ts-ignore
 			const queryString = new URLSearchParams({
 				...options,
-				isTypeScript: isTypeScript.toString(),
-				isJsx: isJsx.toString(),
+				typescript: isTypeScript.toString(),
+				jsx: isJsx.toString(),
 			}).toString();
 			const url = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${queryString}#${encodeCode(
 				code,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Accidentally broke the url persistence for `isJsx` and `isTypeScript`
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

[Loom link](https://www.loom.com/share/79cf0fe42d3e40e39faa44e3af1a23e2)
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
