### PR TITLE
feature(rome_analyze:) lint rule context and typed service bag

### DIFF
--- a/crates/rome_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_analyze/src/analyzers/no_double_equals.rs
@@ -1,10 +1,11 @@
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
-use rome_js_syntax::{JsAnyExpression, JsAnyLiteralExpression, JsAnyRoot, JsBinaryExpression, T};
+use rome_js_syntax::{JsAnyExpression, JsAnyLiteralExpression, JsBinaryExpression, T};
 use rome_js_syntax::{JsSyntaxKind::*, JsSyntaxToken};
 use rome_rowan::{AstNodeExt, SyntaxResult};
 
+use crate::context::{JsRuleContext, RuleContext};
 use crate::registry::{JsRuleAction, Rule, RuleDiagnostic};
 use crate::{ActionCategory, RuleCategory};
 
@@ -17,8 +18,9 @@ impl Rule for NoDoubleEquals {
     type Query = JsBinaryExpression;
     type State = JsSyntaxToken;
 
-    fn run(n: &Self::Query) -> Option<Self::State> {
-        let op = n.operator_token().ok()?;
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        let n = ctx.query();
+        let op = ctx.query().operator_token().ok()?;
 
         if !matches!(op.kind(), EQ2 | NEQ) {
             return None;
@@ -32,7 +34,7 @@ impl Rule for NoDoubleEquals {
         Some(op)
     }
 
-    fn diagnostic(_: &Self::Query, op: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(_: &RuleContext<Self>, op: &Self::State) -> Option<RuleDiagnostic> {
         let text_trimmed = op.text_trimmed();
         let suggestion = if op.kind() == EQ2 { "===" } else { "!==" };
 
@@ -50,9 +52,12 @@ impl Rule for NoDoubleEquals {
         )
     }
 
-    fn action(root: JsAnyRoot, _: &Self::Query, op: &Self::State) -> Option<JsRuleAction> {
+    fn action(ctx: &RuleContext<Self>, op: &Self::State) -> Option<JsRuleAction> {
         let suggestion = if op.kind() == EQ2 { T![===] } else { T![!==] };
-        let root = root.replace_token(op.clone(), make::token(suggestion))?;
+        let root = ctx
+            .root()
+            .clone()
+            .replace_token(op.clone(), make::token(suggestion))?;
 
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,

--- a/crates/rome_analyze/src/analyzers/no_negation_else.rs
+++ b/crates/rome_analyze/src/analyzers/no_negation_else.rs
@@ -1,10 +1,11 @@
+use crate::context::{JsRuleContext, RuleContext};
 use crate::registry::{JsRuleAction, Rule, RuleAction, RuleDiagnostic};
 use crate::{ActionCategory, RuleCategory};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
-    JsAnyExpression, JsAnyRoot, JsConditionalExpression, JsIfStatement, JsLanguage, JsSyntaxKind,
+    JsAnyExpression, JsConditionalExpression, JsIfStatement, JsLanguage, JsSyntaxKind,
     JsUnaryExpression, JsUnaryOperator,
 };
 use rome_rowan::{AstNode, AstNodeExt};
@@ -18,8 +19,8 @@ impl Rule for NoNegationElse {
     type Query = JsAnyCondition;
     type State = JsUnaryExpression;
 
-    fn run(n: &Self::Query) -> Option<Self::State> {
-        match n {
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        match ctx.query() {
             JsAnyCondition::JsConditionalExpression(expr) => {
                 if is_negation(&expr.test().ok()?).unwrap_or(false) {
                     Some(expr.test().ok()?.as_js_unary_expression().unwrap().clone())
@@ -38,17 +39,18 @@ impl Rule for NoNegationElse {
         }
     }
 
-    fn diagnostic(node: &Self::Query, _state: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
         Some(RuleDiagnostic::warning(
-            node.range(),
+            ctx.query().range(),
             markup! {
                 "Invert blocks when performing a negation test."
             },
         ))
     }
 
-    fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<JsRuleAction> {
-        let root = match node {
+    fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
+        let node = ctx.query();
+        let root = match ctx.query() {
             JsAnyCondition::JsConditionalExpression(expr) => {
                 let mut next_expr = expr
                     .clone()
@@ -59,7 +61,7 @@ impl Rule for NoNegationElse {
                 next_expr = next_expr
                     .clone()
                     .replace_node(next_expr.consequent().ok()?, expr.alternate().ok()?)?;
-                root.replace_node(
+                ctx.root().clone().replace_node(
                     node.clone(),
                     JsAnyCondition::JsConditionalExpression(next_expr),
                 )
@@ -79,7 +81,9 @@ impl Rule for NoNegationElse {
                     next_stmt.consequent().ok()?,
                     stmt.else_clause()?.alternate().ok()?,
                 )?;
-                root.replace_node(node.clone(), JsAnyCondition::JsIfStatement(next_stmt))
+                ctx.root()
+                    .clone()
+                    .replace_node(node.clone(), JsAnyCondition::JsIfStatement(next_stmt))
             }
         }?;
         Some(RuleAction {

--- a/crates/rome_analyze/src/context.rs
+++ b/crates/rome_analyze/src/context.rs
@@ -1,0 +1,112 @@
+use std::sync::Arc;
+
+use rome_js_syntax::{JsAnyRoot, JsLanguage};
+use rome_rowan::{AstNode, Language};
+
+use crate::{
+    registry::{LanguageRoot, Rule},
+    LanguageOfRule,
+};
+
+/// Specifies which services a language needs
+/// to be able to run all possible lint rules.
+///
+/// Also instantiate all these services.
+pub trait LanguageSpecificServiceBag: Language {
+    type Services;
+
+    fn new(root: LanguageRoot<Self>) -> Self::Services;
+}
+
+/// Easy access to which services a language needs to run all
+/// lint rules.
+type ServicesOf<Language> = <Language as LanguageSpecificServiceBag>::Services;
+
+/// Carries all services a language needs to run all
+/// lint rules
+#[derive(Clone)]
+pub struct RuleContextServiceBag<Language>
+where
+    Language: LanguageSpecificServiceBag,
+{
+    services: Arc<ServicesOf<Language>>,
+}
+
+impl<L> RuleContextServiceBag<L>
+where
+    L: LanguageSpecificServiceBag,
+{
+    pub fn new(root: LanguageRoot<L>) -> Self {
+        Self {
+            services: Arc::new(<L as LanguageSpecificServiceBag>::new(root)),
+        }
+    }
+}
+
+impl<Language> std::ops::Deref for RuleContextServiceBag<Language>
+where
+    Language: LanguageSpecificServiceBag,
+{
+    type Target = ServicesOf<Language>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.services
+    }
+}
+
+/// Gives lint Rules access to everything associated with
+/// a lint analyze run, such as:
+/// - Nodes and the parsed tree
+/// - All services as specified for each language
+pub(crate) struct RuleContext<TRule>
+where
+    TRule: Rule,
+    LanguageOfRule<TRule>: LanguageSpecificServiceBag,
+{
+    query_result: <TRule as Rule>::Query,
+    services: RuleContextServiceBag<LanguageOfRule<TRule>>,
+}
+
+impl<TRule> RuleContext<TRule>
+where
+    TRule: Rule,
+    LanguageOfRule<TRule>: LanguageSpecificServiceBag,
+{
+    pub fn new(
+        query_result: <TRule as Rule>::Query,
+        services: RuleContextServiceBag<LanguageOfRule<TRule>>,
+    ) -> Self {
+        Self {
+            query_result,
+            services,
+        }
+    }
+
+    pub fn query(&self) -> &<TRule as Rule>::Query {
+        &self.query_result
+    }
+}
+
+/// Specific methods for Javascript rules
+pub trait JsRuleContext {
+    fn root(&self) -> &JsAnyRoot;
+}
+
+impl<TRule> JsRuleContext for RuleContext<TRule>
+where
+    TRule: Rule,
+    <TRule as Rule>::Query: AstNode<Language = JsLanguage>,
+{
+    fn root(&self) -> &JsAnyRoot {
+        &self.services.0
+    }
+}
+
+/// Specific services for Javascript Rules
+impl LanguageSpecificServiceBag for JsLanguage {
+    type Services = (JsAnyRoot,);
+
+    fn new(root: LanguageRoot<Self>) -> Self::Services {
+        (root,)
+    }
+}

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -7,6 +7,8 @@ use rome_js_syntax::JsLanguage;
 use rome_js_syntax::TextRange;
 use rome_rowan::{AstNode, Language, SyntaxNode};
 
+use crate::context::{LanguageSpecificServiceBag, RuleContext, RuleContextServiceBag};
+use crate::LanguageOfRule;
 use crate::{
     analyzers::*,
     assists::*,
@@ -16,28 +18,30 @@ use crate::{
 };
 
 /// The rule registry holds type-erased instances of all active analysis rules
-pub(crate) struct RuleRegistry<L: Language> {
+pub(crate) struct RuleRegistry<L: Language + LanguageSpecificServiceBag> {
     rules: Vec<RegistryRule<L>>,
+    services: RuleContextServiceBag<L>,
 }
 
 /// Utility macro for implementing the `with_filter` method of [RuleRegistry]
 macro_rules! impl_registry_builders {
-    ( $( $rule:ident, )* ) => {
-        impl RuleRegistry<JsLanguage> {
-            pub(crate) fn with_filter(filter: &AnalysisFilter) -> Self {
-                let mut rules: Vec<RegistryRule<JsLanguage>> = Vec::new();
+    ( $lang:ident, $( $rule:ident, )* ) => {
+        impl RuleRegistry<$lang> {
+            pub(crate) fn new(services: RuleContextServiceBag<$lang>, filter: &AnalysisFilter) -> Self {
+                let mut rules: Vec<RegistryRule<$lang>> = Vec::new();
 
                 $( if filter.categories.contains($rule::CATEGORY.into()) && filter.rules.map_or(true, |rules| rules.contains(&$rule::NAME)) {
                     rules.push(run::<$rule>);
                 } )*
 
-                Self { rules }
+                Self { rules, services }
             }
         }
     };
 }
 
 impl_registry_builders!(
+    JsLanguage,
     // Analyzers
     NoCompareNegZero,
     NoDebugger,
@@ -57,12 +61,11 @@ impl_registry_builders!(
 pub(crate) type RuleLanguage<R> = NodeLanguage<<R as Rule>::Query>;
 pub(crate) type NodeLanguage<N> = <N as AstNode>::Language;
 
-pub(crate) type RuleRoot<R> = LanguageRoot<RuleLanguage<R>>;
 pub(crate) type LanguageRoot<L> = <L as Language>::Root;
 
 impl<L> RuleRegistry<L>
 where
-    L: Language,
+    L: Language + LanguageSpecificServiceBag,
 {
     // Run all rules known to the registry associated with nodes of type N
     pub(crate) fn analyze<B>(
@@ -73,7 +76,7 @@ where
         callback: &mut impl FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<B>,
     ) -> ControlFlow<B> {
         for rule in &self.rules {
-            if let Some(event) = (rule)(file_id, root, &node) {
+            if let Some(event) = (rule)(file_id, root, &self.services, &node) {
                 if let ControlFlow::Break(b) = callback(&*event) {
                     return ControlFlow::Break(b);
                 }
@@ -88,28 +91,45 @@ where
 type RegistryRule<L> = for<'a> fn(
     FileId,
     &'a LanguageRoot<L>,
+    &'a RuleContextServiceBag<L>,
     &'a SyntaxNode<L>,
 ) -> Option<Box<dyn AnalyzerSignal<L> + 'a>>;
 
 /// Generic implementation of RegistryRule for any rule type R
-fn run<'a, R: Rule + 'static>(
+fn run<'a, R>(
     file_id: FileId,
-    root: &'a RuleRoot<R>,
+    root: &'a LanguageRoot<LanguageOfRule<R>>,
+    services: &'a RuleContextServiceBag<LanguageOfRule<R>>,
     node: &'a SyntaxNode<<R::Query as AstNode>::Language>,
-) -> Option<Box<dyn AnalyzerSignal<RuleLanguage<R>> + 'a>> {
+) -> Option<Box<dyn AnalyzerSignal<RuleLanguage<R>> + 'a>>
+where
+    R: Rule + 'static,
+    LanguageOfRule<R>: LanguageSpecificServiceBag,
+{
     if !<R::Query>::can_cast(node.kind()) {
         return None;
     }
 
-    let node = <R::Query>::cast(node.clone())?;
-    let result = R::run(&node)?;
-    Some(RuleSignal::<R>::new_boxed(file_id, root, node, result))
+    let query_result = <R::Query>::cast(node.clone())?;
+    let ctx = RuleContext::new(query_result, services.clone());
+
+    let state = R::run(&ctx)?;
+
+    Some(RuleSignal::<R>::new_boxed(
+        file_id,
+        root.clone(),
+        ctx,
+        state,
+    ))
 }
 
 /// Trait implemented by all analysis rules: declares interest to a certain AstNode type,
 /// and a callback function to be executed on all nodes matching the query to possibly
 /// raise an analysis event
-pub(crate) trait Rule {
+pub(crate) trait Rule: Sized
+where
+    LanguageOfRule<Self>: LanguageSpecificServiceBag,
+{
     /// The name of this rule, displayed in the diagnostics it emits
     const NAME: &'static str;
     /// The category this rule belong to, this is used for broadly filtering
@@ -128,13 +148,15 @@ pub(crate) trait Rule {
     /// being analyzed. If it returns `Some` the state object will be wrapped
     /// in a generic `AnalyzerSignal`, and the consumer of the analyzer may call
     /// `diagnostic` or `action` on it
-    fn run(node: &Self::Query) -> Option<Self::State>;
+    #[allow(unused)]
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State>;
 
     /// Called by the consumer of the analyzer to try to generate a diagnostic
     /// from a signal raised by `run`
     ///
     /// The default implementation returns None
-    fn diagnostic(_node: &Self::Query, _state: &Self::State) -> Option<RuleDiagnostic> {
+    #[allow(unused)]
+    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
         None
     }
 
@@ -142,10 +164,10 @@ pub(crate) trait Rule {
     /// from a signal raised by `run`
     ///
     /// The default implementation returns None
+    #[allow(unused)]
     fn action(
-        _root: RuleRoot<Self>,
-        _node: &Self::Query,
-        _state: &Self::State,
+        ctx: &RuleContext<Self>,
+        state: &Self::State,
     ) -> Option<RuleAction<RuleLanguage<Self>>> {
         None
     }


### PR DESCRIPTION
PR for this discussion: https://github.com/rome/tools/discussions/2603

The heart of the PR is the type ```RuleContext```. It acts as a simple façade for everything that we want to offer to lint rules. What we offer varies by language. To see an example look at ```JsRuleContext```, which specifies which methods we allow to be called directly on the context (like extension methods), and ```impl LanguageSpecificServiceBag for JsLanguage``` which specifies which services are stored inside the context for each language.

The ```RuleContextServiceBag``` is typed and not a usual ServiceLocator to avoid all ```get(...)``` methods returning ```Option<...>```. This comes with a little bit of complexity but also guarantees that we will not see any runtime errors when linting.

Another nice side effect is that lint rules for other languages will not compile until someone specifies which services these languages need.

Rules now receive just the context as a parameter

```rust
fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
    ...
}
```

And js rules, for example, have one extra method to give access to the root. With nice code completion and all:

![image](https://user-images.githubusercontent.com/83425/172151188-2a1892d9-fa86-451f-b45a-07661f8f093f.png)

# Borrow and Send + Sync

One thing I was not sure about was to constrain all services to be ```Send + Sync```. It seems to make sense, given that we will run rules in a thread pool at some point. But that would eliminate the ```JsAnyRoot```. So I opted to deal with this later.

Also, the context returns a non-mutable borrow, expecting that these services are thread-safe and have interior mutability through normal borrows.