### PR TITLE
fix(rome_js_formatter): change parenthesized expression formatting

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -16,25 +16,10 @@ impl FormatNodeFields<JsSequenceExpression> for FormatNodeRule<JsSequenceExpress
             // Return statement already does the indentation for us
             // Arrow function body can't have a sequence expression unless it's parenthesized, otherwise
             // would be a syntax error
-            if matches!(parent.kind(), JsSyntaxKind::JS_RETURN_STATEMENT) {
-                true
-            } else if matches!(parent.kind(), JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION) {
-                // In case we are inside a sequence expression, we have to go up a level and see the great parent.
-                // Arrow function body and return statements applying indentation for us, so we signal the
-                // sequence expression to not add other indentation levels
-                let great_parent = parent.parent().map(|gp| gp.kind());
-
-                matches!(
-                    great_parent,
-                    Some(
-                        JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION
-                            | JsSyntaxKind::JS_RETURN_STATEMENT
-                            | JsSyntaxKind::JS_PROPERTY_OBJECT_MEMBER
-                    )
-                )
-            } else {
-                false
-            }
+            matches!(
+                parent.kind(),
+                JsSyntaxKind::JS_RETURN_STATEMENT | JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION
+            )
         });
 
         // Find the left most sequence expression

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -264,7 +264,11 @@ fn should_not_indent_if_parent_indents(current_node: &JsSyntaxNode) -> bool {
 
     matches!(
         parent_kind,
-        Some(JsSyntaxKind::JS_RETURN_STATEMENT | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION)
+        Some(
+            JsSyntaxKind::JS_RETURN_STATEMENT
+                | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION
+                | JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION
+        )
     )
 }
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 244
+assertion_line: 257
 expression: sequence_expression.js
 ---
 # Input
@@ -51,15 +51,13 @@ const f = () => (
 	____________third
 );
 
-(
-	____________first,
-		____________second,
-		____________third,
-		____________third,
-		____________third,
-		____________third,
-		____________third
-);
+(____________first,
+____________second,
+____________third,
+____________third,
+____________third,
+____________third,
+____________third);
 
 function a() {
 	return (
@@ -74,15 +72,13 @@ function a() {
 }
 
 const object = {
-	something: (
-		____________first,
-		____________second,
-		____________third,
-		____________third,
-		____________third,
-		____________third,
-		____________third
-	),
+	something: (____________first,
+	____________second,
+	____________third,
+	____________third,
+	____________third,
+	____________third,
+	____________third),
 };
 
 aLongIdentifierName,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/call.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 182
 expression: call.js
-
 ---
 # Input
 ```js
@@ -78,38 +77,38 @@ expression: call.js
 ```js
 (
   aaaaaaaaaaaaaaaaaaaaaaaaa &&
-    bbbbbbbbbbbbbbbbbbbbbbbbb &&
-    ccccccccccccccccccccccccc &&
-    ddddddddddddddddddddddddd &&
-    eeeeeeeeeeeeeeeeeeeeeeeee
+  bbbbbbbbbbbbbbbbbbbbbbbbb &&
+  ccccccccccccccccccccccccc &&
+  ddddddddddddddddddddddddd &&
+  eeeeeeeeeeeeeeeeeeeeeeeee
 )();
 
 (aa && bb && cc && dd && ee)();
 
 (
   aaaaaaaaaaaaaaaaaaaaaaaaa +
-    bbbbbbbbbbbbbbbbbbbbbbbbb +
-    ccccccccccccccccccccccccc +
-    ddddddddddddddddddddddddd +
-    eeeeeeeeeeeeeeeeeeeeeeeee
+  bbbbbbbbbbbbbbbbbbbbbbbbb +
+  ccccccccccccccccccccccccc +
+  ddddddddddddddddddddddddd +
+  eeeeeeeeeeeeeeeeeeeeeeeee
 )();
 
 (aa + bb + cc + dd + ee)();
 
 (
   aaaaaaaaaaaaaaaaaaaaaaaaa &&
-    bbbbbbbbbbbbbbbbbbbbbbbbb &&
-    ccccccccccccccccccccccccc &&
-    ddddddddddddddddddddddddd &&
-    eeeeeeeeeeeeeeeeeeeeeeeee
+  bbbbbbbbbbbbbbbbbbbbbbbbb &&
+  ccccccccccccccccccccccccc &&
+  ddddddddddddddddddddddddd &&
+  eeeeeeeeeeeeeeeeeeeeeeeee
 )()()();
 
 (
   aaaaaaaaaaaaaaaaaaaaaaaaa &&
-    bbbbbbbbbbbbbbbbbbbbbbbbb &&
-    ccccccccccccccccccccccccc &&
-    ddddddddddddddddddddddddd &&
-    eeeeeeeeeeeeeeeeeeeeeeeee
+  bbbbbbbbbbbbbbbbbbbbbbbbb &&
+  ccccccccccccccccccccccccc &&
+  ddddddddddddddddddddddddd &&
+  eeeeeeeeeeeeeeeeeeeeeeeee
 )(
   aaaaaaaaaaaaaaaaaaaaaaaaa &&
     bbbbbbbbbbbbbbbbbbbbbbbbb &&

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/comment.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: comment.js
 ---
 # Input
@@ -110,15 +111,15 @@ foo[
 
 !(
   a +
-    a + // comment
-    a +
-    !(
-      b +
-        b +
-        b + // comment
-        b +
-        b
-    )
+  a + // comment
+  a +
+  !(
+    b +
+    b +
+    b + // comment
+    b +
+    b
+  )
 );
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: inline-object-array.js
 ---
 # Input
@@ -172,12 +173,12 @@ const create = () => {
   const result = doSomething();
   return (
     shouldReturn &&
-      result.ok &&
-      {
-        status: "ok",
-        createdAt: result.createdAt,
-        updatedAt: result.updatedAt,
-      }
+    result.ok &&
+    {
+      status: "ok",
+      createdAt: result.createdAt,
+      updatedAt: result.updatedAt,
+    }
   );
 };
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/member/logical.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/member/logical.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 182
 expression: logical.js
-
 ---
 # Input
 ```js
@@ -18,8 +17,8 @@ expression: logical.js
 
 (
   veryLongVeryLongVeryLong ||
-    anotherVeryLongVeryLongVeryLong ||
-    veryVeryVeryLongError
+  anotherVeryLongVeryLongVeryLong ||
+  veryVeryVeryLongError
 ).prop;
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/logical.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/logical.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: logical.js
 ---
 # Input
@@ -42,14 +43,14 @@ const someLongVariableName = (
 
 (
   veryLongVeryLongVeryLong ||
-    anotherVeryLongVeryLongVeryLong ||
-    veryVeryVeryLongError
+  anotherVeryLongVeryLongVeryLong ||
+  veryVeryVeryLongError
 ).map((tickets) => TicketRecord.createFromSomeLongString());
 
 (
   veryLongVeryLongVeryLong ||
-    anotherVeryLongVeryLongVeryLong ||
-    veryVeryVeryLongError
+  anotherVeryLongVeryLongVeryLong ||
+  veryVeryVeryLongError
 ).map(
   (tickets) => TicketRecord.createFromSomeLongString(),
 ).filter((obj) => !!obj);

--- a/crates/rome_js_formatter/tests/specs/prettier/js/objects/expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/objects/expression.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 181
+assertion_line: 182
 expression: expression.js
 ---
 # Input
@@ -51,17 +51,14 @@ const a1 = {
 };
 
 const a2 = {
-  someKey: (
-    longLongLongLongLongLongLongLongLongLongLongLongLongLongName, shortName
-  ),
+  someKey: (longLongLongLongLongLongLongLongLongLongLongLongLongLongName,
+  shortName),
 };
 
 const a3 = {
-  someKey: (
-    longLongLongLongLongLongLongLongLongLongLongLongLongLongName,
-    longLongLongLongLongLongLongLongLongLongLongLongLongLongName,
-    longLongLongLongLongLongLongLongLongLongLongLongLongLongName
-  ),
+  someKey: (longLongLongLongLongLongLongLongLongLongLongLongLongLongName,
+  longLongLongLongLongLongLongLongLongLongLongLongLongLongName,
+  longLongLongLongLongLongLongLongLongLongLongLongLongLongName),
 };
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/optional-chaining/chaining.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/optional-chaining/chaining.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 182
 expression: chaining.js
-
 ---
 # Input
 ```js
@@ -158,8 +157,8 @@ a?.[b ? c : d];
 (a?.(x)).x;
 (
   aaaaaaaaaaaaaaaaaaaaaaaa &&
-    aaaaaaaaaaaaaaaaaaaaaaaa &&
-    aaaaaaaaaaaaaaaaaaaaaaaa
+  aaaaaaaaaaaaaaaaaaaaaaaa &&
+  aaaaaaaaaaaaaaaaaaaaaaaa
 )?.();
 
 let f = () => ({}?.());

--- a/crates/rome_js_formatter/tests/specs/prettier/js/preserve-line/member-chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/preserve-line/member-chain.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: member-chain.js
 ---
 # Input
@@ -100,8 +101,8 @@ helloWorld.text().then((t) => t);
 
 (
   veryLongVeryLongVeryLong ||
-    anotherVeryLongVeryLongVeryLong ||
-    veryVeryVeryLongError
+  anotherVeryLongVeryLongVeryLong ||
+  veryVeryVeryLongError
 ).map(
   (tickets) => TicketRecord.createFromSomeLongString(),
 ).filter((obj) => !!obj);

--- a/crates/rome_js_formatter/tests/specs/prettier/js/return/binaryish.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/return/binaryish.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: binaryish.js
 ---
 # Input
@@ -35,13 +36,13 @@ function f() {
 function f() {
   return (
     property.isIdentifier() &&
-      FUNCTIONS[property.node.name] &&
-      (
-        object.isIdentifier(
-          JEST_GLOBAL,
-        ) || (callee.isMemberExpression() && shouldHoistExpression(object))
-      ) &&
-      FUNCTIONS[property.node.name](expr.get("arguments"))
+    FUNCTIONS[property.node.name] &&
+    (
+      object.isIdentifier(
+        JEST_GLOBAL,
+      ) || (callee.isMemberExpression() && shouldHoistExpression(object))
+    ) &&
+    FUNCTIONS[property.node.name](expr.get("arguments"))
   );
 
   return (

--- a/crates/rome_js_formatter/tests/specs/prettier/js/template-literals/sequence-expressions.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/template-literals/sequence-expressions.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: sequence-expressions.js
 ---
 # Input
@@ -10,9 +11,8 @@ expression: sequence-expressions.js
 
 # Output
 ```js
-`111111111 222222222 333333333 444444444 555555555 666666666 777777777 ${(
-  1, 2
-)}`;
+`111111111 222222222 333333333 444444444 555555555 666666666 777777777 ${(1,
+2)}`;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/binary.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/binary.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: binary.js
 ---
 # Input
@@ -40,9 +41,9 @@ room =
         ) => (
           (
             rowIndex === 0 ||
-              colIndex === 0 ||
-              rowIndex === height ||
-              colIndex === width
+            colIndex === 0 ||
+            rowIndex === height ||
+            colIndex === width
           ) ? 1 : 0
         ),
       )

--- a/crates/rome_js_formatter/tests/specs/prettier/js/throw_statement/binaryish.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/throw_statement/binaryish.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: binaryish.js
 ---
 # Input
@@ -35,13 +36,13 @@ function f() {
 function f() {
   throw (
     property.isIdentifier() &&
-      FUNCTIONS[property.node.name] &&
-      (
-        object.isIdentifier(
-          JEST_GLOBAL,
-        ) || (callee.isMemberExpression() && shouldHoistExpression(object))
-      ) &&
-      FUNCTIONS[property.node.name](expr.get("arguments"))
+    FUNCTIONS[property.node.name] &&
+    (
+      object.isIdentifier(
+        JEST_GLOBAL,
+      ) || (callee.isMemberExpression() && shouldHoistExpression(object))
+    ) &&
+    FUNCTIONS[property.node.name](expr.get("arguments"))
   );
 
   throw chalk.bold(

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/private-fields-in-in/basic.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/private-fields-in-in/basic.ts.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 182
 expression: basic.ts
-
 ---
 # Input
 ```js
@@ -35,9 +34,9 @@ class Person {
   equals(other: unknown) {
     return (
       other &&
-        typeof other === "object" &&
-        (#name in other) && // <- this is new!
-        this.#name === other.#name
+      typeof other === "object" &&
+      (#name in other) && // <- this is new!
+      this.#name === other.#name
     );
   }
 }


### PR DESCRIPTION
## Summary

This PR increases Prettier alignment by:
- Preventing binary expressions and sequence expressions from adding indentation when parenthesized
- Preventing sequence expressions from being soft block indented when parenthesized except for when they're a return argument or a unary operand.

Closes #2427

TODO: This introduces a `check_reformat` instability for `binaryish_expression` and `logical_expression` that I still need to troubleshoot.

## Test Plan

Confirm snapshots move closer to Prettier output.
