### PR TITLE
refactor(rome_js_formatter): avoid snapshot when formatting skipped token trivia

### DIFF
--- a/crates/rome_rowan/src/syntax/trivia.rs
+++ b/crates/rome_rowan/src/syntax/trivia.rs
@@ -87,9 +87,13 @@ impl TriviaPiece {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct SyntaxTriviaPieceNewline<L: Language>(SyntaxTriviaPiece<L>);
+#[derive(Debug, Clone)]
 pub struct SyntaxTriviaPieceWhitespace<L: Language>(SyntaxTriviaPiece<L>);
+#[derive(Debug, Clone)]
 pub struct SyntaxTriviaPieceComments<L: Language>(SyntaxTriviaPiece<L>);
+#[derive(Debug, Clone)]
 pub struct SyntaxTriviaPieceSkipped<L: Language>(SyntaxTriviaPiece<L>);
 
 impl<L: Language> SyntaxTriviaPieceNewline<L> {


### PR DESCRIPTION
## Summary

This removes the need to take a snapshot before formatting leading trivia by collecting the comments into a `Vec`. The performance characteristics of the new implementation should be similar to the old because it removes the need to allocate a temporary `VecBuffer` to be able to reverse the written comments in the end. 

I find this solution slightly easier to reason about and results in slightly less code: 

Before:
*  3.5%  10.9% 422.4KiB rome_js_formatter
*  0.1%   0.4%   9.7KiB rome_js_formatter <rome_js_formatter::builders::FormatLeadingTrivia as rome_formatter::Format<rome_js_formatter::context::JsFormatContext>>::fmt


After:

*  3.3%  10.6% 407.1KiB rome_js_formatter
* `FormatLeadingTrivia` no longer shows up. 

It also gives us the option to use a `SmallVec` to store comments if profiling shows that this is beneficial. 

## Test Plan

`cargo test`
