### PR TITLE
test(rome_js_formatter): support report prettier metric as a json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ npm/cli-*
 # https://github.com/nnethercote/dhat-rs output file
 dhat-heap.json
 
-crates/rome_js_formatter/report.md
+crates/rome_js_formatter/report.*

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -278,32 +278,21 @@ enum ReportType {
     Markdown,
 }
 
-#[derive(Debug, PartialEq, Serialize, Default)]
-struct SingleFileJsonReport {
-    filename: String,
-    single_file_compatibility: f64,
-}
-
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 struct SingleFileMetricData {
     filename: String,
     single_file_compatibility: f64,
+    #[serde(skip)]
     diff: String,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize)]
 struct PrettierCompatibilityMetricData {
     file_based_average_prettier_similarity: f64,
     line_based_average_prettier_similarity: f64,
     files: Vec<SingleFileMetricData>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Default)]
-struct ReportJson {
-    file_based_average_prettier_similarity: f64,
-    line_based_average_prettier_similarity: f64,
-    files: Vec<SingleFileJsonReport>,
-}
 impl FromStr for ReportType {
     type Err = String;
 
@@ -519,30 +508,7 @@ impl DiffReport {
         report_filename: String,
         report_metric_data: PrettierCompatibilityMetricData,
     ) {
-        let report_json = ReportJson {
-            file_based_average_prettier_similarity: report_metric_data
-                .file_based_average_prettier_similarity,
-            line_based_average_prettier_similarity: report_metric_data
-                .line_based_average_prettier_similarity,
-            files: report_metric_data
-                .files
-                .into_iter()
-                .map(
-                    |SingleFileMetricData {
-                         filename,
-                         single_file_compatibility,
-                         diff: _,
-                     }| {
-                        SingleFileJsonReport {
-                            filename,
-                            single_file_compatibility,
-                        }
-                    },
-                )
-                .collect::<Vec<_>>(),
-        };
-
-        let json_content = serde_json::to_string(&report_json).unwrap();
+        let json_content = serde_json::to_string(&report_metric_data).unwrap();
         write(report_filename, json_content).unwrap();
     }
 }

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -412,7 +412,7 @@ impl DiffReport {
         let mut state = self.state.lock();
         state.sort_by_key(|DiffReportItem { file_name, .. }| *file_name);
         let mut report_metric_data = PrettierCompatibilityMetricData::default();
-        let mut sum_of_per_compatibility_file = 0_f64;
+        let mut sum_of_single_compatibility_file = 0_f64;
         let mut total_line = 0;
         let mut total_matched_line = 0;
         let mut file_count = 0;
@@ -428,7 +428,7 @@ impl DiffReport {
             let rome_lines = rome_formatted_result.lines().count();
             let prettier_lines = prettier_formatted_result.lines().count();
             let mut matched_lines = 0;
-            let mut per_file_compatibility = 1f64;
+            let mut single_file_compatibility = 1f64;
             let mut diff = String::new();
             if *match_category == MatchCategory::Diff {
                 writeln!(diff, "```diff").unwrap();
@@ -445,25 +445,25 @@ impl DiffReport {
                     writeln!(diff, "{}{}", tag, line).unwrap();
                 }
 
-                per_file_compatibility =
+                single_file_compatibility =
                     matched_lines as f64 / rome_lines.max(prettier_lines) as f64;
-                sum_of_per_compatibility_file += per_file_compatibility;
+                sum_of_single_compatibility_file += single_file_compatibility;
                 writeln!(diff, "```").unwrap();
             } else {
                 // in this branch `rome_lines` == `prettier_lines` == `matched_lines`
                 assert!(rome_lines == prettier_lines);
                 matched_lines = rome_lines;
-                sum_of_per_compatibility_file += per_file_compatibility;
+                sum_of_single_compatibility_file += single_file_compatibility;
             }
             total_line += rome_lines.max(prettier_lines);
             total_matched_line += matched_lines;
             single_file_metric_data.diff = diff;
             single_file_metric_data.filename = file_name.to_string();
-            single_file_metric_data.single_file_compatibility = per_file_compatibility;
+            single_file_metric_data.single_file_compatibility = single_file_compatibility;
             report_metric_data.files.push(single_file_metric_data);
         }
         report_metric_data.file_based_average_prettier_similarity =
-            sum_of_per_compatibility_file / file_count as f64;
+            sum_of_single_compatibility_file / file_count as f64;
         report_metric_data.line_based_average_prettier_similarity =
             total_matched_line as f64 / total_line as f64;
         match report_type {

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -279,7 +279,7 @@ enum ReportType {
 }
 
 #[derive(Debug, PartialEq, Serialize, Default)]
-struct PeerFileJsonReport {
+struct SingleFileJsonReport {
     filename: String,
     single_file_compatibility: f64,
 }
@@ -302,7 +302,7 @@ struct PrettierCompatibilityMetricData {
 struct ReportJson {
     file_based_average_prettier_similarity: f64,
     line_based_average_prettier_similarity: f64,
-    files: Vec<PeerFileJsonReport>,
+    files: Vec<SingleFileJsonReport>,
 }
 impl FromStr for ReportType {
     type Err = String;
@@ -533,7 +533,7 @@ impl DiffReport {
                          single_file_compatibility,
                          diff: _,
                      }| {
-                        PeerFileJsonReport {
+                        SingleFileJsonReport {
                             filename,
                             single_file_compatibility,
                         }

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -504,7 +504,6 @@ impl DiffReport {
                     matched_lines as f64 / rome_lines.max(prettier_lines) as f64;
                 sum_of_per_compatibility_file += compatibility_per_file;
             } else {
-                // in this branch `rome_lines` == `prettier_lines` == `matched_lines`
                 assert!(rome_lines == prettier_lines);
                 matched_lines = rome_lines;
                 compatibility_per_file = 1_f64;
@@ -518,16 +517,12 @@ impl DiffReport {
                 prettier_similarity: compatibility_per_file,
             });
         }
-        // extra two space force markdown render insert a new line
         let line_based = sum_of_per_compatibility_file / file_count as f64;
         let file_based = total_matched_line as f64 / total_line as f64;
         report_json.line_based_average_prettier_similarity = line_based;
         report_json.file_based_average_prettier_similarity = file_based;
 
         let json_content = serde_json::to_string(&report_json).unwrap();
-        // report = format!(
-        //     "**File Based Average Prettier Similarity**: {:.2}%  \n**Line Based Average Prettier Similarity**: {:.2}%  \n the definition of similarity you could found here: https://github.com/rome/tools/issues/2555#issuecomment-1124787893 \n",
-        // ) + &report;
         write(report_filename, json_content).unwrap();
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
part of https://github.com/rome/tools/issues/2555
To achieve printing diff between `main` branch and pull request branch,  a few steps we need to do list below

1. save `prettier compatibility metric` on `main`  branch 
2. switch to `pull request branch` 
3. save `prettier compatibility metric` on `pull request`  branch
4. compare two metrics and echo the diff.

Obviously, `Markdown`  is not a good format for comparing, so we need to add an extra format to save metrics, which is `Json` 
just like `Parser conformance`

This pull request introduces these two changes:
1. Add an option to report the prettier compatibility metric in `json` or `markdown` format.
2. Support choosing file_name to save.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
No need to test
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
