### PR TITLE
fix(parser): Fix JSX parser dropping content

### DIFF
--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/html-like/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/html-like/comment.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: comment.js
-
 ---
 # Input
 ```js
@@ -21,12 +19,17 @@ alert(1)
 
 # Errors
 ```
-error[SyntaxError]: type assertions are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
+error[SyntaxError]: Expected an expression for the left hand side of the `<` operator.
   ┌─ comment.js:1:1
-  │  
-1 │ ┌ <!--
-2 │ │ alert(1)
-  │ └────────^ TypeScript only syntax
+  │
+1 │ <!--
+  │ ^ This operator requires a left hand side value
+
+error[SyntaxError]: Invalid assignment to `alert(1)`
+  ┌─ comment.js:2:1
+  │
+2 │ alert(1)
+  │ ^^^^^^^^ This expression cannot be assigned to
 
 error[SyntaxError]: expected an identifier, or a member expression but instead found '>'
   ┌─ comment.js:3:3

--- a/crates/rome_js_parser/src/syntax/jsx/jsx_parse_errors.rs
+++ b/crates/rome_js_parser/src/syntax/jsx/jsx_parse_errors.rs
@@ -5,14 +5,6 @@ use crate::{
 use rome_diagnostics::Diagnostic;
 use rome_js_syntax::TextRange;
 
-pub(crate) fn jsx_only_syntax_error(p: &Parser, syntax: &str, range: TextRange) -> Diagnostic {
-    p.err_builder(&format!(
-        "{} are a JSX only feature. Convert your file to a JSX file or remove the syntax.",
-        syntax
-    ))
-    .primary(range, "JSX only syntax")
-}
-
 pub(crate) fn jsx_expected_attribute(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("JSX attribute", range).to_diagnostic(p)
 }

--- a/crates/rome_js_parser/src/syntax/typescript/ts_parse_error.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/ts_parse_error.rs
@@ -89,11 +89,6 @@ pub(crate) fn ts_set_accessor_return_type_error(
         .primary(type_annotation.range(p), "")
 }
 
-pub(crate) fn ts_type_assertion_on_new_expr(p: &Parser, type_expr: &CompletedMarker) -> Diagnostic {
-    p.err_builder("Type assertions cannot be used at 'new' expressions.")
-        .primary(type_expr.range(p), "")
-}
-
 pub(crate) fn expected_ts_type(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("type", range).to_diagnostic(p)
 }

--- a/crates/rome_js_parser/test_data/inline/err/ts_type_assertions_not_valid_at_new_expr.rast
+++ b/crates/rome_js_parser/test_data/inline/err/ts_type_assertions_not_valid_at_new_expr.rast
@@ -13,31 +13,36 @@ JsModule {
                         variable_annotation: missing (optional),
                         initializer: JsInitializerClause {
                             eq_token: EQ@10..12 "=" [] [Whitespace(" ")],
-                            expression: JsNewExpression {
-                                new_token: NEW_KW@12..16 "new" [] [Whitespace(" ")],
-                                callee: TsTypeAssertionExpression {
-                                    l_angle_token: L_ANGLE@16..17 "<" [] [],
-                                    ty: TsAnyType {
-                                        any_token: ANY_KW@17..20 "any" [] [],
-                                    },
-                                    r_angle_token: R_ANGLE@20..21 ">" [] [],
-                                    expression: JsCallExpression {
-                                        callee: JsIdentifierExpression {
-                                            name: JsReferenceIdentifier {
-                                                value_token: IDENT@21..26 "Test2" [] [],
-                                            },
-                                        },
-                                        optional_chain_token: missing (optional),
+                            expression: JsBinaryExpression {
+                                left: JsBinaryExpression {
+                                    left: JsNewExpression {
+                                        new_token: NEW_KW@12..16 "new" [] [Whitespace(" ")],
+                                        callee: missing (required),
                                         type_arguments: missing (optional),
-                                        arguments: JsCallArguments {
-                                            l_paren_token: L_PAREN@26..27 "(" [] [],
-                                            args: JsCallArgumentList [],
-                                            r_paren_token: R_PAREN@27..28 ")" [] [],
+                                        arguments: missing (optional),
+                                    },
+                                    operator_token: L_ANGLE@16..17 "<" [] [],
+                                    right: JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@17..20 "any" [] [],
                                         },
                                     },
                                 },
-                                type_arguments: missing (optional),
-                                arguments: missing (optional),
+                                operator_token: R_ANGLE@20..21 ">" [] [],
+                                right: JsCallExpression {
+                                    callee: JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@21..26 "Test2" [] [],
+                                        },
+                                    },
+                                    optional_chain_token: missing (optional),
+                                    type_arguments: missing (optional),
+                                    arguments: JsCallArguments {
+                                        l_paren_token: L_PAREN@26..27 "(" [] [],
+                                        args: JsCallArgumentList [],
+                                        r_paren_token: R_PAREN@27..28 ")" [] [],
+                                    },
+                                },
                             },
                         },
                     },
@@ -63,33 +68,36 @@ JsModule {
             1: (empty)
             2: JS_INITIALIZER_CLAUSE@10..28
               0: EQ@10..12 "=" [] [Whitespace(" ")]
-              1: JS_NEW_EXPRESSION@12..28
-                0: NEW_KW@12..16 "new" [] [Whitespace(" ")]
-                1: TS_TYPE_ASSERTION_EXPRESSION@16..28
-                  0: L_ANGLE@16..17 "<" [] []
-                  1: TS_ANY_TYPE@17..20
-                    0: ANY_KW@17..20 "any" [] []
-                  2: R_ANGLE@20..21 ">" [] []
-                  3: JS_CALL_EXPRESSION@21..28
-                    0: JS_IDENTIFIER_EXPRESSION@21..26
-                      0: JS_REFERENCE_IDENTIFIER@21..26
-                        0: IDENT@21..26 "Test2" [] []
+              1: JS_BINARY_EXPRESSION@12..28
+                0: JS_BINARY_EXPRESSION@12..20
+                  0: JS_NEW_EXPRESSION@12..16
+                    0: NEW_KW@12..16 "new" [] [Whitespace(" ")]
                     1: (empty)
                     2: (empty)
-                    3: JS_CALL_ARGUMENTS@26..28
-                      0: L_PAREN@26..27 "(" [] []
-                      1: JS_CALL_ARGUMENT_LIST@27..27
-                      2: R_PAREN@27..28 ")" [] []
-                2: (empty)
-                3: (empty)
+                    3: (empty)
+                  1: L_ANGLE@16..17 "<" [] []
+                  2: JS_IDENTIFIER_EXPRESSION@17..20
+                    0: JS_REFERENCE_IDENTIFIER@17..20
+                      0: IDENT@17..20 "any" [] []
+                1: R_ANGLE@20..21 ">" [] []
+                2: JS_CALL_EXPRESSION@21..28
+                  0: JS_IDENTIFIER_EXPRESSION@21..26
+                    0: JS_REFERENCE_IDENTIFIER@21..26
+                      0: IDENT@21..26 "Test2" [] []
+                  1: (empty)
+                  2: (empty)
+                  3: JS_CALL_ARGUMENTS@26..28
+                    0: L_PAREN@26..27 "(" [] []
+                    1: JS_CALL_ARGUMENT_LIST@27..27
+                    2: R_PAREN@27..28 ")" [] []
       1: SEMICOLON@28..29 ";" [] []
   3: EOF@29..30 "" [Newline("\n")] []
 --
-error[SyntaxError]: Type assertions cannot be used at 'new' expressions.
+error[SyntaxError]: expected an expression but instead found '<'
   ┌─ ts_type_assertions_not_valid_at_new_expr.ts:1:17
   │
 1 │ var test2 = new <any>Test2();
-  │                 ^^^^^^^^^^^^
+  │                 ^ Expected an expression here
 
 --
 var test2 = new <any>Test2();


### PR DESCRIPTION
Reverts #2508 because `parse_any_jsx_tag` returns `Absent` even when it parsed out the opening element and the tags content.

PR #2508 added a checkpoint in the parse binary expression to rewind if that happens but not to any other call sites of the function. Parsing a tag with an incomplete JSX child then gets skipped by the parser because the parse list assumes that it reached the end.

PR #2508 mentions that it fixes a bug when parsing `let a = <number> undefined`. I haven't been able to reproduce this issue except if JSX is enabled but type assertions aren't valid in TS when JSX is enabled.
