### PR TITLE
refactor(formatter): Change binary like expression to format left to right

### DIFF
--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -212,6 +212,8 @@ fn needs_parens(
     Ok(result)
 }
 
+// False positive, Removing the `+ 'a` lifetime fails to compile with `hidden type for `impl Trait` captures lifetime that does not appear in bounds`
+#[allow(clippy::needless_lifetimes)]
 fn format_sub_expression<'a>(
     parent_operator: BinaryLikeOperator,
     sub_expression: &'a JsAnyBinaryLikeLeftExpression,


### PR DESCRIPTION
## Summary

Refactors the binary like expression formatting to lazily write the expressions rather than allocating vectors with the sub results. 

The basic idea remains the same. The implementation flattens an expression. What's different to before is that this is now a two-stage process:

1. Flatten the binary expression  and specify for each "part" how it should be formatted (left, right, or a group)
2. Format the flattened expressions 

I think this also improves readability because it makes it clear what concepts exist in this algorithm (left hand side, right hand side, and a sub-group). 

## Test Plan

`cargo test`
