### PR TITLE
refactor(rome_formatter): Add `Interned` `FormatElement`

### DIFF
--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -8,6 +8,7 @@ use rome_rowan::{Language, SyntaxNode, SyntaxToken, SyntaxTokenText, TextLen};
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::marker::PhantomData;
+use std::ops::Deref;
 
 /// A line break that only gets printed if the enclosing `Group` doesn't fit on a single line.
 /// It's omitted if the enclosing `Group` fits on a single line.
@@ -463,7 +464,7 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{format, format_args};
+/// use rome_formatter::{format, write, format_args};
 /// use rome_formatter::prelude::*;
 ///
 /// let elements = format!(
@@ -471,15 +472,22 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 ///     [
 ///         group_elements(&format_args![
 ///             comment(&format_args![token("// test"), hard_line_break()]),
-///             token("a"),
+///             format_with(|f| {
+///                 write!(f, [
+///                     comment(&format_args![token("/* inline */"), hard_line_break()]).memoized(),
+///                     token("a"),
+///                     soft_line_break_or_space(),
+///                 ])
+///             }).memoized(),
+///             token("b"),
 ///             soft_line_break_or_space(),
-///             token("b")
+///             token("c")
 ///         ])
 ///     ]
 /// ).unwrap();
 ///
 /// assert_eq!(
-///     "// test\na b",
+///     "// test\n/* inline */\na b c",
 ///     elements.print().as_code()
 /// );
 /// ```
@@ -983,6 +991,60 @@ impl<'inner, Context> GroupElementsBuffer<'inner, Context> {
     fn into_vec(self) -> Vec<FormatElement> {
         self.content
     }
+
+    fn write_interned(&mut self, interned: Interned) -> FormatResult<()> {
+        debug_assert!(self.content.is_empty());
+
+        match interned.deref() {
+            FormatElement::Comment(_) => {
+                self.inner.write_element(FormatElement::Interned(interned))
+            }
+            FormatElement::List(list) => {
+                let mut content_start = 0;
+
+                for element in list.iter() {
+                    match element {
+                        element @ FormatElement::Comment(_) => {
+                            content_start += 1;
+                            // Cloning comments should be alright as they are rarely nested
+                            // and the case where all elements of an interned data structure are comments
+                            // are rare
+                            self.inner.write_element(element.clone())?;
+                        }
+                        FormatElement::Interned(interned) => {
+                            self.write_interned(interned.clone())?;
+                            content_start += 1;
+
+                            if !self.content.is_empty() {
+                                // Interned struct contained non-comment
+                                break;
+                            }
+                        }
+                        _ => {
+                            // Found the first non-comment / nested interned element
+                            break;
+                        }
+                    }
+                }
+
+                // No leading comments, this group has no comments
+                if content_start == 0 {
+                    self.content.push(FormatElement::Interned(interned));
+                    return Ok(());
+                }
+
+                let content = &list[content_start..];
+
+                // It is necessary to mutate the interned elements, write cloned elements
+                self.write_elements(content.iter().cloned())
+            }
+            FormatElement::Interned(interned) => self.write_interned(interned.clone()),
+            _ => {
+                self.content.push(FormatElement::Interned(interned));
+                Ok(())
+            }
+        }
+    }
 }
 
 impl<Context> Buffer for GroupElementsBuffer<'_, Context> {
@@ -994,6 +1056,10 @@ impl<Context> Buffer for GroupElementsBuffer<'_, Context> {
                 FormatElement::List(list) => {
                     self.write_elements(list.into_vec())?;
                 }
+                FormatElement::Interned(interned) => match Interned::try_unwrap(interned) {
+                    Ok(owned) => self.write_element(owned)?,
+                    Err(interned) => self.write_interned(interned)?,
+                },
                 comment @ FormatElement::Comment { .. } => {
                     self.inner.write_element(comment)?;
                 }

--- a/crates/rome_formatter/src/format_extensions.rs
+++ b/crates/rome_formatter/src/format_extensions.rs
@@ -118,15 +118,15 @@ pub trait MemoizeFormat<Context> {
     ///
     /// // Calls `format` for everytime the object gets formatted
     /// assert_eq!(
-    ///     format!(SimpleFormatContext::default(), [token("Formatted 1 times."), token("Formatted 2 times.")]),
-    ///     format!(SimpleFormatContext::default(), [normal, normal])
+    ///     "Formatted 1 times. Formatted 2 times.",
+    ///     format!(SimpleFormatContext::default(), [normal, space_token(), normal]).unwrap().print().as_code()
     /// );
     ///
     /// // Memoized memoizes the result and calls `format` only once.
     /// let memoized = normal.memoized();
     /// assert_eq!(
-    ///     format!(SimpleFormatContext::default(), [token("Formatted 3 times."), token("Formatted 3 times.")]),
-    ///     format![SimpleFormatContext::default(), [memoized, memoized]]
+    ///     "Formatted 3 times. Formatted 3 times.",
+    ///     format![SimpleFormatContext::default(), [memoized, space_token(), memoized]].unwrap().print().as_code()
     /// );
     /// ```
     ///
@@ -143,7 +143,7 @@ impl<T, Context> MemoizeFormat<Context> for T where T: Format<Context> {}
 /// Memoizes the output of its inner [Format] to avoid re-formatting a potential expensive object.
 pub struct Memoized<F, Context> {
     inner: F,
-    memory: RefCell<Option<FormatResult<Vec<FormatElement>>>>,
+    memory: RefCell<Option<FormatResult<FormatElement>>>,
     options: PhantomData<Context>,
 }
 
@@ -169,9 +169,7 @@ where
         if let Some(memory) = self.memory.borrow().as_ref() {
             return match memory {
                 Ok(elements) => {
-                    for element in elements {
-                        f.write_element(element.clone())?;
-                    }
+                    f.write_element(elements.clone())?;
 
                     Ok(())
                 }
@@ -184,12 +182,12 @@ where
 
         match result {
             Ok(_) => {
-                let elements = buffer.into_vec();
-                for element in &elements {
-                    f.write_element(element.clone())?;
-                }
+                let elements = buffer.into_element();
+                let interned = elements.intern();
 
-                *self.memory.borrow_mut() = Some(Ok(elements));
+                f.write_element(interned.clone())?;
+
+                *self.memory.borrow_mut() = Some(Ok(interned));
 
                 Ok(())
             }

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -299,6 +299,7 @@ impl<'a> Printer<'a> {
                     }
                 }
             }
+            FormatElement::Interned(content) => queue.enqueue(PrintElementCall::new(content, args)),
         }
     }
 
@@ -813,6 +814,7 @@ fn fits_element_on_line<'a, 'rest>(
                 return Fits::No;
             }
         }
+        FormatElement::Interned(content) => queue.enqueue(PrintElementCall::new(content, args)),
     }
 
     Fits::Maybe


### PR DESCRIPTION
## Summary

Introduces a new reference-counted `FormatElement`. Useful for situations where the same content is part of the resulting IR twice but with different parent formatting. To this point, it has been necessary to clone the whole sub-tree. The ref counted FormatElement on the other hand only requires bumping the ref count. 

## Test Plan

`cargo test`
