### PR TITLE
feat(rome_analyze): implement the useSingleCaseStatement rule

### DIFF
--- a/crates/rome_analyze/src/analyzers.rs
+++ b/crates/rome_analyze/src/analyzers.rs
@@ -1,16 +1,18 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-mod use_while;
-pub(crate) use use_while::UseWhile;
+mod no_compare_neg_zero;
+pub(crate) use no_compare_neg_zero::NoCompareNegZero;
 mod no_delete;
 pub(crate) use no_delete::NoDelete;
 mod no_double_equals;
 pub(crate) use no_double_equals::NoDoubleEquals;
 mod no_negation_else;
 pub(crate) use no_negation_else::NoNegationElse;
-mod no_compare_neg_zero;
-pub(crate) use no_compare_neg_zero::NoCompareNegZero;
-mod use_valid_typeof;
-pub(crate) use use_valid_typeof::UseValidTypeof;
+mod use_single_case_statement;
+pub(crate) use use_single_case_statement::UseSingleCaseStatement;
 mod use_single_var_declarator;
 pub(crate) use use_single_var_declarator::UseSingleVarDeclarator;
+mod use_valid_typeof;
+pub(crate) use use_valid_typeof::UseValidTypeof;
+mod use_while;
+pub(crate) use use_while::UseWhile;

--- a/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
+++ b/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
@@ -1,0 +1,118 @@
+use std::iter;
+
+use rome_console::markup;
+use rome_diagnostics::{Applicability, Severity};
+use rome_js_factory::make;
+use rome_js_syntax::{
+    JsAnyRoot, JsAnyStatement, JsCaseClause, JsCaseClauseFields, JsSyntaxToken, TriviaPieceKind, T,
+};
+use rome_rowan::{AstNode, AstNodeExt, AstNodeList, TriviaPiece};
+
+use crate::registry::{JsRuleAction, Rule, RuleDiagnostic};
+use crate::{ActionCategory, RuleCategory};
+
+/// Enforces case clauses have a single statement, emits a quick fix wrapping
+/// the statements in a block
+pub(crate) enum UseSingleCaseStatement {}
+
+impl Rule for UseSingleCaseStatement {
+    const NAME: &'static str = "useSingleCaseStatement";
+    const CATEGORY: RuleCategory = RuleCategory::Lint;
+
+    type Query = JsCaseClause;
+    type State = ();
+
+    fn run(n: &Self::Query) -> Option<Self::State> {
+        if n.consequent().len() > 1 {
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn diagnostic(n: &Self::Query, _: &Self::State) -> Option<RuleDiagnostic> {
+        Some(RuleDiagnostic {
+            severity: Severity::Warning,
+            message: markup! {
+                "A switch case should only have a single statement."
+            }
+            .to_owned(),
+            range: n.consequent().syntax().text_trimmed_range(),
+        })
+    }
+
+    fn action(root: JsAnyRoot, n: &Self::Query, _: &Self::State) -> Option<JsRuleAction> {
+        let JsCaseClauseFields {
+            case_token,
+            colon_token,
+            consequent,
+            ..
+        } = n.as_fields();
+
+        // Move the trailing trivia of the colon token to the opening bracket token,
+        // this ensure comments stay in the right place
+        let mut opening_token = String::from(" {");
+        let mut trailing = Vec::new();
+
+        if let Ok(token) = colon_token {
+            for piece in token.trailing_trivia().pieces() {
+                opening_token.push_str(piece.text());
+                trailing.push(TriviaPiece::new(piece.kind(), piece.text_len()));
+            }
+        }
+
+        // Copy the leading trivia of the case token on the closing bracket token
+        // up to the first newline to align the indentation level
+        let mut closing_token = String::new();
+        let mut leading = Vec::new();
+
+        if let Ok(token) = case_token {
+            let leading_trivia = token.leading_trivia().pieces();
+            let num_pieces = leading_trivia.len();
+            let skip_count = leading_trivia
+                .rev()
+                .position(|piece| piece.is_newline())
+                .and_then(|index| num_pieces.checked_sub(index + 1))
+                .unwrap_or(0);
+
+            for piece in token.leading_trivia().pieces().skip(skip_count) {
+                closing_token.push_str(piece.text());
+                leading.push(TriviaPiece::new(piece.kind(), piece.text_len()));
+            }
+        }
+
+        closing_token.push('}');
+
+        let node = n
+            .clone()
+            .with_consequent(make::js_statement_list(iter::once(
+                JsAnyStatement::JsBlockStatement(make::js_block_statement(
+                    JsSyntaxToken::new_detached(
+                        T!['{'],
+                        &opening_token,
+                        [TriviaPiece::new(TriviaPieceKind::Whitespace, 1)],
+                        trailing,
+                    ),
+                    consequent,
+                    JsSyntaxToken::new_detached(T!['}'], &closing_token, leading, []),
+                )),
+            )));
+
+        let node = if let Ok(colon_token) = n.colon_token() {
+            node.with_colon_token(colon_token.with_trailing_trivia(iter::empty()))
+        } else {
+            node
+        };
+
+        let root = root
+            .replace_node(n.clone(), node)
+            .expect("failed to replace node");
+
+        Some(JsRuleAction {
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::MaybeIncorrect,
+            message: markup! { "Wrap the statements in a block" }.to_owned(),
+            root,
+        })
+    }
+}

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -36,13 +36,14 @@ macro_rules! impl_registry_builders {
 
 impl_registry_builders!(
     // Analyzers
-    UseWhile,
+    NoCompareNegZero,
     NoDelete,
     NoDoubleEquals,
     NoNegationElse,
-    NoCompareNegZero,
-    UseValidTypeof,
+    UseSingleCaseStatement,
     UseSingleVarDeclarator,
+    UseValidTypeof,
+    UseWhile,
     // Assists
     FlipBinExp,
 );

--- a/crates/rome_analyze/tests/specs/useSingleCaseStatement.js
+++ b/crates/rome_analyze/tests/specs/useSingleCaseStatement.js
@@ -1,0 +1,42 @@
+switch (foo) {
+    case true:
+    case false:
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    // comment
+    case false :
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    case false : // comment
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    case false
+    /* comment */ :
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    case true:
+    case false:
+        'yes';
+}
+
+switch (foo) {
+    case true: {
+        // empty
+    }
+}
+
+switch (foo) {
+    case true:
+}

--- a/crates/rome_analyze/tests/specs/useSingleCaseStatement.js.snap
+++ b/crates/rome_analyze/tests/specs/useSingleCaseStatement.js.snap
@@ -1,0 +1,152 @@
+---
+source: crates/rome_analyze/tests/spec_tests.rs
+expression: useSingleCaseStatement.js
+---
+# Input
+```js
+switch (foo) {
+    case true:
+    case false:
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    // comment
+    case false :
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    case false : // comment
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    case false
+    /* comment */ :
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    case true:
+    case false:
+        'yes';
+}
+
+switch (foo) {
+    case true: {
+        // empty
+    }
+}
+
+switch (foo) {
+    case true:
+}
+
+```
+
+# Diagnostics
+```
+warning[useSingleCaseStatement]: A switch case should only have a single statement.
+  ┌─ useSingleCaseStatement.js:4:9
+  │  
+4 │ ┌         let foo = '';
+5 │ │         foo;
+  │ └────────────' A switch case should only have a single statement.
+
+Wrap the statements in a block
+    | @@ -1,8 +1,9 @@
+0 0 |   switch (foo) {
+1 1 |       case true:
+2   | -     case false:
+  2 | +     case false: {
+3 3 |           let foo = '';
+4 4 |           foo;
+  5 | +     }
+5 6 |   }
+6 7 |   
+7 8 |   switch (foo) {
+
+
+```
+
+```
+warning[useSingleCaseStatement]: A switch case should only have a single statement.
+   ┌─ useSingleCaseStatement.js:11:9
+   │  
+11 │ ┌         let foo = '';
+12 │ │         foo;
+   │ └────────────' A switch case should only have a single statement.
+
+Wrap the statements in a block
+      | @@ -7,9 +7,10 @@
+ 6  6 |   
+ 7  7 |   switch (foo) {
+ 8  8 |       // comment
+ 9    | -     case false :
+    9 | +     case false : {
+10 10 |           let foo = '';
+11 11 |           foo;
+   12 | +     }
+12 13 |   }
+13 14 |   
+14 15 |   switch (foo) {
+
+
+```
+
+```
+warning[useSingleCaseStatement]: A switch case should only have a single statement.
+   ┌─ useSingleCaseStatement.js:17:9
+   │  
+17 │ ┌         let foo = '';
+18 │ │         foo;
+   │ └────────────' A switch case should only have a single statement.
+
+Wrap the statements in a block
+      | @@ -13,9 +13,10 @@
+12 12 |   }
+13 13 |   
+14 14 |   switch (foo) {
+15    | -     case false : // comment
+   15 | +     case false : { // comment
+16 16 |           let foo = '';
+17 17 |           foo;
+   18 | +     }
+18 19 |   }
+19 20 |   
+20 21 |   switch (foo) {
+
+
+```
+
+```
+warning[useSingleCaseStatement]: A switch case should only have a single statement.
+   ┌─ useSingleCaseStatement.js:24:9
+   │  
+24 │ ┌         let foo = '';
+25 │ │         foo;
+   │ └────────────' A switch case should only have a single statement.
+
+Wrap the statements in a block
+      | @@ -20,9 +20,10 @@
+19 19 |   
+20 20 |   switch (foo) {
+21 21 |       case false
+22    | -     /* comment */ :
+   22 | +     /* comment */ : {
+23 23 |           let foo = '';
+24 24 |           foo;
+   25 | +     }
+25 26 |   }
+26 27 |   
+27 28 |   switch (foo) {
+
+
+```
+
+


### PR DESCRIPTION
## Summary

This adds the [useSingleCaseStatement](https://github.com/rome/tools/blob/archived-js/website/src/docs/lint/rules/js/useSingleCaseStatement.md) rule back after it was removed in the analyzer refactor

## Test Plan

I added a snapshot test for the rule reusing the examples for the rule from Rome JS
