### PR TITLE
refactor(formatter): Rename `FormatError::MissingRequiredChild` to `SyntaxError`

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -321,8 +321,9 @@ pub type FormatResult<F> = Result<F, FormatError>;
 #[derive(Debug, PartialEq, Copy, Clone)]
 /// Series of errors encountered during formatting
 pub enum FormatError {
-    /// Node is missing and it should be required for a correct formatting
-    MissingRequiredChild,
+    /// In case a node can't be formatted because it either misses a require child element or
+    /// a child is present that should not (e.g. a trailing comma after a rest element).
+    SyntaxError,
 
     /// In case our formatter doesn't know how to format a certain language
     UnsupportedLanguage,
@@ -334,7 +335,7 @@ pub enum FormatError {
 impl fmt::Display for FormatError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FormatError::MissingRequiredChild => fmt.write_str("missing required child"),
+            FormatError::SyntaxError => fmt.write_str("syntax error"),
             FormatError::UnsupportedLanguage => fmt.write_str("language is not supported"),
             FormatError::CapabilityDisabled => fmt.write_str("formatting capability is disabled"),
         }
@@ -352,7 +353,7 @@ impl From<SyntaxError> for FormatError {
 impl From<&SyntaxError> for FormatError {
     fn from(syntax_error: &SyntaxError) -> Self {
         match syntax_error {
-            SyntaxError::MissingRequiredChild => FormatError::MissingRequiredChild,
+            SyntaxError::MissingRequiredChild => FormatError::SyntaxError,
         }
     }
 }

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -105,7 +105,7 @@ where
         }
 
         if piece.is_skipped() {
-            return Err(FormatError::MissingRequiredChild);
+            return Err(FormatError::SyntaxError);
         }
 
         if piece.is_newline() {
@@ -158,7 +158,7 @@ where
         } else if piece.is_newline() && trim_mode == TriviaPrintMode::Full {
             line_count += 1;
         } else if piece.is_skipped() {
-            return Err(FormatError::MissingRequiredChild);
+            return Err(FormatError::SyntaxError);
         }
     }
 

--- a/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
@@ -33,9 +33,7 @@ impl FormatRule<JsVariableDeclaratorList> for FormatJsVariableDeclaratorList {
             })
         });
 
-        let leading_element = declarators
-            .next()
-            .ok_or(FormatError::MissingRequiredChild)?;
+        let leading_element = declarators.next().ok_or(FormatError::SyntaxError)?;
 
         let other_declarators = format_once(|f| {
             if node.len() == 1 {

--- a/crates/rome_js_formatter/src/separated.rs
+++ b/crates/rome_js_formatter/src/separated.rs
@@ -47,7 +47,7 @@ where
                     }
                     TrailingSeparator::Disallowed => {
                         // A trailing separator was present where it wasn't allowed, opt out of formatting
-                        return Err(FormatError::MissingRequiredChild);
+                        return Err(FormatError::SyntaxError);
                     }
                 }
             } else {


### PR DESCRIPTION

## Summary


Rename `MissingRequiredChild` to `SyntaxError` to account for other syntax errors, for example, when a rest element has a trailing comma.

## Test Plan

`cargo test`