### PR TITLE
feat(rome_rowan): implement `DoubleEndedIterator` for node lists

### DIFF
--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -417,10 +417,9 @@ impl<L: Language, N: AstNode<Language = L>> DoubleEndedIterator
                         Err(SyntaxError::MissingRequiredChild),
                     ),
                 }
-                // Some(SyntaxSlot::Node(node)) => panic!("Malformed separated list, separator expected but found node {:?} instead. You must add missing markers for missing separators.", node),
             }
             None => {
-                // then we should find the node
+                // there wasn't any separator, let's try to go back and see if we find
                 let node = match self.slots.next_back()? {
                     // The node for this element is missing if the next child is a token instead of a node.
                     SyntaxSlot::Token(token) => panic!("Malformed list, node expected but found token {:?} instead. You must add missing markers for missing elements.", token),
@@ -432,25 +431,6 @@ impl<L: Language, N: AstNode<Language = L>> DoubleEndedIterator
                 (node, Ok(None))
             }
         };
-        // we should find the separator first
-        // let separator = match slot {
-        //     Some(SyntaxSlot::Empty) => Err(
-        //         SyntaxError::MissingRequiredChild,
-        //     ),
-        //     Some(SyntaxSlot::Token(token)) => Ok(Some(token)),
-        //     // End of list, no trailing separator
-        //     None => Ok(None),
-        //     Some(SyntaxSlot::Node(node)) => panic!("Malformed separated list, separator expected but found node {:?} instead. You must add missing markers for missing separators.", node),
-        // };
-        //
-        // // then we should find the node
-        // let node = match self.slots.next_back()? {
-        //     // The node for this element is missing if the next child is a token instead of a node.
-        //     SyntaxSlot::Token(token) => panic!("Malformed list, node expected but found token {:?} instead. You must add missing markers for missing elements.", token),
-        //     // Missing element
-        //     SyntaxSlot::Empty => Err(SyntaxError::MissingRequiredChild),
-        //     SyntaxSlot::Node(node) => Ok(N::unwrap_cast(node))
-        // };
 
         Some(AstSeparatedElement {
             node,

--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -645,15 +645,14 @@ mod tests {
         SeparatedExpressionList::new(node.into_list())
     }
 
+    type MappedElement = Vec<(Option<f64>, Option<String>)>;
+
     fn map_elements<'a>(
         actual: impl Iterator<Item = AstSeparatedElement<RawLanguage, LiteralExpression>>
             + DoubleEndedIterator,
         expected: impl IntoIterator<Item = (Option<f64>, Option<&'a str>)>,
         revert: bool,
-    ) -> (
-        Vec<(Option<f64>, Option<String>)>,
-        Vec<(Option<f64>, Option<String>)>,
-    ) {
+    ) -> (MappedElement, MappedElement) {
         let actual: Vec<_> = if revert {
             actual.rev().collect()
         } else {

--- a/crates/rome_rowan/src/cursor/node.rs
+++ b/crates/rome_rowan/src/cursor/node.rs
@@ -660,7 +660,7 @@ impl SyntaxSlots {
         let len = parent.green().slots().len() as i32;
         Self {
             front_next_position: 0,
-            back_next_position: len - 1,
+            back_next_position: len,
             parent,
         }
     }

--- a/crates/rome_rowan/src/cursor/node.rs
+++ b/crates/rome_rowan/src/cursor/node.rs
@@ -651,16 +651,15 @@ impl From<SyntaxElement> for SyntaxSlot {
 #[derive(Debug, Clone)]
 pub(crate) struct SyntaxSlots {
     front_next_position: u32,
-    back_next_position: i32,
+    back_next_position: u32,
     parent: SyntaxNode,
 }
 
 impl SyntaxSlots {
     fn new(parent: SyntaxNode) -> Self {
-        let len = parent.green().slots().len() as i32;
         Self {
             front_next_position: 0,
-            back_next_position: len,
+            back_next_position: 0,
             parent,
         }
     }
@@ -741,10 +740,10 @@ impl FusedIterator for SyntaxSlots {}
 impl DoubleEndedIterator for SyntaxSlots {
     fn next_back(&mut self) -> Option<Self::Item> {
         let mut slots = self.parent.green().slots();
-        let current_position = self.back_next_position;
-        if current_position >= 0 {
-            let previous_slot = slots.nth(current_position as usize);
-            self.back_next_position -= 1;
+        let current_position = self.back_next_position as usize;
+        if current_position < slots.len() {
+            let previous_slot = slots.nth_back(current_position as usize);
+            self.back_next_position += 1;
             previous_slot.map(|slot| self.map_slot(slot, current_position as u32))
         } else {
             None
@@ -752,7 +751,7 @@ impl DoubleEndedIterator for SyntaxSlots {
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.back_next_position -= n as i32;
+        self.back_next_position += n as u32;
         self.next_back()
     }
 }

--- a/crates/rome_rowan/src/cursor/node.rs
+++ b/crates/rome_rowan/src/cursor/node.rs
@@ -650,9 +650,13 @@ impl From<SyntaxElement> for SyntaxSlot {
 /// Iterator over a node's slots
 #[derive(Debug, Clone)]
 pub(crate) struct SyntaxSlots {
-    // current consuming position tracked from the front
+    /// Current consuming position tracked from the front
     front_next_position: u32,
-    // current consuming position tracked from the back
+    /// Current consuming position tracked from the back
+    /// **The index is from the end of the iterator!**
+    /// The API uses [`nth_back`] to retrieve the item:
+    ///
+    /// [nth_back]: https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html#method.nth_back
     back_next_position: u32,
     parent: SyntaxNode,
 }

--- a/crates/rome_rowan/src/raw_language.rs
+++ b/crates/rome_rowan/src/raw_language.rs
@@ -94,6 +94,7 @@ impl AstNode for RawLanguageRoot {
 }
 
 #[doc(hidden)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct LiteralExpression {
     node: SyntaxNode<RawLanguage>,
 }

--- a/crates/rome_rowan/src/raw_language.rs
+++ b/crates/rome_rowan/src/raw_language.rs
@@ -94,7 +94,6 @@ impl AstNode for RawLanguageRoot {
 }
 
 #[doc(hidden)]
-#[derive(Eq, PartialEq, Debug)]
 pub struct LiteralExpression {
     node: SyntaxNode<RawLanguage>,
 }

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -755,4 +755,8 @@ impl<L: Language> DoubleEndedIterator for SyntaxSlots<L> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.raw.next_back().map(SyntaxSlot::from)
     }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.raw.nth_back(n).map(SyntaxSlot::from)
+    }
 }

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -750,3 +750,9 @@ impl<'a, L: Language> ExactSizeIterator for SyntaxSlots<L> {
         self.raw.len()
     }
 }
+
+impl<L: Language> DoubleEndedIterator for SyntaxSlots<L> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.raw.next_back().map(SyntaxSlot::from)
+    }
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds the ability to consume an `AstSeparatedList` from the back by implementing `DoubleEndedIterator`.

The reason why I implemented this is because there have been cases where I needed to retrieve the last elements of a list. This will be useful, for example, inside the formatter when implementing the formatting of call arguments.

Checking a separated list from the back adds a bit more of complexity because the **last** separator is not mandatory, which means that we should handle cases where this is not an error. 

In order to achieve that, I had to make the slots peekable, because sometimes we don't want to consume two slots. An example is when we have `[1, separator, 3, separator, 5]`. We want to consume only `5` in the first iteration, but then we want to consume `separator` and `3`. 

I added the `unreacheable` macro. If we hit that macro, it means that are edge cases we have to handle.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Created new tests to cover the cases:
- consuming from the back
- consuming from both ends and make sure that once the iterator is consumed from both ends, `None` is returned
- updated all the current tests with a new assertion called `assert_rev_elements`, we call `rev` on all vectors (`rev` needs `next_back`), so we should cover all the edge cases that were previously handled.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
