### PR TITLE
feat(formatter): Treat skipped token trivia as syntax error

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -321,8 +321,10 @@ pub type FormatResult<F> = Result<F, FormatError>;
 #[derive(Debug, PartialEq, Copy, Clone)]
 /// Series of errors encountered during formatting
 pub enum FormatError {
-    /// Node is missing and it should be required for a correct formatting
-    MissingRequiredChild,
+    /// Formatting failed because the node or one of its children contains a syntax error.
+    /// A node has a syntax error if it misses any of its required children or
+    /// if any token has any skipped leading trivia.
+    SyntaxError,
 
     /// In case our formatter doesn't know how to format a certain language
     UnsupportedLanguage,
@@ -334,7 +336,7 @@ pub enum FormatError {
 impl fmt::Display for FormatError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FormatError::MissingRequiredChild => fmt.write_str("missing required child"),
+            FormatError::SyntaxError => fmt.write_str("syntax error"),
             FormatError::UnsupportedLanguage => fmt.write_str("language is not supported"),
             FormatError::CapabilityDisabled => fmt.write_str("formatting capability is disabled"),
         }
@@ -352,7 +354,7 @@ impl From<SyntaxError> for FormatError {
 impl From<&SyntaxError> for FormatError {
     fn from(syntax_error: &SyntaxError) -> Self {
         match syntax_error {
-            SyntaxError::MissingRequiredChild => FormatError::MissingRequiredChild,
+            SyntaxError::MissingRequiredChild => FormatError::SyntaxError,
         }
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
@@ -33,9 +33,7 @@ impl FormatRule<JsVariableDeclaratorList> for FormatJsVariableDeclaratorList {
             })
         });
 
-        let leading_element = declarators
-            .next()
-            .ok_or(FormatError::MissingRequiredChild)?;
+        let leading_element = declarators.next().ok_or(FormatError::SyntaxError)?;
 
         let other_declarators = format_once(|f| {
             if node.len() == 1 {

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -19,8 +19,8 @@ use rome_rowan::SyntaxResult;
 use rome_rowan::TextRange;
 
 use crate::builders::{
-    format_leading_trivia, format_suppressed_node, format_trailing_trivia, format_trimmed_token,
-    TriviaPrintMode,
+    format_leading_comments, format_suppressed_node, format_trailing_comments,
+    format_trimmed_token, TriviaPrintMode,
 };
 use crate::context::JsFormatContext;
 use crate::cst::FormatJsSyntaxNode;
@@ -213,9 +213,9 @@ impl FormatRule<JsSyntaxToken> for FormatJsSyntaxToken {
         write!(
             f,
             [
-                format_leading_trivia(token, TriviaPrintMode::Full),
+                format_leading_comments(token, TriviaPrintMode::Full),
                 format_trimmed_token(token),
-                format_trailing_trivia(token),
+                format_trailing_comments(token),
             ]
         )
     }

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -8,8 +8,8 @@ pub use rome_formatter::prelude::*;
 pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
 
 pub use crate::builders::{
-    format_delimited, format_leading_trivia, format_or_verbatim, format_replaced,
-    format_suppressed_node, format_trailing_trivia, format_trimmed_token, format_unknown_node,
+    format_delimited, format_leading_comments, format_or_verbatim, format_replaced,
+    format_suppressed_node, format_trailing_comments, format_trimmed_token, format_unknown_node,
     format_verbatim_node,
 };
 

--- a/crates/rome_js_formatter/src/separated.rs
+++ b/crates/rome_js_formatter/src/separated.rs
@@ -46,8 +46,8 @@ where
                         write!(f, [separator.format()])?;
                     }
                     TrailingSeparator::Disallowed => {
-                        // A trailing separator was present where it wasn't allowed, opt out of formatting
-                        return Err(FormatError::MissingRequiredChild);
+                        // A trailing separator was present where it isn't allowed, opt out of formatting
+                        return Err(FormatError::SyntaxError);
                     }
                 }
             } else {

--- a/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/decorators.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/decorators.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: decorators.js
-
 ---
 # Input
 ```js
@@ -43,14 +41,14 @@ function enumerable(value) {
 // https://babeljs.io/docs/en/babel-plugin-proposal-decorators
 
 @annotation
-class MyClass {}
+class MyClass { }
 
 function annotation(target) {
   target.annotated = true;
 }
 
 @isTestable(true)
-class MyClass {}
+class MyClass { }
 
 function isTestable(value) {
   return function decorator(target) {
@@ -60,7 +58,7 @@ function isTestable(value) {
 
 class C {
   @enumerable(false)
-  method() {}
+  method() { }
 }
 
 function enumerable(value) {

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorators/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorators/comments.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: comments.js
-
 ---
 # Input
 ```js
@@ -49,7 +47,9 @@ var x = 100;
   // test
   b: '2'
 })
-class X {}
+class X {
+
+}
 
 @NgModule({
   // Imports.
@@ -69,7 +69,7 @@ export class AppModule {}
 // B
 @Bar()
 // C
-export class Bar {}
+export class Bar{}
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorators/mixed.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorators/mixed.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: mixed.js
-
 ---
 # Input
 ```js
@@ -23,7 +21,8 @@ export default class MyComponent {
 @foo
 export default class MyComponent {
   @task
-  *foo() {}
+  *foo() {
+  }
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorators/mobx.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorators/mobx.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: mobx.js
 ---
 # Input
@@ -73,16 +72,14 @@ import { observable } from "mobx";
   setPrice(price) {
     this.price = price;
   }
-
+  
   @computed @computed @computed @computed @computed @computed @computed get total() {
     return this.price * this.amount;
   }
 
-  @action handleDecrease = (event: React.ChangeEvent<HTMLInputElement>) =>
-    this.count--;
-
-  @action handleSomething = (event: React.ChangeEvent<HTMLInputElement>) =>
-    doSomething();
+  @action handleDecrease = (event: React.ChangeEvent<HTMLInputElement>) => this.count--;
+  
+  @action handleSomething = (event: React.ChangeEvent<HTMLInputElement>) => doSomething();
 }
 
 ```
@@ -119,5 +116,7 @@ error[SyntaxError]: Type annotations are a TypeScript only feature. Convert your
 # Lines exceeding max width of 80 characters
 ```
    29:   @computed @computed @computed @computed @computed @computed @computed get total() {
+   33:   @action handleDecrease = (event: React.ChangeEvent<HTMLInputElement>) => this.count--;
+   35:   @action handleSomething = (event: React.ChangeEvent<HTMLInputElement>) => doSomething();
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorators/multiple.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorators/multiple.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: multiple.js
 ---
 # Input
@@ -35,11 +34,11 @@ const dog = {
 @readonly
   @nonenumerable
   @doubledValue
-eyes: 2;
+  eyes: 2
 }
 
 const foo = {
-@multipleDecorators @inline @theyWontAllFitInOneline aVeryLongPropName: ("A very long string as value");
+@multipleDecorators @inline @theyWontAllFitInOneline aVeryLongPropName: "A very long string as value"
 }
 
 ```
@@ -81,6 +80,6 @@ error[SyntaxError]: expected a statement but instead found '}'
 
 # Lines exceeding max width of 80 characters
 ```
-   15: @multipleDecorators @inline @theyWontAllFitInOneline aVeryLongPropName: ("A very long string as value");
+   15: @multipleDecorators @inline @theyWontAllFitInOneline aVeryLongPropName: "A very long string as value"
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorators/parens.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorators/parens.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: parens.js
-
 ---
 # Input
 ```js
@@ -17,7 +15,7 @@ class X {
 ```js
 class X {
   @(computed().volatile())
-  x;
+  x
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/angular-component-examples/test.component.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/angular-component-examples/test.component.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: test.component.ts
-
 ---
 # Input
 ```js
@@ -44,7 +42,7 @@ class     TestComponent {}
 
 ]
 })
-class TestComponent {}
+class     TestComponent {}
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators-ts/mobx.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators-ts/mobx.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: mobx.ts
-
 ---
 # Input
 ```js
@@ -21,11 +19,11 @@ class X {
 ```js
 class X {
   @deco x() {
-    return this.count * 2;
-  }
+      return this.count * 2;
+	}
   @deco get x() {
-    return this.count * 2;
-  }
+      return this.count * 2;
+	}
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators-ts/typeorm.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators-ts/typeorm.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: typeorm.ts
-
 ---
 # Input
 ```js
@@ -35,23 +33,25 @@ export class Board {
 ```js
 @Entity()
 export class Board {
-  @PrimaryGeneratedColumn()
-  id: number;
 
-  @Column()
-  slug: string;
+    @PrimaryGeneratedColumn()
+    id: number;
 
-  @Column()
-  name: string;
+    @Column()
+    slug: string;
 
-  @Column()
-  theme: string;
+    @Column()
+    name: string;
 
-  @Column()
-  description: string;
+    @Column()
+    theme: string;
 
-  @OneToMany(type => Topic, topic => topic.board)
-  topics: Topic[];
+    @Column()
+    description: string;
+
+    @OneToMany(type => Topic, topic => topic.board)
+    topics: Topic[]
+
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/argument-list-preserve-line.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/argument-list-preserve-line.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: argument-list-preserve-line.ts
-
 ---
 # Input
 ```js
@@ -26,13 +24,16 @@ class Foo {
 ```js
 class Foo {
   constructor(
-    @inject(Bar)
-    private readonly bar: IBar,
-    @inject(MyProcessor)
-    private readonly myProcessor: IMyProcessor,
-    @inject(InjectionTypes.AnotherThing)
-    private readonly anotherThing: IAnotherThing | undefined,
-  ) {}
+        @inject(Bar)
+        private readonly bar: IBar,
+
+        @inject(MyProcessor)
+        private readonly myProcessor: IMyProcessor,
+
+        @inject(InjectionTypes.AnotherThing)
+
+        private readonly anotherThing: IAnotherThing | undefined,
+    ) { }
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorator-type-assertion.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorator-type-assertion.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: decorator-type-assertion.ts
-
 ---
 # Input
 ```js
@@ -21,10 +19,14 @@ class Decorated {
 # Output
 ```js
 @(bind as ClassDecorator)
-class Decorated {}
+class Decorated {
+
+}
 
 @(<ClassDecorator>bind)
-class Decorated {}
+class Decorated {
+
+}
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorators-comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorators-comments.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: decorators-comments.ts
-
 ---
 # Input
 ```js
@@ -55,32 +53,32 @@ class Something3 {
 ```js
 class Foo1 {
   @foo
-  // comment
-  async method() {}
+    // comment
+    async method() {}
 }
 
 class Foo2 {
   @foo
-  // comment
-  private method() {}
+    // comment
+    private method() {}
 }
 
 class Foo3 {
   @foo
-  // comment
-  *method() {}
+    // comment
+    *method() {}
 }
 
 class Foo4 {
   @foo
-  // comment
-  async *method() {}
+    // comment
+    async *method() {}
 }
 
 class Something {
   @foo()
-  // comment
-  readonly property: Array<string>;
+    // comment
+    readonly property: Array<string>
 }
 
 class Something2 {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorators.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorators.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: decorators.ts
-
 ---
 # Input
 ```js
@@ -89,11 +87,15 @@ class Class6 {
 # Output
 ```js
 export class TestTextFileService {
-  constructor(@ILifecycleService lifecycleService) {}
+  constructor(
+		@ILifecycleService lifecycleService,
+	) {
+	}
 }
 
 @commonEditorContribution
-export class TabCompletionController {}
+export class TabCompletionController {
+}
 
 @Component({
   selector: 'angular-component',
@@ -105,7 +107,7 @@ class AngularComponent {
 class Class {
   method(
     @Decorator
-    { prop1, prop2 }: Type,
+    { prop1, prop2 }: Type
   ) {
     doSomething();
   }
@@ -115,7 +117,7 @@ class Class2 {
   method(
     @Decorator1
     @Decorator2
-    { prop1, prop2 }: Type,
+    { prop1, prop2 }: Type
   ) {
     doSomething();
   }
@@ -125,7 +127,7 @@ class Class3 {
   method(
     @Decorator
     { prop1_1, prop1_2 }: Type,
-    { prop2_1, prop2_2 }: Type,
+    { prop2_1, prop2_2 }: Type
   ) {
     doSomething();
   }
@@ -135,24 +137,30 @@ class Class4 {
   method(
     param1,
     @Decorator
-    { prop1, prop2 }: Type,
+    { prop1, prop2 }: Type
   ) {}
 }
 
 class Class5 {
-  method(@Decorator { prop1 }: Type) {}
+  method(
+    @Decorator { prop1 }: Type
+  ) {}
 }
 
 class Class6 {
-  method(@Decorator({}) { prop1 }: Type) {}
   method(
-    @Decorator(
-      {}) { prop1 }: Type,
+    @Decorator({}) { prop1 }: Type
   ) {}
-  method(@Decorator([]) { prop1 }: Type) {}
   method(
     @Decorator(
-      []) { prop1 }: Type,
+      {}) { prop1 }: Type
+  ) {}
+  method(
+    @Decorator([]) { prop1 }: Type
+  ) {}
+  method(
+    @Decorator(
+      []) { prop1 }: Type
   ) {}
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/inline-decorators.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/inline-decorators.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: inline-decorators.ts
-
 ---
 # Input
 ```js
@@ -71,16 +69,16 @@ class Class2 {
     @d2(foo)
     @d3.bar
     @d4.baz()
-  method1() {}
+    method1() {}
 
   @d1
-  method2() {}
+    method2() {}
 
   @d2(foo)
-  method3() {}
+    method3() {}
 
   @d3.bar
-  method4() {}
+    method4() {}
 }
 
 class Class3 {
@@ -89,14 +87,14 @@ class Class3 {
   @d3.bar fieldC;
   @d4.baz() fieldD;
 
-  constructor(
-    @d1 private x: number,
-    @d2(foo) private y: number,
-    @d3('foo') private z: number,
-    @d4({
+  constructor (
+        @d1 private x: number,
+        @d2(foo) private y: number,
+        @d3('foo') private z: number,
+        @d4({
             x: string
         }) private a: string,
-  ) {}
+    ) {}
 }
 
 @decorated class Foo {}
@@ -106,11 +104,13 @@ class Bar {
 }
 
 class MyContainerComponent {
-  @ContentChildren(MyComponent) components: QueryListSomeBigName<
-    MyComponentThat
-  >;
+  @ContentChildren(MyComponent) components: QueryListSomeBigName<MyComponentThat>;
 }
 
 ```
 
+# Lines exceeding max width of 80 characters
+```
+   47:   @ContentChildren(MyComponent) components: QueryListSomeBigName<MyComponentThat>;
+```
 

--- a/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
@@ -63,11 +63,7 @@ class Test {
 	@readonly
 	prop: string;
 
-	constructor(
-		@param test,
-		@readonly private other,
-		@aVeryLongDecoratorNameLetsSeeWhatHappensWithIt last,
-	) {}
+	constructor(@param test, @readonly private other, @aVeryLongDecoratorNameLetsSeeWhatHappensWithIt last) {}
 
 	method(@param a) {}
 
@@ -86,13 +82,30 @@ export class Test {}
 @test // first decorator
 // Leading comment before class
 class Test2 {
+
+
+
+
+
 	/*
 	 * Leading multiline comment
 	 */
 
+
+
 	@test /* trailing multiline comment
 	 for decorator */ @anotherDecorator()
-	// leading comment
+
+
+
+
+		// leading comment
 	prop: string;
+
 }
+
+
+## Lines exceeding width of 80 characters
+
+    6: 	constructor(@param test, @readonly private other, @aVeryLongDecoratorNameLetsSeeWhatHappensWithIt last) {}
 


### PR DESCRIPTION
**Merge AFTER the release cut**

## Summary
The parser uses skipped token trivia to recover from unrecognised syntax. For example, it could skip over the token `5` in `import 5 from "test";` because that allows to continue parsing the rest of the `from` statement.

Up to this point, we decided to format nodes with skipped token as if the nodes don't contain any syntax error because skipped token is, so far, only used to skip over decorator syntax. The issue with that is that our parser doesn't guarantee that the skipped decorators actually are valid and don't contain any syntax errors AND skipped token trivia might be used for real syntax errors at any point in the future. Thus, we shouldn't rely on that skipped token trivia is only used for syntax that Rome doesn't fully support.

This PR renames `FormatError::MissingRequiredChild` to `SyntaxError` and changes the leading trivia formatting to return `Err(FormatError::SyntaxError)` if any piece is a skipped token trivia to align it with how the rest of the formatter handles syntax errors.

This results in a few regressions on decorator formatting. The fix for that is to implement decorator parsing support.

## Test Plan

`cargo test`. Reviewed the updated snapshots. 


