### PR TITLE
feat(rome_formatter): make formatter language aware

### DIFF
--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -11,8 +11,9 @@ use std::cell::RefCell;
 /// The formatter is passed to the [Format] implementation of every node in the CST so that they
 /// can use it to format their children.
 #[derive(Default)]
-pub struct Formatter<Options> {
-    options: Options,
+pub struct Formatter<Context> {
+    /// Yields various information that belong to the current instance of the formatter
+    context: Context,
     group_id_builder: UniqueGroupIdBuilder,
     // This is using a RefCell as it only exists in debug mode,
     // the Formatter is still completely immutable in release builds
@@ -20,11 +21,11 @@ pub struct Formatter<Options> {
     pub printed_tokens: RefCell<PrintedTokens>,
 }
 
-impl<Options> Formatter<Options> {
+impl<Context> Formatter<Context> {
     /// Creates a new context that uses the given formatter options
-    pub fn new(options: Options) -> Self {
+    pub fn new(options: Context) -> Self {
         Self {
-            options,
+            context: options,
             group_id_builder: Default::default(),
             #[cfg(debug_assertions)]
             printed_tokens: Default::default(),
@@ -32,8 +33,8 @@ impl<Options> Formatter<Options> {
     }
 
     /// Returns the [FormatOptions] specifying how to format the current CST
-    pub fn options(&self) -> &Options {
-        &self.options
+    pub fn context(&self) -> &Context {
+        &self.context
     }
 
     /// Creates a new group id that is unique to this document. The passed debug name is used in the
@@ -70,7 +71,7 @@ impl<Options> Formatter<Options> {
     ///
     /// Returns the [Err] of the first item that failed to format.
     #[inline]
-    pub fn format_all<T: Format<Options = Options>>(
+    pub fn format_all<T: Format<Context = Context>>(
         &self,
         nodes: impl IntoIterator<Item = T>,
     ) -> FormatResult<impl Iterator<Item = FormatElement>> {
@@ -89,7 +90,7 @@ impl<Options> Formatter<Options> {
     }
 }
 
-impl<Options> Formatter<Options> {
+impl<Context> Formatter<Context> {
     /// Take a snapshot of the state of the formatter
     #[inline]
     pub fn snapshot(&self) -> FormatterSnapshot {

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -166,11 +166,11 @@ impl From<LineWidth> for u16 {
     }
 }
 
-/// Options configuring how an object gets formatted.
+/// Context configuring how an object gets formatted.
 ///
 /// Defines the common formatting options. Implementations can define additional options that
 /// are specific to formatting a specific object.
-pub trait FormatOptions {
+pub trait FormatContext {
     /// The indent style.
     fn indent_style(&self) -> IndentStyle;
 
@@ -337,16 +337,16 @@ impl From<&SyntaxError> for FormatError {
 /// Implementing `Format` for a custom struct
 ///
 /// ```
-/// use rome_formatter::{format, FormatOptions, IndentStyle, LineWidth};
+/// use rome_formatter::{format, FormatContext, IndentStyle, LineWidth};
 /// use rome_formatter::prelude::*;
 /// use rome_rowan::TextSize;
 ///
 /// struct Paragraph(String);
 ///
 /// impl Format for Paragraph {
-///     type Options = Options;
+///     type Context = Context;
 ///
-///     fn format(&self, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+///     fn format(&self, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
 ///         formatted![
 ///             formatter,
 ///             [
@@ -358,9 +358,9 @@ impl From<&SyntaxError> for FormatError {
 ///     }
 /// }
 ///
-/// struct Options;
+/// struct Context;
 ///
-/// impl FormatOptions for Options {
+/// impl FormatContext for Context {
 ///     fn indent_style(&self) -> IndentStyle {
 ///         IndentStyle::Tab
 ///     }
@@ -375,25 +375,25 @@ impl From<&SyntaxError> for FormatError {
 /// }
 ///
 /// let paragraph = Paragraph(String::from("test"));
-/// let printed = format(Options, &paragraph).unwrap().print();
+/// let printed = format(Context, &paragraph).unwrap().print();
 ///
 /// assert_eq!("test\n", printed.as_code())
 /// ```
 pub trait Format {
     /// Type of the formatter options.
-    type Options;
+    type Context;
 
     /// Formats the object
-    fn format(&self, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement>;
+    fn format(&self, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement>;
 }
 
 impl<T> Format for &T
 where
     T: ?Sized + Format,
 {
-    type Options = T::Options;
+    type Context = T::Context;
 
-    fn format(&self, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
         Format::format(&**self, formatter)
     }
 }
@@ -402,9 +402,9 @@ impl<T> Format for &mut T
 where
     T: ?Sized + Format,
 {
-    type Options = T::Options;
+    type Context = T::Context;
 
-    fn format(&self, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
         Format::format(&**self, formatter)
     }
 }
@@ -413,9 +413,9 @@ impl<T> Format for Option<T>
 where
     T: Format,
 {
-    type Options = T::Options;
+    type Context = T::Context;
 
-    fn format(&self, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
         match self {
             Some(value) => value.format(formatter),
             None => Ok(empty_element()),
@@ -427,9 +427,9 @@ impl<T> Format for SyntaxResult<T>
 where
     T: Format,
 {
-    type Options = T::Options;
+    type Context = T::Context;
 
-    fn format(&self, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
         match self {
             Ok(value) => value.format(formatter),
             Err(err) => Err(err.into()),
@@ -461,7 +461,7 @@ impl<O> IntoFormatElement<O> for FormatResult<FormatElement> {
 
 impl<T, O> IntoFormatElement<O> for T
 where
-    T: Format<Options = O>,
+    T: Format<Context = O>,
 {
     #[inline]
     fn into_format_element(self, formatter: &Formatter<O>) -> FormatResult<FormatElement> {
@@ -480,9 +480,9 @@ where
 /// That's why the `rome_js_formatter` crate must define a new-type that implements the formatting
 /// of `JsIfStatement`.
 pub trait FormatRule<T> {
-    type Options;
+    type Context;
 
-    fn format(item: &T, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement>;
+    fn format(item: &T, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement>;
 }
 
 /// Trait for an object that formats an object with a specified rule.
@@ -500,9 +500,9 @@ pub trait FormatRule<T> {
 ///
 /// ```
 /// use rome_formatter::prelude::*;
-/// use rome_formatter::{FormatOptions, FormatWithRule};
+/// use rome_formatter::{FormatContext, FormatWithRule};
 /// use rome_rowan::{Language, SyntaxNode};
-/// fn format_node<L: Language, F: FormatWithRule<Item=SyntaxNode<L>, Options=()>>(node: F) -> FormatResult<FormatElement> {
+/// fn format_node<L: Language, F: FormatWithRule<Item=SyntaxNode<L>, Context=()>>(node: F) -> FormatResult<FormatElement> {
 ///     let formatter = Formatter::default();
 ///
 ///     let formatted = node.format(&formatter);
@@ -555,10 +555,10 @@ impl<T, R> Format for FormatRefWithRule<'_, T, R>
 where
     R: FormatRule<T>,
 {
-    type Options = R::Options;
+    type Context = R::Context;
 
     #[inline]
-    fn format(&self, formatter: &Formatter<R::Options>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<R::Context>) -> FormatResult<FormatElement> {
         R::format(self.item, formatter)
     }
 }
@@ -597,10 +597,10 @@ impl<T, R> Format for FormatOwnedWithRule<T, R>
 where
     R: FormatRule<T>,
 {
-    type Options = R::Options;
+    type Context = R::Context;
 
     #[inline]
-    fn format(&self, formatter: &Formatter<R::Options>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<R::Context>) -> FormatResult<FormatElement> {
         R::format(&self.item, formatter)
     }
 }
@@ -619,9 +619,9 @@ where
 /// Formats any value that implements [Format].
 ///
 /// Please note that [format_node] is preferred to format a [JsSyntaxNode]
-pub fn format<O: FormatOptions>(
+pub fn format<O: FormatContext>(
     options: O,
-    root: &dyn Format<Options = O>,
+    root: &dyn Format<Context = O>,
 ) -> FormatResult<Formatted> {
     tracing::trace_span!("format").in_scope(move || {
         let printer_options = options.as_print_options();
@@ -635,9 +635,9 @@ pub fn format<O: FormatOptions>(
 ///
 /// It returns a [Formatted] result, which the user can use to override a file.
 pub fn format_node<
-    O: FormatOptions,
+    O: FormatContext,
     L: Language,
-    N: FormatWithRule<Item = SyntaxNode<L>, Options = O>,
+    N: FormatWithRule<Item = SyntaxNode<L>, Context = O>,
 >(
     options: O,
     root: &N,
@@ -700,7 +700,7 @@ where
 /// gets formatted instead of the smallest sub-expression that fits the range
 ///
 /// This runs a simple heuristic to determine the initial indentation
-/// level of the node based on the provided [FormatOptions], which
+/// level of the node based on the provided [FormatContext], which
 /// must match currently the current initial of the file. Additionally,
 /// because the reformatting happens only locally the resulting code
 /// will be indented with the same level as the original selection,
@@ -708,16 +708,16 @@ where
 ///
 /// It returns a [Formatted] result with a range corresponding to the
 /// range of the input that was effectively overwritten by the formatter
-pub fn format_range<Options, L, R, P>(
-    options: Options,
+pub fn format_range<Context, L, R, P>(
+    options: Context,
     root: &SyntaxNode<L>,
     mut range: TextRange,
     mut predicate: P,
 ) -> FormatResult<Printed>
 where
-    Options: FormatOptions,
+    Context: FormatContext,
     L: Language,
-    R: FormatRule<SyntaxNode<L>, Options = Options>,
+    R: FormatRule<SyntaxNode<L>, Context = Context>,
     P: FnMut(&SyntaxNode<L>) -> bool,
 {
     if range.is_empty() {
@@ -931,7 +931,7 @@ where
 /// Formats a single node within a file, supported by Rome.
 ///
 /// This runs a simple heuristic to determine the initial indentation
-/// level of the node based on the provided [FormatOptions], which
+/// level of the node based on the provided [FormatContext], which
 /// must match currently the current initial of the file. Additionally,
 /// because the reformatting happens only locally the resulting code
 /// will be indented with the same level as the original selection,
@@ -939,9 +939,9 @@ where
 ///
 /// It returns a [Formatted] result
 pub fn format_sub_tree<
-    O: FormatOptions,
+    O: FormatContext,
     L: Language,
-    N: FormatWithRule<Item = SyntaxNode<L>, Options = O>,
+    N: FormatWithRule<Item = SyntaxNode<L>, Context = O>,
 >(
     options: O,
     root: &N,

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -619,9 +619,9 @@ where
 /// Formats any value that implements [Format].
 ///
 /// Please note that [format_node] is preferred to format a [JsSyntaxNode]
-pub fn format<O: FormatContext>(
-    options: O,
-    root: &dyn Format<Context = O>,
+pub fn format<C: FormatContext>(
+    options: C,
+    root: &dyn Format<Context = C>,
 ) -> FormatResult<Formatted> {
     tracing::trace_span!("format").in_scope(move || {
         let printer_options = options.as_print_options();
@@ -635,11 +635,11 @@ pub fn format<O: FormatContext>(
 ///
 /// It returns a [Formatted] result, which the user can use to override a file.
 pub fn format_node<
-    O: FormatContext,
+    C: FormatContext,
     L: Language,
-    N: FormatWithRule<Item = SyntaxNode<L>, Context = O>,
+    N: FormatWithRule<Item = SyntaxNode<L>, Context = C>,
 >(
-    options: O,
+    options: C,
     root: &N,
 ) -> FormatResult<Formatted> {
     tracing::trace_span!("format_node").in_scope(move || {
@@ -939,11 +939,11 @@ where
 ///
 /// It returns a [Formatted] result
 pub fn format_sub_tree<
-    O: FormatContext,
+    C: FormatContext,
     L: Language,
-    N: FormatWithRule<Item = SyntaxNode<L>, Context = O>,
+    N: FormatWithRule<Item = SyntaxNode<L>, Context = C>,
 >(
-    options: O,
+    context: C,
     root: &N,
 ) -> FormatResult<Printed> {
     let syntax = root.item();
@@ -985,7 +985,7 @@ pub fn format_sub_tree<
             // of indentation type detection yet. Unfortunately this
             // may not actually match the current content of the file
             let length = trivia.text().len() as u16;
-            match options.indent_style() {
+            match context.indent_style() {
                 IndentStyle::Tab => length,
                 IndentStyle::Space(width) => length / u16::from(width),
             }
@@ -995,7 +995,7 @@ pub fn format_sub_tree<
         None => 0,
     };
 
-    let formatted = format_node(options, root)?;
+    let formatted = format_node(context, root)?;
     let printed = formatted.print_with_indent(initial_indent);
     let sourcemap = Vec::from(printed.sourcemap());
     let verbatim_ranges = Vec::from(printed.verbatim_ranges());

--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -26,7 +26,7 @@ use std::marker::PhantomData;
 /// You would write it like the following:
 ///
 /// ```rust
-/// use rome_formatter::{FormatOptions, Formatted};
+/// use rome_formatter::{FormatContext, Formatted};
 /// use rome_formatter::prelude::*;
 ///
 /// let element = format_elements![
@@ -44,7 +44,7 @@ use std::marker::PhantomData;
 /// ```
 /// Or you can also create single element:
 /// ```
-/// use rome_formatter::{Formatted, FormatOptions};
+/// use rome_formatter::{Formatted, FormatContext};
 /// use rome_formatter::prelude::*;
 ///
 /// use rome_formatter::prelude::*;
@@ -81,14 +81,14 @@ macro_rules! format_elements {
 /// you would write:
 ///
 /// ```rust
-/// use rome_formatter::FormatOptions;
+/// use rome_formatter::FormatContext;
 /// use rome_formatter::prelude::*;
 ///
 /// struct TestFormat;
 ///
 /// impl Format for TestFormat {
-///     type Options = ();
-///     fn format(&self, _: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+///     type Context = ();
+///     fn format(&self, _: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
 ///         Ok(token("test"))
 ///     }
 /// }
@@ -122,7 +122,7 @@ macro_rules! format_elements {
 /// Or you can also create single element:
 /// ```
 /// use rome_formatter::prelude::*;
-/// use rome_formatter::FormatOptions;
+/// use rome_formatter::FormatContext;
 ///
 /// let formatter = Formatter::<()>::default();
 ///
@@ -315,8 +315,8 @@ mod tests {
     struct TestFormat;
 
     impl Format for TestFormat {
-        type Options = ();
-        fn format(&self, _: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+        type Context = ();
+        fn format(&self, _: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
             Ok(token("test"))
         }
     }

--- a/crates/rome_js_formatter/src/check_reformat.rs
+++ b/crates/rome_js_formatter/src/check_reformat.rs
@@ -1,4 +1,4 @@
-use crate::{format_node, JsFormatOptions};
+use crate::{format_node, JsFormatContext};
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
 use rome_js_parser::parse;
 use rome_js_syntax::{JsSyntaxNode, SourceType};
@@ -8,7 +8,7 @@ pub struct CheckReformatParams<'a> {
     pub text: &'a str,
     pub source_type: SourceType,
     pub file_name: &'a str,
-    pub format_options: JsFormatOptions,
+    pub format_context: JsFormatContext,
 }
 
 /// Perform a second pass of formatting on a file, printing a diff if the
@@ -19,7 +19,7 @@ pub fn check_reformat(params: CheckReformatParams) {
         text,
         source_type,
         file_name,
-        format_options,
+        format_context: format_options,
     } = params;
 
     let re_parse = parse(text, 0, source_type);

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -1,21 +1,52 @@
 use rome_formatter::printer::PrinterOptions;
-use rome_formatter::{FormatOptions, IndentStyle, LineWidth};
+use rome_formatter::{FormatContext, IndentStyle, LineWidth};
+use rome_js_syntax::SourceType;
 use std::fmt;
+use std::fmt::Debug;
 use std::str::FromStr;
 
 #[derive(Debug, Copy, Clone, Default)]
-pub struct JsFormatOptions {
+pub struct JsFormatContext {
     /// The indent style.
     pub indent_style: IndentStyle,
 
     /// What's the max width of a line. Defaults to 80.
     pub line_width: LineWidth,
 
+    /// Options of current instance of the formatter
+    pub options: JsFormatOptions,
+
+    /// Information relative to the current file
+    pub source_type: SourceType,
+}
+
+impl JsFormatContext {
+    pub fn new(
+        indent_style: IndentStyle,
+        line_width: LineWidth,
+        options: JsFormatOptions,
+        source_type: SourceType,
+    ) -> Self {
+        Self {
+            indent_style,
+            line_width,
+            options,
+            source_type,
+        }
+    }
+
+    pub fn quote_style(&self) -> QuoteStyle {
+        self.options.quote_style
+    }
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct JsFormatOptions {
     // The style for quotes. Defaults to double.
     pub quote_style: QuoteStyle,
 }
 
-impl JsFormatOptions {
+impl JsFormatContext {
     pub fn tab_width(&self) -> u8 {
         match self.indent_style {
             IndentStyle::Tab => 2,
@@ -24,7 +55,7 @@ impl JsFormatOptions {
     }
 }
 
-impl FormatOptions for JsFormatOptions {
+impl FormatContext for JsFormatContext {
     fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -40,10 +71,17 @@ impl FormatOptions for JsFormatOptions {
     }
 }
 
-impl fmt::Display for JsFormatOptions {
+impl fmt::Display for JsFormatContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Indent style: {}", self.indent_style)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
+        write!(f, "{}", self.options)?;
+        Ok(())
+    }
+}
+
+impl fmt::Display for JsFormatOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Quote style: {}", self.quote_style)?;
         Ok(())
     }

--- a/crates/rome_js_formatter/src/cst.rs
+++ b/crates/rome_js_formatter/src/cst.rs
@@ -1,17 +1,17 @@
 use crate::prelude::*;
 use rome_formatter::{FormatOwnedWithRule, FormatRefWithRule};
 
-use crate::{AsFormat, IntoFormat, JsFormatOptions};
+use crate::{AsFormat, IntoFormat, JsFormatContext};
 use rome_js_syntax::{map_syntax_node, JsSyntaxNode};
 
 pub struct FormatJsSyntaxNode;
 
 impl rome_formatter::FormatRule<JsSyntaxNode> for FormatJsSyntaxNode {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsSyntaxNode,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         map_syntax_node!(node.clone(), node => formatted![formatter, [node.format()]])
     }

--- a/crates/rome_js_formatter/src/formatter.rs
+++ b/crates/rome_js_formatter/src/formatter.rs
@@ -1,9 +1,7 @@
 use crate::prelude::*;
-
+use crate::{AsFormat, JsFormatContext};
 use rome_formatter::{normalize_newlines, FormatResult, GroupId, LINE_TERMINATORS};
 use rome_js_syntax::{JsLanguage, JsSyntaxNode, JsSyntaxToken};
-
-use crate::{AsFormat, JsFormatOptions};
 use rome_rowan::{AstNode, AstNodeList, AstSeparatedList, Language, SyntaxTriviaPiece, TextRange};
 
 use std::iter::once;
@@ -76,9 +74,9 @@ pub struct FormatVerbatimNode<'node> {
 }
 
 impl Format for FormatVerbatimNode<'_> {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
-    fn format(&self, formatter: &Formatter<JsFormatOptions>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<JsFormatContext>) -> FormatResult<FormatElement> {
         let verbatim = format_verbatim_node_or_token(self.node, formatter);
         Ok(FormatElement::Verbatim(Verbatim::new_verbatim(
             verbatim,
@@ -99,9 +97,9 @@ pub struct FormatUnknownNode<'node> {
 }
 
 impl Format for FormatUnknownNode<'_> {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
-    fn format(&self, formatter: &Formatter<JsFormatOptions>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<JsFormatContext>) -> FormatResult<FormatElement> {
         Ok(FormatElement::Verbatim(Verbatim::new_unknown(
             format_verbatim_node_or_token(self.node, formatter),
         )))
@@ -119,9 +117,9 @@ pub struct FormatSuppressedNode<'node> {
 }
 
 impl Format for FormatSuppressedNode<'_> {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
-    fn format(&self, formatter: &Formatter<JsFormatOptions>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<JsFormatContext>) -> FormatResult<FormatElement> {
         formatted![
             formatter,
             [
@@ -138,7 +136,7 @@ impl Format for FormatSuppressedNode<'_> {
 
 fn format_verbatim_node_or_token(
     node: &JsSyntaxNode,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatElement {
     for token in node.descendants_tokens() {
         formatter.track_token(&token);
@@ -438,7 +436,7 @@ where
 
 /// JS specific formatter extensions
 pub(crate) trait JsFormatter {
-    fn as_formatter(&self) -> &Formatter<JsFormatOptions>;
+    fn as_formatter(&self) -> &Formatter<JsFormatContext>;
 
     #[must_use]
     fn delimited<'a, 'fmt>(
@@ -599,8 +597,8 @@ pub(crate) trait JsFormatter {
     }
 }
 
-impl JsFormatter for Formatter<JsFormatOptions> {
-    fn as_formatter(&self) -> &Formatter<JsFormatOptions> {
+impl JsFormatter for Formatter<JsFormatContext> {
+    fn as_formatter(&self) -> &Formatter<JsFormatContext> {
         self
     }
 }
@@ -615,7 +613,7 @@ pub struct FormatDelimited<'a, 'fmt> {
     content: FormatElement,
     close_token: &'a JsSyntaxToken,
     mode: DelimitedMode,
-    formatter: &'fmt Formatter<JsFormatOptions>,
+    formatter: &'fmt Formatter<JsFormatContext>,
 }
 
 impl<'a, 'fmt> FormatDelimited<'a, 'fmt> {
@@ -623,7 +621,7 @@ impl<'a, 'fmt> FormatDelimited<'a, 'fmt> {
         open_token: &'a JsSyntaxToken,
         content: FormatElement,
         close_token: &'a JsSyntaxToken,
-        formatter: &'fmt Formatter<JsFormatOptions>,
+        formatter: &'fmt Formatter<JsFormatContext>,
     ) -> Self {
         Self {
             open_token,

--- a/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyArrayAssignmentPatternElement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayAssignmentPatternElement;
 impl FormatRule<JsAnyArrayAssignmentPatternElement> for FormatJsAnyArrayAssignmentPatternElement {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyArrayAssignmentPatternElement,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(node) => {

--- a/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyArrayBindingPatternElement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayBindingPatternElement;
 impl FormatRule<JsAnyArrayBindingPatternElement> for FormatJsAnyArrayBindingPatternElement {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyArrayBindingPatternElement,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyArrayBindingPatternElement::JsArrayHole(node) => {

--- a/crates/rome_js_formatter/src/js/any/array_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_element.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyArrayElement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayElement;
 impl FormatRule<JsAnyArrayElement> for FormatJsAnyArrayElement {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyArrayElement,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyArrayElement::JsAnyExpression(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
+++ b/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyArrowFunctionParameters;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrowFunctionParameters;
 impl FormatRule<JsAnyArrowFunctionParameters> for FormatJsAnyArrowFunctionParameters {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyArrowFunctionParameters,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyArrowFunctionParameters::JsParameters(node) => {

--- a/crates/rome_js_formatter/src/js/any/assignment.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyAssignment;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyAssignment;
 impl FormatRule<JsAnyAssignment> for FormatJsAnyAssignment {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyAssignment,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyAssignment::JsIdentifierAssignment(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyAssignmentPattern;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyAssignmentPattern;
 impl FormatRule<JsAnyAssignmentPattern> for FormatJsAnyAssignmentPattern {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyAssignmentPattern,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyAssignmentPattern::JsAnyAssignment(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/binding.rs
+++ b/crates/rome_js_formatter/src/js/any/binding.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyBinding;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyBinding;
 impl FormatRule<JsAnyBinding> for FormatJsAnyBinding {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyBinding,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyBinding::JsIdentifierBinding(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/binding_pattern.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyBindingPattern;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyBindingPattern;
 impl FormatRule<JsAnyBindingPattern> for FormatJsAnyBindingPattern {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyBindingPattern,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyBindingPattern::JsAnyBinding(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/call_argument.rs
+++ b/crates/rome_js_formatter/src/js/any/call_argument.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyCallArgument;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyCallArgument;
 impl FormatRule<JsAnyCallArgument> for FormatJsAnyCallArgument {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyCallArgument,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyCallArgument::JsAnyExpression(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/class.rs
+++ b/crates/rome_js_formatter/src/js/any/class.rs
@@ -4,11 +4,11 @@ use rome_js_syntax::JsAnyClass;
 use rome_rowan::AstNode;
 
 impl FormatRule<JsAnyClass> for FormatJsAnyClass {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsAnyClass,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let abstract_token = node.abstract_token();
         let id = node.id();

--- a/crates/rome_js_formatter/src/js/any/class_member.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyClassMember;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClassMember;
 impl FormatRule<JsAnyClassMember> for FormatJsAnyClassMember {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyClassMember,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyClassMember::JsConstructorClassMember(node) => {

--- a/crates/rome_js_formatter/src/js/any/class_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member_name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyClassMemberName;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClassMemberName;
 impl FormatRule<JsAnyClassMemberName> for FormatJsAnyClassMemberName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyClassMemberName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyClassMemberName::JsLiteralMemberName(node) => {

--- a/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyConstructorParameter;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyConstructorParameter;
 impl FormatRule<JsAnyConstructorParameter> for FormatJsAnyConstructorParameter {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyConstructorParameter,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyConstructorParameter::JsAnyFormalParameter(node) => {

--- a/crates/rome_js_formatter/src/js/any/declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyDeclaration;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyDeclaration;
 impl FormatRule<JsAnyDeclaration> for FormatJsAnyDeclaration {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyDeclaration,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyDeclaration::JsClassDeclaration(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration_clause.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyDeclarationClause;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyDeclarationClause;
 impl FormatRule<JsAnyDeclarationClause> for FormatJsAnyDeclarationClause {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyDeclarationClause,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyDeclarationClause::JsClassDeclaration(node) => {

--- a/crates/rome_js_formatter/src/js/any/export_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/export_clause.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyExportClause;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportClause;
 impl FormatRule<JsAnyExportClause> for FormatJsAnyExportClause {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyExportClause,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyExportClause::JsExportDefaultDeclarationClause(node) => {

--- a/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyExportDefaultDeclaration;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportDefaultDeclaration;
 impl FormatRule<JsAnyExportDefaultDeclaration> for FormatJsAnyExportDefaultDeclaration {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyExportDefaultDeclaration,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyExportDefaultDeclaration::JsClassExportDefaultDeclaration(node) => {

--- a/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyExportNamedSpecifier;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportNamedSpecifier;
 impl FormatRule<JsAnyExportNamedSpecifier> for FormatJsAnyExportNamedSpecifier {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyExportNamedSpecifier,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyExportNamedSpecifier::JsExportNamedShorthandSpecifier(node) => {

--- a/crates/rome_js_formatter/src/js/any/expression.rs
+++ b/crates/rome_js_formatter/src/js/any/expression.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyExpression;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExpression;
 impl FormatRule<JsAnyExpression> for FormatJsAnyExpression {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyExpression,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyExpression::JsAnyLiteralExpression(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyForInOrOfInitializer;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyForInOrOfInitializer;
 impl FormatRule<JsAnyForInOrOfInitializer> for FormatJsAnyForInOrOfInitializer {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyForInOrOfInitializer,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyForInOrOfInitializer::JsAnyAssignmentPattern(node) => {

--- a/crates/rome_js_formatter/src/js/any/for_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_initializer.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyForInitializer;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyForInitializer;
 impl FormatRule<JsAnyForInitializer> for FormatJsAnyForInitializer {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyForInitializer,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyForInitializer::JsVariableDeclaration(node) => {

--- a/crates/rome_js_formatter/src/js/any/formal_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/formal_parameter.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyFormalParameter;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFormalParameter;
 impl FormatRule<JsAnyFormalParameter> for FormatJsAnyFormalParameter {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyFormalParameter,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyFormalParameter::JsFormalParameter(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -7,11 +7,11 @@ use rome_js_syntax::{
 };
 
 impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsAnyFunction,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let mut tokens = vec![];
 

--- a/crates/rome_js_formatter/src/js/any/function_body.rs
+++ b/crates/rome_js_formatter/src/js/any/function_body.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyFunctionBody;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFunctionBody;
 impl FormatRule<JsAnyFunctionBody> for FormatJsAnyFunctionBody {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyFunctionBody,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyFunctionBody::JsAnyExpression(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyImportAssertionEntry;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyImportAssertionEntry;
 impl FormatRule<JsAnyImportAssertionEntry> for FormatJsAnyImportAssertionEntry {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyImportAssertionEntry,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyImportAssertionEntry::JsImportAssertionEntry(node) => {

--- a/crates/rome_js_formatter/src/js/any/import_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/import_clause.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyImportClause;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyImportClause;
 impl FormatRule<JsAnyImportClause> for FormatJsAnyImportClause {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyImportClause,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyImportClause::JsImportBareClause(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/in_property.rs
+++ b/crates/rome_js_formatter/src/js/any/in_property.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyInProperty;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyInProperty;
 impl FormatRule<JsAnyInProperty> for FormatJsAnyInProperty {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyInProperty,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyInProperty::JsPrivateName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/any/literal_expression.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyLiteralExpression;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyLiteralExpression;
 impl FormatRule<JsAnyLiteralExpression> for FormatJsAnyLiteralExpression {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyLiteralExpression,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyLiteralExpression::JsStringLiteralExpression(node) => {

--- a/crates/rome_js_formatter/src/js/any/method_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/method_modifier.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyMethodModifier;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyMethodModifier;
 impl FormatRule<JsAnyMethodModifier> for FormatJsAnyMethodModifier {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyMethodModifier,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyMethodModifier::TsAccessibilityModifier(node) => {

--- a/crates/rome_js_formatter/src/js/any/module_item.rs
+++ b/crates/rome_js_formatter/src/js/any/module_item.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyModuleItem;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyModuleItem;
 impl FormatRule<JsAnyModuleItem> for FormatJsAnyModuleItem {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyModuleItem,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyModuleItem::JsAnyStatement(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/name.rs
+++ b/crates/rome_js_formatter/src/js/any/name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyName;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyName;
 impl FormatRule<JsAnyName> for FormatJsAnyName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyName::JsName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/named_import.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyNamedImport;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyNamedImport;
 impl FormatRule<JsAnyNamedImport> for FormatJsAnyNamedImport {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyNamedImport,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyNamedImport::JsNamedImportSpecifiers(node) => {

--- a/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyNamedImportSpecifier;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyNamedImportSpecifier;
 impl FormatRule<JsAnyNamedImportSpecifier> for FormatJsAnyNamedImportSpecifier {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyNamedImportSpecifier,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyNamedImportSpecifier::JsShorthandNamedImportSpecifier(node) => {

--- a/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyObjectAssignmentPatternMember;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectAssignmentPatternMember;
 impl FormatRule<JsAnyObjectAssignmentPatternMember> for FormatJsAnyObjectAssignmentPatternMember {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyObjectAssignmentPatternMember,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyObjectAssignmentPatternMember::JsObjectAssignmentPatternShorthandProperty(

--- a/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyObjectBindingPatternMember;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectBindingPatternMember;
 impl FormatRule<JsAnyObjectBindingPatternMember> for FormatJsAnyObjectBindingPatternMember {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyObjectBindingPatternMember,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyObjectBindingPatternMember::JsObjectBindingPatternProperty(node) => {

--- a/crates/rome_js_formatter/src/js/any/object_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyObjectMember;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectMember;
 impl FormatRule<JsAnyObjectMember> for FormatJsAnyObjectMember {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyObjectMember,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyObjectMember::JsPropertyObjectMember(node) => {

--- a/crates/rome_js_formatter/src/js/any/object_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member_name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyObjectMemberName;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectMemberName;
 impl FormatRule<JsAnyObjectMemberName> for FormatJsAnyObjectMemberName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyObjectMemberName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyObjectMemberName::JsLiteralMemberName(node) => {

--- a/crates/rome_js_formatter/src/js/any/parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/parameter.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyParameter;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyParameter;
 impl FormatRule<JsAnyParameter> for FormatJsAnyParameter {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyParameter,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyParameter::JsAnyFormalParameter(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/property_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/property_modifier.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyPropertyModifier;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyPropertyModifier;
 impl FormatRule<JsAnyPropertyModifier> for FormatJsAnyPropertyModifier {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyPropertyModifier,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyPropertyModifier::TsAccessibilityModifier(node) => {

--- a/crates/rome_js_formatter/src/js/any/root.rs
+++ b/crates/rome_js_formatter/src/js/any/root.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyRoot;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyRoot;
 impl FormatRule<JsAnyRoot> for FormatJsAnyRoot {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyRoot,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyRoot::JsScript(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/statement.rs
+++ b/crates/rome_js_formatter/src/js/any/statement.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyStatement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyStatement;
 impl FormatRule<JsAnyStatement> for FormatJsAnyStatement {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyStatement,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyStatement::JsBlockStatement(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/switch_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/switch_clause.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnySwitchClause;
 use crate::prelude::*;
 use rome_js_syntax::JsAnySwitchClause;
 impl FormatRule<JsAnySwitchClause> for FormatJsAnySwitchClause {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnySwitchClause,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnySwitchClause::JsCaseClause(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/js/any/template_element.rs
+++ b/crates/rome_js_formatter/src/js/any/template_element.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsAnyTemplateElement;
 use crate::prelude::*;
 use rome_js_syntax::JsAnyTemplateElement;
 impl FormatRule<JsAnyTemplateElement> for FormatJsAnyTemplateElement {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsAnyTemplateElement,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsAnyTemplateElement::JsTemplateChunkElement(node) => {

--- a/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsArrayAssignmentPatternFields;
 impl FormatNodeFields<JsArrayAssignmentPattern> for FormatNodeRule<JsArrayAssignmentPattern> {
     fn format_fields(
         node: &JsArrayAssignmentPattern,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsArrayAssignmentPatternFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
+++ b/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsArrayAssignmentPatternRestElement>
 {
     fn format_fields(
         node: &JsArrayAssignmentPatternRestElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsArrayAssignmentPatternRestElementFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/assignments/assignment_with_default.rs
+++ b/crates/rome_js_formatter/src/js/assignments/assignment_with_default.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsAssignmentWithDefaultFields;
 impl FormatNodeFields<JsAssignmentWithDefault> for FormatNodeRule<JsAssignmentWithDefault> {
     fn format_fields(
         node: &JsAssignmentWithDefault,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsAssignmentWithDefaultFields {
             pattern,

--- a/crates/rome_js_formatter/src/js/assignments/computed_member_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/computed_member_assignment.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsComputedMemberAssignmentFields;
 impl FormatNodeFields<JsComputedMemberAssignment> for FormatNodeRule<JsComputedMemberAssignment> {
     fn format_fields(
         node: &JsComputedMemberAssignment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsComputedMemberAssignmentFields {
             object,

--- a/crates/rome_js_formatter/src/js/assignments/identifier_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/identifier_assignment.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsIdentifierAssignmentFields;
 impl FormatNodeFields<JsIdentifierAssignment> for FormatNodeRule<JsIdentifierAssignment> {
     fn format_fields(
         node: &JsIdentifierAssignment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsIdentifierAssignmentFields { name_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsObjectAssignmentPatternFields;
 impl FormatNodeFields<JsObjectAssignmentPattern> for FormatNodeRule<JsObjectAssignmentPattern> {
     fn format_fields(
         node: &JsObjectAssignmentPattern,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsObjectAssignmentPatternFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_property.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_property.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectAssignmentPatternProperty>
 {
     fn format_fields(
         node: &JsObjectAssignmentPatternProperty,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsObjectAssignmentPatternPropertyFields {
             member,

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_rest.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_rest.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectAssignmentPatternRest>
 {
     fn format_fields(
         node: &JsObjectAssignmentPatternRest,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsObjectAssignmentPatternRestFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectAssignmentPatternShorthandProperty>
 {
     fn format_fields(
         node: &JsObjectAssignmentPatternShorthandProperty,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsObjectAssignmentPatternShorthandPropertyFields { identifier, init } =
             node.as_fields();

--- a/crates/rome_js_formatter/src/js/assignments/parenthesized_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/parenthesized_assignment.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsParenthesizedAssignmentFields;
 impl FormatNodeFields<JsParenthesizedAssignment> for FormatNodeRule<JsParenthesizedAssignment> {
     fn format_fields(
         node: &JsParenthesizedAssignment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsParenthesizedAssignmentFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/assignments/static_member_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/static_member_assignment.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsStaticMemberAssignmentFields;
 impl FormatNodeFields<JsStaticMemberAssignment> for FormatNodeRule<JsStaticMemberAssignment> {
     fn format_fields(
         node: &JsStaticMemberAssignment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsStaticMemberAssignmentFields {
             object,

--- a/crates/rome_js_formatter/src/js/auxiliary/array_hole.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/array_hole.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsArrayHole;
 impl FormatNodeFields<JsArrayHole> for FormatNodeRule<JsArrayHole> {
     fn format_fields(
         _: &JsArrayHole,
-        _: &Formatter<JsFormatOptions>,
+        _: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(empty_element())
     }

--- a/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsCaseClauseFields;
 impl FormatNodeFields<JsCaseClause> for FormatNodeRule<JsCaseClause> {
     fn format_fields(
         node: &JsCaseClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsCaseClauseFields {
             case_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/catch_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/catch_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsCatchClauseFields;
 impl FormatNodeFields<JsCatchClause> for FormatNodeRule<JsCatchClause> {
     fn format_fields(
         node: &JsCatchClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsCatchClauseFields {
             catch_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNodeList;
 impl FormatNodeFields<JsDefaultClause> for FormatNodeRule<JsDefaultClause> {
     fn format_fields(
         node: &JsDefaultClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsDefaultClauseFields {
             default_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/directive.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/directive.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsDirectiveFields;
 impl FormatNodeFields<JsDirective> for FormatNodeRule<JsDirective> {
     fn format_fields(
         node: &JsDirective,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsDirectiveFields {
             value_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/else_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/else_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsElseClauseFields;
 impl FormatNodeFields<JsElseClause> for FormatNodeRule<JsElseClause> {
     fn format_fields(
         node: &JsElseClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsElseClauseFields {
             else_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/expression_snipped.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/expression_snipped.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExpressionSnippedFields;
 impl FormatNodeFields<JsExpressionSnipped> for FormatNodeRule<JsExpressionSnipped> {
     fn format_fields(
         node: &JsExpressionSnipped,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExpressionSnippedFields {
             expression,

--- a/crates/rome_js_formatter/src/js/auxiliary/finally_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/finally_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsFinallyClauseFields;
 impl FormatNodeFields<JsFinallyClause> for FormatNodeRule<JsFinallyClause> {
     fn format_fields(
         node: &JsFinallyClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsFinallyClauseFields {
             finally_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsFunctionBodyFields;
 impl FormatNodeFields<JsFunctionBody> for FormatNodeRule<JsFunctionBody> {
     fn format_fields(
         node: &JsFunctionBody,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsFunctionBodyFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/initializer_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/initializer_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsInitializerClauseFields;
 impl FormatNodeFields<JsInitializerClause> for FormatNodeRule<JsInitializerClause> {
     fn format_fields(
         node: &JsInitializerClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsInitializerClauseFields {
             eq_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/module.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/module.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsModuleFields;
 impl FormatNodeFields<JsModule> for FormatNodeRule<JsModule> {
     fn format_fields(
         node: &JsModule,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsModuleFields {
             interpreter_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/name.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/name.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNameFields;
 impl FormatNodeFields<JsName> for FormatNodeRule<JsName> {
     fn format_fields(
         node: &JsName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsNameFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/auxiliary/new_target.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/new_target.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::NewTargetFields;
 impl FormatNodeFields<NewTarget> for FormatNodeRule<NewTarget> {
     fn format_fields(
         node: &NewTarget,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let NewTargetFields {
             new_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/private_name.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/private_name.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsPrivateNameFields;
 impl FormatNodeFields<JsPrivateName> for FormatNodeRule<JsPrivateName> {
     fn format_fields(
         node: &JsPrivateName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsPrivateNameFields {
             hash_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/reference_identifier.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/reference_identifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsReferenceIdentifierFields;
 impl FormatNodeFields<JsReferenceIdentifier> for FormatNodeRule<JsReferenceIdentifier> {
     fn format_fields(
         node: &JsReferenceIdentifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsReferenceIdentifierFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/auxiliary/script.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/script.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsScriptFields;
 impl FormatNodeFields<JsScript> for FormatNodeRule<JsScript> {
     fn format_fields(
         node: &JsScript,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsScriptFields {
             interpreter_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/spread.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/spread.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsSpreadFields;
 impl FormatNodeFields<JsSpread> for FormatNodeRule<JsSpread> {
     fn format_fields(
         node: &JsSpread,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsSpreadFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/auxiliary/static_modifier.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/static_modifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsStaticModifierFields;
 impl FormatNodeFields<JsStaticModifier> for FormatNodeRule<JsStaticModifier> {
     fn format_fields(
         node: &JsStaticModifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsStaticModifierFields { modifier_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/auxiliary/variable_declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/variable_declaration_clause.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsVariableDeclarationClauseFields;
 impl FormatNodeFields<JsVariableDeclarationClause> for FormatNodeRule<JsVariableDeclarationClause> {
     fn format_fields(
         node: &JsVariableDeclarationClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsVariableDeclarationClauseFields {
             declaration,

--- a/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsVariableDeclaratorFields;
 impl FormatNodeFields<JsVariableDeclarator> for FormatNodeRule<JsVariableDeclarator> {
     fn format_fields(
         node: &JsVariableDeclarator,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsVariableDeclaratorFields {
             id,

--- a/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsArrayBindingPatternFields;
 impl FormatNodeFields<JsArrayBindingPattern> for FormatNodeRule<JsArrayBindingPattern> {
     fn format_fields(
         node: &JsArrayBindingPattern,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsArrayBindingPatternFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
+++ b/crates/rome_js_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsArrayBindingPatternRestElement>
 {
     fn format_fields(
         node: &JsArrayBindingPatternRestElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsArrayBindingPatternRestElementFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/bindings/binding_pattern_with_default.rs
+++ b/crates/rome_js_formatter/src/js/bindings/binding_pattern_with_default.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsBindingPatternWithDefaultFields;
 impl FormatNodeFields<JsBindingPatternWithDefault> for FormatNodeRule<JsBindingPatternWithDefault> {
     fn format_fields(
         node: &JsBindingPatternWithDefault,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsBindingPatternWithDefaultFields {
             pattern,

--- a/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsConstructorParametersFields;
 impl FormatNodeFields<JsConstructorParameters> for FormatNodeRule<JsConstructorParameters> {
     fn format_fields(
         node: &JsConstructorParameters,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsConstructorParametersFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/bindings/formal_parameter.rs
+++ b/crates/rome_js_formatter/src/js/bindings/formal_parameter.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsFormalParameterFields;
 impl FormatNodeFields<JsFormalParameter> for FormatNodeRule<JsFormalParameter> {
     fn format_fields(
         node: &JsFormalParameter,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsFormalParameterFields {
             binding,

--- a/crates/rome_js_formatter/src/js/bindings/identifier_binding.rs
+++ b/crates/rome_js_formatter/src/js/bindings/identifier_binding.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsIdentifierBindingFields;
 impl FormatNodeFields<JsIdentifierBinding> for FormatNodeRule<JsIdentifierBinding> {
     fn format_fields(
         node: &JsIdentifierBinding,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsIdentifierBindingFields { name_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsObjectBindingPatternFields;
 impl FormatNodeFields<JsObjectBindingPattern> for FormatNodeRule<JsObjectBindingPattern> {
     fn format_fields(
         node: &JsObjectBindingPattern,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsObjectBindingPatternFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectBindingPatternProperty>
 {
     fn format_fields(
         node: &JsObjectBindingPatternProperty,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsObjectBindingPatternPropertyFields {
             member,

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_rest.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_rest.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsObjectBindingPatternRestFields;
 impl FormatNodeFields<JsObjectBindingPatternRest> for FormatNodeRule<JsObjectBindingPatternRest> {
     fn format_fields(
         node: &JsObjectBindingPatternRest,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsObjectBindingPatternRestFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsObjectBindingPatternShorthandProperty>
 {
     fn format_fields(
         node: &JsObjectBindingPatternShorthandProperty,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsObjectBindingPatternShorthandPropertyFields { identifier, init } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/parameters.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsParametersFields;
 impl FormatNodeFields<JsParameters> for FormatNodeRule<JsParameters> {
     fn format_fields(
         node: &JsParameters,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsParametersFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/bindings/rest_parameter.rs
+++ b/crates/rome_js_formatter/src/js/bindings/rest_parameter.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsRestParameterFields;
 impl FormatNodeFields<JsRestParameter> for FormatNodeRule<JsRestParameter> {
     fn format_fields(
         node: &JsRestParameter,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsRestParameterFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsConstructorClassMemberFields;
 impl FormatNodeFields<JsConstructorClassMember> for FormatNodeRule<JsConstructorClassMember> {
     fn format_fields(
         node: &JsConstructorClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsConstructorClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsEmptyClassMemberFields;
 impl FormatNodeFields<JsEmptyClassMember> for FormatNodeRule<JsEmptyClassMember> {
     fn format_fields(
         node: &JsEmptyClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsEmptyClassMemberFields { semicolon_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/classes/extends_clause.rs
+++ b/crates/rome_js_formatter/src/js/classes/extends_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExtendsClauseFields;
 impl FormatNodeFields<JsExtendsClause> for FormatNodeRule<JsExtendsClause> {
     fn format_fields(
         node: &JsExtendsClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExtendsClauseFields {
             extends_token,

--- a/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsGetterClassMemberFields;
 impl FormatNodeFields<JsGetterClassMember> for FormatNodeRule<JsGetterClassMember> {
     fn format_fields(
         node: &JsGetterClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsGetterClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/method_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/method_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsMethodClassMemberFields;
 impl FormatNodeFields<JsMethodClassMember> for FormatNodeRule<JsMethodClassMember> {
     fn format_fields(
         node: &JsMethodClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsMethodClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/property_class_member.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsPropertyClassMemberFields;
 impl FormatNodeFields<JsPropertyClassMember> for FormatNodeRule<JsPropertyClassMember> {
     fn format_fields(
         node: &JsPropertyClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsPropertyClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsSetterClassMemberFields;
 impl FormatNodeFields<JsSetterClassMember> for FormatNodeRule<JsSetterClassMember> {
     fn format_fields(
         node: &JsSetterClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsSetterClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsStaticInitializationBlockClassMember>
 {
     fn format_fields(
         node: &JsStaticInitializationBlockClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsStaticInitializationBlockClassMemberFields {
             static_token,

--- a/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsCatchDeclarationFields;
 impl FormatNodeFields<JsCatchDeclaration> for FormatNodeRule<JsCatchDeclaration> {
     fn format_fields(
         node: &JsCatchDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsCatchDeclarationFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/declarations/class_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/class_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyClass, JsClassDeclaration};
 impl FormatNodeFields<JsClassDeclaration> for FormatNodeRule<JsClassDeclaration> {
     fn format_fields(
         node: &JsClassDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyClass::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/declarations/class_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/class_export_default_declaration.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsClassExportDefaultDeclaration>
 {
     fn format_fields(
         node: &JsClassExportDefaultDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyClass::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/declarations/for_variable_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/for_variable_declaration.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsForVariableDeclarationFields;
 impl FormatNodeFields<JsForVariableDeclaration> for FormatNodeRule<JsForVariableDeclaration> {
     fn format_fields(
         node: &JsForVariableDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsForVariableDeclarationFields {
             kind_token,

--- a/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyFunction, JsFunctionDeclaration};
 impl FormatNodeFields<JsFunctionDeclaration> for FormatNodeRule<JsFunctionDeclaration> {
     fn format_fields(
         node: &JsFunctionDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyFunction::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsFunctionExportDefaultDeclaration>
 {
     fn format_fields(
         node: &JsFunctionExportDefaultDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyFunction::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/declarations/variable_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/variable_declaration.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsVariableDeclarationFields;
 impl FormatNodeFields<JsVariableDeclaration> for FormatNodeRule<JsVariableDeclaration> {
     fn format_fields(
         node: &JsVariableDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsVariableDeclarationFields { kind, declarators } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/array_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/array_expression.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsArrayExpressionFields;
 impl FormatNodeFields<JsArrayExpression> for FormatNodeRule<JsArrayExpression> {
     fn format_fields(
         node: &JsArrayExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsArrayExpressionFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyFunction, JsArrowFunctionExpression};
 impl FormatNodeFields<JsArrowFunctionExpression> for FormatNodeRule<JsArrowFunctionExpression> {
     fn format_fields(
         node: &JsArrowFunctionExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyFunction::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsAssignmentExpressionFields;
 impl FormatNodeFields<JsAssignmentExpression> for FormatNodeRule<JsAssignmentExpression> {
     fn format_fields(
         node: &JsAssignmentExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsAssignmentExpressionFields {
             left,

--- a/crates/rome_js_formatter/src/js/expressions/await_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/await_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsAwaitExpressionFields;
 impl FormatNodeFields<JsAwaitExpression> for FormatNodeRule<JsAwaitExpression> {
     fn format_fields(
         node: &JsAwaitExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsAwaitExpressionFields {
             await_token,

--- a/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::JsBigIntLiteralExpressionFields;
 impl FormatNodeFields<JsBigIntLiteralExpression> for FormatNodeRule<JsBigIntLiteralExpression> {
     fn format_fields(
         node: &JsBigIntLiteralExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsBigIntLiteralExpressionFields { value_token } = node.as_fields();
         let value_token = value_token?;

--- a/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsBinaryExpression;
 impl FormatNodeFields<JsBinaryExpression> for FormatNodeRule<JsBinaryExpression> {
     fn format_fields(
         node: &JsBinaryExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_binary_like_expression(
             JsAnyBinaryLikeExpression::JsBinaryExpression(node.clone()),

--- a/crates/rome_js_formatter/src/js/expressions/boolean_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/boolean_literal_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsBooleanLiteralExpressionFields;
 impl FormatNodeFields<JsBooleanLiteralExpression> for FormatNodeRule<JsBooleanLiteralExpression> {
     fn format_fields(
         node: &JsBooleanLiteralExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsBooleanLiteralExpressionFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -9,7 +9,7 @@ use rome_rowan::{AstSeparatedList, SyntaxResult};
 impl FormatNodeFields<JsCallArguments> for FormatNodeRule<JsCallArguments> {
     fn format_fields(
         node: &JsCallArguments,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsCallArgumentsFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/expressions/call_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_expression.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsCallExpression> for FormatNodeRule<JsCallExpression> {
     fn format_fields(
         node: &JsCallExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_call_expression(node.syntax(), formatter)
     }

--- a/crates/rome_js_formatter/src/js/expressions/class_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/class_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyClass, JsClassExpression};
 impl FormatNodeFields<JsClassExpression> for FormatNodeRule<JsClassExpression> {
     fn format_fields(
         node: &JsClassExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyClass::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/expressions/computed_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/computed_member_expression.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsComputedMemberExpression> for FormatNodeRule<JsComputedMemberExpression> {
     fn format_fields(
         node: &JsComputedMemberExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let mut current = node.clone();
 

--- a/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsConditionalExpression;
 impl FormatNodeFields<JsConditionalExpression> for FormatNodeRule<JsConditionalExpression> {
     fn format_fields(
         node: &JsConditionalExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_conditional(Conditional::Expression(node.clone()), formatter, false)
     }

--- a/crates/rome_js_formatter/src/js/expressions/function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/function_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsAnyFunction, JsFunctionExpression};
 impl FormatNodeFields<JsFunctionExpression> for FormatNodeRule<JsFunctionExpression> {
     fn format_fields(
         node: &JsFunctionExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [JsAnyFunction::from(node.clone()).format()]]
     }

--- a/crates/rome_js_formatter/src/js/expressions/identifier_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/identifier_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsIdentifierExpressionFields;
 impl FormatNodeFields<JsIdentifierExpression> for FormatNodeRule<JsIdentifierExpression> {
     fn format_fields(
         node: &JsIdentifierExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsIdentifierExpressionFields { name } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/import_call_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/import_call_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportCallExpressionFields;
 impl FormatNodeFields<JsImportCallExpression> for FormatNodeRule<JsImportCallExpression> {
     fn format_fields(
         node: &JsImportCallExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsImportCallExpressionFields {
             import_token,

--- a/crates/rome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/in_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsInExpression;
 impl FormatNodeFields<JsInExpression> for FormatNodeRule<JsInExpression> {
     fn format_fields(
         node: &JsInExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_binary_like_expression(
             JsAnyBinaryLikeExpression::JsInExpression(node.clone()),

--- a/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsInstanceofExpression;
 impl FormatNodeFields<JsInstanceofExpression> for FormatNodeRule<JsInstanceofExpression> {
     fn format_fields(
         node: &JsInstanceofExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_binary_like_expression(
             JsAnyBinaryLikeExpression::JsInstanceofExpression(node.clone()),

--- a/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsLogicalExpression;
 impl FormatNodeFields<JsLogicalExpression> for FormatNodeRule<JsLogicalExpression> {
     fn format_fields(
         node: &JsLogicalExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_binary_like_expression(
             JsAnyBinaryLikeExpression::JsLogicalExpression(node.clone()),

--- a/crates/rome_js_formatter/src/js/expressions/new_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/new_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNewExpressionFields;
 impl FormatNodeFields<JsNewExpression> for FormatNodeRule<JsNewExpression> {
     fn format_fields(
         node: &JsNewExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsNewExpressionFields {
             new_token,

--- a/crates/rome_js_formatter/src/js/expressions/null_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/null_literal_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNullLiteralExpressionFields;
 impl FormatNodeFields<JsNullLiteralExpression> for FormatNodeRule<JsNullLiteralExpression> {
     fn format_fields(
         node: &JsNullLiteralExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsNullLiteralExpressionFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNumberLiteralExpressionFields;
 impl FormatNodeFields<JsNumberLiteralExpression> for FormatNodeRule<JsNumberLiteralExpression> {
     fn format_fields(
         node: &JsNumberLiteralExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsNumberLiteralExpressionFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/object_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/object_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsObjectExpressionFields;
 impl FormatNodeFields<JsObjectExpression> for FormatNodeRule<JsObjectExpression> {
     fn format_fields(
         node: &JsObjectExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsObjectExpressionFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -11,7 +11,7 @@ use rome_rowan::{AstNode, SyntaxResult};
 impl FormatNodeFields<JsParenthesizedExpression> for FormatNodeRule<JsParenthesizedExpression> {
     fn format_fields(
         node: &JsParenthesizedExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsParenthesizedExpressionFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsPostUpdateExpressionFields;
 impl FormatNodeFields<JsPostUpdateExpression> for FormatNodeRule<JsPostUpdateExpression> {
     fn format_fields(
         node: &JsPostUpdateExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsPostUpdateExpressionFields {
             operand,

--- a/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsPreUpdateExpressionFields;
 impl FormatNodeFields<JsPreUpdateExpression> for FormatNodeRule<JsPreUpdateExpression> {
     fn format_fields(
         node: &JsPreUpdateExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsPreUpdateExpressionFields {
             operator_token,

--- a/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsRegexLiteralExpressionFields;
 impl FormatNodeFields<JsRegexLiteralExpression> for FormatNodeRule<JsRegexLiteralExpression> {
     fn format_fields(
         node: &JsRegexLiteralExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsRegexLiteralExpressionFields { value_token } = node.as_fields();
         let value_token = value_token?;

--- a/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsSequenceExpression> for FormatNodeRule<JsSequenceExpression> {
     fn format_fields(
         node: &JsSequenceExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let mut current = node.clone();
         let parent = current.syntax().parent();

--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::JsStaticMemberExpressionFields;
 impl FormatNodeFields<JsStaticMemberExpression> for FormatNodeRule<JsStaticMemberExpression> {
     fn format_fields(
         node: &JsStaticMemberExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsStaticMemberExpressionFields {
             object,

--- a/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -10,7 +10,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsStringLiteralExpression> for FormatNodeRule<JsStringLiteralExpression> {
     fn format_fields(
         node: &JsStringLiteralExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsStringLiteralExpressionFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/super_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/super_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsSuperExpressionFields;
 impl FormatNodeFields<JsSuperExpression> for FormatNodeRule<JsSuperExpression> {
     fn format_fields(
         node: &JsSuperExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsSuperExpressionFields { super_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/template.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsTemplateFields;
 impl FormatNodeFields<JsTemplate> for FormatNodeRule<JsTemplate> {
     fn format_fields(
         node: &JsTemplate,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsTemplateFields {
             tag,

--- a/crates/rome_js_formatter/src/js/expressions/template_chunk_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_chunk_element.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{JsTemplateChunkElement, JsTemplateChunkElementFields};
 impl FormatNodeFields<JsTemplateChunkElement> for FormatNodeRule<JsTemplateChunkElement> {
     fn format_fields(
         node: &JsTemplateChunkElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsTemplateChunkElementFields {
             template_chunk_token,

--- a/crates/rome_js_formatter/src/js/expressions/template_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_element.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsTemplateElement;
 impl FormatNodeFields<JsTemplateElement> for FormatNodeRule<JsTemplateElement> {
     fn format_fields(
         node: &JsTemplateElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_template_literal(TemplateElement::Js(node.clone()), formatter)
     }

--- a/crates/rome_js_formatter/src/js/expressions/this_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/this_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsThisExpressionFields;
 impl FormatNodeFields<JsThisExpression> for FormatNodeRule<JsThisExpression> {
     fn format_fields(
         node: &JsThisExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsThisExpressionFields { this_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{JsUnaryExpressionFields, JsUnaryOperator};
 impl FormatNodeFields<JsUnaryExpression> for FormatNodeRule<JsUnaryExpression> {
     fn format_fields(
         node: &JsUnaryExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsUnaryExpressionFields {
             operator_token,

--- a/crates/rome_js_formatter/src/js/expressions/yield_argument.rs
+++ b/crates/rome_js_formatter/src/js/expressions/yield_argument.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsYieldArgumentFields;
 impl FormatNodeFields<JsYieldArgument> for FormatNodeRule<JsYieldArgument> {
     fn format_fields(
         node: &JsYieldArgument,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsYieldArgumentFields {
             star_token,

--- a/crates/rome_js_formatter/src/js/expressions/yield_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/yield_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsYieldExpressionFields;
 impl FormatNodeFields<JsYieldExpression> for FormatNodeRule<JsYieldExpression> {
     fn format_fields(
         node: &JsYieldExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsYieldExpressionFields {
             yield_token,

--- a/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
@@ -4,11 +4,11 @@ use crate::utils::array::format_array_node;
 use rome_js_syntax::JsArrayAssignmentPatternElementList;
 
 impl FormatRule<JsArrayAssignmentPatternElementList> for FormatJsArrayAssignmentPatternElementList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsArrayAssignmentPatternElementList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_array_node(node, formatter)
     }

--- a/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
@@ -4,11 +4,11 @@ use crate::utils::array::format_array_node;
 use rome_js_syntax::JsArrayBindingPatternElementList;
 
 impl FormatRule<JsArrayBindingPatternElementList> for FormatJsArrayBindingPatternElementList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsArrayBindingPatternElementList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_array_node(node, formatter)
     }

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -11,11 +11,11 @@ use rome_js_syntax::{JsAnyExpression, JsArrayElementList};
 use rome_rowan::{AstNode, AstSeparatedList};
 
 impl FormatRule<JsArrayElementList> for FormatJsArrayElementList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsArrayElementList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Self::format_with_group_id(node, formatter, None)
     }
@@ -25,7 +25,7 @@ impl FormatJsArrayElementList {
     /// Formats the array list with
     pub fn format_with_group_id(
         node: &JsArrayElementList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
         group_id: Option<GroupId>,
     ) -> FormatResult<FormatElement> {
         if !has_formatter_trivia(node.syntax()) && can_print_fill(node) {

--- a/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsCallArgumentList;
 
 impl FormatRule<JsCallArgumentList> for FormatJsCallArgumentList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsCallArgumentList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/class_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/class_member_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsClassMemberList;
 
 impl FormatRule<JsClassMemberList> for FormatJsClassMemberList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsClassMemberList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(formatter.format_list(node))
     }

--- a/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
@@ -4,11 +4,11 @@ use rome_js_syntax::JsConstructorModifierList;
 use rome_rowan::AstNodeList;
 
 impl FormatRule<JsConstructorModifierList> for FormatJsConstructorModifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsConstructorModifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsConstructorParameterList;
 
 impl FormatRule<JsConstructorParameterList> for FormatJsConstructorParameterList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsConstructorParameterList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/directive_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/directive_list.rs
@@ -4,11 +4,11 @@ use rome_js_syntax::JsDirectiveList;
 use rome_rowan::{AstNode, AstNodeList};
 
 impl FormatRule<JsDirectiveList> for FormatJsDirectiveList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsDirectiveList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         if !node.is_empty() {
             let syntax_node = node.syntax();

--- a/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsExportNamedFromSpecifierList;
 
 impl FormatRule<JsExportNamedFromSpecifierList> for FormatJsExportNamedFromSpecifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsExportNamedFromSpecifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsExportNamedSpecifierList;
 
 impl FormatRule<JsExportNamedSpecifierList> for FormatJsExportNamedSpecifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsExportNamedSpecifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsImportAssertionEntryList;
 
 impl FormatRule<JsImportAssertionEntryList> for FormatJsImportAssertionEntryList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsImportAssertionEntryList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
@@ -4,11 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::JsMethodModifierList;
 
 impl FormatRule<JsMethodModifierList> for FormatJsMethodModifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsMethodModifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/js/lists/module_item_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/module_item_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsModuleItemList;
 
 impl FormatRule<JsModuleItemList> for FormatJsModuleItemList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsModuleItemList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(formatter.format_list(node))
     }

--- a/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsNamedImportSpecifierList;
 
 impl FormatRule<JsNamedImportSpecifierList> for FormatJsNamedImportSpecifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsNamedImportSpecifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
@@ -6,11 +6,11 @@ use rome_js_syntax::{JsAnyObjectAssignmentPatternMember, JsObjectAssignmentPatte
 impl FormatRule<JsObjectAssignmentPatternPropertyList>
     for FormatJsObjectAssignmentPatternPropertyList
 {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsObjectAssignmentPatternPropertyList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         // The trailing separator is disallowed after a rest element
         let has_trailing_rest = match node.into_iter().last() {

--- a/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
@@ -4,11 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::{JsAnyObjectBindingPatternMember, JsObjectBindingPatternPropertyList};
 
 impl FormatRule<JsObjectBindingPatternPropertyList> for FormatJsObjectBindingPatternPropertyList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsObjectBindingPatternPropertyList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         // The trailing separator is disallowed after a rest element
         let has_trailing_rest = match node.into_iter().last() {

--- a/crates/rome_js_formatter/src/js/lists/object_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_member_list.rs
@@ -4,11 +4,11 @@ use rome_js_syntax::JsObjectMemberList;
 use rome_rowan::{AstNode, AstSeparatedList};
 
 impl FormatRule<JsObjectMemberList> for FormatJsObjectMemberList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsObjectMemberList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let members = formatter.format_separated(node, || token(","))?;
 

--- a/crates/rome_js_formatter/src/js/lists/parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/parameter_list.rs
@@ -4,11 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::{JsAnyParameter, JsParameterList};
 
 impl FormatRule<JsParameterList> for FormatJsParameterList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsParameterList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         // The trailing separator is disallowed if the last element in the list is a rest parameter
         let has_trailing_rest = match node.into_iter().last() {

--- a/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
@@ -4,11 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::JsPropertyModifierList;
 
 impl FormatRule<JsPropertyModifierList> for FormatJsPropertyModifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsPropertyModifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/js/lists/statement_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/statement_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsStatementList;
 
 impl FormatRule<JsStatementList> for FormatJsStatementList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsStatementList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(formatter.format_list(node))
     }

--- a/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsSwitchCaseList;
 
 impl FormatRule<JsSwitchCaseList> for FormatJsSwitchCaseList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsSwitchCaseList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(formatter.format_list(node))
     }

--- a/crates/rome_js_formatter/src/js/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/template_element_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsTemplateElementList;
 
 impl FormatRule<JsTemplateElementList> for FormatJsTemplateElementList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsTemplateElementList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(concat_elements(
             formatter

--- a/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
@@ -6,11 +6,11 @@ use rome_js_syntax::JsVariableDeclaratorList;
 use rome_rowan::AstSeparatedList;
 
 impl FormatRule<JsVariableDeclaratorList> for FormatJsVariableDeclaratorList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsVariableDeclaratorList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let last_index = node.len().saturating_sub(1);
 

--- a/crates/rome_js_formatter/src/js/module/default_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/default_import_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsDefaultImportSpecifierFields;
 impl FormatNodeFields<JsDefaultImportSpecifier> for FormatNodeRule<JsDefaultImportSpecifier> {
     fn format_fields(
         node: &JsDefaultImportSpecifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsDefaultImportSpecifierFields {
             local_name,

--- a/crates/rome_js_formatter/src/js/module/export.rs
+++ b/crates/rome_js_formatter/src/js/module/export.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportFields;
 impl FormatNodeFields<JsExport> for FormatNodeRule<JsExport> {
     fn format_fields(
         node: &JsExport,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportFields {
             export_token,

--- a/crates/rome_js_formatter/src/js/module/export_as_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_as_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportAsClauseFields;
 impl FormatNodeFields<JsExportAsClause> for FormatNodeRule<JsExportAsClause> {
     fn format_fields(
         node: &JsExportAsClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportAsClauseFields {
             as_token,

--- a/crates/rome_js_formatter/src/js/module/export_default_declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_default_declaration_clause.rs
@@ -7,7 +7,7 @@ impl FormatNodeFields<JsExportDefaultDeclarationClause>
 {
     fn format_fields(
         node: &JsExportDefaultDeclarationClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportDefaultDeclarationClauseFields {
             default_token,

--- a/crates/rome_js_formatter/src/js/module/export_default_expression_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_default_expression_clause.rs
@@ -10,7 +10,7 @@ impl FormatNodeFields<JsExportDefaultExpressionClause>
 {
     fn format_fields(
         node: &JsExportDefaultExpressionClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportDefaultExpressionClauseFields {
             default_token,

--- a/crates/rome_js_formatter/src/js/module/export_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_from_clause.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsExportFromClauseFields;
 impl FormatNodeFields<JsExportFromClause> for FormatNodeRule<JsExportFromClause> {
     fn format_fields(
         node: &JsExportFromClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportFromClauseFields {
             star_token,

--- a/crates/rome_js_formatter/src/js/module/export_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_clause.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsExportNamedClauseFields;
 impl FormatNodeFields<JsExportNamedClause> for FormatNodeRule<JsExportNamedClause> {
     fn format_fields(
         node: &JsExportNamedClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
@@ -10,7 +10,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsExportNamedFromClause> for FormatNodeRule<JsExportNamedFromClause> {
     fn format_fields(
         node: &JsExportNamedFromClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedFromClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/export_named_from_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportNamedFromSpecifierFields;
 impl FormatNodeFields<JsExportNamedFromSpecifier> for FormatNodeRule<JsExportNamedFromSpecifier> {
     fn format_fields(
         node: &JsExportNamedFromSpecifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedFromSpecifierFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/export_named_shorthand_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_shorthand_specifier.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsExportNamedShorthandSpecifier>
 {
     fn format_fields(
         node: &JsExportNamedShorthandSpecifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedShorthandSpecifierFields { type_token, name } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/module/export_named_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportNamedSpecifierFields;
 impl FormatNodeFields<JsExportNamedSpecifier> for FormatNodeRule<JsExportNamedSpecifier> {
     fn format_fields(
         node: &JsExportNamedSpecifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExportNamedSpecifierFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/import.rs
+++ b/crates/rome_js_formatter/src/js/module/import.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsImportFields;
 impl FormatNodeFields<JsImport> for FormatNodeRule<JsImport> {
     fn format_fields(
         node: &JsImport,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsImportFields {
             import_token,

--- a/crates/rome_js_formatter/src/js/module/import_assertion.rs
+++ b/crates/rome_js_formatter/src/js/module/import_assertion.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportAssertionFields;
 impl FormatNodeFields<JsImportAssertion> for FormatNodeRule<JsImportAssertion> {
     fn format_fields(
         node: &JsImportAssertion,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsImportAssertionFields {
             assert_token,

--- a/crates/rome_js_formatter/src/js/module/import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/module/import_assertion_entry.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::{JsImportAssertionEntry, JsSyntaxKind};
 impl FormatNodeFields<JsImportAssertionEntry> for FormatNodeRule<JsImportAssertionEntry> {
     fn format_fields(
         node: &JsImportAssertionEntry,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsImportAssertionEntryFields {
             key,

--- a/crates/rome_js_formatter/src/js/module/import_bare_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_bare_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportBareClauseFields;
 impl FormatNodeFields<JsImportBareClause> for FormatNodeRule<JsImportBareClause> {
     fn format_fields(
         node: &JsImportBareClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsImportBareClauseFields { source, assertion } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/module/import_default_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_default_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportDefaultClauseFields;
 impl FormatNodeFields<JsImportDefaultClause> for FormatNodeRule<JsImportDefaultClause> {
     fn format_fields(
         node: &JsImportDefaultClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsImportDefaultClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/import_meta.rs
+++ b/crates/rome_js_formatter/src/js/module/import_meta.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::ImportMetaFields;
 impl FormatNodeFields<ImportMeta> for FormatNodeRule<ImportMeta> {
     fn format_fields(
         node: &ImportMeta,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let ImportMetaFields {
             import_token,

--- a/crates/rome_js_formatter/src/js/module/import_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_named_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportNamedClauseFields;
 impl FormatNodeFields<JsImportNamedClause> for FormatNodeRule<JsImportNamedClause> {
     fn format_fields(
         node: &JsImportNamedClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsImportNamedClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/import_namespace_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_namespace_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportNamespaceClauseFields;
 impl FormatNodeFields<JsImportNamespaceClause> for FormatNodeRule<JsImportNamespaceClause> {
     fn format_fields(
         node: &JsImportNamespaceClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsImportNamespaceClauseFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/literal_export_name.rs
+++ b/crates/rome_js_formatter/src/js/module/literal_export_name.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsLiteralExportNameFields;
 impl FormatNodeFields<JsLiteralExportName> for FormatNodeRule<JsLiteralExportName> {
     fn format_fields(
         node: &JsLiteralExportName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsLiteralExportNameFields { value } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/module/module_source.rs
+++ b/crates/rome_js_formatter/src/js/module/module_source.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsModuleSourceFields;
 impl FormatNodeFields<JsModuleSource> for FormatNodeRule<JsModuleSource> {
     fn format_fields(
         node: &JsModuleSource,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsModuleSourceFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/module/named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/named_import_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNamedImportSpecifierFields;
 impl FormatNodeFields<JsNamedImportSpecifier> for FormatNodeRule<JsNamedImportSpecifier> {
     fn format_fields(
         node: &JsNamedImportSpecifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsNamedImportSpecifierFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
+++ b/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNamedImportSpecifiersFields;
 impl FormatNodeFields<JsNamedImportSpecifiers> for FormatNodeRule<JsNamedImportSpecifiers> {
     fn format_fields(
         node: &JsNamedImportSpecifiers,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsNamedImportSpecifiersFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/module/namespace_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/namespace_import_specifier.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsNamespaceImportSpecifierFields;
 impl FormatNodeFields<JsNamespaceImportSpecifier> for FormatNodeRule<JsNamespaceImportSpecifier> {
     fn format_fields(
         node: &JsNamespaceImportSpecifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsNamespaceImportSpecifierFields {
             star_token,

--- a/crates/rome_js_formatter/src/js/module/shorthand_named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/shorthand_named_import_specifier.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsShorthandNamedImportSpecifier>
 {
     fn format_fields(
         node: &JsShorthandNamedImportSpecifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsShorthandNamedImportSpecifierFields {
             type_token,

--- a/crates/rome_js_formatter/src/js/objects/computed_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/computed_member_name.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsComputedMemberNameFields;
 impl FormatNodeFields<JsComputedMemberName> for FormatNodeRule<JsComputedMemberName> {
     fn format_fields(
         node: &JsComputedMemberName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsComputedMemberNameFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/js/objects/getter_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/getter_object_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsGetterObjectMemberFields;
 impl FormatNodeFields<JsGetterObjectMember> for FormatNodeRule<JsGetterObjectMember> {
     fn format_fields(
         node: &JsGetterObjectMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsGetterObjectMemberFields {
             get_token,

--- a/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::{JsLiteralMemberName, JsSyntaxKind};
 impl FormatNodeFields<JsLiteralMemberName> for FormatNodeRule<JsLiteralMemberName> {
     fn format_fields(
         node: &JsLiteralMemberName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsLiteralMemberNameFields { value } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/objects/method_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/method_object_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsMethodObjectMemberFields;
 impl FormatNodeFields<JsMethodObjectMember> for FormatNodeRule<JsMethodObjectMember> {
     fn format_fields(
         node: &JsMethodObjectMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsMethodObjectMemberFields {
             async_token,

--- a/crates/rome_js_formatter/src/js/objects/private_class_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/private_class_member_name.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsPrivateClassMemberNameFields;
 impl FormatNodeFields<JsPrivateClassMemberName> for FormatNodeRule<JsPrivateClassMemberName> {
     fn format_fields(
         node: &JsPrivateClassMemberName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsPrivateClassMemberNameFields {
             hash_token,

--- a/crates/rome_js_formatter/src/js/objects/property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/property_object_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsPropertyObjectMemberFields;
 impl FormatNodeFields<JsPropertyObjectMember> for FormatNodeRule<JsPropertyObjectMember> {
     fn format_fields(
         node: &JsPropertyObjectMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsPropertyObjectMemberFields {
             name,

--- a/crates/rome_js_formatter/src/js/objects/setter_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/setter_object_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsSetterObjectMemberFields;
 impl FormatNodeFields<JsSetterObjectMember> for FormatNodeRule<JsSetterObjectMember> {
     fn format_fields(
         node: &JsSetterObjectMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsSetterObjectMemberFields {
             set_token,

--- a/crates/rome_js_formatter/src/js/objects/shorthand_property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/shorthand_property_object_member.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<JsShorthandPropertyObjectMember>
 {
     fn format_fields(
         node: &JsShorthandPropertyObjectMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsShorthandPropertyObjectMemberFields { name } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/js/statements/block_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/block_statement.rs
@@ -11,7 +11,7 @@ use rome_rowan::{AstNode, AstNodeList};
 impl FormatNodeFields<JsBlockStatement> for FormatNodeRule<JsBlockStatement> {
     fn format_fields(
         node: &JsBlockStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsBlockStatementFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/js/statements/break_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/break_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsBreakStatementFields;
 impl FormatNodeFields<JsBreakStatement> for FormatNodeRule<JsBreakStatement> {
     fn format_fields(
         node: &JsBreakStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsBreakStatementFields {
             break_token,

--- a/crates/rome_js_formatter/src/js/statements/continue_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/continue_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsContinueStatementFields;
 impl FormatNodeFields<JsContinueStatement> for FormatNodeRule<JsContinueStatement> {
     fn format_fields(
         node: &JsContinueStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsContinueStatementFields {
             continue_token,

--- a/crates/rome_js_formatter/src/js/statements/debugger_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/debugger_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsDebuggerStatementFields;
 impl FormatNodeFields<JsDebuggerStatement> for FormatNodeRule<JsDebuggerStatement> {
     fn format_fields(
         node: &JsDebuggerStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsDebuggerStatementFields {
             debugger_token,

--- a/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{JsAnyStatement, JsDoWhileStatement};
 impl FormatNodeFields<JsDoWhileStatement> for FormatNodeRule<JsDoWhileStatement> {
     fn format_fields(
         node: &JsDoWhileStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsDoWhileStatementFields {
             do_token,

--- a/crates/rome_js_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/empty_statement.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsEmptyStatement> for FormatNodeRule<JsEmptyStatement> {
     fn format_fields(
         node: &JsEmptyStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsEmptyStatementFields { semicolon_token } = node.as_fields();
         let parent_kind = node.syntax().parent().map(|p| p.kind());

--- a/crates/rome_js_formatter/src/js/statements/expression_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/expression_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsExpressionStatementFields;
 impl FormatNodeFields<JsExpressionStatement> for FormatNodeRule<JsExpressionStatement> {
     fn format_fields(
         node: &JsExpressionStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsExpressionStatementFields {
             expression,

--- a/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsForInStatementFields;
 impl FormatNodeFields<JsForInStatement> for FormatNodeRule<JsForInStatement> {
     fn format_fields(
         node: &JsForInStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsForInStatementFields {
             for_token,

--- a/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsForOfStatementFields;
 impl FormatNodeFields<JsForOfStatement> for FormatNodeRule<JsForOfStatement> {
     fn format_fields(
         node: &JsForOfStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsForOfStatementFields {
             for_token,

--- a/crates/rome_js_formatter/src/js/statements/for_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsForStatementFields;
 impl FormatNodeFields<JsForStatement> for FormatNodeRule<JsForStatement> {
     fn format_fields(
         node: &JsForStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsForStatementFields {
             for_token,

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::{JsElseClause, JsIfStatementFields};
 impl FormatNodeFields<JsIfStatement> for FormatNodeRule<JsIfStatement> {
     fn format_fields(
         node: &JsIfStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let (head, mut else_clause) = format_if_element(formatter, None, node)?;
 
@@ -45,7 +45,7 @@ impl FormatNodeFields<JsIfStatement> for FormatNodeRule<JsIfStatement> {
 
 /// Format a single `else? if(test) consequent` element, returning the next else clause
 fn format_if_element(
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
     else_token: Option<JsSyntaxToken>,
     stmt: &JsIfStatement,
 ) -> FormatResult<(FormatElement, Option<JsElseClause>)> {
@@ -84,7 +84,7 @@ fn format_if_element(
 
 /// Wraps the statement into a block if its not already a JsBlockStatement
 fn into_block(
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
     stmt: JsAnyStatement,
 ) -> FormatResult<FormatElement> {
     if matches!(stmt, JsAnyStatement::JsBlockStatement(_)) {

--- a/crates/rome_js_formatter/src/js/statements/labeled_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/labeled_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{JsAnyStatement, JsLabeledStatement};
 impl FormatNodeFields<JsLabeledStatement> for FormatNodeRule<JsLabeledStatement> {
     fn format_fields(
         node: &JsLabeledStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsLabeledStatementFields {
             label_token,

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsReturnStatement> for FormatNodeRule<JsReturnStatement> {
     fn format_fields(
         node: &JsReturnStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsReturnStatementFields {
             return_token,

--- a/crates/rome_js_formatter/src/js/statements/switch_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/switch_statement.rs
@@ -6,7 +6,7 @@ use rome_rowan::{AstNode, AstNodeList};
 impl FormatNodeFields<JsSwitchStatement> for FormatNodeRule<JsSwitchStatement> {
     fn format_fields(
         node: &JsSwitchStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsSwitchStatementFields {
             switch_token,

--- a/crates/rome_js_formatter/src/js/statements/throw_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/throw_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsThrowStatementFields;
 impl FormatNodeFields<JsThrowStatement> for FormatNodeRule<JsThrowStatement> {
     fn format_fields(
         node: &JsThrowStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsThrowStatementFields {
             throw_token,

--- a/crates/rome_js_formatter/src/js/statements/try_finally_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/try_finally_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsTryFinallyStatementFields;
 impl FormatNodeFields<JsTryFinallyStatement> for FormatNodeRule<JsTryFinallyStatement> {
     fn format_fields(
         node: &JsTryFinallyStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsTryFinallyStatementFields {
             try_token,

--- a/crates/rome_js_formatter/src/js/statements/try_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/try_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsTryStatementFields;
 impl FormatNodeFields<JsTryStatement> for FormatNodeRule<JsTryStatement> {
     fn format_fields(
         node: &JsTryStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsTryStatementFields {
             try_token,

--- a/crates/rome_js_formatter/src/js/statements/variable_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/variable_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsVariableStatementFields;
 impl FormatNodeFields<JsVariableStatement> for FormatNodeRule<JsVariableStatement> {
     fn format_fields(
         node: &JsVariableStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsVariableStatementFields {
             declaration,

--- a/crates/rome_js_formatter/src/js/statements/while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/while_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsWhileStatementFields;
 impl FormatNodeFields<JsWhileStatement> for FormatNodeRule<JsWhileStatement> {
     fn format_fields(
         node: &JsWhileStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsWhileStatementFields {
             while_token,

--- a/crates/rome_js_formatter/src/js/statements/with_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/with_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsWithStatementFields;
 impl FormatNodeFields<JsWithStatement> for FormatNodeRule<JsWithStatement> {
     fn format_fields(
         node: &JsWithStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsWithStatementFields {
             with_token,

--- a/crates/rome_js_formatter/src/js/unknown/unknown.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknown> for FormatNodeRule<JsUnknown> {
     fn format_fields(
         node: &JsUnknown,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownAssignment> for FormatNodeRule<JsUnknownAssignment> {
     fn format_fields(
         node: &JsUnknownAssignment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownBinding> for FormatNodeRule<JsUnknownBinding> {
     fn format_fields(
         node: &JsUnknownBinding,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownExpression> for FormatNodeRule<JsUnknownExpression> {
     fn format_fields(
         node: &JsUnknownExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
@@ -10,7 +10,7 @@ impl FormatNodeFields<JsUnknownImportAssertionEntry>
 {
     fn format_fields(
         node: &JsUnknownImportAssertionEntry,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownMember> for FormatNodeRule<JsUnknownMember> {
     fn format_fields(
         node: &JsUnknownMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
@@ -10,7 +10,7 @@ impl FormatNodeFields<JsUnknownNamedImportSpecifier>
 {
     fn format_fields(
         node: &JsUnknownNamedImportSpecifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownParameter> for FormatNodeRule<JsUnknownParameter> {
     fn format_fields(
         node: &JsUnknownParameter,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
@@ -8,7 +8,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsUnknownStatement> for FormatNodeRule<JsUnknownStatement> {
     fn format_fields(
         node: &JsUnknownStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         unknown_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/any/attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsxAnyAttribute;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttribute;
 impl FormatRule<JsxAnyAttribute> for FormatJsxAnyAttribute {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsxAnyAttribute,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyAttribute::JsxAttribute(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsxAnyAttributeName;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttributeName;
 impl FormatRule<JsxAnyAttributeName> for FormatJsxAnyAttributeName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsxAnyAttributeName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyAttributeName::JsxName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsxAnyAttributeValue;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttributeValue;
 impl FormatRule<JsxAnyAttributeValue> for FormatJsxAnyAttributeValue {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsxAnyAttributeValue,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyAttributeValue::JsxAnyTag(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/child.rs
+++ b/crates/rome_js_formatter/src/jsx/any/child.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsxAnyChild;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyChild;
 impl FormatRule<JsxAnyChild> for FormatJsxAnyChild {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsxAnyChild,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyChild::JsxElement(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/element_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/element_name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsxAnyElementName;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyElementName;
 impl FormatRule<JsxAnyElementName> for FormatJsxAnyElementName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsxAnyElementName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyElementName::JsxName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsxAnyName;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyName;
 impl FormatRule<JsxAnyName> for FormatJsxAnyName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsxAnyName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyName::JsxName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/any/object_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/object_name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsxAnyObjectName;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyObjectName;
 impl FormatRule<JsxAnyObjectName> for FormatJsxAnyObjectName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsxAnyObjectName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyObjectName::JsxReferenceIdentifier(node) => {

--- a/crates/rome_js_formatter/src/jsx/any/tag.rs
+++ b/crates/rome_js_formatter/src/jsx/any/tag.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatJsxAnyTag;
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyTag;
 impl FormatRule<JsxAnyTag> for FormatJsxAnyTag {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &JsxAnyTag,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             JsxAnyTag::JsxElement(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/jsx/attribute/attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/attribute.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxAttribute, JsxAttributeFields};
 impl FormatNodeFields<JsxAttribute> for FormatNodeRule<JsxAttribute> {
     fn format_fields(
         node: &JsxAttribute,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxAttributeFields { name, initializer } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/jsx/attribute/attribute_initializer_clause.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/attribute_initializer_clause.rs
@@ -7,7 +7,7 @@ impl FormatNodeFields<JsxAttributeInitializerClause>
 {
     fn format_fields(
         node: &JsxAttributeInitializerClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxAttributeInitializerClauseFields { eq_token, value } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{
 impl FormatNodeFields<JsxExpressionAttributeValue> for FormatNodeRule<JsxExpressionAttributeValue> {
     fn format_fields(
         node: &JsxExpressionAttributeValue,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxExpressionAttributeValueFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/jsx/attribute/spread_attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/spread_attribute.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxSpreadAttribute, JsxSpreadAttributeFields};
 impl FormatNodeFields<JsxSpreadAttribute> for FormatNodeRule<JsxSpreadAttribute> {
     fn format_fields(
         node: &JsxSpreadAttribute,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxSpreadAttributeFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsxExpressionChild> for FormatNodeRule<JsxExpressionChild> {
     fn format_fields(
         node: &JsxExpressionChild,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/name.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxName, JsxNameFields};
 impl FormatNodeFields<JsxName> for FormatNodeRule<JsxName> {
     fn format_fields(
         node: &JsxName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxNameFields { value_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/jsx/auxiliary/namespace_name.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/namespace_name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxNamespaceName, JsxNamespaceNameFields};
 impl FormatNodeFields<JsxNamespaceName> for FormatNodeRule<JsxNamespaceName> {
     fn format_fields(
         node: &JsxNamespaceName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxNamespaceNameFields {
             namespace,

--- a/crates/rome_js_formatter/src/jsx/auxiliary/reference_identifier.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/reference_identifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsxReferenceIdentifier;
 impl FormatNodeFields<JsxReferenceIdentifier> for FormatNodeRule<JsxReferenceIdentifier> {
     fn format_fields(
         node: &JsxReferenceIdentifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [node.value_token().format()]]
     }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/spread_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/spread_child.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsxSpreadChild> for FormatNodeRule<JsxSpreadChild> {
     fn format_fields(
         node: &JsxSpreadChild,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/string.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/string.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsxString;
 impl FormatNodeFields<JsxString> for FormatNodeRule<JsxString> {
     fn format_fields(
         node: &JsxString,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [node.value_token().format()]]
     }

--- a/crates/rome_js_formatter/src/jsx/auxiliary/text.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/text.rs
@@ -8,7 +8,7 @@ use std::str::CharIndices;
 impl FormatNodeFields<JsxText> for FormatNodeRule<JsxText> {
     fn format_fields(
         node: &JsxText,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxTextFields { value_token } = node.as_fields();
         let token = value_token?;

--- a/crates/rome_js_formatter/src/jsx/expressions/tag_expression.rs
+++ b/crates/rome_js_formatter/src/jsx/expressions/tag_expression.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsxTagExpression;
 impl FormatNodeFields<JsxTagExpression> for FormatNodeRule<JsxTagExpression> {
     fn format_fields(
         node: &JsxTagExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatted![formatter, [node.tag().format()]]
     }

--- a/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::JsxAttributeList;
 
 impl FormatRule<JsxAttributeList> for FormatJsxAttributeList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsxAttributeList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let attributes = join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/jsx/lists/child_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/child_list.rs
@@ -5,11 +5,11 @@ use rome_js_syntax::JsxChildList;
 use rome_rowan::AstNode;
 
 impl FormatRule<JsxChildList> for FormatJsxChildList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &JsxChildList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/objects/member_name.rs
+++ b/crates/rome_js_formatter/src/jsx/objects/member_name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxMemberName, JsxMemberNameFields};
 impl FormatNodeFields<JsxMemberName> for FormatNodeRule<JsxMemberName> {
     fn format_fields(
         node: &JsxMemberName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxMemberNameFields {
             object,

--- a/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsxClosingElement> for FormatNodeRule<JsxClosingElement> {
     fn format_fields(
         node: &JsxClosingElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/tag/closing_fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/closing_fragment.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxClosingFragment, JsxClosingFragmentFields};
 impl FormatNodeFields<JsxClosingFragment> for FormatNodeRule<JsxClosingFragment> {
     fn format_fields(
         node: &JsxClosingFragment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxClosingFragmentFields {
             r_angle_token,

--- a/crates/rome_js_formatter/src/jsx/tag/element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/element.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsxElement> for FormatNodeRule<JsxElement> {
     fn format_fields(
         node: &JsxElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/tag/fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/fragment.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxFragment, JsxFragmentFields};
 impl FormatNodeFields<JsxFragment> for FormatNodeRule<JsxFragment> {
     fn format_fields(
         node: &JsxFragment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxFragmentFields {
             opening_fragment,

--- a/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<JsxOpeningElement> for FormatNodeRule<JsxOpeningElement> {
     fn format_fields(
         node: &JsxOpeningElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         verbatim_node(node.syntax()).format(formatter)
     }

--- a/crates/rome_js_formatter/src/jsx/tag/opening_fragment.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/opening_fragment.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxOpeningFragment, JsxOpeningFragmentFields};
 impl FormatNodeFields<JsxOpeningFragment> for FormatNodeRule<JsxOpeningFragment> {
     fn format_fields(
         node: &JsxOpeningFragment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxOpeningFragmentFields {
             r_angle_token,

--- a/crates/rome_js_formatter/src/jsx/tag/self_closing_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/self_closing_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsxSelfClosingElement, JsxSelfClosingElementFields};
 impl FormatNodeFields<JsxSelfClosingElement> for FormatNodeRule<JsxSelfClosingElement> {
     fn format_fields(
         node: &JsxSelfClosingElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let JsxSelfClosingElementFields {
             l_angle_token,

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -488,7 +488,7 @@ mod test {
 
 "#;
         let syntax = SourceType::jsx();
-        let tree = parse(src, 0, syntax.clone());
+        let tree = parse(src, 0, syntax);
         let result = format_node(JsFormatContext::default(), &tree.syntax())
             .unwrap()
             .print();

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -20,8 +20,8 @@ use rome_rowan::AstNode;
 use rome_rowan::SyntaxResult;
 use rome_rowan::TextRange;
 
+use crate::context::JsFormatContext;
 use crate::cst::FormatJsSyntaxNode;
-use crate::options::JsFormatOptions;
 use std::iter::FusedIterator;
 use std::marker::PhantomData;
 
@@ -29,7 +29,7 @@ use std::marker::PhantomData;
 
 /// Used to get an object that knows how to format this object.
 pub trait AsFormat<'a> {
-    type Format: Format<Options = JsFormatOptions>;
+    type Format: Format<Context = JsFormatContext>;
 
     /// Returns an object that is able to format this object.
     fn format(&'a self) -> Self::Format;
@@ -171,9 +171,9 @@ where
     N: AstNode<Language = JsLanguage>,
     FormatNodeRule<N>: FormatNodeFields<N>,
 {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
-    fn format(node: &N, formatter: &Formatter<JsFormatOptions>) -> FormatResult<FormatElement> {
+    fn format(node: &N, formatter: &Formatter<JsFormatContext>) -> FormatResult<FormatElement> {
         let syntax = node.syntax();
         let element = if has_formatter_suppressions(syntax) {
             suppressed_node(syntax).format(formatter)?
@@ -192,7 +192,7 @@ where
     /// Formats the node's fields.
     fn format_fields(
         item: &T,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement>;
 }
 
@@ -200,11 +200,11 @@ where
 pub struct FormatJsSyntaxToken;
 
 impl FormatRule<JsSyntaxToken> for FormatJsSyntaxToken {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         token: &JsSyntaxToken,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         formatter.track_token(token);
 
@@ -244,7 +244,7 @@ impl IntoFormat for JsSyntaxToken {
 /// It returns a [Formatted] result with a range corresponding to the
 /// range of the input that was effectively overwritten by the formatter
 pub fn format_range(
-    options: JsFormatOptions,
+    options: JsFormatContext,
     root: &JsSyntaxNode,
     range: TextRange,
 ) -> FormatResult<Printed> {
@@ -275,7 +275,7 @@ fn is_range_formatting_root(node: &JsSyntaxNode) -> bool {
 /// Formats a JavaScript (and its super languages) file based on its features.
 ///
 /// It returns a [Formatted] result, which the user can use to override a file.
-pub fn format_node(options: JsFormatOptions, root: &JsSyntaxNode) -> FormatResult<Formatted> {
+pub fn format_node(options: JsFormatContext, root: &JsSyntaxNode) -> FormatResult<Formatted> {
     rome_formatter::format_node(options, &root.format())
 }
 
@@ -289,7 +289,7 @@ pub fn format_node(options: JsFormatOptions, root: &JsSyntaxNode) -> FormatResul
 /// even if it's a mismatch from the rest of the block the selection is in
 ///
 /// It returns a [Formatted] result
-pub fn format_sub_tree(options: JsFormatOptions, root: &JsSyntaxNode) -> FormatResult<Printed> {
+pub fn format_sub_tree(options: JsFormatContext, root: &JsSyntaxNode) -> FormatResult<Printed> {
     rome_formatter::format_sub_tree(options, &root.format())
 }
 
@@ -298,7 +298,7 @@ mod tests {
 
     use super::format_range;
 
-    use crate::options::JsFormatOptions;
+    use crate::context::JsFormatContext;
     use rome_formatter::IndentStyle;
     use rome_js_parser::parse_script;
     use rome_rowan::{TextRange, TextSize};
@@ -335,9 +335,9 @@ while(
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions {
+            JsFormatContext {
                 indent_style: IndentStyle::Space(4),
-                ..JsFormatOptions::default()
+                ..JsFormatContext::default()
             },
             &tree.syntax(),
             TextRange::new(range_start, range_end),
@@ -370,9 +370,9 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions {
+            JsFormatContext {
                 indent_style: IndentStyle::Space(4),
-                ..JsFormatOptions::default()
+                ..JsFormatContext::default()
             },
             &tree.syntax(),
             TextRange::new(range_start, range_end),
@@ -404,9 +404,9 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions {
+            JsFormatContext {
                 indent_style: IndentStyle::Space(4),
-                ..JsFormatOptions::default()
+                ..JsFormatContext::default()
             },
             &tree.syntax(),
             TextRange::new(range_start, range_end),
@@ -426,9 +426,9 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions {
+            JsFormatContext {
                 indent_style: IndentStyle::Space(4),
-                ..JsFormatOptions::default()
+                ..JsFormatContext::default()
             },
             &tree.syntax(),
             TextRange::new(range_start, range_end),
@@ -451,9 +451,9 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions {
+            JsFormatContext {
                 indent_style: IndentStyle::Space(4),
-                ..JsFormatOptions::default()
+                ..JsFormatContext::default()
             },
             &tree.syntax(),
             TextRange::new(range_start, range_end),
@@ -469,12 +469,12 @@ function() {
 mod check_reformat;
 #[rustfmt::skip]
 mod generated;
-pub mod options;
+pub mod context;
 
 #[cfg(test)]
 mod test {
     use crate::check_reformat::{check_reformat, CheckReformatParams};
-    use crate::{format_node, JsFormatOptions};
+    use crate::{format_node, JsFormatContext};
     use rome_js_parser::parse;
     use rome_js_syntax::SourceType;
 
@@ -489,7 +489,7 @@ mod test {
 "#;
         let syntax = SourceType::jsx();
         let tree = parse(src, 0, syntax.clone());
-        let result = format_node(JsFormatOptions::default(), &tree.syntax())
+        let result = format_node(JsFormatContext::default(), &tree.syntax())
             .unwrap()
             .print();
         check_reformat(CheckReformatParams {
@@ -497,7 +497,7 @@ mod test {
             text: result.as_code(),
             source_type: syntax,
             file_name: "quick_test",
-            format_options: JsFormatOptions::default(),
+            format_context: JsFormatContext::default(),
         });
         assert_eq!(
             result.as_code(),

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -244,12 +244,12 @@ impl IntoFormat for JsSyntaxToken {
 /// It returns a [Formatted] result with a range corresponding to the
 /// range of the input that was effectively overwritten by the formatter
 pub fn format_range(
-    options: JsFormatContext,
+    context: JsFormatContext,
     root: &JsSyntaxNode,
     range: TextRange,
 ) -> FormatResult<Printed> {
     rome_formatter::format_range::<_, _, FormatJsSyntaxNode, _>(
-        options,
+        context,
         root,
         range,
         is_range_formatting_root,
@@ -275,8 +275,8 @@ fn is_range_formatting_root(node: &JsSyntaxNode) -> bool {
 /// Formats a JavaScript (and its super languages) file based on its features.
 ///
 /// It returns a [Formatted] result, which the user can use to override a file.
-pub fn format_node(options: JsFormatContext, root: &JsSyntaxNode) -> FormatResult<Formatted> {
-    rome_formatter::format_node(options, &root.format())
+pub fn format_node(context: JsFormatContext, root: &JsSyntaxNode) -> FormatResult<Formatted> {
+    rome_formatter::format_node(context, &root.format())
 }
 
 /// Formats a single node within a file, supported by Rome.
@@ -289,8 +289,8 @@ pub fn format_node(options: JsFormatContext, root: &JsSyntaxNode) -> FormatResul
 /// even if it's a mismatch from the rest of the block the selection is in
 ///
 /// It returns a [Formatted] result
-pub fn format_sub_tree(options: JsFormatContext, root: &JsSyntaxNode) -> FormatResult<Printed> {
-    rome_formatter::format_sub_tree(options, &root.format())
+pub fn format_sub_tree(context: JsFormatContext, root: &JsSyntaxNode) -> FormatResult<Printed> {
+    rome_formatter::format_sub_tree(context, &root.format())
 }
 
 #[cfg(test)]

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -2,7 +2,7 @@
 //! when implementing the [crate::FormatNode] trait.
 
 pub(crate) use crate::{
-    AsFormat as _, FormatNodeRule, FormattedIterExt, JsFormatOptions, JsFormatter as _,
+    AsFormat as _, FormatNodeRule, FormattedIterExt, JsFormatContext, JsFormatter as _,
 };
 pub use rome_formatter::prelude::*;
 pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};

--- a/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
+++ b/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyExternalModuleDeclarationBody;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyExternalModuleDeclarationBody;
 impl FormatRule<TsAnyExternalModuleDeclarationBody> for FormatTsAnyExternalModuleDeclarationBody {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyExternalModuleDeclarationBody,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyExternalModuleDeclarationBody::TsEmptyExternalModuleDeclarationBody(node) => {

--- a/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyIndexSignatureModifier;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyIndexSignatureModifier;
 impl FormatRule<TsAnyIndexSignatureModifier> for FormatTsAnyIndexSignatureModifier {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyIndexSignatureModifier,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyIndexSignatureModifier::JsStaticModifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyMethodSignatureModifier;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyMethodSignatureModifier;
 impl FormatRule<TsAnyMethodSignatureModifier> for FormatTsAnyMethodSignatureModifier {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyMethodSignatureModifier,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyMethodSignatureModifier::TsAccessibilityModifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/module_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyModuleName;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyModuleName;
 impl FormatRule<TsAnyModuleName> for FormatTsAnyModuleName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyModuleName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyModuleName::TsIdentifierBinding(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/ts/any/module_reference.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_reference.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyModuleReference;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyModuleReference;
 impl FormatRule<TsAnyModuleReference> for FormatTsAnyModuleReference {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyModuleReference,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyModuleReference::TsAnyName(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/ts/any/name.rs
+++ b/crates/rome_js_formatter/src/ts/any/name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyName;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyName;
 impl FormatRule<TsAnyName> for FormatTsAnyName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyName::JsReferenceIdentifier(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/ts/any/property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_annotation.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyPropertyAnnotation;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertyAnnotation;
 impl FormatRule<TsAnyPropertyAnnotation> for FormatTsAnyPropertyAnnotation {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyPropertyAnnotation,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyPropertyAnnotation::TsTypeAnnotation(node) => {

--- a/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyPropertyParameterModifier;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertyParameterModifier;
 impl FormatRule<TsAnyPropertyParameterModifier> for FormatTsAnyPropertyParameterModifier {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyPropertyParameterModifier,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyPropertyParameterModifier::TsAccessibilityModifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyPropertySignatureAnnotation;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertySignatureAnnotation;
 impl FormatRule<TsAnyPropertySignatureAnnotation> for FormatTsAnyPropertySignatureAnnotation {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyPropertySignatureAnnotation,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyPropertySignatureAnnotation::TsTypeAnnotation(node) => {

--- a/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyPropertySignatureModifier;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertySignatureModifier;
 impl FormatRule<TsAnyPropertySignatureModifier> for FormatTsAnyPropertySignatureModifier {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyPropertySignatureModifier,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyPropertySignatureModifier::TsDeclareModifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/return_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/return_type.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyReturnType;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyReturnType;
 impl FormatRule<TsAnyReturnType> for FormatTsAnyReturnType {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyReturnType,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyReturnType::TsType(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/ts/any/template_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/template_element.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyTemplateElement;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTemplateElement;
 impl FormatRule<TsAnyTemplateElement> for FormatTsAnyTemplateElement {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyTemplateElement,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyTemplateElement::TsTemplateChunkElement(node) => {

--- a/crates/rome_js_formatter/src/ts/any/ts_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/ts_type.rs
@@ -4,8 +4,8 @@ use crate::generated::FormatTsType;
 use crate::prelude::*;
 use rome_js_syntax::TsType;
 impl FormatRule<TsType> for FormatTsType {
-    type Options = JsFormatOptions;
-    fn format(node: &TsType, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+    type Context = JsFormatContext;
+    fn format(node: &TsType, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
         match node {
             TsType::TsAnyType(node) => formatted![formatter, [node.format()]],
             TsType::TsUnknownType(node) => formatted![formatter, [node.format()]],

--- a/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyTupleTypeElement;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTupleTypeElement;
 impl FormatRule<TsAnyTupleTypeElement> for FormatTsAnyTupleTypeElement {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyTupleTypeElement,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyTupleTypeElement::TsNamedTupleTypeElement(node) => {

--- a/crates/rome_js_formatter/src/ts/any/type_member.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_member.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyTypeMember;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTypeMember;
 impl FormatRule<TsAnyTypeMember> for FormatTsAnyTypeMember {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyTypeMember,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyTypeMember::TsCallSignatureTypeMember(node) => {

--- a/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyTypePredicateParameterName;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTypePredicateParameterName;
 impl FormatRule<TsAnyTypePredicateParameterName> for FormatTsAnyTypePredicateParameterName {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyTypePredicateParameterName,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyTypePredicateParameterName::JsReferenceIdentifier(node) => {

--- a/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
@@ -4,10 +4,10 @@ use crate::generated::FormatTsAnyVariableAnnotation;
 use crate::prelude::*;
 use rome_js_syntax::TsAnyVariableAnnotation;
 impl FormatRule<TsAnyVariableAnnotation> for FormatTsAnyVariableAnnotation {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
     fn format(
         node: &TsAnyVariableAnnotation,
-        formatter: &Formatter<Self::Options>,
+        formatter: &Formatter<Self::Context>,
     ) -> FormatResult<FormatElement> {
         match node {
             TsAnyVariableAnnotation::TsTypeAnnotation(node) => {

--- a/crates/rome_js_formatter/src/ts/assignments/as_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/as_assignment.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAsAssignmentFields;
 impl FormatNodeFields<TsAsAssignment> for FormatNodeRule<TsAsAssignment> {
     fn format_fields(
         node: &TsAsAssignment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsAsAssignmentFields {
             assignment,

--- a/crates/rome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/non_null_assertion_assignment.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsNonNullAssertionAssignment>
 {
     fn format_fields(
         node: &TsNonNullAssertionAssignment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsNonNullAssertionAssignmentFields {
             assignment,

--- a/crates/rome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/type_assertion_assignment.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsTypeAssertionAssignment;
 impl FormatNodeFields<TsTypeAssertionAssignment> for FormatNodeRule<TsTypeAssertionAssignment> {
     fn format_fields(
         node: &TsTypeAssertionAssignment,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeAssertionAssignmentFields {
             l_angle_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/abstract_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/abstract_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAbstractModifierFields;
 impl FormatNodeFields<TsAbstractModifier> for FormatNodeRule<TsAbstractModifier> {
     fn format_fields(
         node: &TsAbstractModifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsAbstractModifierFields { modifier_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/accessibility_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/accessibility_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAccessibilityModifierFields;
 impl FormatNodeFields<TsAccessibilityModifier> for FormatNodeRule<TsAccessibilityModifier> {
     fn format_fields(
         node: &TsAccessibilityModifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsAccessibilityModifierFields { modifier_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/asserts_condition.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/asserts_condition.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAssertsConditionFields;
 impl FormatNodeFields<TsAssertsCondition> for FormatNodeRule<TsAssertsCondition> {
     fn format_fields(
         node: &TsAssertsCondition,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsAssertsConditionFields { is_token, ty } = node.as_fields();
         formatted![formatter, [is_token.format(), space_token(), ty.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/call_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/call_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsCallSignatureTypeMember, TsCallSignatureTypeMemberFields}
 impl FormatNodeFields<TsCallSignatureTypeMember> for FormatNodeRule<TsCallSignatureTypeMember> {
     fn format_fields(
         node: &TsCallSignatureTypeMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsCallSignatureTypeMemberFields {
             type_parameters,

--- a/crates/rome_js_formatter/src/ts/auxiliary/construct_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/construct_signature_type_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsConstructSignatureTypeMember>
 {
     fn format_fields(
         node: &TsConstructSignatureTypeMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsConstructSignatureTypeMemberFields {
             new_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/declare_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/declare_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsDeclareModifierFields;
 impl FormatNodeFields<TsDeclareModifier> for FormatNodeRule<TsDeclareModifier> {
     fn format_fields(
         node: &TsDeclareModifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsDeclareModifierFields { modifier_token } = node.as_fields();
         formatted![formatter, [modifier_token.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/default_type_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/default_type_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsDefaultTypeClause, TsDefaultTypeClauseFields};
 impl FormatNodeFields<TsDefaultTypeClause> for FormatNodeRule<TsDefaultTypeClause> {
     fn format_fields(
         node: &TsDefaultTypeClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsDefaultTypeClauseFields { eq_token, ty } = node.as_fields();
         formatted![formatter, [eq_token.format(), space_token(), ty.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/definite_property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/definite_property_annotation.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsDefinitePropertyAnnotation>
 {
     fn format_fields(
         node: &TsDefinitePropertyAnnotation,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsDefinitePropertyAnnotationFields {
             excl_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/definite_variable_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/definite_variable_annotation.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsDefiniteVariableAnnotation>
 {
     fn format_fields(
         node: &TsDefiniteVariableAnnotation,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsDefiniteVariableAnnotationFields {
             excl_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/empty_external_module_declaration_body.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/empty_external_module_declaration_body.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsEmptyExternalModuleDeclarationBody>
 {
     fn format_fields(
         node: &TsEmptyExternalModuleDeclarationBody,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsEmptyExternalModuleDeclarationBodyFields { semicolon_token } = node.as_fields();
         formatted![formatter, [semicolon_token.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/enum_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/enum_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsEnumMember, TsEnumMemberFields};
 impl FormatNodeFields<TsEnumMember> for FormatNodeRule<TsEnumMember> {
     fn format_fields(
         node: &TsEnumMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsEnumMemberFields { name, initializer } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/external_module_reference.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/external_module_reference.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsExternalModuleReferenceFields;
 impl FormatNodeFields<TsExternalModuleReference> for FormatNodeRule<TsExternalModuleReference> {
     fn format_fields(
         node: &TsExternalModuleReference,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsExternalModuleReferenceFields {
             require_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/getter_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/getter_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsGetterSignatureTypeMember, TsGetterSignatureTypeMemberFie
 impl FormatNodeFields<TsGetterSignatureTypeMember> for FormatNodeRule<TsGetterSignatureTypeMember> {
     fn format_fields(
         node: &TsGetterSignatureTypeMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsGetterSignatureTypeMemberFields {
             get_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/implements_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/implements_clause.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsImplementsClauseFields;
 impl FormatNodeFields<TsImplementsClause> for FormatNodeRule<TsImplementsClause> {
     fn format_fields(
         node: &TsImplementsClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsImplementsClauseFields {
             implements_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/index_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/index_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsIndexSignatureTypeMember, TsIndexSignatureTypeMemberField
 impl FormatNodeFields<TsIndexSignatureTypeMember> for FormatNodeRule<TsIndexSignatureTypeMember> {
     fn format_fields(
         node: &TsIndexSignatureTypeMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsIndexSignatureTypeMemberFields {
             readonly_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_as_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_as_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsMappedTypeAsClause, TsMappedTypeAsClauseFields};
 impl FormatNodeFields<TsMappedTypeAsClause> for FormatNodeRule<TsMappedTypeAsClause> {
     fn format_fields(
         node: &TsMappedTypeAsClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsMappedTypeAsClauseFields { as_token, ty } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_optional_modifier_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_optional_modifier_clause.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsMappedTypeOptionalModifierClause>
 {
     fn format_fields(
         node: &TsMappedTypeOptionalModifierClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsMappedTypeOptionalModifierClauseFields {
             operator_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_readonly_modifier_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mapped_type_readonly_modifier_clause.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsMappedTypeReadonlyModifierClause>
 {
     fn format_fields(
         node: &TsMappedTypeReadonlyModifierClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsMappedTypeReadonlyModifierClauseFields {
             operator_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/method_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/method_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsMethodSignatureTypeMember, TsMethodSignatureTypeMemberFie
 impl FormatNodeFields<TsMethodSignatureTypeMember> for FormatNodeRule<TsMethodSignatureTypeMember> {
     fn format_fields(
         node: &TsMethodSignatureTypeMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsMethodSignatureTypeMemberFields {
             name,

--- a/crates/rome_js_formatter/src/ts/auxiliary/module_block.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/module_block.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsModuleBlockFields;
 impl FormatNodeFields<TsModuleBlock> for FormatNodeRule<TsModuleBlock> {
     fn format_fields(
         node: &TsModuleBlock,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsModuleBlockFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/named_tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/named_tuple_type_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNamedTupleTypeElement, TsNamedTupleTypeElementFields};
 impl FormatNodeFields<TsNamedTupleTypeElement> for FormatNodeRule<TsNamedTupleTypeElement> {
     fn format_fields(
         node: &TsNamedTupleTypeElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsNamedTupleTypeElementFields {
             ty,

--- a/crates/rome_js_formatter/src/ts/auxiliary/optional_property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/optional_property_annotation.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsOptionalPropertyAnnotation>
 {
     fn format_fields(
         node: &TsOptionalPropertyAnnotation,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsOptionalPropertyAnnotationFields {
             question_mark_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/optional_tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/optional_tuple_type_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsOptionalTupleTypeElement, TsOptionalTupleTypeElementField
 impl FormatNodeFields<TsOptionalTupleTypeElement> for FormatNodeRule<TsOptionalTupleTypeElement> {
     fn format_fields(
         node: &TsOptionalTupleTypeElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsOptionalTupleTypeElementFields {
             ty,

--- a/crates/rome_js_formatter/src/ts/auxiliary/override_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/override_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsOverrideModifierFields;
 impl FormatNodeFields<TsOverrideModifier> for FormatNodeRule<TsOverrideModifier> {
     fn format_fields(
         node: &TsOverrideModifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsOverrideModifierFields { modifier_token } = node.as_fields();
         formatted![formatter, [modifier_token.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsPropertySignatureTypeMember>
 {
     fn format_fields(
         node: &TsPropertySignatureTypeMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsPropertySignatureTypeMemberFields {
             readonly_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/qualified_module_name.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/qualified_module_name.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsQualifiedModuleNameFields;
 impl FormatNodeFields<TsQualifiedModuleName> for FormatNodeRule<TsQualifiedModuleName> {
     fn format_fields(
         node: &TsQualifiedModuleName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsQualifiedModuleNameFields {
             left,

--- a/crates/rome_js_formatter/src/ts/auxiliary/qualified_name.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/qualified_name.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsQualifiedNameFields;
 impl FormatNodeFields<TsQualifiedName> for FormatNodeRule<TsQualifiedName> {
     fn format_fields(
         node: &TsQualifiedName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsQualifiedNameFields {
             left,

--- a/crates/rome_js_formatter/src/ts/auxiliary/readonly_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/readonly_modifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsReadonlyModifierFields;
 impl FormatNodeFields<TsReadonlyModifier> for FormatNodeRule<TsReadonlyModifier> {
     fn format_fields(
         node: &TsReadonlyModifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsReadonlyModifierFields { modifier_token } = node.as_fields();
         formatted![formatter, [modifier_token.format()]]

--- a/crates/rome_js_formatter/src/ts/auxiliary/rest_tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/rest_tuple_type_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsRestTupleTypeElement, TsRestTupleTypeElementFields};
 impl FormatNodeFields<TsRestTupleTypeElement> for FormatNodeRule<TsRestTupleTypeElement> {
     fn format_fields(
         node: &TsRestTupleTypeElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsRestTupleTypeElementFields {
             dotdotdot_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/return_type_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/return_type_annotation.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsReturnTypeAnnotationFields;
 impl FormatNodeFields<TsReturnTypeAnnotation> for FormatNodeRule<TsReturnTypeAnnotation> {
     fn format_fields(
         node: &TsReturnTypeAnnotation,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsReturnTypeAnnotationFields { colon_token, ty } = node.as_fields();
         formatted![

--- a/crates/rome_js_formatter/src/ts/auxiliary/setter_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/setter_signature_type_member.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsSetterSignatureTypeMember, TsSetterSignatureTypeMemberFie
 impl FormatNodeFields<TsSetterSignatureTypeMember> for FormatNodeRule<TsSetterSignatureTypeMember> {
     fn format_fields(
         node: &TsSetterSignatureTypeMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsSetterSignatureTypeMemberFields {
             set_token,

--- a/crates/rome_js_formatter/src/ts/auxiliary/type_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/type_annotation.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeAnnotation, TsTypeAnnotationFields};
 impl FormatNodeFields<TsTypeAnnotation> for FormatNodeRule<TsTypeAnnotation> {
     fn format_fields(
         node: &TsTypeAnnotation,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeAnnotationFields { colon_token, ty } = node.as_fields();
         let colon = colon_token.format();

--- a/crates/rome_js_formatter/src/ts/auxiliary/type_constraint_clause.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/type_constraint_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeConstraintClause, TsTypeConstraintClauseFields};
 impl FormatNodeFields<TsTypeConstraintClause> for FormatNodeRule<TsTypeConstraintClause> {
     fn format_fields(
         node: &TsTypeConstraintClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeConstraintClauseFields { extends_token, ty } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/auxiliary/type_parameter_name.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/type_parameter_name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeParameterName, TsTypeParameterNameFields};
 impl FormatNodeFields<TsTypeParameterName> for FormatNodeRule<TsTypeParameterName> {
     fn format_fields(
         node: &TsTypeParameterName,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeParameterNameFields { ident_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/bindings/identifier_binding.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/identifier_binding.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsIdentifierBinding, TsIdentifierBindingFields};
 impl FormatNodeFields<TsIdentifierBinding> for FormatNodeRule<TsIdentifierBinding> {
     fn format_fields(
         node: &TsIdentifierBinding,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsIdentifierBindingFields { name_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/bindings/index_signature_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/index_signature_parameter.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsIndexSignatureParameter, TsIndexSignatureParameterFields}
 impl FormatNodeFields<TsIndexSignatureParameter> for FormatNodeRule<TsIndexSignatureParameter> {
     fn format_fields(
         node: &TsIndexSignatureParameter,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsIndexSignatureParameterFields {
             binding,

--- a/crates/rome_js_formatter/src/ts/bindings/property_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/property_parameter.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsPropertyParameter, TsPropertyParameterFields};
 impl FormatNodeFields<TsPropertyParameter> for FormatNodeRule<TsPropertyParameter> {
     fn format_fields(
         node: &TsPropertyParameter,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsPropertyParameterFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/bindings/this_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/this_parameter.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsThisParameter, TsThisParameterFields};
 impl FormatNodeFields<TsThisParameter> for FormatNodeRule<TsThisParameter> {
     fn format_fields(
         node: &TsThisParameter,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsThisParameterFields {
             this_token,

--- a/crates/rome_js_formatter/src/ts/bindings/type_parameter.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/type_parameter.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeParameter, TsTypeParameterFields};
 impl FormatNodeFields<TsTypeParameter> for FormatNodeRule<TsTypeParameter> {
     fn format_fields(
         node: &TsTypeParameter,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeParameterFields {
             name,

--- a/crates/rome_js_formatter/src/ts/bindings/type_parameters.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/type_parameters.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeParameters, TsTypeParametersFields};
 impl FormatNodeFields<TsTypeParameters> for FormatNodeRule<TsTypeParameters> {
     fn format_fields(
         node: &TsTypeParameters,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeParametersFields {
             items,

--- a/crates/rome_js_formatter/src/ts/classes/constructor_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/constructor_signature_class_member.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<TsConstructorSignatureClassMember>
 {
     fn format_fields(
         node: &TsConstructorSignatureClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsConstructorSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/extends_clause.rs
+++ b/crates/rome_js_formatter/src/ts/classes/extends_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsExtendsClause, TsExtendsClauseFields};
 impl FormatNodeFields<TsExtendsClause> for FormatNodeRule<TsExtendsClause> {
     fn format_fields(
         node: &TsExtendsClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsExtendsClauseFields {
             extends_token,

--- a/crates/rome_js_formatter/src/ts/classes/getter_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/getter_signature_class_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsGetterSignatureClassMember>
 {
     fn format_fields(
         node: &TsGetterSignatureClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsGetterSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/index_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/index_signature_class_member.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsIndexSignatureClassMemberFields;
 impl FormatNodeFields<TsIndexSignatureClassMember> for FormatNodeRule<TsIndexSignatureClassMember> {
     fn format_fields(
         node: &TsIndexSignatureClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsIndexSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/method_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/method_signature_class_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsMethodSignatureClassMember>
 {
     fn format_fields(
         node: &TsMethodSignatureClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsMethodSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsPropertySignatureClassMember>
 {
     fn format_fields(
         node: &TsPropertySignatureClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsPropertySignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/classes/setter_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/setter_signature_class_member.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsSetterSignatureClassMember>
 {
     fn format_fields(
         node: &TsSetterSignatureClassMember,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsSetterSignatureClassMemberFields {
             modifiers,

--- a/crates/rome_js_formatter/src/ts/declarations/declare_function_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/declare_function_declaration.rs
@@ -9,7 +9,7 @@ impl FormatNodeFields<TsDeclareFunctionDeclaration>
 {
     fn format_fields(
         node: &TsDeclareFunctionDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsDeclareFunctionDeclarationFields {
             async_token,

--- a/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
@@ -7,7 +7,7 @@ use rome_rowan::AstNode;
 impl FormatNodeFields<TsEnumDeclaration> for FormatNodeRule<TsEnumDeclaration> {
     fn format_fields(
         node: &TsEnumDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsEnumDeclarationFields {
             const_token,

--- a/crates/rome_js_formatter/src/ts/declarations/external_module_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/external_module_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsExternalModuleDeclarationFields;
 impl FormatNodeFields<TsExternalModuleDeclaration> for FormatNodeRule<TsExternalModuleDeclaration> {
     fn format_fields(
         node: &TsExternalModuleDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsExternalModuleDeclarationFields {
             body,

--- a/crates/rome_js_formatter/src/ts/declarations/global_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/global_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsGlobalDeclarationFields;
 impl FormatNodeFields<TsGlobalDeclaration> for FormatNodeRule<TsGlobalDeclaration> {
     fn format_fields(
         node: &TsGlobalDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsGlobalDeclarationFields { global_token, body } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/declarations/import_equals_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/import_equals_declaration.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsImportEqualsDeclarationFields;
 impl FormatNodeFields<TsImportEqualsDeclaration> for FormatNodeRule<TsImportEqualsDeclaration> {
     fn format_fields(
         node: &TsImportEqualsDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsImportEqualsDeclarationFields {
             import_token,

--- a/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsInterfaceDeclaration, TsInterfaceDeclarationFields};
 impl FormatNodeFields<TsInterfaceDeclaration> for FormatNodeRule<TsInterfaceDeclaration> {
     fn format_fields(
         node: &TsInterfaceDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsInterfaceDeclarationFields {
             interface_token,

--- a/crates/rome_js_formatter/src/ts/declarations/module_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/module_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsModuleDeclarationFields;
 impl FormatNodeFields<TsModuleDeclaration> for FormatNodeRule<TsModuleDeclaration> {
     fn format_fields(
         node: &TsModuleDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsModuleDeclarationFields {
             module_or_namespace,

--- a/crates/rome_js_formatter/src/ts/declarations/type_alias_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/type_alias_declaration.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsTypeAliasDeclaration, TsTypeAliasDeclarationFields};
 impl FormatNodeFields<TsTypeAliasDeclaration> for FormatNodeRule<TsTypeAliasDeclaration> {
     fn format_fields(
         node: &TsTypeAliasDeclaration,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeAliasDeclarationFields {
             type_token,

--- a/crates/rome_js_formatter/src/ts/expressions/as_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/as_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAsExpressionFields;
 impl FormatNodeFields<TsAsExpression> for FormatNodeRule<TsAsExpression> {
     fn format_fields(
         node: &TsAsExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsAsExpressionFields {
             ty,

--- a/crates/rome_js_formatter/src/ts/expressions/name_with_type_arguments.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/name_with_type_arguments.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNameWithTypeArguments, TsNameWithTypeArgumentsFields};
 impl FormatNodeFields<TsNameWithTypeArguments> for FormatNodeRule<TsNameWithTypeArguments> {
     fn format_fields(
         node: &TsNameWithTypeArguments,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsNameWithTypeArgumentsFields {
             name,

--- a/crates/rome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/non_null_assertion_expression.rs
@@ -8,7 +8,7 @@ impl FormatNodeFields<TsNonNullAssertionExpression>
 {
     fn format_fields(
         node: &TsNonNullAssertionExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsNonNullAssertionExpressionFields {
             expression,

--- a/crates/rome_js_formatter/src/ts/expressions/template_chunk_element.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/template_chunk_element.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsTemplateChunkElement, TsTemplateChunkElementFields};
 impl FormatNodeFields<TsTemplateChunkElement> for FormatNodeRule<TsTemplateChunkElement> {
     fn format_fields(
         node: &TsTemplateChunkElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTemplateChunkElementFields {
             template_chunk_token,

--- a/crates/rome_js_formatter/src/ts/expressions/template_element.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/template_element.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsTemplateElement;
 impl FormatNodeFields<TsTemplateElement> for FormatNodeRule<TsTemplateElement> {
     fn format_fields(
         node: &TsTemplateElement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_template_literal(TemplateElement::Ts(node.clone()), formatter)
     }

--- a/crates/rome_js_formatter/src/ts/expressions/template_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/template_literal_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsTemplateLiteralTypeFields;
 impl FormatNodeFields<TsTemplateLiteralType> for FormatNodeRule<TsTemplateLiteralType> {
     fn format_fields(
         node: &TsTemplateLiteralType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTemplateLiteralTypeFields {
             l_tick_token,

--- a/crates/rome_js_formatter/src/ts/expressions/type_arguments.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/type_arguments.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeArguments, TsTypeArgumentsFields};
 impl FormatNodeFields<TsTypeArguments> for FormatNodeRule<TsTypeArguments> {
     fn format_fields(
         node: &TsTypeArguments,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeArgumentsFields {
             l_angle_token,

--- a/crates/rome_js_formatter/src/ts/expressions/type_assertion_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/type_assertion_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsTypeAssertionExpressionFields;
 impl FormatNodeFields<TsTypeAssertionExpression> for FormatNodeRule<TsTypeAssertionExpression> {
     fn format_fields(
         node: &TsTypeAssertionExpression,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeAssertionExpressionFields {
             l_angle_token,

--- a/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::TsEnumMemberList;
 
 impl FormatRule<TsEnumMemberList> for FormatTsEnumMemberList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsEnumMemberList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
@@ -4,11 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::TsIndexSignatureModifierList;
 
 impl FormatRule<TsIndexSignatureModifierList> for FormatTsIndexSignatureModifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsIndexSignatureModifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
@@ -4,11 +4,11 @@ use rome_js_syntax::TsIntersectionTypeElementList;
 use rome_rowan::AstSeparatedList;
 
 impl FormatRule<TsIntersectionTypeElementList> for FormatTsIntersectionTypeElementList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsIntersectionTypeElementList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let mut elements = Vec::with_capacity(node.len());
         let last_index = node.len().saturating_sub(1);

--- a/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
@@ -4,11 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::TsMethodSignatureModifierList;
 
 impl FormatRule<TsMethodSignatureModifierList> for FormatTsMethodSignatureModifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsMethodSignatureModifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
@@ -4,11 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::TsPropertyParameterModifierList;
 
 impl FormatRule<TsPropertyParameterModifierList> for FormatTsPropertyParameterModifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsPropertyParameterModifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
@@ -4,11 +4,11 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::TsPropertySignatureModifierList;
 
 impl FormatRule<TsPropertySignatureModifierList> for FormatTsPropertySignatureModifierList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsPropertySignatureModifierList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             space_token(),

--- a/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
@@ -4,11 +4,11 @@ use rome_js_syntax::TsTemplateElementList;
 use rome_rowan::AstNodeList;
 
 impl FormatRule<TsTemplateElementList> for FormatTsTemplateElementList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsTemplateElementList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(concat_elements(
             formatter

--- a/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 use rome_js_syntax::TsTupleTypeElementList;
 
 impl FormatRule<TsTupleTypeElementList> for FormatTsTupleTypeElementList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsTupleTypeElementList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
@@ -4,11 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::TsTypeArgumentList;
 
 impl FormatRule<TsTypeArgumentList> for FormatTsTypeArgumentList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsTypeArgumentList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         Ok(join_elements(
             soft_line_break_or_space(),

--- a/crates/rome_js_formatter/src/ts/lists/type_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_list.rs
@@ -4,11 +4,11 @@ use crate::prelude::*;
 use rome_js_syntax::TsTypeList;
 
 impl FormatRule<TsTypeList> for FormatTsTypeList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsTypeList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         // the grouping will be applied by the parent
         Ok(join_elements(

--- a/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
@@ -4,11 +4,11 @@ use rome_js_syntax::TsTypeMemberList;
 use rome_rowan::AstNodeList;
 
 impl FormatRule<TsTypeMemberList> for FormatTsTypeMemberList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsTypeMemberList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let items = node.iter();
         let last_index = items.len().saturating_sub(1);

--- a/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
@@ -5,11 +5,11 @@ use rome_js_syntax::TsTypeParameterList;
 use rome_rowan::AstSeparatedList;
 
 impl FormatRule<TsTypeParameterList> for FormatTsTypeParameterList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsTypeParameterList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         // nodes and formatter are not aware of the source type (TSX vs TS), which means we can't
         // exactly pin point the exact case.

--- a/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
@@ -4,11 +4,11 @@ use rome_js_syntax::TsUnionTypeVariantList;
 use rome_rowan::AstSeparatedList;
 
 impl FormatRule<TsUnionTypeVariantList> for FormatTsUnionTypeVariantList {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
     fn format(
         node: &TsUnionTypeVariantList,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let mut elements = Vec::with_capacity(node.len());
         let last_index = node.len().saturating_sub(1);

--- a/crates/rome_js_formatter/src/ts/module/export_as_namespace_clause.rs
+++ b/crates/rome_js_formatter/src/ts/module/export_as_namespace_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsExportAsNamespaceClauseFields;
 impl FormatNodeFields<TsExportAsNamespaceClause> for FormatNodeRule<TsExportAsNamespaceClause> {
     fn format_fields(
         node: &TsExportAsNamespaceClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsExportAsNamespaceClauseFields {
             as_token,

--- a/crates/rome_js_formatter/src/ts/module/export_assignment_clause.rs
+++ b/crates/rome_js_formatter/src/ts/module/export_assignment_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsExportAssignmentClauseFields;
 impl FormatNodeFields<TsExportAssignmentClause> for FormatNodeRule<TsExportAssignmentClause> {
     fn format_fields(
         node: &TsExportAssignmentClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsExportAssignmentClauseFields {
             eq_token,

--- a/crates/rome_js_formatter/src/ts/module/export_declare_clause.rs
+++ b/crates/rome_js_formatter/src/ts/module/export_declare_clause.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsExportDeclareClauseFields;
 impl FormatNodeFields<TsExportDeclareClause> for FormatNodeRule<TsExportDeclareClause> {
     fn format_fields(
         node: &TsExportDeclareClause,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsExportDeclareClauseFields {
             declare_token,

--- a/crates/rome_js_formatter/src/ts/module/import_type.rs
+++ b/crates/rome_js_formatter/src/ts/module/import_type.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::TsImportTypeFields;
 impl FormatNodeFields<TsImportType> for FormatNodeRule<TsImportType> {
     fn format_fields(
         node: &TsImportType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsImportTypeFields {
             typeof_token,

--- a/crates/rome_js_formatter/src/ts/module/import_type_qualifier.rs
+++ b/crates/rome_js_formatter/src/ts/module/import_type_qualifier.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsImportTypeQualifierFields;
 impl FormatNodeFields<TsImportTypeQualifier> for FormatNodeRule<TsImportTypeQualifier> {
     fn format_fields(
         node: &TsImportTypeQualifier,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsImportTypeQualifierFields { dot_token, right } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/statements/declare_statement.rs
+++ b/crates/rome_js_formatter/src/ts/statements/declare_statement.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsDeclareStatementFields;
 impl FormatNodeFields<TsDeclareStatement> for FormatNodeRule<TsDeclareStatement> {
     fn format_fields(
         node: &TsDeclareStatement,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsDeclareStatementFields {
             declaration,

--- a/crates/rome_js_formatter/src/ts/types/any_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/any_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsAnyType, TsAnyTypeFields};
 impl FormatNodeFields<TsAnyType> for FormatNodeRule<TsAnyType> {
     fn format_fields(
         node: &TsAnyType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsAnyTypeFields { any_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/array_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/array_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsArrayType, TsArrayTypeFields};
 impl FormatNodeFields<TsArrayType> for FormatNodeRule<TsArrayType> {
     fn format_fields(
         node: &TsArrayType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsArrayTypeFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/ts/types/asserts_return_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/asserts_return_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsAssertsReturnTypeFields;
 impl FormatNodeFields<TsAssertsReturnType> for FormatNodeRule<TsAssertsReturnType> {
     fn format_fields(
         node: &TsAssertsReturnType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsAssertsReturnTypeFields {
             parameter_name,

--- a/crates/rome_js_formatter/src/ts/types/big_int_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/big_int_literal_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsBigIntLiteralType, TsBigIntLiteralTypeFields};
 impl FormatNodeFields<TsBigIntLiteralType> for FormatNodeRule<TsBigIntLiteralType> {
     fn format_fields(
         node: &TsBigIntLiteralType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsBigIntLiteralTypeFields {
             minus_token,

--- a/crates/rome_js_formatter/src/ts/types/bigint_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/bigint_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsBigintType, TsBigintTypeFields};
 impl FormatNodeFields<TsBigintType> for FormatNodeRule<TsBigintType> {
     fn format_fields(
         node: &TsBigintType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsBigintTypeFields { bigint_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/boolean_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/boolean_literal_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsBooleanLiteralType, TsBooleanLiteralTypeFields};
 impl FormatNodeFields<TsBooleanLiteralType> for FormatNodeRule<TsBooleanLiteralType> {
     fn format_fields(
         node: &TsBooleanLiteralType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsBooleanLiteralTypeFields { literal } = node.as_fields();
         formatted![formatter, [literal.format()]]

--- a/crates/rome_js_formatter/src/ts/types/boolean_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/boolean_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsBooleanType, TsBooleanTypeFields};
 impl FormatNodeFields<TsBooleanType> for FormatNodeRule<TsBooleanType> {
     fn format_fields(
         node: &TsBooleanType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsBooleanTypeFields { boolean_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/conditional_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/conditional_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsConditionalType;
 impl FormatNodeFields<TsConditionalType> for FormatNodeRule<TsConditionalType> {
     fn format_fields(
         node: &TsConditionalType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         format_conditional(Conditional::Type(node.clone()), formatter, false)
     }

--- a/crates/rome_js_formatter/src/ts/types/constructor_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/constructor_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsConstructorTypeFields;
 impl FormatNodeFields<TsConstructorType> for FormatNodeRule<TsConstructorType> {
     fn format_fields(
         node: &TsConstructorType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsConstructorTypeFields {
             abstract_token,

--- a/crates/rome_js_formatter/src/ts/types/function_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/function_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsFunctionTypeFields;
 impl FormatNodeFields<TsFunctionType> for FormatNodeRule<TsFunctionType> {
     fn format_fields(
         node: &TsFunctionType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsFunctionTypeFields {
             parameters,

--- a/crates/rome_js_formatter/src/ts/types/indexed_access_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/indexed_access_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsIndexedAccessTypeFields;
 impl FormatNodeFields<TsIndexedAccessType> for FormatNodeRule<TsIndexedAccessType> {
     fn format_fields(
         node: &TsIndexedAccessType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsIndexedAccessTypeFields {
             object_type,

--- a/crates/rome_js_formatter/src/ts/types/infer_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/infer_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsInferType, TsInferTypeFields};
 impl FormatNodeFields<TsInferType> for FormatNodeRule<TsInferType> {
     fn format_fields(
         node: &TsInferType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsInferTypeFields {
             infer_token,

--- a/crates/rome_js_formatter/src/ts/types/intersection_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/intersection_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsIntersectionTypeFields;
 impl FormatNodeFields<TsIntersectionType> for FormatNodeRule<TsIntersectionType> {
     fn format_fields(
         node: &TsIntersectionType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsIntersectionTypeFields {
             leading_separator_token,

--- a/crates/rome_js_formatter/src/ts/types/mapped_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/mapped_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsMappedType, TsMappedTypeFields};
 impl FormatNodeFields<TsMappedType> for FormatNodeRule<TsMappedType> {
     fn format_fields(
         node: &TsMappedType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsMappedTypeFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/ts/types/never_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/never_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNeverType, TsNeverTypeFields};
 impl FormatNodeFields<TsNeverType> for FormatNodeRule<TsNeverType> {
     fn format_fields(
         node: &TsNeverType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsNeverTypeFields { never_token } = node.as_fields();
         formatted![formatter, [never_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/non_primitive_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/non_primitive_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNonPrimitiveType, TsNonPrimitiveTypeFields};
 impl FormatNodeFields<TsNonPrimitiveType> for FormatNodeRule<TsNonPrimitiveType> {
     fn format_fields(
         node: &TsNonPrimitiveType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsNonPrimitiveTypeFields { object_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/null_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/null_literal_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNullLiteralType, TsNullLiteralTypeFields};
 impl FormatNodeFields<TsNullLiteralType> for FormatNodeRule<TsNullLiteralType> {
     fn format_fields(
         node: &TsNullLiteralType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsNullLiteralTypeFields { literal_token } = node.as_fields();
         formatted![formatter, [literal_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/number_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/number_literal_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNumberLiteralType, TsNumberLiteralTypeFields};
 impl FormatNodeFields<TsNumberLiteralType> for FormatNodeRule<TsNumberLiteralType> {
     fn format_fields(
         node: &TsNumberLiteralType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsNumberLiteralTypeFields {
             minus_token,

--- a/crates/rome_js_formatter/src/ts/types/number_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/number_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsNumberType, TsNumberTypeFields};
 impl FormatNodeFields<TsNumberType> for FormatNodeRule<TsNumberType> {
     fn format_fields(
         node: &TsNumberType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsNumberTypeFields { number_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/object_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/object_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsObjectType, TsObjectTypeFields};
 impl FormatNodeFields<TsObjectType> for FormatNodeRule<TsObjectType> {
     fn format_fields(
         node: &TsObjectType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsObjectTypeFields {
             l_curly_token,

--- a/crates/rome_js_formatter/src/ts/types/parenthesized_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/parenthesized_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsParenthesizedTypeFields;
 impl FormatNodeFields<TsParenthesizedType> for FormatNodeRule<TsParenthesizedType> {
     fn format_fields(
         node: &TsParenthesizedType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsParenthesizedTypeFields {
             l_paren_token,

--- a/crates/rome_js_formatter/src/ts/types/predicate_return_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/predicate_return_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsPredicateReturnTypeFields;
 impl FormatNodeFields<TsPredicateReturnType> for FormatNodeRule<TsPredicateReturnType> {
     fn format_fields(
         node: &TsPredicateReturnType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsPredicateReturnTypeFields {
             parameter_name,

--- a/crates/rome_js_formatter/src/ts/types/reference_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/reference_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsReferenceType, TsReferenceTypeFields};
 impl FormatNodeFields<TsReferenceType> for FormatNodeRule<TsReferenceType> {
     fn format_fields(
         node: &TsReferenceType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsReferenceTypeFields {
             name,

--- a/crates/rome_js_formatter/src/ts/types/string_literal_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/string_literal_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{TsStringLiteralType, TsStringLiteralTypeFields};
 impl FormatNodeFields<TsStringLiteralType> for FormatNodeRule<TsStringLiteralType> {
     fn format_fields(
         node: &TsStringLiteralType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsStringLiteralTypeFields { literal_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/string_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/string_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsStringType, TsStringTypeFields};
 impl FormatNodeFields<TsStringType> for FormatNodeRule<TsStringType> {
     fn format_fields(
         node: &TsStringType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsStringTypeFields { string_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/symbol_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/symbol_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsSymbolType, TsSymbolTypeFields};
 impl FormatNodeFields<TsSymbolType> for FormatNodeRule<TsSymbolType> {
     fn format_fields(
         node: &TsSymbolType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsSymbolTypeFields { symbol_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/this_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/this_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsThisType, TsThisTypeFields};
 impl FormatNodeFields<TsThisType> for FormatNodeRule<TsThisType> {
     fn format_fields(
         node: &TsThisType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsThisTypeFields { this_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/tuple_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/tuple_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTupleType, TsTupleTypeFields};
 impl FormatNodeFields<TsTupleType> for FormatNodeRule<TsTupleType> {
     fn format_fields(
         node: &TsTupleType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTupleTypeFields {
             l_brack_token,

--- a/crates/rome_js_formatter/src/ts/types/type_operator_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/type_operator_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeOperatorType, TsTypeOperatorTypeFields};
 impl FormatNodeFields<TsTypeOperatorType> for FormatNodeRule<TsTypeOperatorType> {
     fn format_fields(
         node: &TsTypeOperatorType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeOperatorTypeFields { operator_token, ty } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/typeof_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/typeof_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsTypeofType, TsTypeofTypeFields};
 impl FormatNodeFields<TsTypeofType> for FormatNodeRule<TsTypeofType> {
     fn format_fields(
         node: &TsTypeofType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsTypeofTypeFields {
             typeof_token,

--- a/crates/rome_js_formatter/src/ts/types/undefined_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/undefined_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsUndefinedType, TsUndefinedTypeFields};
 impl FormatNodeFields<TsUndefinedType> for FormatNodeRule<TsUndefinedType> {
     fn format_fields(
         node: &TsUndefinedType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsUndefinedTypeFields { undefined_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/ts/types/union_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/union_type.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::TsUnionTypeFields;
 impl FormatNodeFields<TsUnionType> for FormatNodeRule<TsUnionType> {
     fn format_fields(
         node: &TsUnionType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsUnionTypeFields {
             leading_separator_token,

--- a/crates/rome_js_formatter/src/ts/types/unknown_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/unknown_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsUnknownType, TsUnknownTypeFields};
 impl FormatNodeFields<TsUnknownType> for FormatNodeRule<TsUnknownType> {
     fn format_fields(
         node: &TsUnknownType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsUnknownTypeFields { unknown_token } = node.as_fields();
         formatted![formatter, [unknown_token.format()]]

--- a/crates/rome_js_formatter/src/ts/types/void_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/void_type.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{TsVoidType, TsVoidTypeFields};
 impl FormatNodeFields<TsVoidType> for FormatNodeRule<TsVoidType> {
     fn format_fields(
         node: &TsVoidType,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let TsVoidTypeFields { void_token } = node.as_fields();
 

--- a/crates/rome_js_formatter/src/utils/array.rs
+++ b/crates/rome_js_formatter/src/utils/array.rs
@@ -10,7 +10,7 @@ use rome_rowan::{AstNode, AstSeparatedList};
 /// Utility function to print array-like nodes (array expressions, array bindings and assignment patterns)
 pub(crate) fn format_array_node<N, I>(
     node: &N,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatResult<FormatElement>
 where
     N: AstSeparatedList<Language = JsLanguage, Node = I>,

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -95,7 +95,7 @@ use std::iter::FusedIterator;
 /// which is what we wanted since the beginning!
 pub(crate) fn format_binary_like_expression(
     expression: JsAnyBinaryLikeExpression,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatResult<FormatElement> {
     let mut flatten_items = FlattenItems::default();
     let current_node = expression.syntax().clone();
@@ -169,7 +169,7 @@ fn format_with_or_without_parenthesis(
     parent_operator: BinaryLikeOperator,
     node: &JsSyntaxNode,
     formatted_node: FormatElement,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatResult<(FormatElement, bool)> {
     let compare_to = match JsAnyExpression::cast(node.clone()) {
         Some(JsAnyExpression::JsLogicalExpression(logical)) => {
@@ -297,7 +297,7 @@ impl FlattenItems {
         &mut self,
         expression: JsAnyBinaryLikeExpression,
         parent_operator: Option<JsSyntaxToken>,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<()> {
         let should_flatten = expression.can_flatten()?;
 
@@ -313,7 +313,7 @@ impl FlattenItems {
         &mut self,
         binary_like_expression: JsAnyBinaryLikeExpression,
         parent_operator: Option<JsSyntaxToken>,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<()> {
         let right = binary_like_expression.right()?;
         let has_comments = right.syntax().has_comments_direct();
@@ -340,7 +340,7 @@ impl FlattenItems {
         &mut self,
         binary_like_expression: JsAnyBinaryLikeExpression,
         parent_operator: Option<JsSyntaxToken>,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<()> {
         if let Some(last) = self.items.last_mut() {
             // Remove any line breaks and the trailing operator so that the operator/trailing aren't part
@@ -415,7 +415,7 @@ impl FlattenItems {
     fn take_format_element(
         &mut self,
         current_node: &JsSyntaxNode,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let can_hard_group = can_hard_group(&self.items);
         let len = self.items.len();
@@ -867,9 +867,9 @@ impl AstNode for JsAnyBinaryLikeLeftExpression {
 }
 
 impl Format for JsAnyBinaryLikeLeftExpression {
-    type Options = JsFormatOptions;
+    type Context = JsFormatContext;
 
-    fn format(&self, formatter: &Formatter<JsFormatOptions>) -> FormatResult<FormatElement> {
+    fn format(&self, formatter: &Formatter<JsFormatContext>) -> FormatResult<FormatElement> {
         match self {
             JsAnyBinaryLikeLeftExpression::JsAnyExpression(expression) => {
                 formatted![formatter, [expression.format()]]

--- a/crates/rome_js_formatter/src/utils/format_conditional.rs
+++ b/crates/rome_js_formatter/src/utils/format_conditional.rs
@@ -29,7 +29,7 @@ impl Conditional {
 
     fn into_format_element(
         self,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
         parent_is_conditional: bool,
     ) -> FormatResult<FormatElement> {
         let (head, body) = match self {
@@ -46,7 +46,7 @@ impl Conditional {
         formatted![formatter, [head, body]]
     }
 
-    fn format_head(&self, formatter: &Formatter<JsFormatOptions>) -> FormatResult<FormatElement> {
+    fn format_head(&self, formatter: &Formatter<JsFormatContext>) -> FormatResult<FormatElement> {
         match self {
             Conditional::Expression(expr) => {
                 formatted![formatter, [expr.test()?.format(), space_token(),]]
@@ -88,7 +88,7 @@ impl Conditional {
 
     fn format_body(
         &self,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
         parent_is_conditional: bool,
     ) -> FormatResult<FormatElement> {
         let mut left_or_right_is_conditional = false;
@@ -127,7 +127,7 @@ impl Conditional {
 
     fn format_with_consequent(
         &self,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
         consequent: Option<FormatElement>,
     ) -> FormatResult<FormatElement> {
         match self {
@@ -174,7 +174,7 @@ impl Conditional {
 
     fn format_with_alternate(
         &self,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
         alternate: Option<FormatElement>,
     ) -> FormatResult<FormatElement> {
         match self {
@@ -225,7 +225,7 @@ impl Conditional {
 /// - [rome_js_syntax::JsConditionalExpression]
 pub fn format_conditional(
     conditional: Conditional,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
     parent_is_conditional: bool,
 ) -> FormatResult<FormatElement> {
     conditional.into_format_element(formatter, parent_is_conditional)

--- a/crates/rome_js_formatter/src/utils/member_chain/groups.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/groups.rs
@@ -1,8 +1,6 @@
 use crate::prelude::*;
 use crate::utils::member_chain::flatten_item::FlattenItem;
 use crate::utils::member_chain::simple_argument::SimpleArgument;
-
-use crate::options::JsFormatOptions;
 use rome_js_syntax::JsCallExpression;
 use rome_rowan::{AstSeparatedList, SyntaxResult};
 use std::mem;
@@ -20,7 +18,7 @@ pub(crate) struct Groups<'f> {
     current_group: Vec<FlattenItem>,
 
     /// instance of the formatter
-    formatter: &'f Formatter<JsFormatOptions>,
+    formatter: &'f Formatter<JsFormatContext>,
 
     /// This is a threshold of when we should start breaking the groups
     ///
@@ -29,7 +27,7 @@ pub(crate) struct Groups<'f> {
 }
 
 impl<'f> Groups<'f> {
-    pub fn new(formatter: &'f Formatter<JsFormatOptions>, in_expression_statement: bool) -> Self {
+    pub fn new(formatter: &'f Formatter<JsFormatContext>, in_expression_statement: bool) -> Self {
         Self {
             formatter,
             in_expression_statement,
@@ -148,7 +146,7 @@ impl<'f> Groups<'f> {
     /// This is an heuristic needed to check when the first element of the group
     /// Should be part of the "head" or the "tail".
     fn should_not_wrap(&self, first_group: &HeadGroup) -> SyntaxResult<bool> {
-        let tab_with = self.formatter.options().tab_width();
+        let tab_with = self.formatter.context().tab_width();
         let has_computed_property = if self.groups.len() > 1 {
             // SAFETY: guarded by the previous check
             let group = &self.groups[0];

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -119,7 +119,7 @@ use rome_rowan::AstNode;
 /// [Prettier applies]: https://github.com/prettier/prettier/blob/main/src/language-js/print/member-chain.js
 pub fn format_call_expression(
     syntax_node: &JsSyntaxNode,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatResult<FormatElement> {
     let mut flattened_items = vec![];
     let parent_is_expression_statement = syntax_node.parent().map_or(false, |parent| {
@@ -234,7 +234,7 @@ fn compute_first_group_index(flatten_items: &[FlattenItem]) -> usize {
 fn compute_groups(
     flatten_items: impl Iterator<Item = FlattenItem>,
     in_expression_statement: bool,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatResult<Groups> {
     let mut has_seen_call_expression = false;
     let mut groups = Groups::new(formatter, in_expression_statement);
@@ -320,7 +320,7 @@ fn format_groups(
 fn flatten_call_expression(
     queue: &mut Vec<FlattenItem>,
     node: JsSyntaxNode,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatResult<()> {
     match node.kind() {
         JsSyntaxKind::JS_CALL_EXPRESSION => {

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -23,7 +23,7 @@ use rome_js_syntax::{JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, AstNodeList};
 use std::borrow::Cow;
 
-use crate::options::{JsFormatOptions, QuoteStyle};
+use crate::context::QuoteStyle;
 pub(crate) use simple::*;
 
 /// Utility function to format the separators of the nodes that belong to the unions
@@ -34,7 +34,7 @@ pub(crate) use simple::*;
 /// So here, we create - on purpose - an empty node.
 pub(crate) fn format_type_member_separator(
     separator_token: Option<JsSyntaxToken>,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatElement {
     if let Some(separator) = separator_token {
         formatter.format_replaced(&separator, empty_element())
@@ -45,7 +45,7 @@ pub(crate) fn format_type_member_separator(
 
 /// Utility function to format the node [rome_js_syntax::JsInitializerClause]
 pub(crate) fn format_initializer_clause(
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
     initializer: Option<JsInitializerClause>,
 ) -> FormatResult<FormatElement> {
     formatted![
@@ -58,7 +58,7 @@ pub(crate) fn format_initializer_clause(
 
 pub(crate) fn format_interpreter(
     interpreter: Option<JsSyntaxToken>,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatResult<FormatElement> {
     formatted![
         formatter,
@@ -123,7 +123,7 @@ pub(crate) fn has_leading_newline(node: &JsSyntaxNode) -> bool {
 /// This will place the head element inside a [hard_group_elements], but
 /// the body will broken out of flat printing if its a single statement
 pub(crate) fn format_head_body_statement(
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
     head: FormatElement,
     body: JsAnyStatement,
 ) -> FormatResult<FormatElement> {
@@ -158,7 +158,7 @@ where
 /// Utility to format
 pub(crate) fn format_template_chunk(
     chunk: JsSyntaxToken,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatResult<FormatElement> {
     // Per https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-static-semantics-trv:
     // In template literals, the '\r' and '\r\n' line terminators are normalized to '\n'
@@ -175,7 +175,7 @@ pub(crate) fn format_template_chunk(
 /// Function to format template literals and template literal types
 pub(crate) fn format_template_literal(
     literal: TemplateElement,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatResult<FormatElement> {
     literal.into_format_element(formatter)
 }
@@ -188,7 +188,7 @@ pub(crate) enum TemplateElement {
 impl TemplateElement {
     pub fn into_format_element(
         self,
-        formatter: &Formatter<JsFormatOptions>,
+        formatter: &Formatter<JsFormatContext>,
     ) -> FormatResult<FormatElement> {
         let expression_is_plain = self.is_plain_expression()?;
         let has_comments = self.has_comments();
@@ -364,7 +364,7 @@ impl FormatPrecedence {
 /// semicolon insertion if it was missing in the input source and the
 /// preceeding element wasn't an unknown node
 pub(crate) fn format_with_semicolon(
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
     content: FormatElement,
     semicolon: Option<JsSyntaxToken>,
 ) -> FormatResult<FormatElement> {
@@ -388,10 +388,10 @@ pub(crate) fn format_with_semicolon(
 
 pub(crate) fn format_string_literal_token(
     token: JsSyntaxToken,
-    formatter: &Formatter<JsFormatOptions>,
+    formatter: &Formatter<JsFormatContext>,
 ) -> FormatElement {
     let quoted = token.text_trimmed();
-    let (primary_quote_char, secondary_quote_char) = match formatter.options().quote_style {
+    let (primary_quote_char, secondary_quote_char) = match formatter.context().quote_style() {
         QuoteStyle::Double => ('"', '\''),
         QuoteStyle::Single => ('\'', '"'),
     };

--- a/crates/rome_js_formatter/tests/check_reformat.rs
+++ b/crates/rome_js_formatter/tests/check_reformat.rs
@@ -1,6 +1,6 @@
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
+use rome_js_formatter::context::JsFormatContext;
 use rome_js_formatter::format_node;
-use rome_js_formatter::options::JsFormatOptions;
 use rome_js_parser::parse;
 use rome_js_syntax::{JsSyntaxNode, SourceType};
 
@@ -9,7 +9,7 @@ pub struct CheckReformatParams<'a> {
     pub text: &'a str,
     pub source_type: SourceType,
     pub file_name: &'a str,
-    pub format_options: JsFormatOptions,
+    pub format_context: JsFormatContext,
 }
 
 /// Perform a second pass of formatting on a file, printing a diff if the
@@ -20,7 +20,7 @@ pub fn check_reformat(params: CheckReformatParams) {
         text,
         source_type,
         file_name,
-        format_options,
+        format_context: format_options,
     } = params;
 
     let re_parse = parse(text, 0, source_type);

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -53,7 +53,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
         input_file.try_into().unwrap()
     };
 
-    let parsed = parse(&parse_input, 0, source_type.clone());
+    let parsed = parse(&parse_input, 0, source_type);
 
     let has_errors = parsed.has_errors();
     let syntax = parsed.syntax();

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -14,7 +14,7 @@ use std::{
 
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
 use rome_formatter::IndentStyle;
-use rome_js_formatter::options::JsFormatOptions;
+use rome_js_formatter::context::JsFormatContext;
 use rome_js_parser::parse;
 use rome_js_syntax::SourceType;
 
@@ -58,9 +58,9 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
     let has_errors = parsed.has_errors();
     let syntax = parsed.syntax();
 
-    let options = JsFormatOptions {
+    let context = JsFormatContext {
         indent_style: IndentStyle::Space(2),
-        ..JsFormatOptions::default()
+        ..JsFormatContext::default()
     };
 
     let result = match (range_start_index, range_end_index) {
@@ -72,7 +72,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
             }
 
             rome_js_formatter::format_range(
-                options,
+                context,
                 &syntax,
                 TextRange::new(
                     TextSize::try_from(start).unwrap(),
@@ -80,7 +80,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
                 ),
             )
         }
-        _ => rome_js_formatter::format_node(options, &syntax).map(|formatted| formatted.print()),
+        _ => rome_js_formatter::format_node(context, &syntax).map(|formatted| formatted.print()),
     };
 
     let formatted = result.expect("formatting failed");
@@ -104,7 +104,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
                     text: &result,
                     source_type,
                     file_name,
-                    format_options: options,
+                    format_context: context,
                 });
             }
 
@@ -153,7 +153,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
         writeln!(snapshot).unwrap();
     }
 
-    let max_width = options.line_width.value() as usize;
+    let max_width = context.line_width.value() as usize;
     let mut lines_exceeding_max_width = formatted
         .lines()
         .enumerate()

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -210,7 +210,7 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
             check_reformat::check_reformat(check_reformat::CheckReformatParams {
                 root: &root,
                 text: printed.as_code(),
-                source_type: source_type,
+                source_type,
                 file_name,
                 format_context: JsFormatContext::default(),
             });

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -1,8 +1,8 @@
 use rome_formatter::LineWidth;
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
+use rome_js_formatter::context::{JsFormatContext, JsFormatOptions, QuoteStyle};
 use rome_js_formatter::format_node;
-use rome_js_formatter::options::{JsFormatOptions, QuoteStyle};
 use rome_js_parser::parse;
 use rome_js_syntax::{ModuleKind, SourceType};
 use rome_service::workspace::{FeatureName, SupportsFeatureParams};
@@ -49,7 +49,7 @@ impl From<SerializableQuoteStyle> for QuoteStyle {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
-pub struct SerializableFormatOptions {
+pub struct SerializableFormatContext {
     /// The indent style.
     pub indent_style: Option<SerializableIndentStyle>,
 
@@ -60,8 +60,8 @@ pub struct SerializableFormatOptions {
     pub quote_style: Option<SerializableQuoteStyle>,
 }
 
-impl From<SerializableFormatOptions> for JsFormatOptions {
-    fn from(test: SerializableFormatOptions) -> Self {
+impl From<SerializableFormatContext> for JsFormatContext {
+    fn from(test: SerializableFormatContext) -> Self {
         Self {
             indent_style: test
                 .indent_style
@@ -70,26 +70,29 @@ impl From<SerializableFormatOptions> for JsFormatOptions {
                 .line_width
                 .and_then(|width| LineWidth::try_from(width).ok())
                 .unwrap_or_default(),
-            quote_style: test
-                .quote_style
-                .map_or_else(|| QuoteStyle::Double, |value| value.into()),
+            options: JsFormatOptions {
+                quote_style: test
+                    .quote_style
+                    .map_or_else(|| QuoteStyle::Double, |value| value.into()),
+            },
+            source_type: SourceType::default(),
         }
     }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 struct TestOptions {
-    cases: Vec<SerializableFormatOptions>,
+    cases: Vec<SerializableFormatContext>,
 }
 
 #[derive(Debug, Default)]
 struct SnapshotContent {
     input: String,
-    output: Vec<(String, JsFormatOptions)>,
+    output: Vec<(String, JsFormatContext)>,
 }
 
 impl SnapshotContent {
-    fn add_output(&mut self, formatted: Printed, options: JsFormatOptions) {
+    fn add_output(&mut self, formatted: Printed, options: JsFormatContext) {
         let code = formatted.as_code();
         let mut output: String = code.to_string();
         if !formatted.verbatim_ranges().is_empty() {
@@ -194,12 +197,12 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
         let input = fs::read_to_string(file_path).unwrap();
         snapshot_content.set_input(input.as_str());
 
-        let parsed = parse(buffer.as_str(), 0, source_type.clone());
+        let parsed = parse(buffer.as_str(), 0, source_type);
         let has_errors = parsed.has_errors();
         let root = parsed.syntax();
 
         // we ignore the error for now
-        let formatted = format_node(JsFormatOptions::default(), &root).unwrap();
+        let formatted = format_node(JsFormatContext::default(), &root).unwrap();
         let printed = formatted.print();
         let file_name = spec_input_file.file_name().unwrap().to_str().unwrap();
 
@@ -207,13 +210,13 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
             check_reformat::check_reformat(check_reformat::CheckReformatParams {
                 root: &root,
                 text: printed.as_code(),
-                source_type: source_type.clone(),
+                source_type: source_type,
                 file_name,
-                format_options: JsFormatOptions::default(),
+                format_context: JsFormatContext::default(),
             });
         }
 
-        snapshot_content.add_output(printed, JsFormatOptions::default());
+        snapshot_content.add_output(printed, JsFormatContext::default());
 
         let test_directory = PathBuf::from(test_directory);
         let options_path = test_directory.join("options.json");
@@ -225,21 +228,24 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
                     serde_json::from_str(options_path.get_buffer_from_file().as_str()).unwrap();
 
                 for test_case in options.cases {
-                    let format_options: JsFormatOptions = test_case.into();
-                    let formatted = format_node(format_options, &root).unwrap();
+                    let mut format_context: JsFormatContext = test_case.into();
+                    // we don't track the source type inside the serializable structs, so we
+                    // inject it here
+                    format_context.source_type = source_type;
+                    let formatted = format_node(format_context, &root).unwrap();
                     let printed = formatted.print();
 
                     if !has_errors {
                         check_reformat::check_reformat(check_reformat::CheckReformatParams {
                             root: &root,
                             text: printed.as_code(),
-                            source_type: source_type.clone(),
+                            source_type,
                             file_name,
-                            format_options,
+                            format_context,
                         });
                     }
 
-                    snapshot_content.add_output(printed, format_options);
+                    snapshot_content.add_output(printed, format_context);
                 }
             }
         }

--- a/crates/rome_js_syntax/src/source_type.rs
+++ b/crates/rome_js_syntax/src/source_type.rs
@@ -102,7 +102,7 @@ impl Default for Language {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct SourceType {
     language: Language,
     variant: LanguageVariant,

--- a/crates/rome_lsp/src/config.rs
+++ b/crates/rome_lsp/src/config.rs
@@ -1,5 +1,5 @@
 use rome_formatter::{IndentStyle, LineWidth};
-use rome_js_formatter::options::QuoteStyle;
+use rome_js_formatter::context::QuoteStyle;
 use rome_service::settings;
 use serde::{Deserialize, Serialize};
 use serde_json::{Error, Value};

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -2,8 +2,8 @@ use rome_analyze::{analyze, AnalysisFilter, AnalyzerAction, RuleCategories};
 use rome_diagnostics::Diagnostic;
 use rome_formatter::{IndentStyle, LineWidth, Printed};
 use rome_fs::RomePath;
-use rome_js_formatter::options::QuoteStyle;
-use rome_js_formatter::{format_node, options::JsFormatOptions};
+use rome_js_formatter::context::{JsFormatOptions, QuoteStyle};
+use rome_js_formatter::{context::JsFormatContext, format_node};
 use rome_js_parser::Parse;
 use rome_js_syntax::{JsAnyRoot, JsLanguage, SourceType, TextRange, TextSize, TokenAtOffset};
 use rome_rowan::AstNode;
@@ -22,11 +22,12 @@ pub struct JsFormatSettings {
     pub indent_style: Option<IndentStyle>,
     pub line_width: Option<LineWidth>,
     pub quote_style: Option<QuoteStyle>,
+    pub source_type: Option<SourceType>,
 }
 
 impl Language for JsLanguage {
     type FormatSettings = JsFormatSettings;
-    type FormatOptions = JsFormatOptions;
+    type FormatContext = JsFormatContext;
 
     fn lookup_settings(languages: &LanguagesSettings) -> &LanguageSettings<Self> {
         &languages.javascript
@@ -36,8 +37,8 @@ impl Language for JsLanguage {
         global: &FormatSettings,
         language: &JsFormatSettings,
         editor: IndentStyle,
-    ) -> JsFormatOptions {
-        JsFormatOptions {
+    ) -> JsFormatContext {
+        JsFormatContext {
             indent_style: language
                 .indent_style
                 .or(global.indent_style)
@@ -46,7 +47,10 @@ impl Language for JsLanguage {
                 .line_width
                 .or(global.line_width)
                 .unwrap_or_default(),
-            quote_style: language.quote_style.unwrap_or_default(),
+            options: JsFormatOptions {
+                quote_style: language.quote_style.unwrap_or_default(),
+            },
+            source_type: language.source_type.unwrap_or_default(),
         }
     }
 }

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -1,6 +1,7 @@
 use std::sync::{RwLock, RwLockReadGuard};
 
 use rome_formatter::{IndentStyle, LineWidth};
+use rome_fs::RomePath;
 use rome_js_syntax::JsLanguage;
 
 /// Global settings for the entire workspace
@@ -39,10 +40,11 @@ pub trait Language: rome_rowan::Language {
 
     /// Resolve the formatter options from the global (workspace level),
     /// per-language and editor provided formatter settings
-    fn resolve_format_options(
+    fn resolve_format_context(
         global: &FormatSettings,
         language: &Self::FormatSettings,
         editor: IndentStyle,
+        path: &RomePath,
     ) -> Self::FormatContext;
 }
 
@@ -76,15 +78,16 @@ impl<'a, E> AsRef<WorkspaceSettings> for SettingsHandle<'a, E> {
 }
 
 impl<'a> SettingsHandle<'a, IndentStyle> {
-    /// Resolve the formatting options for the given language
-    pub(crate) fn format_options<L>(self) -> L::FormatContext
+    /// Resolve the formatting context for the given language
+    pub(crate) fn format_context<L>(self, path: &RomePath) -> L::FormatContext
     where
         L: Language,
     {
-        L::resolve_format_options(
+        L::resolve_format_context(
             &self.inner.format,
             &L::lookup_settings(&self.inner.languages).format,
             self.editor,
+            path,
         )
     }
 }

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -32,7 +32,7 @@ pub trait Language: rome_rowan::Language {
     /// Formatter settings type for this language
     type FormatSettings: Default;
     /// Fully resolved formatter options type for this language
-    type FormatOptions: rome_formatter::FormatOptions;
+    type FormatContext: rome_formatter::FormatContext;
 
     /// Read the settings type for this language from the [LanguagesSettings] map
     fn lookup_settings(languages: &LanguagesSettings) -> &LanguageSettings<Self>;
@@ -43,7 +43,7 @@ pub trait Language: rome_rowan::Language {
         global: &FormatSettings,
         language: &Self::FormatSettings,
         editor: IndentStyle,
-    ) -> Self::FormatOptions;
+    ) -> Self::FormatContext;
 }
 
 #[derive(Default)]
@@ -77,7 +77,7 @@ impl<'a, E> AsRef<WorkspaceSettings> for SettingsHandle<'a, E> {
 
 impl<'a> SettingsHandle<'a, IndentStyle> {
     /// Resolve the formatting options for the given language
-    pub(crate) fn format_options<L>(self) -> L::FormatOptions
+    pub(crate) fn format_options<L>(self) -> L::FormatContext
     where
         L: Language,
     {

--- a/website/playground/src/lib.rs
+++ b/website/playground/src/lib.rs
@@ -5,8 +5,8 @@ use rome_diagnostics::file::SimpleFiles;
 use rome_diagnostics::termcolor::{ColorSpec, WriteColor};
 use rome_diagnostics::Emitter;
 use rome_formatter::IndentStyle;
+use rome_js_formatter::context::{JsFormatContext, JsFormatOptions};
 use rome_js_formatter::format_node;
-use rome_js_formatter::options::JsFormatOptions;
 use rome_js_parser::parse;
 use rome_js_syntax::{LanguageVariant, SourceType};
 use serde_json::json;
@@ -173,10 +173,13 @@ pub fn run(
         IndentStyle::Tab
     };
 
-    let options = JsFormatOptions {
+    let context = JsFormatContext {
         indent_style,
         line_width: options.line_width.try_into().unwrap_or_default(),
-        quote_style: options.quote_style.parse().unwrap_or_default(),
+        options: JsFormatOptions {
+            quote_style: options.quote_style.parse().unwrap_or_default(),
+        },
+        source_type,
     };
 
     let (cst, ast) = if output_json {
@@ -195,7 +198,7 @@ pub fn run(
         (format!("{:#?}", syntax), format!("{:#?}", parse.tree()))
     };
 
-    let formatted = format_node(options, &syntax).unwrap();
+    let formatted = format_node(context, &syntax).unwrap();
     let formatted_code = formatted.print().into_code();
 
     let root_element = formatted.into_format_element();

--- a/xtask/bench/src/features/formatter.rs
+++ b/xtask/bench/src/features/formatter.rs
@@ -1,7 +1,7 @@
 use crate::BenchmarkSummary;
 use rome_formatter::Printed;
+use rome_js_formatter::context::JsFormatContext;
 use rome_js_formatter::format_node;
-use rome_js_formatter::options::JsFormatOptions;
 use rome_js_syntax::JsSyntaxNode;
 use std::fmt::{Display, Formatter};
 use std::time::Duration;
@@ -23,7 +23,7 @@ pub fn benchmark_format_lib(id: &str, root: &JsSyntaxNode) -> BenchmarkSummary {
 }
 
 pub fn run_format(root: &JsSyntaxNode) -> Printed {
-    format_node(JsFormatOptions::default(), root)
+    format_node(JsFormatContext::default(), root)
         .unwrap()
         .print()
 }

--- a/xtask/bench/src/lib.rs
+++ b/xtask/bench/src/lib.rs
@@ -142,16 +142,16 @@ pub fn run(args: RunArgs) {
 
                     group.bench_function(&id, |b| match args.feature {
                         FeatureToBenchmark::Parser => b.iter(|| {
-                            criterion::black_box(run_parse(code, source_type.clone()));
+                            criterion::black_box(run_parse(code, source_type));
                         }),
                         FeatureToBenchmark::Formatter => {
-                            let root = parse(code, 0, source_type.clone()).syntax();
+                            let root = parse(code, 0, source_type).syntax();
                             b.iter(|| {
                                 criterion::black_box(run_format(&root));
                             })
                         }
                         FeatureToBenchmark::Analyzer => {
-                            let root = parse(code, 0, source_type.clone()).tree();
+                            let root = parse(code, 0, source_type).tree();
                             b.iter(|| {
                                 run_analyzer(&root);
                             })
@@ -162,14 +162,14 @@ pub fn run(args: RunArgs) {
                     //warmup
                     match args.feature {
                         FeatureToBenchmark::Parser => {
-                            run_parse(code, source_type.clone());
+                            run_parse(code, source_type);
                         }
                         FeatureToBenchmark::Formatter => {
-                            let root = parse(code, 0, source_type.clone()).syntax();
+                            let root = parse(code, 0, source_type).syntax();
                             run_format(&root);
                         }
                         FeatureToBenchmark::Analyzer => {
-                            let root = parse(code, 0, source_type.clone()).tree();
+                            let root = parse(code, 0, source_type).tree();
                             run_analyzer(&root);
                         }
                     }

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -309,9 +309,9 @@ pub fn generate_formatter() {
                 use rome_js_syntax::#node_id;
 
                 impl FormatRule<#node_id> for #format_id {
-                    type Options = JsFormatOptions;
+                    type Context = JsFormatContext;
 
-                    fn format(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+                    fn format(node: &#node_id, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
                         Ok(formatter.format_list(node))
                     }
                 }
@@ -323,9 +323,9 @@ pub fn generate_formatter() {
                 use rome_js_syntax::#node_id;
 
                 impl FormatRule<#node_id> for #format_id {
-                    type Options = JsFormatOptions;
+                    type Context = JsFormatContext;
 
-                    fn format(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+                    fn format(node: &#node_id, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
                         verbatim_node(node.syntax()).format(formatter)
                     }
                 }
@@ -338,7 +338,7 @@ pub fn generate_formatter() {
                     use rome_js_syntax::#node_id;
 
                     impl FormatNodeFields<#node_id> for FormatNodeRule<#node_id> {
-                        fn format_fields(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+                        fn format_fields(node: &#node_id, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
                             verbatim_node(node.syntax()).format(formatter)
                         }
                     }
@@ -352,7 +352,7 @@ pub fn generate_formatter() {
                     use rome_js_syntax::#node_id;
 
                     impl FormatNodeFields<#node_id> for FormatNodeRule<#node_id> {
-                        fn format_fields(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
+                        fn format_fields(node: &#node_id, formatter: &Formatter<Self::Context>) -> FormatResult<FormatElement> {
                             unknown_node(node.syntax()).format(formatter)
                         }
                     }
@@ -374,7 +374,7 @@ pub fn generate_formatter() {
                     use rome_js_syntax::#node_id;
 
                     impl FormatRule<#node_id> for #format_id {
-                        type Options = JsFormatOptions;
+                        type Context = JsFormatContext;
 
                         fn format(node: &#node_id, formatter: &Formatter<Self::Options>) -> FormatResult<FormatElement> {
                             match node {

--- a/xtask/coverage/src/js/test262.rs
+++ b/xtask/coverage/src/js/test262.rs
@@ -97,8 +97,7 @@ impl Test262TestCase {
             .filter(|neg| neg.phase == Phase::Parse)
             .is_some();
 
-        let files =
-            TestCaseFiles::single(self.name.clone(), self.code.clone(), source_type.clone());
+        let files = TestCaseFiles::single(self.name.clone(), self.code.clone(), source_type);
 
         match parse(&code, 0, source_type).ok() {
             Ok(root) if !should_fail => {

--- a/xtask/coverage/src/jsx/jsx_babel.rs
+++ b/xtask/coverage/src/jsx/jsx_babel.rs
@@ -36,11 +36,7 @@ impl TestCase for BabelJsxTestCase {
 
     fn run(&self) -> TestRunOutcome {
         let source_type = SourceType::jsx().with_module_kind(ModuleKind::Script);
-        let files = TestCaseFiles::single(
-            self.name().to_string(),
-            self.code.clone(),
-            source_type.clone(),
-        );
+        let files = TestCaseFiles::single(self.name().to_string(), self.code.clone(), source_type);
         let result = parse(&self.code, 0, source_type);
 
         if result.diagnostics().is_empty() {

--- a/xtask/coverage/src/runner.rs
+++ b/xtask/coverage/src/runner.rs
@@ -82,7 +82,7 @@ pub(crate) struct TestCaseFile {
 
 impl TestCaseFile {
     pub(crate) fn parse(&self) -> Parse<JsAnyRoot> {
-        parse(&self.code, self.id, self.source_type.clone())
+        parse(&self.code, self.id, self.source_type)
     }
 
     pub(crate) fn name(&self) -> &str {

--- a/xtask/coverage/src/ts/ts_babel.rs
+++ b/xtask/coverage/src/ts/ts_babel.rs
@@ -42,11 +42,7 @@ impl TestCase for BabelTypescriptTestCase {
 
     fn run(&self) -> TestRunOutcome {
         let source_type = SourceType::ts().with_variant(self.variant);
-        let files = TestCaseFiles::single(
-            self.name().to_string(),
-            self.code.clone(),
-            source_type.clone(),
-        );
+        let files = TestCaseFiles::single(self.name().to_string(), self.code.clone(), source_type);
 
         let result = rome_js_parser::parse(&self.code, 0, source_type);
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #2546 

In order to make the formatter language aware, we need to store information that belong to the current file. In order to do so - after a brief [discussion we had on discord](https://discord.com/channels/678763474494423051/978663597053984808) - we decided to rename `Options` into `Context`, which will be the place where to store different information inside the current instance of the formatter.

Everything around options has been renamed to context, and inside this context we have also options that belong to the language. For example, `quote_style` has been moved inside `JsFormatContext::options` because it's an information that belong to JS only, while `line_width` belongs to context because it's an information that belong to all languages.

Work done:
- changed the codegen with the new code;
- updated all the code inside `rome_js_formatter/src/*` to use the new `JsFormatContext`;
- updated all the tests to use the new `JsFormatContext`;
- updated `rome_services` to consume the new `JsFormatContext`;
- modified the code inside `rome_js_formatter/src/utils/mod.rs` to use the new method to retrieve the `quote_style`;
- updated examples and doc tests;
- updated the code in the playground;
- updated the code in the xtask benchmarking; 


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

All existing tests should pass

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
