### PR TITLE
docs(formatter): fix some mistakes in doc comments

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -495,7 +495,7 @@ pub trait FormatRule<T> {
 /// ## Examples
 ///
 /// This can be useful if you want to format a `SyntaxNode` inside rome_formatter.. `SyntaxNode` doesn't implement [Format]
-/// itself but the language agnostic crate implements `AsFormat` and `IntoFormat` for it and the returned [Format]
+/// itself but the language specific crate implements `AsFormat` and `IntoFormat` for it and the returned [Format]
 /// implement [FormatWithRule].
 ///
 /// ```

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -37,7 +37,7 @@ pub trait AsFormat<'a> {
     fn format(&'a self) -> Self::Format;
 }
 
-/// Implement [AsFormat] for all types that have an associated [FormatRule].
+/// Implement [AsFormat] for references to types that implement [AsFormat].
 impl<'a, T> AsFormat<'a> for &'a T
 where
     T: AsFormat<'a>,
@@ -100,7 +100,7 @@ where
     }
 }
 
-/// Implement [AsFormat] for [Option] when `T` implements [AsFormat]
+/// Implement [IntoFormat] for [Option] when `T` implements [IntoFormat]
 ///
 /// Allows to call format on optional AST fields without having to unwrap the field first.
 impl<T> IntoFormat for Option<T>


### PR DESCRIPTION
## Summary

Fixes some (presumed) mistakes in doc comments for the formatter. 
