### PR TITLE
feature(rome_js_parser): JSX support in .js files

### DIFF
--- a/crates/rome_analyze/tests/specs/flipBinExp.js
+++ b/crates/rome_analyze/tests/specs/flipBinExp.js
@@ -24,7 +24,7 @@ const a = b ** c;
 
 const a = b << c;
 const a = b >> c;
-const a = b <<< c;
+const a = b >>> c;
 const a = b & c;
 const a = b | c;
 const a = b ^ c;

--- a/crates/rome_analyze/tests/specs/flipBinExp.js.snap
+++ b/crates/rome_analyze/tests/specs/flipBinExp.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_analyze/tests/spec_tests.rs
-assertion_line: 92
 expression: flipBinExp.js
-
 ---
 # Input
 ```js
@@ -32,7 +30,7 @@ const a = b ** c;
 
 const a = b << c;
 const a = b >> c;
-const a = b <<< c;
+const a = b >>> c;
 const a = b & c;
 const a = b | c;
 const a = b ^ c;
@@ -170,7 +168,7 @@ const a = b ^ c;
       | @@ -25,6 +25,6 @@
 24 24 |   const a = b << c;
 25 25 |   const a = b >> c;
-26 26 |   const a = b <<< c;
+26 26 |   const a = b >>> c;
 27    | - const a = b & c;
    27 | + const a = c & b;
 28 28 |   const a = b | c;
@@ -181,7 +179,7 @@ const a = b ^ c;
 ```
       | @@ -26,5 +26,5 @@
 25 25 |   const a = b >> c;
-26 26 |   const a = b <<< c;
+26 26 |   const a = b >>> c;
 27 27 |   const a = b & c;
 28    | - const a = b | c;
    28 | + const a = c | b;
@@ -191,7 +189,7 @@ const a = b ^ c;
 
 ```
       | @@ -27,4 +27,4 @@
-26 26 |   const a = b <<< c;
+26 26 |   const a = b >>> c;
 27 27 |   const a = b & c;
 28 28 |   const a = b | c;
 29    | - const a = b ^ c;

--- a/crates/rome_js_parser/src/lexer/mod.rs
+++ b/crates/rome_js_parser/src/lexer/mod.rs
@@ -312,7 +312,7 @@ impl<'src> Lexer<'src> {
             ReLexContext::BinaryOperator => self.re_lex_binary_operator(),
             ReLexContext::TypeArgumentLessThan => self.re_lex_type_argument_less_than(),
             ReLexContext::JsxIdentifier => self.re_lex_jsx_identifier(old_position),
-            ReLexContext::JsxChild => self.lex_jsx_child_token(),
+            ReLexContext::JsxChild if !self.is_eof() => self.lex_jsx_child_token(),
             _ => self.current(),
         };
 

--- a/crates/rome_js_parser/src/syntax/jsx/mod.rs
+++ b/crates/rome_js_parser/src/syntax/jsx/mod.rs
@@ -35,11 +35,12 @@ use super::typescript::parse_ts_type_arguments;
 // <div />
 
 // test_err jsx_or_type_assertion
+// // SCRIPT
 // function f() {
 //     let a = <div>a</div>; // JSX
-//     let b = <string>b; //type assertion
+//     let b = <string>b; // type assertion
 //     let c = <string>b<a>d; // type assertion
-//     let d = <div>a</div>/; // ambigous: JSX or "type assertion a less than regex /div>/". Probably JSX.
+//     let d = <div>a</div>/; // ambiguous: JSX or "type assertion a less than regex /div>/". Probably JSX.
 //     let d = <string>a</string>/;
 // }
 

--- a/crates/rome_js_parser/test_data/inline/err/jsx_or_type_assertion.js
+++ b/crates/rome_js_parser/test_data/inline/err/jsx_or_type_assertion.js
@@ -1,7 +1,8 @@
+// SCRIPT
 function f() {
     let a = <div>a</div>; // JSX
-    let b = <string>b; //type assertion
+    let b = <string>b; // type assertion
     let c = <string>b<a>d; // type assertion
-    let d = <div>a</div>/; // ambigous: JSX or "type assertion a less than regex /div>/". Probably JSX.
+    let d = <div>a</div>/; // ambiguous: JSX or "type assertion a less than regex /div>/". Probably JSX.
     let d = <string>a</string>/;
 }

--- a/crates/rome_js_parser/test_data/inline/err/jsx_or_type_assertion.rast
+++ b/crates/rome_js_parser/test_data/inline/err/jsx_or_type_assertion.rast
@@ -1,63 +1,63 @@
-JsModule {
+JsScript {
     interpreter_token: missing (optional),
     directives: JsDirectiveList [],
-    items: JsModuleItemList [
+    statements: JsStatementList [
         JsFunctionDeclaration {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            function_token: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
-                name_token: IDENT@9..10 "f" [] [],
+                name_token: IDENT@19..20 "f" [] [],
             },
             type_parameters: missing (optional),
             parameters: JsParameters {
-                l_paren_token: L_PAREN@10..11 "(" [] [],
+                l_paren_token: L_PAREN@20..21 "(" [] [],
                 items: JsParameterList [],
-                r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
+                r_paren_token: R_PAREN@21..23 ")" [] [Whitespace(" ")],
             },
             return_type_annotation: missing (optional),
             body: JsFunctionBody {
-                l_curly_token: L_CURLY@13..14 "{" [] [],
+                l_curly_token: L_CURLY@23..24 "{" [] [],
                 directives: JsDirectiveList [],
                 statements: JsStatementList [
                     JsVariableStatement {
                         declaration: JsVariableDeclaration {
-                            kind: LET_KW@14..23 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                            kind: LET_KW@24..33 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                             declarators: JsVariableDeclaratorList [
                                 JsVariableDeclarator {
                                     id: JsIdentifierBinding {
-                                        name_token: IDENT@23..25 "a" [] [Whitespace(" ")],
+                                        name_token: IDENT@33..35 "a" [] [Whitespace(" ")],
                                     },
                                     variable_annotation: missing (optional),
                                     initializer: JsInitializerClause {
-                                        eq_token: EQ@25..27 "=" [] [Whitespace(" ")],
+                                        eq_token: EQ@35..37 "=" [] [Whitespace(" ")],
                                         expression: JsBinaryExpression {
                                             left: JsUnknownExpression {
                                                 items: [
-                                                    L_ANGLE@27..28 "<" [] [],
+                                                    L_ANGLE@37..38 "<" [] [],
                                                     TsReferenceType {
                                                         name: JsReferenceIdentifier {
-                                                            value_token: IDENT@28..31 "div" [] [],
+                                                            value_token: IDENT@38..41 "div" [] [],
                                                         },
                                                         type_arguments: missing (optional),
                                                     },
-                                                    R_ANGLE@31..32 ">" [] [],
+                                                    R_ANGLE@41..42 ">" [] [],
                                                     JsIdentifierExpression {
                                                         name: JsReferenceIdentifier {
-                                                            value_token: IDENT@32..33 "a" [] [],
+                                                            value_token: IDENT@42..43 "a" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            operator_token: L_ANGLE@33..34 "<" [] [],
+                                            operator_token: L_ANGLE@43..44 "<" [] [],
                                             right: JsBinaryExpression {
                                                 left: JsRegexLiteralExpression {
-                                                    value_token: JS_REGEX_LITERAL@34..42 "/div>; /" [] [],
+                                                    value_token: JS_REGEX_LITERAL@44..52 "/div>; /" [] [],
                                                 },
-                                                operator_token: SLASH@42..44 "/" [] [Whitespace(" ")],
+                                                operator_token: SLASH@52..54 "/" [] [Whitespace(" ")],
                                                 right: JsIdentifierExpression {
                                                     name: JsReferenceIdentifier {
-                                                        value_token: IDENT@44..47 "JSX" [] [],
+                                                        value_token: IDENT@54..57 "JSX" [] [],
                                                     },
                                                 },
                                             },
@@ -70,25 +70,25 @@ JsModule {
                     },
                     JsVariableStatement {
                         declaration: JsVariableDeclaration {
-                            kind: LET_KW@47..56 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                            kind: LET_KW@57..66 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                             declarators: JsVariableDeclaratorList [
                                 JsVariableDeclarator {
                                     id: JsIdentifierBinding {
-                                        name_token: IDENT@56..58 "b" [] [Whitespace(" ")],
+                                        name_token: IDENT@66..68 "b" [] [Whitespace(" ")],
                                     },
                                     variable_annotation: missing (optional),
                                     initializer: JsInitializerClause {
-                                        eq_token: EQ@58..60 "=" [] [Whitespace(" ")],
+                                        eq_token: EQ@68..70 "=" [] [Whitespace(" ")],
                                         expression: JsUnknownExpression {
                                             items: [
-                                                L_ANGLE@60..61 "<" [] [],
+                                                L_ANGLE@70..71 "<" [] [],
                                                 TsStringType {
-                                                    string_token: STRING_KW@61..67 "string" [] [],
+                                                    string_token: STRING_KW@71..77 "string" [] [],
                                                 },
-                                                R_ANGLE@67..68 ">" [] [],
+                                                R_ANGLE@77..78 ">" [] [],
                                                 JsIdentifierExpression {
                                                     name: JsReferenceIdentifier {
-                                                        value_token: IDENT@68..69 "b" [] [],
+                                                        value_token: IDENT@78..79 "b" [] [],
                                                     },
                                                 },
                                             ],
@@ -97,46 +97,46 @@ JsModule {
                                 },
                             ],
                         },
-                        semicolon_token: SEMICOLON@69..87 ";" [] [Whitespace(" "), Comments("//type assertion")],
+                        semicolon_token: SEMICOLON@79..98 ";" [] [Whitespace(" "), Comments("// type assertion")],
                     },
                     JsVariableStatement {
                         declaration: JsVariableDeclaration {
-                            kind: LET_KW@87..96 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                            kind: LET_KW@98..107 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                             declarators: JsVariableDeclaratorList [
                                 JsVariableDeclarator {
                                     id: JsIdentifierBinding {
-                                        name_token: IDENT@96..98 "c" [] [Whitespace(" ")],
+                                        name_token: IDENT@107..109 "c" [] [Whitespace(" ")],
                                     },
                                     variable_annotation: missing (optional),
                                     initializer: JsInitializerClause {
-                                        eq_token: EQ@98..100 "=" [] [Whitespace(" ")],
+                                        eq_token: EQ@109..111 "=" [] [Whitespace(" ")],
                                         expression: JsBinaryExpression {
                                             left: JsBinaryExpression {
                                                 left: JsUnknownExpression {
                                                     items: [
-                                                        L_ANGLE@100..101 "<" [] [],
+                                                        L_ANGLE@111..112 "<" [] [],
                                                         TsStringType {
-                                                            string_token: STRING_KW@101..107 "string" [] [],
+                                                            string_token: STRING_KW@112..118 "string" [] [],
                                                         },
-                                                        R_ANGLE@107..108 ">" [] [],
+                                                        R_ANGLE@118..119 ">" [] [],
                                                         JsIdentifierExpression {
                                                             name: JsReferenceIdentifier {
-                                                                value_token: IDENT@108..109 "b" [] [],
+                                                                value_token: IDENT@119..120 "b" [] [],
                                                             },
                                                         },
                                                     ],
                                                 },
-                                                operator_token: L_ANGLE@109..110 "<" [] [],
+                                                operator_token: L_ANGLE@120..121 "<" [] [],
                                                 right: JsIdentifierExpression {
                                                     name: JsReferenceIdentifier {
-                                                        value_token: IDENT@110..111 "a" [] [],
+                                                        value_token: IDENT@121..122 "a" [] [],
                                                     },
                                                 },
                                             },
-                                            operator_token: R_ANGLE@111..112 ">" [] [],
+                                            operator_token: R_ANGLE@122..123 ">" [] [],
                                             right: JsIdentifierExpression {
                                                 name: JsReferenceIdentifier {
-                                                    value_token: IDENT@112..113 "d" [] [],
+                                                    value_token: IDENT@123..124 "d" [] [],
                                                 },
                                             },
                                         },
@@ -144,281 +144,282 @@ JsModule {
                                 },
                             ],
                         },
-                        semicolon_token: SEMICOLON@113..132 ";" [] [Whitespace(" "), Comments("// type assertion")],
+                        semicolon_token: SEMICOLON@124..143 ";" [] [Whitespace(" "), Comments("// type assertion")],
                     },
                     JsVariableStatement {
                         declaration: JsVariableDeclaration {
-                            kind: LET_KW@132..141 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                            kind: LET_KW@143..152 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                             declarators: JsVariableDeclaratorList [
                                 JsVariableDeclarator {
                                     id: JsIdentifierBinding {
-                                        name_token: IDENT@141..143 "d" [] [Whitespace(" ")],
+                                        name_token: IDENT@152..154 "d" [] [Whitespace(" ")],
                                     },
                                     variable_annotation: missing (optional),
                                     initializer: JsInitializerClause {
-                                        eq_token: EQ@143..145 "=" [] [Whitespace(" ")],
+                                        eq_token: EQ@154..156 "=" [] [Whitespace(" ")],
                                         expression: JsBinaryExpression {
                                             left: JsUnknownExpression {
                                                 items: [
-                                                    L_ANGLE@145..146 "<" [] [],
+                                                    L_ANGLE@156..157 "<" [] [],
                                                     TsReferenceType {
                                                         name: JsReferenceIdentifier {
-                                                            value_token: IDENT@146..149 "div" [] [],
+                                                            value_token: IDENT@157..160 "div" [] [],
                                                         },
                                                         type_arguments: missing (optional),
                                                     },
-                                                    R_ANGLE@149..150 ">" [] [],
+                                                    R_ANGLE@160..161 ">" [] [],
                                                     JsIdentifierExpression {
                                                         name: JsReferenceIdentifier {
-                                                            value_token: IDENT@150..151 "a" [] [],
+                                                            value_token: IDENT@161..162 "a" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            operator_token: L_ANGLE@151..152 "<" [] [],
+                                            operator_token: L_ANGLE@162..163 "<" [] [],
                                             right: JsRegexLiteralExpression {
-                                                value_token: JS_REGEX_LITERAL@152..158 "/div>/" [] [],
+                                                value_token: JS_REGEX_LITERAL@163..169 "/div>/" [] [],
                                             },
                                         },
                                     },
                                 },
                             ],
                         },
-                        semicolon_token: SEMICOLON@158..236 ";" [] [Whitespace(" "), Comments("// ambigous: JSX or \" ...")],
+                        semicolon_token: SEMICOLON@169..248 ";" [] [Whitespace(" "), Comments("// ambiguous: JSX or  ...")],
                     },
                     JsVariableStatement {
                         declaration: JsVariableDeclaration {
-                            kind: LET_KW@236..245 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                            kind: LET_KW@248..257 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                             declarators: JsVariableDeclaratorList [
                                 JsVariableDeclarator {
                                     id: JsIdentifierBinding {
-                                        name_token: IDENT@245..247 "d" [] [Whitespace(" ")],
+                                        name_token: IDENT@257..259 "d" [] [Whitespace(" ")],
                                     },
                                     variable_annotation: missing (optional),
                                     initializer: JsInitializerClause {
-                                        eq_token: EQ@247..249 "=" [] [Whitespace(" ")],
+                                        eq_token: EQ@259..261 "=" [] [Whitespace(" ")],
                                         expression: JsBinaryExpression {
                                             left: JsUnknownExpression {
                                                 items: [
-                                                    L_ANGLE@249..250 "<" [] [],
+                                                    L_ANGLE@261..262 "<" [] [],
                                                     TsStringType {
-                                                        string_token: STRING_KW@250..256 "string" [] [],
+                                                        string_token: STRING_KW@262..268 "string" [] [],
                                                     },
-                                                    R_ANGLE@256..257 ">" [] [],
+                                                    R_ANGLE@268..269 ">" [] [],
                                                     JsIdentifierExpression {
                                                         name: JsReferenceIdentifier {
-                                                            value_token: IDENT@257..258 "a" [] [],
+                                                            value_token: IDENT@269..270 "a" [] [],
                                                         },
                                                     },
                                                 ],
                                             },
-                                            operator_token: L_ANGLE@258..259 "<" [] [],
+                                            operator_token: L_ANGLE@270..271 "<" [] [],
                                             right: JsRegexLiteralExpression {
-                                                value_token: JS_REGEX_LITERAL@259..268 "/string>/" [] [],
+                                                value_token: JS_REGEX_LITERAL@271..280 "/string>/" [] [],
                                             },
                                         },
                                     },
                                 },
                             ],
                         },
-                        semicolon_token: SEMICOLON@268..269 ";" [] [],
+                        semicolon_token: SEMICOLON@280..281 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@269..271 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@281..283 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@271..272 "" [Newline("\n")] [],
+    eof_token: EOF@283..284 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..272
+0: JS_SCRIPT@0..284
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..271
-    0: JS_FUNCTION_DECLARATION@0..271
+  2: JS_STATEMENT_LIST@0..283
+    0: JS_FUNCTION_DECLARATION@0..283
       0: (empty)
-      1: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
+      1: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
       2: (empty)
-      3: JS_IDENTIFIER_BINDING@9..10
-        0: IDENT@9..10 "f" [] []
+      3: JS_IDENTIFIER_BINDING@19..20
+        0: IDENT@19..20 "f" [] []
       4: (empty)
-      5: JS_PARAMETERS@10..13
-        0: L_PAREN@10..11 "(" [] []
-        1: JS_PARAMETER_LIST@11..11
-        2: R_PAREN@11..13 ")" [] [Whitespace(" ")]
+      5: JS_PARAMETERS@20..23
+        0: L_PAREN@20..21 "(" [] []
+        1: JS_PARAMETER_LIST@21..21
+        2: R_PAREN@21..23 ")" [] [Whitespace(" ")]
       6: (empty)
-      7: JS_FUNCTION_BODY@13..271
-        0: L_CURLY@13..14 "{" [] []
-        1: JS_DIRECTIVE_LIST@14..14
-        2: JS_STATEMENT_LIST@14..269
-          0: JS_VARIABLE_STATEMENT@14..47
-            0: JS_VARIABLE_DECLARATION@14..47
-              0: LET_KW@14..23 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
-              1: JS_VARIABLE_DECLARATOR_LIST@23..47
-                0: JS_VARIABLE_DECLARATOR@23..47
-                  0: JS_IDENTIFIER_BINDING@23..25
-                    0: IDENT@23..25 "a" [] [Whitespace(" ")]
+      7: JS_FUNCTION_BODY@23..283
+        0: L_CURLY@23..24 "{" [] []
+        1: JS_DIRECTIVE_LIST@24..24
+        2: JS_STATEMENT_LIST@24..281
+          0: JS_VARIABLE_STATEMENT@24..57
+            0: JS_VARIABLE_DECLARATION@24..57
+              0: LET_KW@24..33 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+              1: JS_VARIABLE_DECLARATOR_LIST@33..57
+                0: JS_VARIABLE_DECLARATOR@33..57
+                  0: JS_IDENTIFIER_BINDING@33..35
+                    0: IDENT@33..35 "a" [] [Whitespace(" ")]
                   1: (empty)
-                  2: JS_INITIALIZER_CLAUSE@25..47
-                    0: EQ@25..27 "=" [] [Whitespace(" ")]
-                    1: JS_BINARY_EXPRESSION@27..47
-                      0: JS_UNKNOWN_EXPRESSION@27..33
-                        0: L_ANGLE@27..28 "<" [] []
-                        1: TS_REFERENCE_TYPE@28..31
-                          0: JS_REFERENCE_IDENTIFIER@28..31
-                            0: IDENT@28..31 "div" [] []
+                  2: JS_INITIALIZER_CLAUSE@35..57
+                    0: EQ@35..37 "=" [] [Whitespace(" ")]
+                    1: JS_BINARY_EXPRESSION@37..57
+                      0: JS_UNKNOWN_EXPRESSION@37..43
+                        0: L_ANGLE@37..38 "<" [] []
+                        1: TS_REFERENCE_TYPE@38..41
+                          0: JS_REFERENCE_IDENTIFIER@38..41
+                            0: IDENT@38..41 "div" [] []
                           1: (empty)
-                        2: R_ANGLE@31..32 ">" [] []
-                        3: JS_IDENTIFIER_EXPRESSION@32..33
-                          0: JS_REFERENCE_IDENTIFIER@32..33
-                            0: IDENT@32..33 "a" [] []
-                      1: L_ANGLE@33..34 "<" [] []
-                      2: JS_BINARY_EXPRESSION@34..47
-                        0: JS_REGEX_LITERAL_EXPRESSION@34..42
-                          0: JS_REGEX_LITERAL@34..42 "/div>; /" [] []
-                        1: SLASH@42..44 "/" [] [Whitespace(" ")]
-                        2: JS_IDENTIFIER_EXPRESSION@44..47
-                          0: JS_REFERENCE_IDENTIFIER@44..47
-                            0: IDENT@44..47 "JSX" [] []
+                        2: R_ANGLE@41..42 ">" [] []
+                        3: JS_IDENTIFIER_EXPRESSION@42..43
+                          0: JS_REFERENCE_IDENTIFIER@42..43
+                            0: IDENT@42..43 "a" [] []
+                      1: L_ANGLE@43..44 "<" [] []
+                      2: JS_BINARY_EXPRESSION@44..57
+                        0: JS_REGEX_LITERAL_EXPRESSION@44..52
+                          0: JS_REGEX_LITERAL@44..52 "/div>; /" [] []
+                        1: SLASH@52..54 "/" [] [Whitespace(" ")]
+                        2: JS_IDENTIFIER_EXPRESSION@54..57
+                          0: JS_REFERENCE_IDENTIFIER@54..57
+                            0: IDENT@54..57 "JSX" [] []
             1: (empty)
-          1: JS_VARIABLE_STATEMENT@47..87
-            0: JS_VARIABLE_DECLARATION@47..69
-              0: LET_KW@47..56 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
-              1: JS_VARIABLE_DECLARATOR_LIST@56..69
-                0: JS_VARIABLE_DECLARATOR@56..69
-                  0: JS_IDENTIFIER_BINDING@56..58
-                    0: IDENT@56..58 "b" [] [Whitespace(" ")]
+          1: JS_VARIABLE_STATEMENT@57..98
+            0: JS_VARIABLE_DECLARATION@57..79
+              0: LET_KW@57..66 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+              1: JS_VARIABLE_DECLARATOR_LIST@66..79
+                0: JS_VARIABLE_DECLARATOR@66..79
+                  0: JS_IDENTIFIER_BINDING@66..68
+                    0: IDENT@66..68 "b" [] [Whitespace(" ")]
                   1: (empty)
-                  2: JS_INITIALIZER_CLAUSE@58..69
-                    0: EQ@58..60 "=" [] [Whitespace(" ")]
-                    1: JS_UNKNOWN_EXPRESSION@60..69
-                      0: L_ANGLE@60..61 "<" [] []
-                      1: TS_STRING_TYPE@61..67
-                        0: STRING_KW@61..67 "string" [] []
-                      2: R_ANGLE@67..68 ">" [] []
-                      3: JS_IDENTIFIER_EXPRESSION@68..69
-                        0: JS_REFERENCE_IDENTIFIER@68..69
-                          0: IDENT@68..69 "b" [] []
-            1: SEMICOLON@69..87 ";" [] [Whitespace(" "), Comments("//type assertion")]
-          2: JS_VARIABLE_STATEMENT@87..132
-            0: JS_VARIABLE_DECLARATION@87..113
-              0: LET_KW@87..96 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
-              1: JS_VARIABLE_DECLARATOR_LIST@96..113
-                0: JS_VARIABLE_DECLARATOR@96..113
-                  0: JS_IDENTIFIER_BINDING@96..98
-                    0: IDENT@96..98 "c" [] [Whitespace(" ")]
+                  2: JS_INITIALIZER_CLAUSE@68..79
+                    0: EQ@68..70 "=" [] [Whitespace(" ")]
+                    1: JS_UNKNOWN_EXPRESSION@70..79
+                      0: L_ANGLE@70..71 "<" [] []
+                      1: TS_STRING_TYPE@71..77
+                        0: STRING_KW@71..77 "string" [] []
+                      2: R_ANGLE@77..78 ">" [] []
+                      3: JS_IDENTIFIER_EXPRESSION@78..79
+                        0: JS_REFERENCE_IDENTIFIER@78..79
+                          0: IDENT@78..79 "b" [] []
+            1: SEMICOLON@79..98 ";" [] [Whitespace(" "), Comments("// type assertion")]
+          2: JS_VARIABLE_STATEMENT@98..143
+            0: JS_VARIABLE_DECLARATION@98..124
+              0: LET_KW@98..107 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+              1: JS_VARIABLE_DECLARATOR_LIST@107..124
+                0: JS_VARIABLE_DECLARATOR@107..124
+                  0: JS_IDENTIFIER_BINDING@107..109
+                    0: IDENT@107..109 "c" [] [Whitespace(" ")]
                   1: (empty)
-                  2: JS_INITIALIZER_CLAUSE@98..113
-                    0: EQ@98..100 "=" [] [Whitespace(" ")]
-                    1: JS_BINARY_EXPRESSION@100..113
-                      0: JS_BINARY_EXPRESSION@100..111
-                        0: JS_UNKNOWN_EXPRESSION@100..109
-                          0: L_ANGLE@100..101 "<" [] []
-                          1: TS_STRING_TYPE@101..107
-                            0: STRING_KW@101..107 "string" [] []
-                          2: R_ANGLE@107..108 ">" [] []
-                          3: JS_IDENTIFIER_EXPRESSION@108..109
-                            0: JS_REFERENCE_IDENTIFIER@108..109
-                              0: IDENT@108..109 "b" [] []
-                        1: L_ANGLE@109..110 "<" [] []
-                        2: JS_IDENTIFIER_EXPRESSION@110..111
-                          0: JS_REFERENCE_IDENTIFIER@110..111
-                            0: IDENT@110..111 "a" [] []
-                      1: R_ANGLE@111..112 ">" [] []
-                      2: JS_IDENTIFIER_EXPRESSION@112..113
-                        0: JS_REFERENCE_IDENTIFIER@112..113
-                          0: IDENT@112..113 "d" [] []
-            1: SEMICOLON@113..132 ";" [] [Whitespace(" "), Comments("// type assertion")]
-          3: JS_VARIABLE_STATEMENT@132..236
-            0: JS_VARIABLE_DECLARATION@132..158
-              0: LET_KW@132..141 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
-              1: JS_VARIABLE_DECLARATOR_LIST@141..158
-                0: JS_VARIABLE_DECLARATOR@141..158
-                  0: JS_IDENTIFIER_BINDING@141..143
-                    0: IDENT@141..143 "d" [] [Whitespace(" ")]
+                  2: JS_INITIALIZER_CLAUSE@109..124
+                    0: EQ@109..111 "=" [] [Whitespace(" ")]
+                    1: JS_BINARY_EXPRESSION@111..124
+                      0: JS_BINARY_EXPRESSION@111..122
+                        0: JS_UNKNOWN_EXPRESSION@111..120
+                          0: L_ANGLE@111..112 "<" [] []
+                          1: TS_STRING_TYPE@112..118
+                            0: STRING_KW@112..118 "string" [] []
+                          2: R_ANGLE@118..119 ">" [] []
+                          3: JS_IDENTIFIER_EXPRESSION@119..120
+                            0: JS_REFERENCE_IDENTIFIER@119..120
+                              0: IDENT@119..120 "b" [] []
+                        1: L_ANGLE@120..121 "<" [] []
+                        2: JS_IDENTIFIER_EXPRESSION@121..122
+                          0: JS_REFERENCE_IDENTIFIER@121..122
+                            0: IDENT@121..122 "a" [] []
+                      1: R_ANGLE@122..123 ">" [] []
+                      2: JS_IDENTIFIER_EXPRESSION@123..124
+                        0: JS_REFERENCE_IDENTIFIER@123..124
+                          0: IDENT@123..124 "d" [] []
+            1: SEMICOLON@124..143 ";" [] [Whitespace(" "), Comments("// type assertion")]
+          3: JS_VARIABLE_STATEMENT@143..248
+            0: JS_VARIABLE_DECLARATION@143..169
+              0: LET_KW@143..152 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+              1: JS_VARIABLE_DECLARATOR_LIST@152..169
+                0: JS_VARIABLE_DECLARATOR@152..169
+                  0: JS_IDENTIFIER_BINDING@152..154
+                    0: IDENT@152..154 "d" [] [Whitespace(" ")]
                   1: (empty)
-                  2: JS_INITIALIZER_CLAUSE@143..158
-                    0: EQ@143..145 "=" [] [Whitespace(" ")]
-                    1: JS_BINARY_EXPRESSION@145..158
-                      0: JS_UNKNOWN_EXPRESSION@145..151
-                        0: L_ANGLE@145..146 "<" [] []
-                        1: TS_REFERENCE_TYPE@146..149
-                          0: JS_REFERENCE_IDENTIFIER@146..149
-                            0: IDENT@146..149 "div" [] []
+                  2: JS_INITIALIZER_CLAUSE@154..169
+                    0: EQ@154..156 "=" [] [Whitespace(" ")]
+                    1: JS_BINARY_EXPRESSION@156..169
+                      0: JS_UNKNOWN_EXPRESSION@156..162
+                        0: L_ANGLE@156..157 "<" [] []
+                        1: TS_REFERENCE_TYPE@157..160
+                          0: JS_REFERENCE_IDENTIFIER@157..160
+                            0: IDENT@157..160 "div" [] []
                           1: (empty)
-                        2: R_ANGLE@149..150 ">" [] []
-                        3: JS_IDENTIFIER_EXPRESSION@150..151
-                          0: JS_REFERENCE_IDENTIFIER@150..151
-                            0: IDENT@150..151 "a" [] []
-                      1: L_ANGLE@151..152 "<" [] []
-                      2: JS_REGEX_LITERAL_EXPRESSION@152..158
-                        0: JS_REGEX_LITERAL@152..158 "/div>/" [] []
-            1: SEMICOLON@158..236 ";" [] [Whitespace(" "), Comments("// ambigous: JSX or \" ...")]
-          4: JS_VARIABLE_STATEMENT@236..269
-            0: JS_VARIABLE_DECLARATION@236..268
-              0: LET_KW@236..245 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
-              1: JS_VARIABLE_DECLARATOR_LIST@245..268
-                0: JS_VARIABLE_DECLARATOR@245..268
-                  0: JS_IDENTIFIER_BINDING@245..247
-                    0: IDENT@245..247 "d" [] [Whitespace(" ")]
+                        2: R_ANGLE@160..161 ">" [] []
+                        3: JS_IDENTIFIER_EXPRESSION@161..162
+                          0: JS_REFERENCE_IDENTIFIER@161..162
+                            0: IDENT@161..162 "a" [] []
+                      1: L_ANGLE@162..163 "<" [] []
+                      2: JS_REGEX_LITERAL_EXPRESSION@163..169
+                        0: JS_REGEX_LITERAL@163..169 "/div>/" [] []
+            1: SEMICOLON@169..248 ";" [] [Whitespace(" "), Comments("// ambiguous: JSX or  ...")]
+          4: JS_VARIABLE_STATEMENT@248..281
+            0: JS_VARIABLE_DECLARATION@248..280
+              0: LET_KW@248..257 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+              1: JS_VARIABLE_DECLARATOR_LIST@257..280
+                0: JS_VARIABLE_DECLARATOR@257..280
+                  0: JS_IDENTIFIER_BINDING@257..259
+                    0: IDENT@257..259 "d" [] [Whitespace(" ")]
                   1: (empty)
-                  2: JS_INITIALIZER_CLAUSE@247..268
-                    0: EQ@247..249 "=" [] [Whitespace(" ")]
-                    1: JS_BINARY_EXPRESSION@249..268
-                      0: JS_UNKNOWN_EXPRESSION@249..258
-                        0: L_ANGLE@249..250 "<" [] []
-                        1: TS_STRING_TYPE@250..256
-                          0: STRING_KW@250..256 "string" [] []
-                        2: R_ANGLE@256..257 ">" [] []
-                        3: JS_IDENTIFIER_EXPRESSION@257..258
-                          0: JS_REFERENCE_IDENTIFIER@257..258
-                            0: IDENT@257..258 "a" [] []
-                      1: L_ANGLE@258..259 "<" [] []
-                      2: JS_REGEX_LITERAL_EXPRESSION@259..268
-                        0: JS_REGEX_LITERAL@259..268 "/string>/" [] []
-            1: SEMICOLON@268..269 ";" [] []
-        3: R_CURLY@269..271 "}" [Newline("\n")] []
-  3: EOF@271..272 "" [Newline("\n")] []
---
-error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
-  ┌─ jsx_or_type_assertion.js:2:13
-  │
-2 │     let a = <div>a</div>; // JSX
-  │             ^^^^^^ TypeScript only syntax
-
+                  2: JS_INITIALIZER_CLAUSE@259..280
+                    0: EQ@259..261 "=" [] [Whitespace(" ")]
+                    1: JS_BINARY_EXPRESSION@261..280
+                      0: JS_UNKNOWN_EXPRESSION@261..270
+                        0: L_ANGLE@261..262 "<" [] []
+                        1: TS_STRING_TYPE@262..268
+                          0: STRING_KW@262..268 "string" [] []
+                        2: R_ANGLE@268..269 ">" [] []
+                        3: JS_IDENTIFIER_EXPRESSION@269..270
+                          0: JS_REFERENCE_IDENTIFIER@269..270
+                            0: IDENT@269..270 "a" [] []
+                      1: L_ANGLE@270..271 "<" [] []
+                      2: JS_REGEX_LITERAL_EXPRESSION@271..280
+                        0: JS_REGEX_LITERAL@271..280 "/string>/" [] []
+            1: SEMICOLON@280..281 ";" [] []
+        3: R_CURLY@281..283 "}" [Newline("\n")] []
+  3: EOF@283..284 "" [Newline("\n")] []
 --
 error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ jsx_or_type_assertion.js:3:13
   │
-3 │     let b = <string>b; //type assertion
-  │             ^^^^^^^^^ TypeScript only syntax
+3 │     let a = <div>a</div>; // JSX
+  │             ^^^^^^ TypeScript only syntax
 
 --
 error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ jsx_or_type_assertion.js:4:13
   │
-4 │     let c = <string>b<a>d; // type assertion
+4 │     let b = <string>b; // type assertion
   │             ^^^^^^^^^ TypeScript only syntax
 
 --
 error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ jsx_or_type_assertion.js:5:13
   │
-5 │     let d = <div>a</div>/; // ambigous: JSX or "type assertion a less than regex /div>/". Probably JSX.
-  │             ^^^^^^ TypeScript only syntax
+5 │     let c = <string>b<a>d; // type assertion
+  │             ^^^^^^^^^ TypeScript only syntax
 
 --
 error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ jsx_or_type_assertion.js:6:13
   │
-6 │     let d = <string>a</string>/;
+6 │     let d = <div>a</div>/; // ambiguous: JSX or "type assertion a less than regex /div>/". Probably JSX.
+  │             ^^^^^^ TypeScript only syntax
+
+--
+error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
+  ┌─ jsx_or_type_assertion.js:7:13
+  │
+7 │     let d = <string>a</string>/;
   │             ^^^^^^^^^ TypeScript only syntax
 
 --
+// SCRIPT
 function f() {
     let a = <div>a</div>; // JSX
-    let b = <string>b; //type assertion
+    let b = <string>b; // type assertion
     let c = <string>b<a>d; // type assertion
-    let d = <div>a</div>/; // ambigous: JSX or "type assertion a less than regex /div>/". Probably JSX.
+    let d = <div>a</div>/; // ambiguous: JSX or "type assertion a less than regex /div>/". Probably JSX.
     let d = <string>a</string>/;
 }

--- a/crates/rome_js_syntax/src/source_type.rs
+++ b/crates/rome_js_syntax/src/source_type.rs
@@ -238,9 +238,8 @@ fn compute_source_type_from_path_or_extension(
         SourceType::d_ts().with_module_kind(ModuleKind::Script)
     } else {
         match extension {
-            "js" | "mjs" => SourceType::js_module(),
             "cjs" => SourceType::js_module().with_module_kind(ModuleKind::Script),
-            "jsx" => SourceType::jsx(),
+            "js" | "mjs" | "jsx" => SourceType::jsx(),
             "ts" | "mts" => SourceType::ts(),
             "cts" => SourceType::ts().with_module_kind(ModuleKind::Script),
             "tsx" => SourceType::tsx(),


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
Addresses #2625. Because TypeScript allows JSX in `.js` files by default, we allow the same. Also makes adoption easier because many users have React components in a `.js` file.

## Test Plan
The existing tests for JSX should suffice.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
