### PR TITLE
feat(rome_rowan): add the root node as an associated type on the language trait

### DIFF
--- a/crates/rome_analyze/src/analyzers/no_delete.rs
+++ b/crates/rome_analyze/src/analyzers/no_delete.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::{
 };
 use rome_rowan::{AstNode, AstNodeExt};
 
-use crate::registry::{Rule, RuleAction, RuleDiagnostic};
+use crate::registry::{JsRuleAction, Rule, RuleDiagnostic};
 use crate::{ActionCategory, RuleCategory};
 
 pub(crate) enum NoDelete {}
@@ -41,7 +41,7 @@ impl Rule for NoDelete {
         })
     }
 
-    fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<RuleAction> {
+    fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<JsRuleAction> {
         let root = root.replace_node(
             JsAnyExpression::from(node.clone()),
             JsAnyExpression::from(make::js_assignment_expression(
@@ -53,7 +53,7 @@ impl Rule for NoDelete {
             )),
         )?;
 
-        Some(RuleAction {
+        Some(JsRuleAction {
             category: ActionCategory::QuickFix,
             applicability: Applicability::MaybeIncorrect,
             message: markup! { "Replace with undefined assignment" }.to_owned(),

--- a/crates/rome_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_analyze/src/analyzers/no_double_equals.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsAnyExpression, JsAnyLiteralExpression, JsAnyRoot, JsBinar
 use rome_js_syntax::{JsSyntaxKind::*, JsSyntaxToken};
 use rome_rowan::{AstNodeExt, SyntaxResult};
 
-use crate::registry::{Rule, RuleAction, RuleDiagnostic};
+use crate::registry::{JsRuleAction, Rule, RuleDiagnostic};
 use crate::{ActionCategory, RuleCategory};
 
 pub(crate) enum NoDoubleEquals {}
@@ -43,13 +43,13 @@ impl Rule for NoDoubleEquals {
         })
     }
 
-    fn action(root: JsAnyRoot, _: &Self::Query, op: &Self::State) -> Option<RuleAction> {
+    fn action(root: JsAnyRoot, _: &Self::Query, op: &Self::State) -> Option<JsRuleAction> {
         let root = root.replace_token(
             op.clone(),
             make::token(if op.kind() == EQ2 { T![===] } else { T![!==] }),
         )?;
 
-        Some(RuleAction {
+        Some(JsRuleAction {
             category: ActionCategory::QuickFix,
             applicability: Applicability::MaybeIncorrect,
             message: markup! { "Replace with strict equality" }.to_owned(),

--- a/crates/rome_analyze/src/analyzers/use_single_var_declarator.rs
+++ b/crates/rome_analyze/src/analyzers/use_single_var_declarator.rs
@@ -11,7 +11,7 @@ use rome_rowan::{AstNode, AstNodeExt, AstNodeList, AstNodeListExt, AstSeparatedL
 
 use crate::{ActionCategory, RuleCategory};
 
-use crate::registry::{Rule, RuleAction, RuleDiagnostic};
+use crate::registry::{JsRuleAction, Rule, RuleDiagnostic};
 
 pub(crate) enum UseSingleVarDeclarator {}
 
@@ -54,7 +54,7 @@ impl Rule for UseSingleVarDeclarator {
         })
     }
 
-    fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<RuleAction> {
+    fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<JsRuleAction> {
         let (kind, declarators, semicolon_token) = state;
 
         let prev_parent = JsStatementList::cast(node.syntax().parent()?)?;
@@ -90,7 +90,7 @@ impl Rule for UseSingleVarDeclarator {
             }),
         );
 
-        Some(RuleAction {
+        Some(JsRuleAction {
             category: ActionCategory::QuickFix,
             applicability: Applicability::MaybeIncorrect,
             message: markup! { "Break out into multiple declarations" }.to_owned(),

--- a/crates/rome_analyze/src/analyzers/use_while.rs
+++ b/crates/rome_analyze/src/analyzers/use_while.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsAnyRoot, JsAnyStatement, JsForStatement, JsForStatementFi
 use rome_rowan::{AstNode, AstNodeExt};
 
 use crate::{
-    registry::{Rule, RuleAction, RuleDiagnostic},
+    registry::{JsRuleAction, Rule, RuleDiagnostic},
     ActionCategory, RuleCategory,
 };
 
@@ -55,7 +55,7 @@ impl Rule for UseWhile {
         })
     }
 
-    fn action(root: JsAnyRoot, node: &Self::Query, _: &Self::State) -> Option<RuleAction> {
+    fn action(root: JsAnyRoot, node: &Self::Query, _: &Self::State) -> Option<JsRuleAction> {
         let JsForStatementFields {
             for_token: _,
             l_paren_token,
@@ -79,7 +79,7 @@ impl Rule for UseWhile {
             )),
         )?;
 
-        Some(RuleAction {
+        Some(JsRuleAction {
             category: ActionCategory::QuickFix,
             applicability: Applicability::MaybeIncorrect,
             message: markup! { "Use a while loop" }.to_owned(),

--- a/crates/rome_analyze/src/assists/flip_bin_exp.rs
+++ b/crates/rome_analyze/src/assists/flip_bin_exp.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{
 use rome_rowan::AstNodeExt;
 
 use crate::{
-    registry::{Rule, RuleAction},
+    registry::{JsRuleAction, Rule},
     ActionCategory, RuleCategory,
 };
 
@@ -34,7 +34,7 @@ impl Rule for FlipBinExp {
         invert_op(node.operator().ok()?)
     }
 
-    fn action(root: JsAnyRoot, node: &Self::Query, op: &Self::State) -> Option<RuleAction> {
+    fn action(root: JsAnyRoot, node: &Self::Query, op: &Self::State) -> Option<JsRuleAction> {
         let prev_left = node.left().ok()?;
         let new_left = node.right().ok()?;
         let new_node = node.clone().replace_node(prev_left, new_left)?;
@@ -47,7 +47,7 @@ impl Rule for FlipBinExp {
         let new_right = node.left().ok()?;
         let new_node = new_node.replace_node(prev_right, new_right)?;
 
-        Some(RuleAction {
+        Some(JsRuleAction {
             category: ActionCategory::Refactor,
             applicability: Applicability::Always,
             message: markup! { "Flip Binary Expression" }.to_owned(),

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -1,7 +1,8 @@
+use registry::LanguageRoot;
 use rome_diagnostics::file::FileId;
 use rome_js_syntax::{
     suppression::{has_suppressions_category, SuppressionCategory},
-    JsAnyRoot, TextRange, WalkEvent,
+    JsLanguage, TextRange, WalkEvent,
 };
 use rome_rowan::AstNode;
 
@@ -30,9 +31,13 @@ pub struct AnalysisFilter<'a> {
 /// Run the analyzer on the provided `root`: this process will use the given `filter`
 /// to selectively restrict analysis to specific rules / a specific source range,
 /// then call the `callback` when an analysis rule emits a diagnostic or action
-pub fn analyze<B>(file_id: FileId, root: &JsAnyRoot, filter: AnalysisFilter, mut callback: B)
-where
-    B: FnMut(&dyn AnalyzerSignal),
+pub fn analyze<B>(
+    file_id: FileId,
+    root: &LanguageRoot<JsLanguage>,
+    filter: AnalysisFilter,
+    mut callback: B,
+) where
+    B: FnMut(&dyn AnalyzerSignal<JsLanguage>),
 {
     let registry = RuleRegistry::with_filter(&filter);
 

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -1,7 +1,8 @@
 use rome_console::MarkupBuf;
 use rome_diagnostics::{file::FileId, Applicability, Severity};
-use rome_js_syntax::{JsAnyRoot, JsSyntaxNode, TextRange};
-use rome_rowan::{AstNode, SyntaxNode};
+use rome_js_syntax::JsLanguage;
+use rome_js_syntax::TextRange;
+use rome_rowan::{AstNode, Language, SyntaxNode};
 
 use crate::{
     analyzers::*,
@@ -12,16 +13,16 @@ use crate::{
 };
 
 /// The rule registry holds type-erased instances of all active analysis rules
-pub(crate) struct RuleRegistry {
-    rules: Vec<RegistryRule>,
+pub(crate) struct RuleRegistry<L: Language> {
+    rules: Vec<RegistryRule<L>>,
 }
 
 /// Utility macro for implementing the `with_filter` method of [RuleRegistry]
 macro_rules! impl_registry_builders {
     ( $( $rule:ident, )* ) => {
-        impl RuleRegistry {
+        impl RuleRegistry<JsLanguage> {
             pub(crate) fn with_filter(filter: &AnalysisFilter) -> Self {
-                let mut rules: Vec<RegistryRule> = Vec::new();
+                let mut rules: Vec<RegistryRule<JsLanguage>> = Vec::new();
 
                 $( if filter.categories.contains($rule::CATEGORY.into()) && filter.rules.map_or(true, |rules| rules.contains(&$rule::NAME)) {
                     rules.push(run::<$rule>);
@@ -43,14 +44,23 @@ impl_registry_builders!(
     FlipBinExp,
 );
 
-impl RuleRegistry {
+pub(crate) type RuleLanguage<R> = NodeLanguage<<R as Rule>::Query>;
+pub(crate) type NodeLanguage<N> = <N as AstNode>::Language;
+
+pub(crate) type RuleRoot<R> = LanguageRoot<RuleLanguage<R>>;
+pub(crate) type LanguageRoot<L> = <L as Language>::Root;
+
+impl<L> RuleRegistry<L>
+where
+    L: Language,
+{
     // Run all rules known to the registry associated with nodes of type N
     pub(crate) fn analyze(
         &self,
         file_id: FileId,
-        root: &JsAnyRoot,
-        node: JsSyntaxNode,
-        callback: &mut impl FnMut(&dyn AnalyzerSignal),
+        root: &LanguageRoot<L>,
+        node: SyntaxNode<L>,
+        callback: &mut impl FnMut(&dyn AnalyzerSignal<L>),
     ) {
         for rule in &self.rules {
             if let Some(event) = (rule)(file_id, root, &node) {
@@ -61,15 +71,18 @@ impl RuleRegistry {
 }
 
 /// Representation of a single rule in the registry as a generic function pointer
-type RegistryRule =
-    for<'a> fn(FileId, &'a JsAnyRoot, &'a JsSyntaxNode) -> Option<Box<dyn AnalyzerSignal + 'a>>;
+type RegistryRule<L> = for<'a> fn(
+    FileId,
+    &'a LanguageRoot<L>,
+    &'a SyntaxNode<L>,
+) -> Option<Box<dyn AnalyzerSignal<L> + 'a>>;
 
 /// Generic implementation of RegistryRule for any rule type R
 fn run<'a, R: Rule + 'static>(
     file_id: FileId,
-    root: &'a JsAnyRoot,
+    root: &'a RuleRoot<R>,
     node: &'a SyntaxNode<<R::Query as AstNode>::Language>,
-) -> Option<Box<dyn AnalyzerSignal + 'a>> {
+) -> Option<Box<dyn AnalyzerSignal<RuleLanguage<R>> + 'a>> {
     if !<R::Query>::can_cast(node.kind()) {
         return None;
     }
@@ -115,7 +128,11 @@ pub(crate) trait Rule {
     /// from a signal raised by `run`
     ///
     /// The default implementation returns None
-    fn action(_root: JsAnyRoot, _node: &Self::Query, _state: &Self::State) -> Option<RuleAction> {
+    fn action(
+        _root: RuleRoot<Self>,
+        _node: &Self::Query,
+        _state: &Self::State,
+    ) -> Option<RuleAction<RuleLanguage<Self>>> {
         None
     }
 }
@@ -128,9 +145,11 @@ pub struct RuleDiagnostic {
 }
 
 /// Code Action object returned by a single analysis rule
-pub struct RuleAction {
+pub struct RuleAction<L: Language> {
     pub category: ActionCategory,
     pub applicability: Applicability,
     pub message: MarkupBuf,
-    pub root: JsAnyRoot,
+    pub root: LanguageRoot<L>,
 }
+
+pub type JsRuleAction = RuleAction<JsLanguage>;

--- a/crates/rome_analyze/tests/spec_tests.rs
+++ b/crates/rome_analyze/tests/spec_tests.rs
@@ -10,7 +10,7 @@ use rome_console::{
 };
 use rome_diagnostics::{file::SimpleFile, termcolor::NoColor, Diagnostic};
 use rome_js_parser::parse;
-use rome_rowan::AstNode;
+use rome_rowan::{AstNode, Language};
 
 tests_macros::gen_tests! {"tests/specs/**/*.js", crate::run_test, "module"}
 
@@ -115,7 +115,10 @@ fn diagnostic_to_string(name: &str, source: &str, diag: Diagnostic) -> String {
     text
 }
 
-fn code_fix_to_string(source: &str, action: AnalyzerAction) -> String {
+fn code_fix_to_string<L>(source: &str, action: AnalyzerAction<L>) -> String
+where
+    L: Language,
+{
     let output = action.root.syntax().to_string();
 
     markup_to_string(markup! {

--- a/crates/rome_css_syntax/src/syntax_node.rs
+++ b/crates/rome_css_syntax/src/syntax_node.rs
@@ -5,7 +5,7 @@
 //!
 //! This is a simple wrapper around the `rowan` crate which does most of the heavy lifting and is language agnostic.
 
-use crate::CssSyntaxKind;
+use crate::{CssRoot, CssSyntaxKind};
 use rome_rowan::Language;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -13,6 +13,7 @@ pub struct CssLanguage;
 
 impl Language for CssLanguage {
     type Kind = CssSyntaxKind;
+    type Root = CssRoot;
 }
 
 pub type CssSyntaxNode = rome_rowan::SyntaxNode<CssLanguage>;

--- a/crates/rome_js_syntax/src/syntax_node.rs
+++ b/crates/rome_js_syntax/src/syntax_node.rs
@@ -5,7 +5,7 @@
 //!
 //! This is a simple wrapper around the `rowan` crate which does most of the heavy lifting and is language agnostic.
 
-use crate::JsSyntaxKind;
+use crate::{JsAnyRoot, JsSyntaxKind};
 use rome_rowan::Language;
 #[cfg(feature = "serde")]
 use serde_crate::Serialize;
@@ -17,6 +17,7 @@ pub struct JsLanguage;
 
 impl Language for JsLanguage {
     type Kind = JsSyntaxKind;
+    type Root = JsAnyRoot;
 }
 
 pub type JsSyntaxNode = rome_rowan::SyntaxNode<JsLanguage>;

--- a/crates/rome_json_syntax/src/syntax_node.rs
+++ b/crates/rome_json_syntax/src/syntax_node.rs
@@ -5,7 +5,7 @@
 //!
 //! This is a simple wrapper around the `rowan` crate which does most of the heavy lifting and is language agnostic.
 
-use crate::JsonSyntaxKind;
+use crate::{JsonSyntaxKind, JsonValue};
 use rome_rowan::Language;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -13,6 +13,7 @@ pub struct JsonLanguage;
 
 impl Language for JsonLanguage {
     type Kind = JsonSyntaxKind;
+    type Root = JsonValue;
 }
 
 pub type JsonSyntaxNode = rome_rowan::SyntaxNode<JsonLanguage>;

--- a/crates/rome_lsp/src/utils.rs
+++ b/crates/rome_lsp/src/utils.rs
@@ -9,7 +9,7 @@ use rome_console::MarkupBuf;
 use rome_diagnostics::termcolor::NoColor;
 use rome_diagnostics::{Applicability, Diagnostic, SuggestionChange};
 use rome_diagnostics::{CodeSuggestion, Severity};
-use rome_rowan::{TextRange, TextSize};
+use rome_rowan::{Language, TextRange, TextSize};
 use tower_lsp::jsonrpc::Error as LspError;
 use tower_lsp::lsp_types::{self as lsp};
 use tracing::error;
@@ -39,12 +39,15 @@ pub(crate) fn text_range(line_index: &LineIndex, range: lsp::Range) -> TextRange
     TextRange::new(start, end)
 }
 
-pub(crate) fn code_fix_to_lsp(
+pub(crate) fn code_fix_to_lsp<L>(
     url: &lsp::Url,
     line_index: &LineIndex,
     diagnostics: &[lsp::Diagnostic],
-    action: AnalyzerAction,
-) -> lsp::CodeAction {
+    action: AnalyzerAction<L>,
+) -> lsp::CodeAction
+where
+    L: Language,
+{
     // Mark diagnostics emitted by the same rule as resolved by this action
     let diagnostics: Vec<_> = if matches!(action.category, ActionCategory::QuickFix) {
         diagnostics

--- a/crates/rome_rowan/src/raw_language.rs
+++ b/crates/rome_rowan/src/raw_language.rs
@@ -1,4 +1,4 @@
-use crate::raw_language::RawLanguageKind::{COMMA_TOKEN, LITERAL_EXPRESSION};
+use crate::raw_language::RawLanguageKind::{COMMA_TOKEN, LITERAL_EXPRESSION, ROOT};
 ///! Provides a sample language implementation that is useful in API explanation or tests
 use crate::{
     AstNode, AstSeparatedList, Language, ParsedChildren, RawNodeSlots, RawSyntaxKind,
@@ -11,6 +11,7 @@ pub struct RawLanguage;
 
 impl Language for RawLanguage {
     type Kind = RawLanguageKind;
+    type Root = RawLanguageRoot;
 }
 
 #[doc(hidden)]
@@ -56,6 +57,39 @@ impl SyntaxKind for RawLanguageKind {
         assert!(raw.0 < RawLanguageKind::__LAST as u16);
 
         unsafe { std::mem::transmute::<u16, RawLanguageKind>(raw.0) }
+    }
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawLanguageRoot {
+    node: SyntaxNode<RawLanguage>,
+}
+
+impl AstNode for RawLanguageRoot {
+    type Language = RawLanguage;
+
+    fn can_cast(kind: RawLanguageKind) -> bool {
+        kind == ROOT
+    }
+
+    fn cast(syntax: SyntaxNode<RawLanguage>) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if syntax.kind() == ROOT {
+            Some(RawLanguageRoot { node: syntax })
+        } else {
+            None
+        }
+    }
+
+    fn syntax(&self) -> &SyntaxNode<RawLanguage> {
+        &self.node
+    }
+
+    fn into_syntax(self) -> SyntaxNode<RawLanguage> {
+        self.node
     }
 }
 

--- a/crates/rome_rowan/src/syntax.rs
+++ b/crates/rome_rowan/src/syntax.rs
@@ -21,7 +21,7 @@ pub use token::SyntaxToken;
 
 use std::fmt;
 
-use crate::RawSyntaxKind;
+use crate::{AstNode, RawSyntaxKind};
 
 /// Type tag for each node or token of a language
 pub trait SyntaxKind: fmt::Debug + PartialEq + Copy {
@@ -40,6 +40,7 @@ pub trait SyntaxKind: fmt::Debug + PartialEq + Copy {
 
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
     type Kind: SyntaxKind;
+    type Root: AstNode<Language = Self> + Clone + Eq + fmt::Debug;
 }
 
 /// A list of `SyntaxNode`s and/or `SyntaxToken`s

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -139,7 +139,11 @@ fn lint(rome_path: &RomePath, parse: AnyParse, categories: RuleCategories) -> Ve
     diagnostics
 }
 
-fn code_actions(rome_path: &RomePath, parse: AnyParse, range: TextRange) -> Vec<AnalyzerAction> {
+fn code_actions(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    range: TextRange,
+) -> Vec<AnalyzerAction<JsLanguage>> {
     let tree = parse.tree();
 
     let mut actions = Vec::new();

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -4,7 +4,7 @@ use rome_analyze::{AnalyzerAction, RuleCategories};
 use rome_diagnostics::Diagnostic;
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
-use rome_js_syntax::{TextRange, TextSize};
+use rome_js_syntax::{JsLanguage, TextRange, TextSize};
 
 use crate::{settings::SettingsHandle, workspace::server::AnyParse, RomeError};
 
@@ -70,7 +70,7 @@ impl std::fmt::Display for Mime {
 type Parse = fn(&RomePath, &str) -> AnyParse;
 type DebugPrint = fn(&RomePath, AnyParse) -> String;
 type Lint = fn(&RomePath, AnyParse, RuleCategories) -> Vec<Diagnostic>;
-type CodeActions = fn(&RomePath, AnyParse, TextRange) -> Vec<AnalyzerAction>;
+type CodeActions = fn(&RomePath, AnyParse, TextRange) -> Vec<AnalyzerAction<JsLanguage>>;
 type Format = fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>) -> Result<Printed, RomeError>;
 type FormatRange =
     fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>, TextRange) -> Result<Printed, RomeError>;

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -57,7 +57,7 @@ use rome_analyze::AnalyzerAction;
 use rome_diagnostics::Diagnostic;
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
-use rome_js_syntax::{TextRange, TextSize};
+use rome_js_syntax::{JsLanguage, TextRange, TextSize};
 
 use crate::{settings::WorkspaceSettings, RomeError};
 
@@ -151,7 +151,10 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
 
     /// Retrieves the list of code actions available for a given cursor
     /// position within a file
-    fn pull_actions(&self, params: PullActionsParams) -> Result<Vec<AnalyzerAction>, RomeError>;
+    fn pull_actions(
+        &self,
+        params: PullActionsParams,
+    ) -> Result<Vec<AnalyzerAction<JsLanguage>>, RomeError>;
 
     /// Runs the given file through the formatter using the provided options
     /// and returns the resulting source code
@@ -209,7 +212,10 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         })
     }
 
-    pub fn pull_actions(&self, range: TextRange) -> Result<Vec<AnalyzerAction>, RomeError> {
+    pub fn pull_actions(
+        &self,
+        range: TextRange,
+    ) -> Result<Vec<AnalyzerAction<JsLanguage>>, RomeError> {
         self.workspace.pull_actions(PullActionsParams {
             path: self.path.clone(),
             range,

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -5,6 +5,7 @@ use rome_analyze::AnalyzerAction;
 use rome_diagnostics::{Diagnostic, Severity};
 use rome_formatter::Printed;
 use rome_fs::RomePath;
+use rome_js_syntax::JsLanguage;
 use rome_rowan::{AstNode, Language as RowanLanguage, SendNode, SyntaxNode};
 
 use crate::{
@@ -220,7 +221,10 @@ impl Workspace for WorkspaceServer {
 
     /// Retrieves the list of code actions available for a given cursor
     /// position within a file
-    fn pull_actions(&self, params: PullActionsParams) -> Result<Vec<AnalyzerAction>, RomeError> {
+    fn pull_actions(
+        &self,
+        params: PullActionsParams,
+    ) -> Result<Vec<AnalyzerAction<JsLanguage>>, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let code_actions = capabilities
             .code_actions


### PR DESCRIPTION
## Summary

This PR is part of the general goal of making the analyzer language-agnostic. It adds a `Root` associated type on the `Language` trait in `rome_rowan` bound to the `AstNode<Language = Self>` trait (as well as `Clone`, `Debug` and `Eq` for convenience) and corresponding to the "document root" node type for this language (eg. `JsAnyRoot` for JavaScript).
This lets most of the analyzer be agnostic over the language it's processing, except at the root level in the `analyze` function since the `RuleRegistry` only has a factory for JS rules at the moment. As an extension of this, the `Workspace` also only supports emitting code actions strongly typed to the JavaScript language for now.
