### PR TITLE
fix(rome_formatter): measure first variant of BestFitting in flat mode

### DIFF
--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -303,4 +303,106 @@ mod tests {
             ]))
         );
     }
+
+    #[test]
+    fn best_fitting_groups() {
+        use crate::prelude::*;
+        use crate::{format, format_args, Formatted};
+
+        let formatted_best_fitting = format!(
+            SimpleFormatContext::default(),
+            [
+                token("aVeryLongIdentifier"),
+                soft_line_break_or_space(),
+                best_fitting!(
+                    format_args!(token(
+                        "Something that will not fit on a 30 character print width."
+                    ),),
+                    format_args![
+                        token("Start"),
+                        soft_line_break(),
+                        &group_elements(&soft_block_indent(&format_args![
+                            token("1,"),
+                            soft_line_break_or_space(),
+                            token("2,"),
+                            soft_line_break_or_space(),
+                            token("3"),
+                        ])),
+                        soft_line_break_or_space(),
+                        &soft_block_indent(&format_args![
+                            token("1,"),
+                            soft_line_break_or_space(),
+                            token("2,"),
+                            soft_line_break_or_space(),
+                            group_elements(&format_args!(
+                                token("A,"),
+                                soft_line_break_or_space(),
+                                token("B")
+                            )),
+                            soft_line_break_or_space(),
+                            token("3")
+                        ]),
+                        soft_line_break_or_space(),
+                        token("End")
+                    ],
+                    format_args!(token("Most"), hard_line_break(), token("Expanded"))
+                )
+            ]
+        )
+        .unwrap();
+
+        let formatted_normal_list = format!(
+            SimpleFormatContext::default(),
+            [
+                token("aVeryLongIdentifier"),
+                soft_line_break_or_space(),
+                format_args![
+                    token("Start"),
+                    soft_line_break(),
+                    &group_elements(&soft_block_indent(&format_args![
+                        token("1,"),
+                        soft_line_break_or_space(),
+                        token("2,"),
+                        soft_line_break_or_space(),
+                        token("3"),
+                    ])),
+                    soft_line_break_or_space(),
+                    &soft_block_indent(&format_args![
+                        token("1,"),
+                        soft_line_break_or_space(),
+                        token("2,"),
+                        soft_line_break_or_space(),
+                        group_elements(&format_args!(
+                            token("A,"),
+                            soft_line_break_or_space(),
+                            token("B")
+                        )),
+                        soft_line_break_or_space(),
+                        token("3")
+                    ]),
+                    soft_line_break_or_space(),
+                    token("End")
+                ],
+            ]
+        )
+        .unwrap();
+
+        let best_fitting_code = Formatted::new(
+            formatted_best_fitting.into_format_element(),
+            PrinterOptions::default().with_print_width(30.try_into().unwrap()),
+        )
+        .print()
+        .as_code()
+        .to_string();
+
+        let normal_list_code = Formatted::new(
+            formatted_normal_list.into_format_element(),
+            PrinterOptions::default().with_print_width(30.try_into().unwrap()),
+        )
+        .print()
+        .as_code()
+        .to_string();
+
+        assert_eq!(best_fitting_code, normal_list_code);
+    }
 }

--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -146,9 +146,7 @@ macro_rules! format {
 ///
 /// ## Examples
 ///
-///  Temporarily ignored because [BestFitting] needs to be adjusted due to the
-/// `fits_element_on_line` changes in https://github.com/rome/tools/pull/2645
-/// ```ignore
+/// ```
 /// use rome_formatter::{Formatted, LineWidth, format, format_args};
 /// use rome_formatter::prelude::*;
 ///

--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -237,9 +237,14 @@ macro_rules! format {
 ///   complexity if used in nested structures.
 ///
 /// ## Prettier
-/// This IR is similar to Prettier's `ConditionalGroupContent` IR. It provides the same functionality but
+/// This IR is similar to Prettier's `ConditionalGroupContent` IR. It provides similar functionality but
 /// differs in that Prettier automatically wraps each variant in a `Group`. Rome doesn't do so.
 /// You can wrap the variant content in a group if you want to use soft line breaks.
+/// Unlike in Prettier, a variant (except the first) will be considered to fit if it can be printed without
+/// overflowing the current line with all of its inner groups expanded. Those inner groups could still end
+/// up being printed in flat mode if they fit on the line while printing. But there is currently no way
+/// to enforce that a specific group inside a variant must be flat when measuring if that variant fits.
+///
 #[macro_export]
 macro_rules! best_fitting {
     ($least_expanded:expr, $($tail:expr),+ $(,)?) => {{

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -272,17 +272,20 @@ impl<'a> Printer<'a> {
                                 // Test if this variant fits and if so, use it. Otherwise try the next
                                 // variant.
 
-                                if fits_on_line(
-                                    &[variant],
-                                    args.with_print_mode(PrintMode::Expanded),
-                                    queue,
-                                    self,
-                                ) {
+                                // Try to fit only the first variant on a single line
+                                let mode = if index == 0 {
+                                    PrintMode::Flat
+                                } else {
+                                    PrintMode::Expanded
+                                };
+
+                                if fits_on_line(&[variant], args.with_print_mode(mode), queue, self)
+                                {
                                     self.state.measured_group_fits = true;
 
                                     queue.enqueue(PrintElementCall::new(
                                         variant,
-                                        args.with_print_mode(PrintMode::Expanded),
+                                        args.with_print_mode(mode),
                                     ));
                                     return;
                                 }


### PR DESCRIPTION
## Summary

This is a minimal fix for the `BestFitting` element that was broken by #2645. It now attempts to fit the first variant in flat mode on a single line. If that doesn't fit, it continues attempting the remaining variants in `PrintMode::Expanded` before defaulting to the `most_expanded` variant. This seems to match the original intention based on the doc comments for the `best_fitting` macro. @MichaReiser?

I don't know if this will be sufficient for our needs, but I believe that matching the exact behavior of Prettier's `conditionalGroup` could involve heavy enough changes to our "fits" measurement and printing that it may be worth trying this out first.

Happy to close this, though, if we'd rather go with a different approach.

## Test Plan

Removed the `ignore` from the broken `best_fitting` doc test.