### PR TITLE
feat(rome_cli): disable markup formatting when unsupported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,7 @@ dependencies = [
 name = "rome_console"
 version = "0.0.0"
 dependencies = [
+ "atty",
  "lazy_static",
  "rome_markup",
  "similar",

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -1,68 +1,84 @@
-use crate::Termination;
+use rome_console::{markup, ConsoleExt, Markup};
 
-const MAIN_HEAD: &str = "Rome v";
-const MAIN_BODY: &str = "
-Available commands:
-- check
-- ci
-- format
-- help
-";
+use crate::{CliSession, Termination};
 
-const CHECK: &str = "Rome Check: Run the linter on a set of files
+const VERSION: &str = match option_env!("ROME_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
 
-USAGE:
+const MAIN: Markup = markup! {
+"Rome CLI v"{VERSION}"
+
+"<Emphasis>"COMMANDS:"</Emphasis>"
+- "<Emphasis>"check"</Emphasis>"
+- "<Emphasis>"ci"</Emphasis>"
+- "<Emphasis>"format"</Emphasis>"
+- "<Emphasis>"help"</Emphasis>"
+"
+};
+
+const CHECK: Markup = markup! {
+    <Emphasis>"Rome Check"</Emphasis>": Run the linter on a set of files
+
+"<Emphasis>"USAGE:"</Emphasis>"
     rome check <INPUTS...>
 
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
-";
+"
+};
 
-const CI: &str = "Rome CI: Run the linter and formatter check on a set of files
+const FORMAT_OPTIONS: Markup = markup! {
+    "
+    "<Dim>"--indent-style <tabs|space>"</Dim>"   Determine whether the formatter should use tabs or spaces for indentation (default: tabs)
+    "<Dim>"--indent-size <number>"</Dim>"        If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
+    "<Dim>"--line-width <number>"</Dim>"         Determine how many characters the formatter is allowed to print in a single line (default: 80)
+    "<Dim>"--quote-style <single|double>"</Dim>" Determine whether the formatter should use single or double quotes for strings (default: double)
+"
+};
 
-USAGE:
+const CI: Markup = markup! {
+"Rome CI: Run the linter and formatter check on a set of files
+
+"<Emphasis>"USAGE:"</Emphasis>"
     rome ci [OPTIONS] <INPUTS...>
 
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
 
-OPTIONS:";
+"<Emphasis>"OPTIONS:"</Emphasis>
+    {FORMAT_OPTIONS}
+};
 
-const FORMAT: &str = "Rome Formatter
+const FORMAT: Markup = markup! {
+"Rome Formatter
 
-USAGE:
+"<Emphasis>"USAGE:"</Emphasis>"
     rome format [OPTIONS] <INPUTS...>
 
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
 
-OPTIONS:
-    --write                       Write the output of the formatter to the files instead of printing the diff to the console
-    --skip-errors                 Skip over files containing syntax errors instead of returning an error";
+"<Emphasis>"OPTIONS:"</Emphasis>"
+    "<Dim>"--write"</Dim>"                       Write the output of the formatter to the files instead of printing the diff to the console
+    "<Dim>"--skip-errors"</Dim>"                 Skip over files containing syntax errors instead of returning an error"
+    {FORMAT_OPTIONS}
+};
 
-const FORMAT_OPTIONS: &str = "
-    --indent-style <tabs|space>   Determine whether the formatter should use tabs or spaces for indentation (default: tabs)
-    --indent-size <number>        If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
-    --line-width <number>         Determine how many characters the formatter is allowed to print in a single line (default: 80)
-    --quote-style <single|double> Determine whether the formatter should use single or double quotes for strings (default: double)
-";
-
-pub(crate) fn help(command: Option<&str>) -> Result<(), Termination> {
+pub(crate) fn help(mut session: CliSession, command: Option<&str>) -> Result<(), Termination> {
     match command {
         Some("help") | None => {
-            print!(
-                "{MAIN_HEAD}{}{MAIN_BODY}",
-                option_env!("ROME_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
-            );
+            session.app.console.log(MAIN);
             Ok(())
         }
         Some("check") => {
-            print!("{CHECK}");
+            session.app.console.log(CHECK);
             Ok(())
         }
         Some("ci") => {
-            print!("{CI}{FORMAT_OPTIONS}");
+            session.app.console.log(CI);
             Ok(())
         }
         Some("format") => {
-            print!("{FORMAT}{FORMAT_OPTIONS}");
+            session.app.console.log(FORMAT);
             Ok(())
         }
 

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -21,9 +21,12 @@ pub struct CliSession<'app> {
 
 impl CliSession<'static> {
     pub fn from_env() -> Self {
+        let mut args = Arguments::from_env();
+        let no_colors = args.contains("--no-colors");
+
         Self {
-            app: App::from_env(),
-            args: Arguments::from_env(),
+            app: App::from_env(no_colors),
+            args,
         }
     }
 }
@@ -53,7 +56,7 @@ pub fn run_cli(mut session: CliSession) -> Result<(), Termination> {
 
     let result = match subcommand.as_deref() {
         // Print the help for the subcommand if it was called with `--help`
-        Some(cmd) if has_help => crate::commands::help::help(Some(cmd)),
+        Some(cmd) if has_help => crate::commands::help::help(session, Some(cmd)),
 
         Some("format") if !is_empty => crate::commands::format::format(session),
         Some("check") if !is_empty => crate::commands::check::check(session),
@@ -61,12 +64,12 @@ pub fn run_cli(mut session: CliSession) -> Result<(), Termination> {
 
         // Print the help for known commands called without any arguments, and exit with an error
         Some(cmd @ ("format" | "check" | "ci")) => {
-            crate::commands::help::help(Some(cmd))?;
+            crate::commands::help::help(session, Some(cmd))?;
             Err(Termination::EmptyArguments)
         }
 
         // Print the general help if no subcommand was specified / the subcommand is `help`
-        None | Some("help") => crate::commands::help::help(None),
+        None | Some("help") => crate::commands::help::help(session, None),
 
         Some(cmd) => Err(Termination::UnknownCommand {
             command: cmd.into(),

--- a/crates/rome_console/Cargo.toml
+++ b/crates/rome_console/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 rome_markup = { path = "../rome_markup" }
+atty = "0.2.14"
 text-size = "1.1.0"
 lazy_static = "1.4.0"
 termcolor = "1.1.2"

--- a/crates/rome_console/src/lib.rs
+++ b/crates/rome_console/src/lib.rs
@@ -55,11 +55,22 @@ pub struct EnvConsole {
     err: StandardStream,
 }
 
-impl Default for EnvConsole {
-    fn default() -> Self {
+impl EnvConsole {
+    pub fn new(no_colors: bool) -> Self {
+        let out_mode = if no_colors || !atty::is(atty::Stream::Stdout) {
+            ColorChoice::Never
+        } else {
+            ColorChoice::Auto
+        };
+        let err_mode = if no_colors || !atty::is(atty::Stream::Stderr) {
+            ColorChoice::Never
+        } else {
+            ColorChoice::Auto
+        };
+
         Self {
-            out: StandardStream::stdout(ColorChoice::Always),
-            err: StandardStream::stderr(ColorChoice::Always),
+            out: StandardStream::stdout(out_mode),
+            err: StandardStream::stderr(err_mode),
         }
     }
 }

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -166,7 +166,7 @@ impl SnapshotContent {
 /// * `json/null` -> input: `tests/specs/json/null.json`, expected output: `tests/specs/json/null.json.snap`
 /// * `null` -> input: `tests/specs/null.json`, expected output: `tests/specs/null.json.snap`
 pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, file_type: &str) {
-    let app = App::from_env();
+    let app = App::from_env(false);
 
     let file_path = &spec_input_file;
     let spec_input_file = Path::new(spec_input_file);

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -80,10 +80,10 @@ impl From<FormatError> for RomeError {
 
 impl App<'static> {
     /// Create a new instance of the app using the [OsFileSystem] and [EnvConsole]
-    pub fn from_env() -> Self {
+    pub fn from_env(no_colors: bool) -> Self {
         Self::with_filesystem_and_console(
             DynRef::Owned(Box::new(OsFileSystem)),
-            DynRef::Owned(Box::new(EnvConsole::default())),
+            DynRef::Owned(Box::new(EnvConsole::new(no_colors))),
         )
     }
 }


### PR DESCRIPTION
## Summary

This PR disables the formatting of markup in the console output when:
- The CLI is called with the `--no-colors` argument
- The standard output stream is not a Unix TTY / Windows Console handle (checked with the `atty` crate)
- The `TERM=dumb` or `NO_COLOR` environment variables are defined

Additionally I also took the opportunity to update the CLI help to use Markup
