### PR TITLE
fix(rome_cli): do not print lint warnings for the format command

### DIFF
--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -247,6 +247,41 @@ mod format {
         assert_eq!(console.buffer.len(), 1);
     }
 
+    // Ensures lint warnings are not printed in format mode
+    #[test]
+    fn lint_warning() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("format.js");
+        fs.insert(file_path.into(), LINT_ERROR.as_bytes());
+
+        let result = run_cli(CliSession {
+            app: App::with_filesystem_and_console(
+                DynRef::Borrowed(&mut fs),
+                DynRef::Borrowed(&mut console),
+            ),
+            args: Arguments::from_vec(vec![OsString::from("format"), file_path.as_os_str().into()]),
+        });
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        let mut file = fs
+            .open(file_path)
+            .expect("formatting target file was removed by the CLI");
+
+        let mut content = String::new();
+        file.read_to_string(&mut content)
+            .expect("failed to read file from memory FS");
+
+        assert_eq!(content, LINT_ERROR);
+
+        // The console buffer is expected to contain the following message:
+        // 0: "Formatter would have printed the following content"
+        // 1: "Compared 1 files"
+        assert_eq!(console.buffer.len(), 2, "console {:#?}", console.buffer);
+    }
+
     #[test]
     fn indent_style_parse_errors() {
         let result = run_cli(CliSession {

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -7,6 +7,7 @@ use crate::utils;
 use futures::stream::futures_unordered::FuturesUnordered;
 use futures::StreamExt;
 use parking_lot::RwLock;
+use rome_analyze::RuleCategories;
 use rome_diagnostics::file::FileId;
 use rome_fs::RomePath;
 use rome_service::workspace;
@@ -93,9 +94,10 @@ impl Session {
         let workspace_settings = self.config.read().get_workspace_settings();
 
         let diagnostics = if workspace_settings.analysis.enable_diagnostics {
-            let diagnostics = self
-                .workspace
-                .pull_diagnostics(PullDiagnosticsParams { path: rome_path })?;
+            let diagnostics = self.workspace.pull_diagnostics(PullDiagnosticsParams {
+                path: rome_path,
+                categories: RuleCategories::SYNTAX | RuleCategories::LINT,
+            })?;
 
             diagnostics
                 .into_iter()

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -116,12 +116,12 @@ fn debug_print(_rome_path: &RomePath, parse: AnyParse) -> String {
     format!("{tree:#?}")
 }
 
-fn lint(rome_path: &RomePath, parse: AnyParse) -> Vec<Diagnostic> {
+fn lint(rome_path: &RomePath, parse: AnyParse, categories: RuleCategories) -> Vec<Diagnostic> {
     let tree = parse.tree();
     let mut diagnostics = parse.into_diagnostics();
 
     let filter = AnalysisFilter {
-        categories: RuleCategories::SYNTAX | RuleCategories::LINT,
+        categories,
         ..AnalysisFilter::default()
     };
 

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
-use rome_analyze::AnalyzerAction;
+use rome_analyze::{AnalyzerAction, RuleCategories};
 use rome_diagnostics::Diagnostic;
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
@@ -69,7 +69,7 @@ impl std::fmt::Display for Mime {
 
 type Parse = fn(&RomePath, &str) -> AnyParse;
 type DebugPrint = fn(&RomePath, AnyParse) -> String;
-type Lint = fn(&RomePath, AnyParse) -> Vec<Diagnostic>;
+type Lint = fn(&RomePath, AnyParse, RuleCategories) -> Vec<Diagnostic>;
 type CodeActions = fn(&RomePath, AnyParse, TextRange) -> Vec<AnalyzerAction>;
 type Format = fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>) -> Result<Printed, RomeError>;
 type FormatRange =

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -61,6 +61,8 @@ use rome_js_syntax::{TextRange, TextSize};
 
 use crate::{settings::WorkspaceSettings, RomeError};
 
+pub use rome_analyze::RuleCategories;
+
 pub(crate) mod server;
 
 pub struct SupportsFeatureParams {
@@ -99,6 +101,7 @@ pub struct CloseFileParams {
 
 pub struct PullDiagnosticsParams {
     pub path: RomePath,
+    pub categories: RuleCategories,
 }
 
 pub struct PullActionsParams {
@@ -196,9 +199,13 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         })
     }
 
-    pub fn pull_diagnostics(&self) -> Result<Vec<Diagnostic>, RomeError> {
+    pub fn pull_diagnostics(
+        &self,
+        categories: RuleCategories,
+    ) -> Result<Vec<Diagnostic>, RomeError> {
         self.workspace.pull_diagnostics(PullDiagnosticsParams {
             path: self.path.clone(),
+            categories,
         })
     }
 

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -215,7 +215,7 @@ impl Workspace for WorkspaceServer {
 
         let parse = self.get_parse(params.path.clone())?;
 
-        Ok(linter(&params.path, parse))
+        Ok(linter(&params.path, parse, params.categories))
     }
 
     /// Retrieves the list of code actions available for a given cursor


### PR DESCRIPTION
## Summary

This PR fixes #2670 by skipping the printing of diagnostics in traversal operations for the `format` commands if no errors were returned by `pull_diagnostics`
Additionally, I exposed the `categories` filter from `rome_analyze`  to consumers of the `pull_diagnostics` method to let clients chose which diagnostics categories they want: in format mode this is used to only run rules with the `SYNTAX` category and ignore `LINT` rules, to avoid emitting diagnostics that would not impact the correctness of formatting in the first place

## Test Plan
I added an additional `lint_warning` test to the CLI verifying no warnings are printed to the console when formatting files with lint errors
