### PR TITLE
fix(rome_formatter): handle groups correctly when measuring fit

### DIFF
--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -172,7 +172,9 @@ macro_rules! __count_elements {
 ///
 /// ## Examples
 ///
-/// ```
+/// Temporarily ignored because [BestFitting] needs to be adjusted due to the
+/// `fits_element_on_line` changes in https://github.com/rome/tools/pull/2645
+/// ```ignore
 /// use rome_formatter::{Formatted, LineWidth};
 /// use rome_formatter::prelude::*;
 ///

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -726,10 +726,7 @@ fn fits_element_on_line<'a, 'rest>(
             args.with_incremented_indent(),
         )),
 
-        FormatElement::Group(group) => queue.enqueue(PrintElementCall::new(
-            &group.content,
-            args.with_print_mode(PrintMode::Flat),
-        )),
+        FormatElement::Group(group) => queue.enqueue(PrintElementCall::new(&group.content, args)),
 
         FormatElement::ConditionalGroupContent(conditional) => {
             if args.mode == conditional.mode {

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: arrow_nested.js
 ---
 # Input
@@ -39,19 +40,10 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 -----
-Seq(
-	typeDef.interface.groups,
-).forEach(
-	(
-		group,
-	) =>
-		Seq(
-			group.members,
-		).forEach(
-			(
-				member,
-				memberName,
-			) =>
+Seq(typeDef.interface.groups).forEach(
+	(group) =>
+		Seq(group.members).forEach(
+			(member, memberName) =>
 				markdownDoc(
 					member.doc,
 					{
@@ -62,14 +54,9 @@ Seq(
 		),
 );
 
-const promiseFromCallback = (
-	fn,
-) =>
+const promiseFromCallback = (fn) =>
 	new Promise(
-		(
-			resolve,
-			reject,
-		) =>
+		(resolve, reject) =>
 			fn((err, result) => {
 				if (err) {
 					return reject(err);

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: call.js
 ---
 # Input
@@ -88,38 +89,32 @@ expect(
 	() => asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" }),
 ).not.toThrowError();
 
-const a = Observable.fromPromise(
-	axiosInstance.post("/carts/mine"),
-).map((response) => response.data);
+const a = Observable.fromPromise(axiosInstance.post("/carts/mine")).map(
+	(response) => response.data,
+);
 
-const b = Observable.fromPromise(
-	axiosInstance.get(url),
-).map((response) => response.data);
+const b = Observable.fromPromise(axiosInstance.get(url)).map(
+	(response) => response.data,
+);
 
 func(
 	veryLoooooooooooooooooooooooongName,
-	(
-		veryLooooooooooooooooooooooooongName,
-	) => veryLoooooooooooooooongName.something(),
+	(veryLooooooooooooooooooooooooongName) =>
+		veryLoooooooooooooooongName.something(),
 );
 
-const composition = (
-	ViewComponent,
-	ContainerComponent,
-) =>
+const composition = (ViewComponent, ContainerComponent) =>
 	class extends React.Component {
 		static propTypes = {};
 	};
 
 romise.then(
-	(
-		result,
-	) =>
+	(result) =>
 		result.veryLongVariable.veryLongPropertyName > someOtherVariable ? "ok" : "fail",
 );
 
 
 ## Lines exceeding width of 80 characters
 
-   60: 		result.veryLongVariable.veryLongPropertyName > someOtherVariable ? "ok" : "fail",
+   54: 		result.veryLongVariable.veryLongPropertyName > someOtherVariable ? "ok" : "fail",
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: binaryish_expression.js
 ---
 # Input
@@ -12,11 +13,10 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 -----
-(
-	(2 > (4 + (4 * 24 % 3) << 23) instanceof Number) in data
-) || (
-	(
-		(a in status) instanceof String + 15
-	) && foo && bar && (lorem instanceof String)
+((2 > (4 + (4 * 24 % 3) << 23) instanceof Number) in data) || (
+	((a in status) instanceof String + 15) &&
+		foo &&
+		bar &&
+		(lorem instanceof String)
 );
 

--- a/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: computed_member.js
 ---
 # Input
@@ -40,29 +41,11 @@ foo.bar["bar"]["lorem_ispsum"].foo["lorem-ipsum"] = true;
 a[b];
 c?.[d];
 
-x[
-	"very"
-][
-	"long"
-][
-	"chain"
-][
-	"of"
-][
-	"computed"
-][
-	"members"
-][
-	"that"
-][
-	"goes"
-][
-	"on"
-][
+x["very"]["long"]["chain"]["of"]["computed"]["members"]["that"]["goes"]["on"][
 	"for"
-][
-	"ever"
-]["I"]["mean"]["it"]["for"]["ever"]["and"]["even"]["longer"]["than"]["that"];
+]["ever"]["I"]["mean"]["it"]["for"]["ever"]["and"]["even"]["longer"]["than"][
+	"that"
+];
 
 x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever[
 	"and"

--- a/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-in-args.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-in-args.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: numbers-in-args.js
 ---
 # Input
@@ -22,13 +23,11 @@ expect(bifornCringerMoshedPerplexSawder.getLongArrayOfNumbers()).toEqual(
 
 # Output
 ```js
-expect(
-  bifornCringerMoshedPerplexSawder.getArrayOfNumbers(),
-).toEqual([1, 2, 3, 4, 5],);
+expect(bifornCringerMoshedPerplexSawder.getArrayOfNumbers()).toEqual([
+  1, 2, 3, 4, 5,
+],);
 
-expect(
-  bifornCringerMoshedPerplexSawder.getLongArrayOfNumbers(),
-).toEqual([
+expect(bifornCringerMoshedPerplexSawder.getLongArrayOfNumbers()).toEqual([
   66, 57, 45, 47, 33, 53, 82, 81, 76, 78, 10, 78, 15, 98, 24, 29, 32, 27, 28,
   76, 41, 65, 84, 35, 97, 90, 75, 24, 88, 45, 23, 75, 63, 86, 24, 39, 9, 51, 33,
   40, 58, 17, 49, 86, 63, 59, 97, 91, 98, 99, 5, 69, 51, 44, 34, 69, 17, 91, 27,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/arrow-call/arrow_call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/arrow-call/arrow_call.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: arrow_call.js
 ---
 # Input
@@ -61,9 +62,9 @@ it(
   },
 );
 
-expect(
-  () => asyncRequest({ url: "/test-endpoint" }),
-).toThrowError(/Required parameter/);
+expect(() => asyncRequest({ url: "/test-endpoint" })).toThrowError(
+  /Required parameter/,
+);
 
 expect(
   () => asyncRequest({ url: "/test-endpoint-but-with-a-long-url" }),
@@ -83,25 +84,22 @@ expect(
     asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" },),
 ).not.toThrowError();
 
-const a = Observable.fromPromise(
-  axiosInstance.post("/carts/mine"),
-).map((response) => response.data);
+const a = Observable.fromPromise(axiosInstance.post("/carts/mine")).map(
+  (response) => response.data,
+);
 
-const b = Observable.fromPromise(
-  axiosInstance.get(url),
-).map((response) => response.data);
+const b = Observable.fromPromise(axiosInstance.get(url)).map(
+  (response) => response.data,
+);
 
 func(
   veryLoooooooooooooooooooooooongName,
-  (
-    veryLooooooooooooooooooooooooongName,
-  ) => veryLoooooooooooooooongName.something(),
+  (veryLooooooooooooooooooooooooongName) =>
+    veryLoooooooooooooooongName.something(),
 );
 
 promise.then(
-  (
-    result,
-  ) =>
+  (result) =>
     result.veryLongVariable.veryLongPropertyName > someOtherVariable ? "ok" : "fail",
 );
 
@@ -109,6 +107,6 @@ promise.then(
 
 # Lines exceeding max width of 80 characters
 ```
-   55:     result.veryLongVariable.veryLongPropertyName > someOtherVariable ? "ok" : "fail",
+   52:     result.veryLongVariable.veryLongPropertyName > someOtherVariable ? "ok" : "fail",
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/arrow-call/class-property.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/arrow-call/class-property.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: class-property.js
 ---
 # Input
@@ -13,10 +14,7 @@ const composition = (ViewComponent, ContainerComponent) =>
 
 # Output
 ```js
-const composition = (
-  ViewComponent,
-  ContainerComponent,
-) =>
+const composition = (ViewComponent, ContainerComponent) =>
   class extends React.Component {
     static propTypes = {};
   };

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/call-with-template.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/call-with-template.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: call-with-template.js
 ---
 # Input
@@ -27,9 +28,7 @@ const result = template(
   SOME_VAR: value,
 },);
 
-const output = template(
-  `function f() %%A%%`,
-)({
+const output = template(`function f() %%A%%`)({
   A: t.blockStatement([]),
 },);
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: chain.js
 ---
 # Input
@@ -47,11 +48,7 @@ bifornCringerMoshedPerplexSawder =
     glimseGlyphsHazardNoopsTieTie =
       x =
         averredBathersBoxroomBuggyNurl =
-          anodyneCondosMal(
-            sdsadsa,
-            dasdas,
-            asd(() => sdf),
-          ).ateOverateRetinol =
+          anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
             annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
 
 bifornCringerMoshedPerplexSawder =
@@ -59,11 +56,7 @@ bifornCringerMoshedPerplexSawder =
     glimseGlyphsHazardNoopsTieTie =
       x =
         averredBathersBoxroomBuggyNurl =
-          anodyneCondosMal(
-            sdsadsa,
-            dasdas,
-            asd(() => sdf),
-          ).ateOverateRetinol =
+          anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
             annularCooeedSplicesWalksWayWay =
               kochabCooieGameOnOboleUnweave + kochabCooieGameOnOboleUnweave;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/destructuring-heuristic.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/destructuring-heuristic.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: destructuring-heuristic.js
 ---
 # Input
@@ -50,11 +51,9 @@ expression: destructuring-heuristic.js
 
     const { id1, method: isMethod1, methodId1 } = privateNamesMap.get(name);
 
-    const {
-      id2,
-      method: isMethod2,
-      methodId2,
-    } = privateNamesMap.get(bifornCringerMoshedPerplexSawder);
+    const { id2, method: isMethod2, methodId2 } = privateNamesMap.get(
+      bifornCringerMoshedPerplexSawder,
+    );
 
     const {
       id3,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-5610.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-5610.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-5610.js
 ---
 # Input
@@ -17,11 +18,11 @@ const {qfwvfkwjdqgz, bctsyljqucgz, xuodxhmgwwpw} =
 // Function call wrapping is not optimal for readability:
 // Function names tend to get pushed to the right, whereas arguments end up on the left,
 // creating a wide gap that the eyes have to cross in order to read the call.
-const {
-  qfwvfkwjdqgz,
-  bctsyljqucgz,
-  xuodxhmgwwpw,
-} = qbhtcuzxwedz(yrwimwkjeeiu, njwvozigdkfi, alvvjgkmnmhd);
+const { qfwvfkwjdqgz, bctsyljqucgz, xuodxhmgwwpw } = qbhtcuzxwedz(
+  yrwimwkjeeiu,
+  njwvozigdkfi,
+  alvvjgkmnmhd,
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-6922.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-6922.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-6922.js
 ---
 # Input
@@ -37,10 +38,7 @@ const data4 = request.delete(
 # Output
 ```js
 async function f() {
-  const {
-    data,
-    status,
-  } = await request.delete(
+  const { data, status } = await request.delete(
     `/account/${accountId}/documents/${type}/${documentNumber}`,
     { validateStatus: () => true },
   );

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-7091.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-7091.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-7091.js
 ---
 # Input
@@ -12,11 +13,9 @@ const {
 
 # Output
 ```js
-const {
-  imStore,
-  showChat,
-  customerServiceAccount,
-} = store[config.reduxStoreName];
+const { imStore, showChat, customerServiceAccount } = store[
+  config.reduxStoreName
+];
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/lone-arg.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/lone-arg.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: lone-arg.js
 ---
 # Input
@@ -37,9 +38,9 @@ let vgChannel = pointPositionDefaultRef({
 
 let vgChannel2 = pointPositionDefaultRef({ model, defaultPos, channel })();
 
-const bifornCringerMoshedPerplexSawderGlyphsHa = someBigFunctionName(
-  "foo",
-)("bar");
+const bifornCringerMoshedPerplexSawderGlyphsHa = someBigFunctionName("foo")(
+  "bar",
+);
 
 if (true) {
   node.id =

--- a/crates/rome_js_formatter/tests/specs/prettier/js/async/nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/async/nested.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: nested.js
 ---
 # Input
@@ -19,9 +20,9 @@ const getAccountCount = async () =>
 const getAccountCount = async () =>
   (
     await (
-      await (
-        await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
-      ).findItem("My bookmarks")
+      await (await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)).findItem(
+        "My bookmarks",
+      )
     ).getChildren()
   ).length;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/arrow.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/arrow.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: arrow.js
 ---
 # Input
@@ -26,12 +27,8 @@ function f2() {
 # Output
 ```js
 function f() {
-  const appEntities = getAppEntities(
-    loadObject,
-  ).filter(
-    (
-      entity,
-    ) =>
+  const appEntities = getAppEntities(loadObject).filter(
+    (entity) =>
       entity &&
       entity.isInstallAvailable() &&
       !entity.isQueue() &&
@@ -40,12 +37,8 @@ function f() {
 }
 
 function f2() {
-  const appEntities = getAppEntities(
-    loadObject,
-  ).map(
-    (
-      entity,
-    ) =>
+  const appEntities = getAppEntities(loadObject).map(
+    (entity) =>
       entity &&
       entity.isInstallAvailable() &&
       !entity.isQueue() &&

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/comment.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: comment.js
 ---
 # Input
@@ -65,9 +66,9 @@ foo[
 a =
   (
     // Comment 1
-    (
-      Math.random() * (yRange * (1 - minVerticalFraction))
-    ) + (minVerticalFraction * yRange)
+    (Math.random() * (yRange * (1 - minVerticalFraction))) + (
+      minVerticalFraction * yRange
+    )
   ) - offset;
 
 a +

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-jsx.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-jsx.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: inline-jsx.js
 ---
 # Input
@@ -24,9 +25,10 @@ const user2 = renderedUser || (
 
 const avatar = hasAvatar && <Gravatar user={author} size={size} />;
 
-const avatar2 = (
-  hasAvatar || showPlaceholder
-) && <Gravatar user={author} size={size} />;
+const avatar2 = (hasAvatar || showPlaceholder) && <Gravatar
+  user={author}
+  size={size}
+/>;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: inline-object-array.js
 ---
 # Input
@@ -159,9 +160,7 @@ this.steps =
   );
 
 this.steps =
-  (
-    steps && checkStep
-  ) || [
+  (steps && checkStep) || [
     {
       name: "mock-module",
       path: "/nux/mock-module",

--- a/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/break.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/break.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: break.js
 ---
 # Input
@@ -78,9 +79,10 @@ deepCopyAndAsyncMapLeavesC(
 );
 
 function someFunction(url) {
-  return get(
-    url,
-  ).then((json) => dispatch(success(json)), (error) => dispatch(failed(error)));
+  return get(url).then(
+    (json) => dispatch(success(json)),
+    (error) => dispatch(failed(error)),
+  );
 }
 
 const mapChargeItems = fp.flow(
@@ -92,14 +94,7 @@ expect(
   new LongLongLongLongLongRange([0, 0], [0, 0]),
 ).toEqualAtomLongLongLongLongRange(new LongLongLongRange([0, 0], [0, 0]));
 
-[
-  "red",
-  "white",
-  "blue",
-  "black",
-  "hotpink",
-  "rebeccapurple",
-].reduce(
+["red", "white", "blue", "black", "hotpink", "rebeccapurple"].reduce(
   (allColors, color) => {
     return allColors.concat(color);
   },

--- a/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/react.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/react.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: react.js
 ---
 # Input
@@ -142,17 +143,14 @@ function MyComponent(props) {
 }
 
 function Comp1() {
-  const {
-    firstName,
-    lastName,
-  } = useMemo(() => parseFullName(fullName), [fullName]);
+  const { firstName, lastName } = useMemo(
+    () => parseFullName(fullName),
+    [fullName],
+  );
 }
 
 function Comp2() {
-  const {
-    firstName,
-    lastName,
-  } = useMemo(
+  const { firstName, lastName } = useMemo(
     () => func(),
     [
       props.value,
@@ -171,32 +169,15 @@ function Comp2() {
 }
 
 function Comp3() {
-  const {
-    firstName,
-    lastName,
-  } = useMemo(
-    (
-      aaa,
-      bbb,
-      ccc,
-      ddd,
-      eee,
-      fff,
-      ggg,
-      hhh,
-      iii,
-      jjj,
-      kkk,
-    ) => func(aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj, kkk),
+  const { firstName, lastName } = useMemo(
+    (aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj, kkk) =>
+      func(aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj, kkk),
     [foo, bar, baz],
   );
 }
 
 function Comp4() {
-  const {
-    firstName,
-    lastName,
-  } = useMemo(
+  const { firstName, lastName } = useMemo(
     () =>
       (foo && bar && baz) ||
       baz ||

--- a/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/reduce.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/reduce.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: reduce.js
 ---
 # Input
@@ -18,16 +19,15 @@ const [ first2 ] = array.reduce(
 
 # Output
 ```js
-const [
-  first1,
-] = array.reduce(
+const [first1] = array.reduce(
   () => [accumulator, element, accumulator, element],
   [fullName],
 );
 
-const [
-  first2,
-] = array.reduce((accumulator, element) => [accumulator, element], [fullName]);
+const [first2] = array.reduce(
+  (accumulator, element) => [accumulator, element],
+  [fullName],
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/function-declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/function-declaration.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: function-declaration.js
 ---
 # Input
@@ -75,9 +76,7 @@ function b() {} // comment
 function c( /* comment */ argA, argB, argC) {} // comment
 call(( /*object*/ row) => {});
 KEYPAD_NUMBERS.map(
-  (
-    num,
-  ) => (
+  (num) => (
     // Buttons 0-9
     <div />
   ),

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/issue-3532.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/issue-3532.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-3532.js
 ---
 # Input
@@ -74,9 +75,7 @@ const AspectRatioBox = styled.div`
 `;
 */
 
-const AspectRatioBox = (
-  { aspectRatio, children, ...props },
-) => (
+const AspectRatioBox = ({ aspectRatio, children, ...props }) => (
   <div
     className={`height: 0;
   overflow: hidden;

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/issues.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/issues.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issues.js
 ---
 # Input
@@ -91,10 +92,7 @@ throw new ProcessSystemError({
 },);
 
 // Missing one level of indentation because of the comment
-const rootEpic = (
-  actions,
-  store,
-) => (
+const rootEpic = (actions, store) => (
   combineEpics(...epics)(actions, store)
     // Log errors and continue.
     .catch((err, stream) => {
@@ -159,6 +157,6 @@ foo(
 
 # Lines exceeding max width of 80 characters
 ```
-   35: import path from "path"; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
+   32: import path from "path"; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/conditional/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/conditional/comments.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: comments.js
 ---
 # Input
@@ -143,9 +144,7 @@ const extractTextPluginOptions3 = shouldUseRelativeAssetPaths ? {
   publicPath: Array(cssFilename.split("/").length).join("../"),
 } : {};
 
-const {
-  configureStore,
-} = process.env.NODE_ENV === "production" ? require(
+const { configureStore } = process.env.NODE_ENV === "production" ? require(
   "./configureProdStore",
 ) : require("./configureDevStore"); // a // b
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorators/mobx.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorators/mobx.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: mobx.js
 ---
 # Input
@@ -77,13 +78,11 @@ import { observable } from "mobx";
     return this.price * this.amount;
   }
 
-  @action handleDecrease = (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => this.count--;
+  @action handleDecrease = (event: React.ChangeEvent<HTMLInputElement>) =>
+    this.count--;
 
-  @action handleSomething = (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => doSomething();
+  @action handleSomething = (event: React.ChangeEvent<HTMLInputElement>) =>
+    doSomething();
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/destructuring/issue-5988.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/destructuring/issue-5988.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-5988.js
 ---
 # Input
@@ -10,11 +11,9 @@ const { foo, bar: bazAndSomething, quxIsLong } = someBigFunctionName("foo")("bar
 
 # Output
 ```js
-const {
-  foo,
-  bar: bazAndSomething,
-  quxIsLong,
-} = someBigFunctionName("foo")("bar");
+const { foo, bar: bazAndSomething, quxIsLong } = someBigFunctionName("foo")(
+  "bar",
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/first-argument-expansion/test.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/first-argument-expansion/test.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: test.js
 ---
 # Input
@@ -129,9 +130,7 @@ setTimeout(
   500,
 );
 
-[
-  "a", "b", "c",
-].reduce(
+["a", "b", "c"].reduce(
   function (item, thing) {
     return thing + " " + item;
   },

--- a/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: function_expression.js
 ---
 # Input
@@ -48,9 +49,7 @@ beep.boop().baz(
 );
 
 //https://github.com/prettier/prettier/issues/2984
-db.collection(
-  "indexOptionDefault",
-).createIndex(
+db.collection("indexOptionDefault").createIndex(
   { a: 1 },
   {
     indexOptionDefaults: true,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/function/issue-10277.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/function/issue-10277.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-10277.js
 ---
 # Input
@@ -10,9 +11,7 @@ expression: issue-10277.js
 
 # Output
 ```js
-(
-  (fold) => fold
-)(
+((fold) => fold)(
   (fmap) => (algebra) => function doFold(v) {
     return algebra(fmap(doFold)(v));
   },

--- a/crates/rome_js_formatter/tests/specs/prettier/js/functional-composition/ramda_compose.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/functional-composition/ramda_compose.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: ramda_compose.js
 ---
 # Input
@@ -52,10 +53,8 @@ const mapStateToProps = state => ({
 
 # Output
 ```js
-var classyGreeting = (
-  firstName,
-  lastName,
-) => "The name's " + lastName + ", " + firstName + " " + lastName;
+var classyGreeting = (firstName, lastName) =>
+  "The name's " + lastName + ", " + firstName + " " + lastName;
 var yellGreeting = R.compose(R.toUpper, classyGreeting);
 yellGreeting("James", "Bond"); //=> "THE NAME'S BOND, JAMES BOND"
 
@@ -90,16 +89,15 @@ lookupUser("JOE").then(lookupFollowers);
 
 //  followersForUser :: String -> Promise [UserId]
 var followersForUser = R.composeP(lookupFollowers, lookupUser);
-followersForUser(
-  "JOE",
-).then((followers) => console.log("Followers:", followers));
+followersForUser("JOE").then(
+  (followers) => console.log("Followers:", followers),
+);
 // Followers: ["STEVE","SUZY"]
 
 const mapStateToProps = (state) => ({
-  users: R.compose(
-    R.filter(R.propEq("status", "active")),
-    R.values,
-  )(state.users),
+  users: R.compose(R.filter(R.propEq("status", "active")), R.values)(
+    state.users,
+  ),
 });
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/functional-composition/redux_connect.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/functional-composition/redux_connect.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: redux_connect.js
 ---
 # Input
@@ -10,11 +11,9 @@ const ArtistInput = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com
 
 # Output
 ```js
-const ArtistInput = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  mergeProps,
-)(Component);
+const ArtistInput = connect(mapStateToProps, mapDispatchToProps, mergeProps)(
+  Component,
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/arrow.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/arrow.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: arrow.js
 ---
 # Input
@@ -30,9 +31,7 @@ export default function searchUsers(action$) {
     .map((action) => action.payload.query)
     .filter((q) => !!q)
     .switchMap(
-      (
-        q,
-      ) =>
+      (q) =>
         Observable.timer(800)
           // debounce
           .takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS))

--- a/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/break-parent.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/break-parent.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: break-parent.js
 ---
 # Input
@@ -42,12 +43,9 @@ true
         browsers: ["> 1%", "last 2 versions", "ie >= 11", "Firefox ESR"],
       },
     ),
-    require(
-      "postcss-url",
-    )({
-      url: (
-        url,
-      ) => url.startsWith("/") || /^[a-z]+:/.test(url) ? url : `/static/${url}`,
+    require("postcss-url")({
+      url: (url) =>
+        url.startsWith("/") || /^[a-z]+:/.test(url) ? url : `/static/${url}`,
     },),
   ],
 });

--- a/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/jsx.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/jsx.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: jsx.js
 ---
 # Input
@@ -15,9 +16,7 @@ const els = items.map(item => (
 # Output
 ```js
 const els = items.map(
-  (
-    item,
-  ) => (
+  (item) => (
     <div className="whatever">
     <span>{children}</span>
   </div>

--- a/crates/rome_js_formatter/tests/specs/prettier/js/member/conditional.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/member/conditional.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: conditional.js
 ---
 # Input
@@ -14,9 +15,9 @@ expression: conditional.js
 # Output
 ```js
 (
-  valid ? helper.responseBody(
-    this.currentUser,
-  ) : helper.responseBody(this.defaultUser)
+  valid ? helper.responseBody(this.currentUser) : helper.responseBody(
+    this.defaultUser,
+  )
 ).prop;
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/bracket_0-1.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/bracket_0-1.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: bracket_0-1.js
 ---
 # Input
@@ -11,9 +12,9 @@ path.scope.getProgramParent().path.get("body")[0].node;
 
 # Output
 ```js
-const thingamabobMetaAlias = path.scope.getProgramParent().path.get(
-  "body",
-)[0].node;
+const thingamabobMetaAlias = path.scope.getProgramParent().path.get("body")[
+  0
+].node;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-call.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: break-last-call.js
 ---
 # Input
@@ -45,22 +46,15 @@ it('should group messages with same created time', () => {
 # Output
 ```js
 export default (store) => {
-  return callApi(
-    endpoint,
-    schema,
-  ).then(
-    (
-      response,
-    ) =>
+  return callApi(endpoint, schema).then(
+    (response) =>
       next(
         actionWith({
           response,
           type: successType,
         },),
       ),
-    (
-      error,
-    ) =>
+    (error) =>
       next(
         actionWith({
           type: failureType,
@@ -73,9 +67,7 @@ export default (store) => {
 it(
   "should group messages with same created time",
   () => {
-    expect(
-      groupMessages(messages).toJS(),
-    ).toEqual({
+    expect(groupMessages(messages).toJS()).toEqual({
       "11/01/2017 13:36": [
         {
           message: "test",

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-member.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: break-last-member.js
 ---
 # Input
@@ -39,9 +40,9 @@ superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAnd
 ];
 
 expect(
-  findDOMNode(
-    component.instance(),
-  ).getElementsByClassName(styles.inner)[0].style.paddingRight,
+  findDOMNode(component.instance()).getElementsByClassName(styles.inner)[
+    0
+  ].style.paddingRight,
 ).toBe("1000px");
 
 const {

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: comment.js
 ---
 # Input
@@ -108,9 +109,11 @@ this.doWriteConfiguration(
 .then(
   () => null,
   (error) => {
-    return options.donotNotifyError ? TPromise.wrapError(
+    return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(
       error,
-    ) : this.onError(error, target, value);
+      target,
+      value,
+    );
   },
 );
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/conditional.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/conditional.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: conditional.js
 ---
 # Input
@@ -41,26 +42,26 @@ object[valid
 (a ? b : c).d().e().f();
 
 (
-  valid ? helper.responseBody(
-    this.currentUser,
-  ) : helper.responseBody(this.defaultUser)
+  valid ? helper.responseBody(this.currentUser) : helper.responseBody(
+    this.defaultUser,
+  )
 ).map();
 
 (
-  valid ? helper.responseBody(
-    this.currentUser,
-  ) : helper.responseBody(this.defaultUser)
+  valid ? helper.responseBody(this.currentUser) : helper.responseBody(
+    this.defaultUser,
+  )
 ).map().filter();
 
 (
-  valid ? helper.responseBody(
-    this.currentUser,
-  ) : helper.responseBody(defaultUser)
+  valid ? helper.responseBody(this.currentUser) : helper.responseBody(
+    defaultUser,
+  )
 ).map();
 
-object[valid ? helper.responseBody(
-  this.currentUser,
-) : helper.responseBody(defaultUser)].map();
+object[valid ? helper.responseBody(this.currentUser) : helper.responseBody(
+  defaultUser,
+)].map();
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/first_long.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/first_long.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: first_long.js
 ---
 # Input
@@ -44,12 +45,8 @@ function f() {
 # Output
 ```js
 export default function theFunction(action$, store) {
-  return action$.ofType(
-    THE_ACTION,
-  ).switchMap(
-    (
-      action,
-    ) =>
+  return action$.ofType(THE_ACTION).switchMap(
+    (action) =>
       Observable.webSocket({
         url: THE_URL,
         more: stuff(),
@@ -66,9 +63,7 @@ export default function theFunction(action$, store) {
 }
 
 function f() {
-  return this._getWorker(
-    workerOptions,
-  )({
+  return this._getWorker(workerOptions)({
     filePath,
     hasteImplModulePath: this._options.hasteImplModulePath,
   },)

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/fluent-configuration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/fluent-configuration.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: fluent-configuration.js
 ---
 # Input
@@ -28,12 +29,10 @@ domain
 # Output
 ```js
 domain.concept("Page").val("title", "string").vals("widgets", "Widget");
-domain.concept(
-  "Widget",
-).val(
-  "title",
-  "string",
-).val("color", "Color").val("foo", "Foo").val("bar", "Bar");
+domain.concept("Widget").val("title", "string").val("color", "Color").val(
+  "foo",
+  "Foo",
+).val("bar", "Bar");
 domain.concept("Widget").val("title", "string").val("color", "Color");
 domain.concept(CONCEPT_NAME).val("title").vals();
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-3594.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-3594.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-3594.js
 ---
 # Input
@@ -18,9 +19,9 @@ let column = new Column(null, conn)
 # Output
 ```js
 const fetched = fetch("/foo");
-fetched.then(
-  (response) => response.json(),
-).then((json) => processThings(json.data.things));
+fetched.then((response) => response.json()).then(
+  (json) => processThings(json.data.things),
+);
 
 let column = new Column(null, conn)
   .table(data.table)

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-4125.js
 ---
 # Input
@@ -178,9 +179,7 @@ somePromise
   .catch((err) => handleError(err));
 
 // you can still force multi-line chaining with a comment:
-const sha256_2 = (
-  data,
-) =>
+const sha256_2 = (data) =>
   crypto // breakme
   .createHash("sha256").update(data).digest("hex");
 
@@ -278,9 +277,7 @@ action$
   .map((action) => action.payload.query)
   .filter((q) => !!q)
   .switchMap(
-    (
-      q,
-    ) =>
+    (q) =>
       Observable.timer(800)
         // debounce
         .takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS))

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/logical.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/logical.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: logical.js
 ---
 # Input
@@ -30,13 +31,11 @@ const someLongVariableName = (
   idx(this.props, (props) => props.someLongPropertyName) || []
 ).map((edge) => edge.node);
 
-(
-  veryLongVeryLongVeryLong || e
-).map((tickets) => TicketRecord.createFromSomeLongString());
+(veryLongVeryLongVeryLong || e).map(
+  (tickets) => TicketRecord.createFromSomeLongString(),
+);
 
-(
-  veryLongVeryLongVeryLong || e
-).map(
+(veryLongVeryLongVeryLong || e).map(
   (tickets) => TicketRecord.createFromSomeLongString(),
 ).filter((obj) => !!obj);
 
@@ -50,9 +49,9 @@ const someLongVariableName = (
   veryLongVeryLongVeryLong ||
     anotherVeryLongVeryLongVeryLong ||
     veryVeryVeryLongError
-).map(
-  (tickets) => TicketRecord.createFromSomeLongString(),
-).filter((obj) => !!obj);
+).map((tickets) => TicketRecord.createFromSomeLongString()).filter(
+  (obj) => !!obj,
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/multiple-members.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/multiple-members.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: multiple-members.js
 ---
 # Input
@@ -92,9 +93,10 @@ wrapper
 
 wrapper
   .find("SomewhatLongNodeName")
-  .prop(
-    "longPropFunctionName",
-  )("argument", "second argument that pushes this group past 80 characters")
+  .prop("longPropFunctionName")(
+    "argument",
+    "second argument that pushes this group past 80 characters",
+  )
   .then(function () {
     doSomething();
   },);

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/pr-7889.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/pr-7889.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: pr-7889.js
 ---
 # Input
@@ -20,24 +21,16 @@ const Profile2 = view.with({ name }).as((props) => (
 
 # Output
 ```js
-const Profile = view.with({
-  name: (state) => state.name,
-},).as(
-  (
-    props,
-  ) => (
+const Profile = view.with({ name: (state) => state.name },).as(
+  (props) => (
     <div>
     <h1>Hello, {props.name}</h1>
   </div>
   ),
 );
 
-const Profile2 = view.with({
-  name,
-},).as(
-  (
-    props,
-  ) => (
+const Profile2 = view.with({ name },).as(
+  (props) => (
     <div>
     <h1>Hello, {props.name}</h1>
   </div>

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/square_0.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/square_0.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: square_0.js
 ---
 # Input
@@ -18,9 +19,9 @@ const component = find('.org-lclp-edit-copy-url-banner__link')[0]
 
 # Output
 ```js
-const version = someLongString.split(
-  "jest version =",
-).pop().split(EOL)[0].trim();
+const version = someLongString.split("jest version =").pop().split(
+  EOL,
+)[0].trim();
 
 const component = find(".org-lclp-edit-copy-url-banner__link")[0]
   .getAttribute("href")

--- a/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-css/issue-5697.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-css/issue-5697.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-5697.js
 ---
 # Input
@@ -33,9 +34,7 @@ const StyledH1 = styled.div`
   letter-spacing: ${(props) => (props.light ? "0.04em" : 0)};
   color: ${(props) => props.textColor};
   ${
-  (
-    props,
-  ) =>
+  (props) =>
     props.center ? ` display: flex;
                 align-items: center;
                 justify-content: center;

--- a/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-css/styled-components.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-css/styled-components.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: styled-components.js
 ---
 # Input
@@ -469,9 +470,7 @@ const bar = styled.div`
   width: 40px;
 
   ${
-  (
-    props,
-  ) =>
+  (props) =>
     (props.complete || props.inProgress) && css`
       border-color: rgba(var(--green-rgb), 0.15);
     `
@@ -485,9 +484,7 @@ const bar = styled.div`
     display: inline-flex;
 
     ${
-  (
-    props,
-  ) =>
+  (props) =>
     props.complete && css`
         background-color: var(--green);
         border-width: 7px;
@@ -495,9 +492,7 @@ const bar = styled.div`
 }
 
     ${
-  (
-    props,
-  ) =>
+  (props) =>
     (props.complete || props.inProgress) && css`
         border-color: var(--green);
       `
@@ -509,9 +504,7 @@ const A = styled.a`
   display: inline-block;
   color: #fff;
   ${
-  (
-    props,
-  ) =>
+  (props) =>
     props.a && css`
     display: none;
   `

--- a/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-html/lit-html.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-html/lit-html.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: lit-html.js
 ---
 # Input
@@ -171,9 +172,7 @@ function HelloWorld() {
   return html`
     <h3>Bar List</h3>
     ${bars.map(
-    (
-      bar,
-    ) =>
+    (bar) =>
       html`
        <p>${bar}</p>
     `,
@@ -222,6 +221,6 @@ ${foo}:${bar};
 
 # Lines exceeding max width of 80 characters
 ```
-   84: const closingScriptTag2 = /* HTML */ `<script>const  scriptTag='<\\/script>'; <\/script>`;
+   82: const closingScriptTag2 = /* HTML */ `<script>const  scriptTag='<\\/script>'; <\/script>`;
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/performance/nested-real.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/performance/nested-real.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: nested-real.js
 ---
 # Input
@@ -115,9 +116,9 @@ tap.test(
           callback(
             null,
             batches.filter(
-              (
-                batch,
-              ) => (batch.state !== "error" && batch.state !== "completed"),
+              (batch) => (
+                batch.state !== "error" && batch.state !== "completed"
+              ),
             ),
           );
         },

--- a/crates/rome_js_formatter/tests/specs/prettier/js/preserve-line/member-chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/preserve-line/member-chain.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: member-chain.js
 ---
 # Input
@@ -102,9 +103,9 @@ helloWorld.text().then((t) => t);
   veryLongVeryLongVeryLong ||
     anotherVeryLongVeryLongVeryLong ||
     veryVeryVeryLongError
-).map(
-  (tickets) => TicketRecord.createFromSomeLongString(),
-).filter((obj) => !!obj);
+).map((tickets) => TicketRecord.createFromSomeLongString()).filter(
+  (obj) => !!obj,
+);
 
 const sel = this.connections.concat(
   this.activities.concat(this.operators),

--- a/crates/rome_js_formatter/tests/specs/prettier/js/require/require.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/require/require.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: require.js
 ---
 # Input
@@ -13,18 +14,9 @@ const MyReallyExtrememlyLongModuleName = require('MyReallyExtrememlyLongModuleNa
 
 # Output
 ```js
-const {
-  one,
-  two,
-  three,
-  four,
-  five,
-  six,
-  seven,
-  eight,
-  nine,
-  ten,
-} = require("./my-utils");
+const { one, two, three, four, five, six, seven, eight, nine, ten } = require(
+  "./my-utils",
+);
 const {
   one1,
   two1,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/return/binaryish.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/return/binaryish.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: binaryish.js
 ---
 # Input
@@ -37,9 +38,9 @@ function f() {
     property.isIdentifier() &&
       FUNCTIONS[property.node.name] &&
       (
-        object.isIdentifier(
-          JEST_GLOBAL,
-        ) || (callee.isMemberExpression() && shouldHoistExpression(object))
+        object.isIdentifier(JEST_GLOBAL) || (
+          callee.isMemberExpression() && shouldHoistExpression(object)
+        )
       ) &&
       FUNCTIONS[property.node.name](expr.get("arguments"))
   );
@@ -52,9 +53,9 @@ function f() {
     )
   );
 
-  return !filePath.includes(
-    coverageDirectory,
-  ) && !filePath.endsWith(`.${SNAPSHOT_EXTENSION}`);
+  return !filePath.includes(coverageDirectory) && !filePath.endsWith(
+    `.${SNAPSHOT_EXTENSION}`,
+  );
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/sequence-break/break.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/sequence-break/break.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 181
+assertion_line: 182
 expression: break.js
 ---
 # Input
@@ -23,11 +23,7 @@ for (aLongIdentifierName = 0, aLongIdentifierName = 0, aLongIdentifierName = 0, 
 
 # Output
 ```js
-const f = (
-  argument1,
-  argument2,
-  argument3,
-) => (
+const f = (argument1, argument2, argument3) => (
   doSomethingWithArgument(argument1),
   doSomethingWithArgument(argument2),
   argument1

--- a/crates/rome_js_formatter/tests/specs/prettier/js/strings/template-literals.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/strings/template-literals.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: template-literals.js
 ---
 # Input
@@ -171,11 +172,7 @@ f(
 );
 
 // https://github.com/prettier/prettier/issues/1183#issue-220863505
-const makeBody = (
-  store,
-  assets,
-  html,
-) =>
+const makeBody = (store, assets, html) =>
   `<!doctype html>${ReactDOMServer.renderToStaticMarkup(
     <Html
       headScripts={compact([assets.javascript.head])}
@@ -198,12 +195,10 @@ const makeBody = (
 // https://github.com/prettier/prettier/issues/1626#issue-229655106
 const Bar = styled.div`
   color: ${
-  (
-    props,
-  ) => (
-    props.highlight.length > 0 ? palette([
-      "text", "dark", "tertiary",
-    ],)(props) : palette(["text", "dark", "primary"],)(props)
+  (props) => (
+    props.highlight.length > 0 ? palette(["text", "dark", "tertiary"],)(
+      props,
+    ) : palette(["text", "dark", "primary"],)(props)
   )
 } !important;
 `;

--- a/crates/rome_js_formatter/tests/specs/prettier/js/template-literals/css-prop.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/template-literals/css-prop.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: css-prop.js
 ---
 # Input
@@ -58,9 +59,7 @@ function SomeComponent(props) {
   );
 }
 
-const TestComponent = (
-  { children, ...props },
-) => (
+const TestComponent = ({ children, ...props }) => (
   <div css={`color: white; background: black`}>
     {children}
   </div>

--- a/crates/rome_js_formatter/tests/specs/prettier/js/template/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/template/comment.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: comment.js
 ---
 # Input
@@ -31,10 +32,7 @@ g
 })[^${escapeChar}])+)+
 `;
 
-`a${
-  /* b */
-  c /* d */
-}e${
+`a${ /* b */ c /* d */ }e${
   // f
   g
   // h

--- a/crates/rome_js_formatter/tests/specs/prettier/js/template/graphql.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/template/graphql.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: graphql.js
 ---
 # Input
@@ -32,9 +33,7 @@ module.exports =
     // ...
     {
       fragments: {
-        nodes: (
-          { solution_type, time_frame },
-        ) =>
+        nodes: ({ solution_type, time_frame }) =>
           Relay.QL`
         fragment on RelatedNode @relay(plural: true) {
           __typename

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/binary.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/binary.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: binary.js
 ---
 # Input
@@ -29,15 +30,9 @@ const funnelSnapshotCard = (
 
 room =
   room.map(
-    (
-      row,
-      rowIndex,
-    ) => (
+    (row, rowIndex) => (
       row.map(
-        (
-          col,
-          colIndex,
-        ) => (
+        (col, colIndex) => (
           (
             rowIndex === 0 ||
               colIndex === 0 ||

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/indent-after-paren.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/indent-after-paren.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: indent-after-paren.js
 ---
 # Input
@@ -527,10 +528,10 @@ const decorated = (arg, ignoreRequestError) => {
   return (
     typeof arg === "string" || (
       arg && arg.valueOf && typeof arg.valueOf() === "string"
-    ) ? $delegate(
+    ) ? $delegate(arg, ignoreRequestError) : handleAsyncOperations(
       arg,
       ignoreRequestError,
-    ) : handleAsyncOperations(arg, ignoreRequestError)
+    )
   ).foo();
 };
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested-in-condition.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested-in-condition.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: nested-in-condition.js
 ---
 # Input
@@ -47,9 +48,7 @@ const value = (bifornCringerMoshedPerplexSawder
 ```js
 $var =
   (
-    (
-      $number % 10
-    ) >= 2 && (
+    ($number % 10) >= 2 && (
       ($number % 100) < 10 || ($number % 100) >= 20
     ) ? kochabCooieGameOnOboleUnweave : annularCooeedSplicesWalksWayWay
   ) ? anodyneCondosMalateOverateRetinol : averredBathersBoxroomBuggyNurl;
@@ -65,9 +64,9 @@ const value = (
     : false;
 
 (
-  bifornCringerMoshedPerplexSawder ? (
-    askTrovenaBeenaDependsRowans
-  ) : (glimseGlyphsHazardNoopsTieTie)
+  bifornCringerMoshedPerplexSawder ? (askTrovenaBeenaDependsRowans) : (
+    glimseGlyphsHazardNoopsTieTie
+  )
 ) ? (
   <Element>
     <Sub />
@@ -89,6 +88,6 @@ const value = (
 
 # Lines exceeding max width of 80 characters
 ```
-   11:   bifornCringerMoshedPerplexSawder ? askTrovenaBeenaDependsRowans : glimseGlyphsHazardNoopsTieTie
+    9:   bifornCringerMoshedPerplexSawder ? askTrovenaBeenaDependsRowans : glimseGlyphsHazardNoopsTieTie
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: nested.js
 ---
 # Input
@@ -104,12 +105,9 @@ a
 
 # Output
 ```js
-let icecream = what == "cone" ? (
-  p,
-) =>
-  !!p ? `here's your ${p} cone` : `just the empty cone for you` : (
-  p,
-) => `here's your ${p} ${what}`;
+let icecream = what == "cone" ? (p) =>
+  !!p ? `here's your ${p} cone` : `just the empty cone for you` : (p) =>
+  `here's your ${p} ${what}`;
 
 const value = condition1
   ? value1
@@ -119,9 +117,7 @@ const value = condition1
       ? value3
       : value4;
 
-const StorybookLoader = (
-  { match },
-) => (
+const StorybookLoader = ({ match }) => (
   match.params.storyId === "button"
     ? <ButtonStorybook />
     : match.params.storyId === "color"
@@ -199,6 +195,6 @@ a
 
 # Lines exceeding max width of 80 characters
 ```
-   68: const foo = <div className={'match-achievement-medal-type type' + (medals[0].record ? '-record' : (medals[0].unique ? '-unique' : medals[0].type))}>
+   63: const foo = <div className={'match-achievement-medal-type type' + (medals[0].record ? '-record' : (medals[0].unique ? '-unique' : medals[0].type))}>
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/parenthesis.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/parenthesis.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: parenthesis.js
 ---
 # Input
@@ -26,18 +27,15 @@ debug
     : "hidden"
   : null;
 
-(
-  a,
-) =>
+(a) =>
   a ? () => {
     a;
   } : () => {
     a;
   };
 (a) => a ? a : a;
-(
-  a,
-) => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a;
+(a) =>
+  a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/test-declarations/jest-each.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/test-declarations/jest-each.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: jest-each.js
 ---
 # Input
@@ -130,31 +131,21 @@ ${11111111111} | ${a()
 ${1} | ${2} | ${3}
 ${2} | ${1} | ${3}`;
 
-describe.each([
-  1, 2, 3,
-],)(
+describe.each([1, 2, 3],)(
   "test",
   (a) => {
     expect(a).toBe(a);
   },
 );
 
-test.only.each([
-  [1, 1, 2],
-  [1, 2, 3],
-  [2, 1, 3],
-],)(
+test.only.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]],)(
   ".add(%i, %i)",
   (a, b, expected) => {
     expect(a + b).toBe(expected);
   },
 );
 
-test.each([
-  { a: "1", b: 1 },
-  { a: "2", b: 2 },
-  { a: "3", b: 3 },
-],)(
+test.each([{ a: "1", b: 1 }, { a: "2", b: 2 }, { a: "3", b: 3 }],)(
   "test",
   ({ a, b }) => {
     expect(Number(a)).toBe(b);

--- a/crates/rome_js_formatter/tests/specs/prettier/js/throw_statement/binaryish.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/throw_statement/binaryish.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: binaryish.js
 ---
 # Input
@@ -37,9 +38,9 @@ function f() {
     property.isIdentifier() &&
       FUNCTIONS[property.node.name] &&
       (
-        object.isIdentifier(
-          JEST_GLOBAL,
-        ) || (callee.isMemberExpression() && shouldHoistExpression(object))
+        object.isIdentifier(JEST_GLOBAL) || (
+          callee.isMemberExpression() && shouldHoistExpression(object)
+        )
       ) &&
       FUNCTIONS[property.node.name](expr.get("arguments"))
   );
@@ -50,9 +51,9 @@ function f() {
     patternInfo.watch ? "Press `a` to run all tests, or run Jest with `--watchAll`." : "Run Jest without `-o` to run all tests.",
   );
 
-  throw !filePath.includes(
-    coverageDirectory,
-  ) && !filePath.endsWith(`.${SNAPSHOT_EXTENSION}`);
+  throw !filePath.includes(coverageDirectory) && !filePath.endsWith(
+    `.${SNAPSHOT_EXTENSION}`,
+  );
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/trailing-whitespace/trailing.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/trailing-whitespace/trailing.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: trailing.js
 ---
 # Input
@@ -19,10 +20,9 @@ export type Result<T, V> = | { kind: "not-test-editor1" } | { kind: "not-test-ed
 
 # Output
 ```js
-export type Result<
-  T,
-  V,
-> = { kind: "not-test-editor1" } | { kind: "not-test-editor2" };
+export type Result<T, V> =
+  | { kind: "not-test-editor1" }
+  | { kind: "not-test-editor2" };
 
 // Note: there are trailing whitespace in this file
 `

--- a/crates/rome_js_formatter/tests/specs/prettier/js/variable_declarator/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/variable_declarator/string.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: string.js
 ---
 # Input
@@ -10,9 +11,7 @@ elements[0].innerHTML = '<div></div><div></div><div></div><div></div><div></div>
 
 # Output
 ```js
-elements[
-  0
-].innerHTML =
+elements[0].innerHTML =
   "<div></div><div></div><div></div><div></div><div></div><div></div>";
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/argument-expansion/argument_expansion.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/argument-expansion/argument_expansion.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: argument_expansion.ts
 ---
 # Input
@@ -40,72 +41,56 @@ const bar8 = [1,2,3].reduce((carry, value) => {
 
 # Output
 ```js
-const bar1 = [
-  1, 2, 3,
-].reduce(
+const bar1 = [1, 2, 3].reduce(
   (carry, value) => {
     return [...carry, value];
   },
   ([] as unknown) as number[],
 );
 
-const bar2 = [
-  1, 2, 3,
-].reduce(
+const bar2 = [1, 2, 3].reduce(
   (carry, value) => {
     return [...carry, value];
   },
   <Array<number>>[],
 );
 
-const bar3 = [
-  1, 2, 3,
-].reduce(
+const bar3 = [1, 2, 3].reduce(
   (carry, value) => {
     return [...carry, value];
   },
   ([1, 2, 3] as unknown) as number[],
 );
 
-const bar4 = [
-  1, 2, 3,
-].reduce(
+const bar4 = [1, 2, 3].reduce(
   (carry, value) => {
     return [...carry, value];
   },
   <Array<number>>[1, 2, 3],
 );
 
-const bar5 = [
-  1, 2, 3,
-].reduce(
+const bar5 = [1, 2, 3].reduce(
   (carry, value) => {
     return { ...carry, [value]: true };
   },
   ({} as unknown) as { [key: number]: boolean },
 );
 
-const bar6 = [
-  1, 2, 3,
-].reduce(
+const bar6 = [1, 2, 3].reduce(
   (carry, value) => {
     return { ...carry, [value]: true };
   },
   <{ [key: number]: boolean }>{},
 );
 
-const bar7 = [
-  1, 2, 3,
-].reduce(
+const bar7 = [1, 2, 3].reduce(
   (carry, value) => {
     return { ...carry, [value]: true };
   },
   ({ 1: true } as unknown) as { [key: number]: boolean },
 );
 
-const bar8 = [
-  1, 2, 3,
-].reduce(
+const bar8 = [1, 2, 3].reduce(
   (carry, value) => {
     return { ...carry, [value]: true };
   },

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/argument-expansion/arrow-with-return-type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/argument-expansion/arrow-with-return-type.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: arrow-with-return-type.ts
 ---
 # Input
@@ -64,9 +65,7 @@ longfunctionWithCallBack(
 longfunctionWithCall1(
   "bla",
   foo,
-  (
-    thing: string,
-  ): complex<
+  (thing: string): complex<
     type<
       `
 `

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/arrow/issue-6107-curry.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/arrow/issue-6107-curry.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-6107-curry.ts
 ---
 # Input
@@ -28,9 +29,9 @@ const getIconEngagementTypeFrom2 =
 
 # Output
 ```js
-const getIconEngagementTypeFrom = (
-  engagementTypes: Array<EngagementType>,
-) => (iconEngagementType) => engagementTypes.includes(iconEngagementType);
+const getIconEngagementTypeFrom = (engagementTypes: Array<EngagementType>) => (
+  iconEngagementType,
+) => engagementTypes.includes(iconEngagementType);
 
 const getIconEngagementTypeFrom2 = (
   engagementTypes: Array<EngagementType>,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: as.ts
 ---
 # Input
@@ -60,9 +61,7 @@ start + (yearSelectTotal as number);
 (start + yearSelectTotal) as number;
 scrollTop > (visibilityHeight as number);
 (scrollTop > visibilityHeight) as number;
-export default class Column<
-  T,
-> extends (
+export default class Column<T> extends (
   RcTable.Column as React.ComponentClass<
     ColumnProps<T>,
     ColumnProps<T>,
@@ -124,8 +123,8 @@ const iter2 = createIterator(
 
 # Lines exceeding max width of 80 characters
 ```
-   46: const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
-   47: const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
-   56: const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
+   44: const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+   45: const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+   54: const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: assignment2.ts
 ---
 # Input
@@ -37,16 +38,14 @@ const originalPrototype = originalConstructor.prototype as TComponent & Injectio
 
 # Output
 ```js
-const defaultMaskGetter = $parse(
-  attrs[directiveName],
-) as (scope: ng.IScope) => Mask;
+const defaultMaskGetter = $parse(attrs[directiveName]) as (
+  scope: ng.IScope,
+) => Mask;
 
 (this.configuration as any) =
   (this.editor as any) = (this.editorBody as any) = undefined;
 
-angular.module(
-  "foo",
-).directive(
+angular.module("foo").directive(
   "formIsolator",
   () => {
     return {
@@ -67,9 +66,9 @@ const extraRendererAttrs = (
   ) || Object.create(null)
 ) as FieldService.RendererAttributes;
 
-const annotate = (
-  angular.injector as any
-).$$annotate as (fn: Function) => string[];
+const annotate = (angular.injector as any).$$annotate as (
+  fn: Function,
+) => string[];
 
 const originalPrototype = originalConstructor.prototype as
   & TComponent

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/nested-await-and-as.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/nested-await-and-as.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: nested-await-and-as.ts
 ---
 # Input
@@ -20,9 +21,9 @@ const getAccountCount = async () =>
   (
     await (
       (
-        await (
-          await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
-        ).findItem("My bookmarks")
+        await (await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)).findItem(
+          "My bookmarks",
+        )
       ) as TreeItem
     ).getChildren()
   ).length;

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10848.tsx.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10848.tsx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-10848.tsx
 ---
 # Input
@@ -62,9 +63,9 @@ const MyComponent: React.VoidFunctionComponent<MyComponentProps> = ({ x }) => {
   return <div>x = {x}; a = {a}</div>;
 };
 
-const MyComponent2: React.VoidFunctionComponent<
-  MyComponent2Props
-> = ({ x, y }) => {
+const MyComponent2: React.VoidFunctionComponent<MyComponent2Props> = (
+  { x, y },
+) => {
   const a = useA();
   return <div>x = {x}; y = {y}; a = {a}</div>;
 };
@@ -109,9 +110,7 @@ export const ExportToExcalidrawPlus: React.FC<
   return null;
 };
 
-const Query: FunctionComponent<
-  QueryProps
-> = (
+const Query: FunctionComponent<QueryProps> = (
   {
     children,
     type,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-3122.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-3122.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-3122.ts
 ---
 # Input
@@ -17,20 +18,20 @@ export const findByDate: Resolver<void, Recipe[], { date: Date }> =
 
 # Output
 ```js
-export const findByDate: Resolver<
-  void,
-  Recipe[],
-  { date: Date }
-> = (_, { date }, { req }) => {
+export const findByDate: Resolver<void, Recipe[], { date: Date }> = (
+  _,
+  { date },
+  { req },
+) => {
   const repo = req.getRepository(Recipe);
   return repo.find({ createDate: date },);
 };
 
-export const findByDate: Resolver<
-  void,
-  Recipe[],
-  { date: Date }
-> = (_, { date }, { req }) => Recipe.find({ createDate: date });
+export const findByDate: Resolver<void, Recipe[], { date: Date }> = (
+  _,
+  { date },
+  { req },
+) => Recipe.find({ createDate: date });
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/break-calls/type_args.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/break-calls/type_args.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: type_args.ts
 ---
 # Input
@@ -13,9 +14,10 @@ const response = something.$http.get<ThingamabobService.DetailsData>(
 
 # Output
 ```js
-const response = something.$http.get<
-  ThingamabobService.DetailsData
->(`api/foo.ashx/foo-details/${myId}`, { cache: quux.httpCache, timeout });
+const response = something.$http.get<ThingamabobService.DetailsData>(
+  `api/foo.ashx/foo-details/${myId}`,
+  { cache: quux.httpCache, timeout },
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/cast/generic-cast.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/cast/generic-cast.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: generic-cast.ts
 ---
 # Input
@@ -102,9 +103,7 @@ function y() {
       | undefined
   >someExistingConfigMap.mergeDeep(fallbackOptions);
 
-  const stillTooLong3 = <
-    Immutable.Map<string>
-  >someExistingConfigMap.mergeDeep(
+  const stillTooLong3 = <Immutable.Map<string>>someExistingConfigMap.mergeDeep(
     fallbackOptions.someMethodWithLongName(param1, param2),
   );
 
@@ -125,9 +124,9 @@ function y() {
     fallbackOptions.someMethodWithLongName(param1, param2),
   );
 
-  const testObjLiteral = <
-    Immutable.Map<string, any>
-  >{ property1: "myPropertyVal" };
+  const testObjLiteral = <Immutable.Map<string, any>>{
+    property1: "myPropertyVal",
+  };
 
   const testObjLiteral2 = <
     Immutable.Map<
@@ -143,9 +142,9 @@ function y() {
     >
   >{ property1: "myPropertyVal" };
 
-  const testArrayLiteral = <
-    Immutable.Map<string, any>
-  >["first", "second", "third"];
+  const testArrayLiteral = <Immutable.Map<string, any>>[
+    "first", "second", "third",
+  ];
 
   const testArrayLiteral2 = <
     Immutable.Map<
@@ -174,9 +173,9 @@ function x() {
   const fitsObjLiteral = <PermissionsChecker<any> | undefined>{ a: "test" };
   const fitsArrayLiteral = <PermissionsChecker<any> | undefined>["t1", "t2"];
 
-  const breakAfterCast = <
-    PermissionsChecker<any> | undefined
-  >(<any>permissions)[receiverType];
+  const breakAfterCast = <PermissionsChecker<any> | undefined>(
+    <any>permissions
+  )[receiverType];
 
   const stillTooLong = <
     PermissionsChecker<object> | undefined | number | string | boolean
@@ -192,9 +191,7 @@ function x() {
       | never
   >(<any>permissions)[receiverType];
 
-  const stillTooLong3 = <
-    PermissionsChecker<object> | undefined
-  >(
+  const stillTooLong3 = <PermissionsChecker<object> | undefined>(
     <any>permissions.someMethodWithLongName(parameter1, parameter2)
   )[receiverTypeLongName];
 
@@ -206,13 +203,13 @@ function x() {
       | boolean
       | null
       | never
-  >(
-    <any>permissions.someMethodWithLongName(parameter1, parameter2)
-  )[receiverTypeLongName];
+  >(<any>permissions.someMethodWithLongName(parameter1, parameter2))[
+    receiverTypeLongName
+  ];
 
-  const testObjLiteral = <
-    PermissionsChecker<any> | undefined
-  >{ prop1: "myPropVal" };
+  const testObjLiteral = <PermissionsChecker<any> | undefined>{
+    prop1: "myPropVal",
+  };
 
   const testObjLiteral2 = <
       | PermissionsChecker<object>
@@ -225,9 +222,9 @@ function x() {
       | object
   >{ prop1: "myPropVal" };
 
-  const testArrayLiteral = <
-    PermissionsChecker<any> | undefined
-  >["first", "second", "third"];
+  const testArrayLiteral = <PermissionsChecker<any> | undefined>[
+    "first", "second", "third",
+  ];
 
   const testArrayLiteral2 = <
       | PermissionsChecker<object>

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/cast/hug-args.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/cast/hug-args.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: hug-args.ts
 ---
 # Input
@@ -46,9 +47,7 @@ window.postMessage(
 );
 
 postMessages(
-  <
-    IActionMessage[]
-  >[
+  <IActionMessage[]>[
     {
       context: item.context,
       topic: item.topic,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/class/extends_implements.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/class/extends_implements.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: extends_implements.ts
 ---
 # Input
@@ -141,10 +142,10 @@ class ImplementsInterfaceAndExtendsAbstractClass1<
   Foo,
 > extends FOOOOOOOOOOOOOOOOO implements FOOOOOOOOOOOOOOOOO, BARRRRRRRRRR {}
 
-class Foo<
-  FOOOOOOOOOOOOOOOOOOOOOOOOOOO,
-  FOOOOOOOOOOOOOOOOOOOOOOOOOOO,
-> implements Foo {}
+class Foo<FOOOOOOOOOOOOOOOOOOOOOOOOOOO, FOOOOOOOOOOOOOOOOOOOOOOOOOOO>
+  implements
+    Foo
+{}
 
 class ImplementsInterfaceAndExtendsAbstractClass2<
   TypeArgumentNumberOne,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conditional-types/infer-type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conditional-types/infer-type.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: infer-type.ts
 ---
 # Input
@@ -16,9 +17,9 @@ type Unpacked<T> =
 
 # Output
 ```js
-type TestReturnType<
-  T extends (...args: any[]) => any,
-> = T extends (...args: any[]) => infer R ? R : any;
+type TestReturnType<T extends (...args: any[]) => any> = T extends (
+  ...args: any[]
+) => infer R ? R : any;
 
 type Unpacked<T> = T extends (infer U)[]
   ? U

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/classes/mixinClassesAnnotated.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/classes/mixinClassesAnnotated.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: mixinClassesAnnotated.ts
 ---
 # Input
@@ -83,11 +84,7 @@ class Derived extends Base {
   }
 }
 
-const Printable = <
-  T extends Constructor<Base>,
->(
-  superClass: T,
-):
+const Printable = <T extends Constructor<Base>>(superClass: T):
   & Constructor<Printable>
   & { message: string }
   & T =>
@@ -98,9 +95,9 @@ const Printable = <
     }
   };
 
-function Tagged<
-  T extends Constructor<{}>,
->(superClass: T): Constructor<Tagged> & T {
+function Tagged<T extends Constructor<{}>>(superClass: T):
+  & Constructor<Tagged>
+  & T {
   class C extends superClass {
     _tag: string;
     constructor(...args: any[]) {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/classes/mixinClassesAnonymous.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/classes/mixinClassesAnonymous.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: mixinClassesAnonymous.ts
 ---
 # Input
@@ -85,11 +86,7 @@ class Derived extends Base {
   }
 }
 
-const Printable = <
-  T extends Constructor<Base>,
->(
-  superClass: T,
-) =>
+const Printable = <T extends Constructor<Base>>(superClass: T) =>
   class extends superClass {
     static message = "hello";
     print() {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/function/single_expand.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/function/single_expand.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: single_expand.ts
 ---
 # Input
@@ -22,14 +23,14 @@ class X {
 
 # Output
 ```js
-function onDidInsertSuggestion(
-  { editor, triggerPosition, re },
-): Promise<void> {}
+function onDidInsertSuggestion({ editor, triggerPosition, re }): Promise<
+  void
+> {}
 
 class X {
-  async onDidInsertSuggestion(
-    { editor, triggerPosition, suggestion },
-  ): Promise<void> {}
+  async onDidInsertSuggestion({ editor, triggerPosition, suggestion }): Promise<
+    void
+  > {}
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/generic/arrow-return-type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/generic/arrow-return-type.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: arrow-return-type.ts
 ---
 # Input
@@ -68,63 +69,51 @@ export const getVehicleDescriptor = async (
 
 # Output
 ```js
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<Descriptor> => {};
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
+  Descriptor
+> => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
   Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 > => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<Descriptor | undefined> => {};
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
+  Descriptor | undefined
+> => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
   Collections.Parts.PrintedCircuitBoardAssembly["attributes"] | undefined
 > => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<Descriptor & undefined> => {};
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
+  Descriptor & undefined
+> => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
   Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
 > => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<Descriptor["attributes"]> => {};
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
+  Descriptor["attributes"]
+> => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
   Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
 > => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<keyof Descriptor> => {};
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
+  keyof Descriptor
+> => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
   keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 > => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<Descriptor[]> => {};
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
+  Descriptor[]
+> => {};
 
-export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<
+export const getVehicleDescriptor = async (vehicleId: string): Promise<
   Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]
 > => {};
 
@@ -132,7 +121,7 @@ export const getVehicleDescriptor = async (
 
 # Lines exceeding max width of 80 characters
 ```
-   38:   Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
-   48:   keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+   30:   Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
+   38:   keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/generic.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/generic.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: generic.ts
 ---
 # Input
@@ -17,10 +18,10 @@ interface Foo<
 
 # Output
 ```js
-interface Foo<
-  FOOOOOOOOOOOOOOOOOOOOOOOOOO,
-  FOOOOOOOOOOOOOOOOOOOOOOO,
-> extends Foo {}
+interface Foo<FOOOOOOOOOOOOOOOOOOOOOOOOOO, FOOOOOOOOOOOOOOOOOOOOOOO>
+  extends
+    Foo
+{}
 
 interface Foo<
   FOOOOOOOOOOOOOOOOOOOOOOOOOO,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/keyword-types/conditional-types.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/keyword-types/conditional-types.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: conditional-types.ts
 ---
 # Input
@@ -25,16 +26,8 @@ export type UnwrappedResultRow<T> = {
 ```js
 export type UnwrappedResultRow<T> = {
   [P in keyof T]: (
-    T[P] extends Req<
-      infer a
-    > ? (
-      a
-    ) : (
-      T[P] extends Opt<
-        infer b
-      > ? (
-        b
-      ) : (
+    T[P] extends Req<infer a> ? (a) : (
+      T[P] extends Opt<infer b> ? (b) : (
         // TEST
         never
       )

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/last-argument-expansion/edge_case.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/last-argument-expansion/edge_case.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: edge_case.ts
 ---
 # Input
@@ -23,9 +24,7 @@ var listener = DOM.listen(
   introCard,
   "click",
   sigil,
-  (
-    event: JavelinEvent,
-  ): void =>
+  (event: JavelinEvent): void =>
     BanzaiLogger.log(
       config,
       { ...logData, ...DataStore.get(event.getNode(sigil)) },

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method/issue-10352-consistency.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method/issue-10352-consistency.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-10352-consistency.ts
 ---
 # Input
@@ -26,25 +27,25 @@ export function loadPlugin(
 # Output
 ```js
 export interface Store {
-  getRecord(
-    collectionName: string,
-    documentPath: string,
-  ): TaskEither<Error, Option<GenericRecord>>;
+  getRecord(collectionName: string, documentPath: string): TaskEither<
+    Error,
+    Option<GenericRecord>
+  >;
 }
 
 export default class StoreImpl extends Service implements Store {
-  getRecord(
-    collectionName: string,
-    documentPath: string,
-  ): TaskEither<Error, Option<GenericRecord>> {
+  getRecord(collectionName: string, documentPath: string): TaskEither<
+    Error,
+    Option<GenericRecord>
+  > {
     // Do some stuff.
   }
 }
 
-export function loadPlugin(
-  name: string,
-  dirname: string,
-): { filepath: string; value: mixed } {
+export function loadPlugin(name: string, dirname: string): {
+  filepath: string;
+  value: mixed;
+} {
   // ...
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature-with-wrapped-return-type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature-with-wrapped-return-type.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: method-signature-with-wrapped-return-type.ts
 ---
 # Input
@@ -28,9 +29,7 @@ type ReleaseToolConfig = {
 };
 
 type ReleaseToolConfig2 = {
-  get(
-    key: "changelog",
-  ): `
+  get(key: "changelog"): `
   `;
 };
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: method-signature.ts
 ---
 # Input
@@ -26,9 +27,7 @@ type Bar = {
 # Output
 ```js
 type Foo = {
-  get(
-    key: "foo",
-  ): `
+  get(key: "foo"): `
   `;
 };
 type Foo = {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/multiparser-css/issue-6259.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/multiparser-css/issue-6259.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-6259.ts
 ---
 # Input
@@ -16,9 +17,7 @@ const yesFrame = (
 
 # Output
 ```js
-const yesFrame = (
-  ...args: Interpolation<ThemedStyledProps<{}, Theme>>[]
-) =>
+const yesFrame = (...args: Interpolation<ThemedStyledProps<{}, Theme>>[]) =>
   css`
     ${ChatRoot}[data-frame="yes"] & {
         ${css({}, ...args)}

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/new/new-signature.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/new/new-signature.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: new-signature.ts
 ---
 # Input
@@ -86,11 +87,7 @@ interface FooConstructor {
 }
 
 interface BarConstructor {
-  new <
-    A,
-    B,
-    C,
-  >(
+  new <A, B, C>(
     a: number,
     b: number,
     c: number,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/non-null/braces.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/non-null/braces.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: braces.ts
 ---
 # Input
@@ -24,9 +25,7 @@ class a extends ({}!) {}
 
 # Output
 ```js
-const myFunction2 = (
-  key: string,
-): number => (
+const myFunction2 = (key: string): number => (
   {
     a: 42,
     b: 42,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/rest-type/infer-type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/rest-type/infer-type.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: infer-type.ts
 ---
 # Input
@@ -28,9 +29,10 @@ type Tail2<T extends any[]> = T extends [infer U, ...(infer R)] ? R : never;
 // but not remove parens from this:
 type Tail3<T extends any[]> = T extends [infer U, ...(infer R)[]] ? R : never;
 
-type ReduceNextElement<
-  T extends readonly unknown[],
-> = T extends readonly [infer V, ...infer R] ? [V, R] : never;
+type ReduceNextElement<T extends readonly unknown[]> = T extends readonly [
+  infer V,
+  ...infer R,
+] ? [V, R] : never;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/template-literal-types/template-literal-types.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/template-literal-types/template-literal-types.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: template-literal-types.ts
 ---
 # Input
@@ -30,9 +31,10 @@ type PropEventSource<T> = {
   on(eventName: `${string & keyof T}Changed`, callback: () => void): void;
 };
 type PropEventSource<T> = {
-  on<
-    K extends string & keyof T,
-  >(eventName: `${K}Changed`, callback: (newValue: T[K]) => void): void;
+  on<K extends string & keyof T>(
+    eventName: `${K}Changed`,
+    callback: (newValue: T[K]) => void,
+  ): void;
 };
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/tsx/react.tsx.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/tsx/react.tsx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: react.tsx
 ---
 # Input
@@ -15,9 +16,7 @@ const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;
 
 # Output
 ```js
-const MyCoolList = (
-  { things },
-) =>
+const MyCoolList = ({ things }) =>
   <ul>
         {things.map(MyCoolThing)}
     </ul>;

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/typeparams/class-method.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/typeparams/class-method.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: class-method.ts
 ---
 # Input
@@ -108,17 +109,13 @@ const appIDs = createSelector(
 ```js
 // https://github.com/prettier/prettier/issues/4070
 export class Thing implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => {});
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider<Opts> => {},
+  );
 }
 
 export class Thing2 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     (type: ObjectType): Provider<Opts> => {
       const someVar = doSomething(type);
       if (someVar) {
@@ -130,11 +127,7 @@ export class Thing2 implements OtherThing {
 }
 
 export class Thing3 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize((type) => {
+  do: (type: Type) => Provider<Prop> = memoize((type) => {
     const someVar = doSomething(type);
     if (someVar) {
       return someVar.method();
@@ -144,86 +137,65 @@ export class Thing3 implements OtherThing {
 }
 
 export class Thing4 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize((type: ObjectType): Provider<Opts> => type.doSomething());
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider<Opts> => type.doSomething(),
+  );
 }
 
 export class Thing5 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize((type: ObjectType): Provider<Opts> => <any>type.doSomething());
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider<Opts> => <any>type.doSomething(),
+  );
 }
 
 export class Thing6 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     (type: ObjectType): Provider<Opts> => <Provider<Opts>>type.doSomething(),
   );
 }
 
 export class Thing7 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize((type: ObjectType) => <Provider<Opts>>type.doSomething());
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType) => <Provider<Opts>>type.doSomething(),
+  );
 }
 
 export class Thing8 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
-    (
-      type: ObjectType,
-    ) =>
-      <
-        Provider<Opts>
-      >type.doSomething(withArgs, soIt, does, not, fit).extraCall(),
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType) =>
+      <Provider<Opts>>type.doSomething(
+        withArgs,
+        soIt,
+        does,
+        not,
+        fit,
+      ).extraCall(),
   );
 }
 
 export class Thing9 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<Prop> = memoize((type: ObjectType) => type.doSomething());
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType) => type.doSomething(),
+  );
 }
 
 export class Thing10 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
-    (
-      veryLongArgName: ObjectType,
-    ): Provider<Options, MoreOptions> => veryLongArgName,
+  do: (type: Type) => Provider<Prop> = memoize(
+    (veryLongArgName: ObjectType): Provider<Options, MoreOptions> =>
+      veryLongArgName,
   );
 }
 
 export class Thing11 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<Prop> = memoize((type: ObjectType): Provider => {});
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider => {},
+  );
 }
 
 // regular non-arrow functions
 
 export class Thing12 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     function (type: ObjectType): Provider<Opts> {
       return type;
     },
@@ -231,11 +203,7 @@ export class Thing12 implements OtherThing {
 }
 
 export class Thing13 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     function (type: ObjectType): Provider<Opts> {
       const someVar = doSomething(type);
       if (someVar) {
@@ -247,11 +215,7 @@ export class Thing13 implements OtherThing {
 }
 
 export class Thing14 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(function (type) {
+  do: (type: Type) => Provider<Prop> = memoize(function (type) {
     const someVar = doSomething(type);
     if (someVar) {
       return someVar.method();
@@ -261,11 +225,7 @@ export class Thing14 implements OtherThing {
 }
 
 export class Thing15 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     function (type: ObjectType): Provider<Opts> {
       return type.doSomething();
     },
@@ -273,11 +233,7 @@ export class Thing15 implements OtherThing {
 }
 
 export class Thing16 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     function (type: ObjectType): Provider<Opts> {
       return <any>type.doSomething();
     },
@@ -285,11 +241,7 @@ export class Thing16 implements OtherThing {
 }
 
 export class Thing17 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     function (type: ObjectType): Provider<Opts> {
       return <Provider<Opts>>type.doSomething();
     },
@@ -297,11 +249,7 @@ export class Thing17 implements OtherThing {
 }
 
 export class Thing18 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     function (type: ObjectType) {
       return <Provider<Opts>>type.doSomething();
     },
@@ -309,25 +257,21 @@ export class Thing18 implements OtherThing {
 }
 
 export class Thing19 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     function (type: ObjectType) {
-      return <
-        Provider<Opts>
-      >type.doSomething(withArgs, soIt, does, not, fit).extraCall();
+      return <Provider<Opts>>type.doSomething(
+        withArgs,
+        soIt,
+        does,
+        not,
+        fit,
+      ).extraCall();
     },
   );
 }
 
 export class Thing20 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     function (type: ObjectType) {
       return type.doSomething();
     },
@@ -335,11 +279,7 @@ export class Thing20 implements OtherThing {
 }
 
 export class Thing21 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<
-    Prop
-  > = memoize(
+  do: (type: Type) => Provider<Prop> = memoize(
     function (veryLongArgName: ObjectType): Provider<Options, MoreOptions> {
       return veryLongArgName;
     },
@@ -347,9 +287,9 @@ export class Thing21 implements OtherThing {
 }
 
 export class Thing22 implements OtherThing {
-  do: (
-    type: Type,
-  ) => Provider<Prop> = memoize(function (type: ObjectType): Provider {});
+  do: (type: Type) => Provider<Prop> = memoize(
+    function (type: ObjectType): Provider {},
+  );
 }
 
 // case from https://github.com/prettier/prettier/issues/2581

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/typeparams/long-function-arg.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/typeparams/long-function-arg.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: long-function-arg.ts
 ---
 # Input
@@ -20,10 +21,7 @@ export const forwardS1 = R.curry(
 # Output
 ```js
 export const forwardS = R.curry(
-  <
-    V,
-    T,
-  >(
+  <V, T>(
     prop: string,
     reducer: ReducerFunction<V, T>,
     value: V,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/union/union-parens.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/union/union-parens.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: union-parens.ts
 ---
 # Input
@@ -162,17 +163,9 @@ type State =
       | { discriminant: "BAZ"; baz: any }
   );
 
-const foo1 = [
-  abc,
-  def,
-  ghi,
-  jkl,
-  mno,
-  pqr,
-  stu,
-  vwx,
-  yz,
-] as (string | undefined)[];
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+  string | undefined
+)[];
 
 const foo2: (
     | AAAAAAAAAAAAAAAAAAAAAA

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/webhost/webtsc.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/webhost/webtsc.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: webtsc.ts
 ---
 # Input
@@ -156,9 +157,9 @@ namespace TypeScript.WebTsc {
             // [0xFF,0xFE] and [0xFE,0xFF] mean utf-16 (little or big endian), otherwise default to utf-8
             fileStream.Charset =
               bom.length >= 2 && (
-                (
-                  bom.charCodeAt(0) === 0xFF && bom.charCodeAt(1) === 0xFE
-                ) || (bom.charCodeAt(0) === 0xFE && bom.charCodeAt(1) === 0xFF)
+                (bom.charCodeAt(0) === 0xFF && bom.charCodeAt(1) === 0xFE) || (
+                  bom.charCodeAt(0) === 0xFE && bom.charCodeAt(1) === 0xFF
+                )
               ) ? "unicode" : "utf-8";
           }
           // ReadText method always strips byte order mark from resulting string

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: type_member.ts
 ---
 # Input
@@ -112,9 +113,7 @@ type F = {
 };
 
 type G = {
-	<
-		Aaaaaaaaaaaaaaaaaaaaa,
-	>(
+	<Aaaaaaaaaaaaaaaaaaaaa>(
 		loreum: string,
 		ipsum: symbol,
 		lapis: symbol,


### PR DESCRIPTION
## Summary

This seems to bring the printer closer to Prettier’s by changing the `fits_on_line` measurement.

Previously, the `fits_element_on_line` function was measuring all groups with `PrintMode::Flat`, including those from the `rest_queue`. This caused elements to be falsely measured as `Fits::No` even if they were followed by a group that could have broken before the end of the desired line width.

This change causes the test for the `best_fitting` macro to fail, but we decided to just ignore it for now to merge this sooner because the `BestFitting` IR isn't currently used anywhere and there's more than one option for how we can fix it.

## Test Plan

Reviewed the snapshot changes. There are no major blocking regressions, and we decided we should merge this ASAP and then follow up later with additional PRs to match Prettier's behavior.