### PR TITLE
feat(rome_rowan): add a `declare_union` macro for one-off union AstNodes

### DIFF
--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -3,11 +3,11 @@ use rome_formatter::{format_args, write, Buffer, VecBuffer};
 
 use rome_js_syntax::{
     JsAnyExpression, JsAnyInProperty, JsBinaryExpression, JsBinaryOperator, JsInExpression,
-    JsInstanceofExpression, JsLanguage, JsLogicalExpression, JsLogicalOperator, JsPrivateName,
-    JsSyntaxKind, JsSyntaxKind::*, JsSyntaxNode, JsSyntaxToken,
+    JsInstanceofExpression, JsLogicalExpression, JsLogicalOperator, JsPrivateName, JsSyntaxKind,
+    JsSyntaxNode, JsSyntaxToken,
 };
 
-use rome_rowan::{AstNode, SyntaxResult};
+use rome_rowan::{declare_union, AstNode, SyntaxResult};
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::iter::FusedIterator;
@@ -724,13 +724,8 @@ impl Iterator for PostorderIterator {
 
 impl FusedIterator for PostorderIterator {}
 
-#[allow(clippy::enum_variant_names)]
-#[derive(Debug, Clone)]
-pub(crate) enum JsAnyBinaryLikeExpression {
-    JsLogicalExpression(JsLogicalExpression),
-    JsBinaryExpression(JsBinaryExpression),
-    JsInstanceofExpression(JsInstanceofExpression),
-    JsInExpression(JsInExpression),
+declare_union! {
+    pub(crate) JsAnyBinaryLikeExpression = JsLogicalExpression | JsBinaryExpression | JsInstanceofExpression | JsInExpression
 }
 
 impl JsAnyBinaryLikeExpression {
@@ -804,61 +799,6 @@ impl JsAnyBinaryLikeExpression {
     }
 }
 
-impl AstNode for JsAnyBinaryLikeExpression {
-    type Language = JsLanguage;
-    fn can_cast(kind: JsSyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
-        matches!(
-            kind,
-            JS_BINARY_EXPRESSION
-                | JS_LOGICAL_EXPRESSION
-                | JS_INSTANCEOF_EXPRESSION
-                | JS_IN_EXPRESSION
-        )
-    }
-
-    fn cast(syntax: JsSyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            JS_BINARY_EXPRESSION => {
-                JsBinaryExpression::cast(syntax).map(JsAnyBinaryLikeExpression::JsBinaryExpression)
-            }
-            JS_LOGICAL_EXPRESSION => JsLogicalExpression::cast(syntax)
-                .map(JsAnyBinaryLikeExpression::JsLogicalExpression),
-            JS_INSTANCEOF_EXPRESSION => JsInstanceofExpression::cast(syntax)
-                .map(JsAnyBinaryLikeExpression::JsInstanceofExpression),
-            JS_IN_EXPRESSION => {
-                JsInExpression::cast(syntax).map(JsAnyBinaryLikeExpression::JsInExpression)
-            }
-            _ => None,
-        }
-    }
-
-    fn syntax(&self) -> &JsSyntaxNode {
-        match self {
-            JsAnyBinaryLikeExpression::JsLogicalExpression(logical) => logical.syntax(),
-            JsAnyBinaryLikeExpression::JsBinaryExpression(binary) => binary.syntax(),
-            JsAnyBinaryLikeExpression::JsInstanceofExpression(instanceof) => instanceof.syntax(),
-            JsAnyBinaryLikeExpression::JsInExpression(in_expression) => in_expression.syntax(),
-        }
-    }
-
-    fn into_syntax(self) -> JsSyntaxNode {
-        match self {
-            JsAnyBinaryLikeExpression::JsLogicalExpression(logical) => logical.into_syntax(),
-            JsAnyBinaryLikeExpression::JsBinaryExpression(binary) => binary.into_syntax(),
-            JsAnyBinaryLikeExpression::JsInstanceofExpression(instanceof) => {
-                instanceof.into_syntax()
-            }
-            JsAnyBinaryLikeExpression::JsInExpression(in_expression) => in_expression.into_syntax(),
-        }
-    }
-}
-
 impl JsAnyBinaryLikeExpression {
     /// Determines if a binary like expression should be flattened or not. As a rule of thumb, an expression
     /// can be flattened if it is of the same kind as the left-hand side sub-expression and uses the same operator.
@@ -890,10 +830,8 @@ impl JsAnyBinaryLikeExpression {
     }
 }
 
-#[derive(Debug)]
-enum JsAnyBinaryLikeLeftExpression {
-    JsAnyExpression(JsAnyExpression),
-    JsPrivateName(JsPrivateName),
+declare_union! {
+    JsAnyBinaryLikeLeftExpression = JsAnyExpression | JsPrivateName
 }
 
 impl JsAnyBinaryLikeLeftExpression {
@@ -901,43 +839,6 @@ impl JsAnyBinaryLikeLeftExpression {
         match self {
             JsAnyBinaryLikeLeftExpression::JsAnyExpression(expression) => Some(expression),
             JsAnyBinaryLikeLeftExpression::JsPrivateName(_) => None,
-        }
-    }
-}
-
-impl AstNode for JsAnyBinaryLikeLeftExpression {
-    type Language = JsLanguage;
-    fn can_cast(kind: JsSyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
-        JsAnyExpression::can_cast(kind) || JsPrivateName::can_cast(kind)
-    }
-
-    fn cast(syntax: JsSyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        if syntax.kind() == JS_PRIVATE_NAME {
-            JsPrivateName::cast(syntax).map(|name| name.into())
-        } else {
-            JsAnyExpression::cast(syntax).map(|expr| expr.into())
-        }
-    }
-
-    fn syntax(&self) -> &JsSyntaxNode {
-        match self {
-            JsAnyBinaryLikeLeftExpression::JsAnyExpression(expression) => expression.syntax(),
-            JsAnyBinaryLikeLeftExpression::JsPrivateName(private_name) => private_name.syntax(),
-        }
-    }
-
-    fn into_syntax(self) -> JsSyntaxNode {
-        match self {
-            JsAnyBinaryLikeLeftExpression::JsAnyExpression(expression) => expression.into_syntax(),
-            JsAnyBinaryLikeLeftExpression::JsPrivateName(private_name) => {
-                private_name.into_syntax()
-            }
         }
     }
 }
@@ -952,18 +853,6 @@ impl Format<JsFormatContext> for JsAnyBinaryLikeLeftExpression {
                 write![f, [private_name.format()]]
             }
         }
-    }
-}
-
-impl From<JsAnyExpression> for JsAnyBinaryLikeLeftExpression {
-    fn from(expression: JsAnyExpression) -> Self {
-        JsAnyBinaryLikeLeftExpression::JsAnyExpression(expression)
-    }
-}
-
-impl From<JsPrivateName> for JsAnyBinaryLikeLeftExpression {
-    fn from(private_name: JsPrivateName) -> Self {
-        JsAnyBinaryLikeLeftExpression::JsPrivateName(private_name)
     }
 }
 

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{
     JsSyntaxNode, JsSyntaxToken,
 };
 
-use rome_rowan::{declare_union, AstNode, SyntaxResult};
+use rome_rowan::{declare_node_union, AstNode, SyntaxResult};
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::iter::FusedIterator;
@@ -724,7 +724,7 @@ impl Iterator for PostorderIterator {
 
 impl FusedIterator for PostorderIterator {}
 
-declare_union! {
+declare_node_union! {
     pub(crate) JsAnyBinaryLikeExpression = JsLogicalExpression | JsBinaryExpression | JsInstanceofExpression | JsInExpression
 }
 
@@ -830,7 +830,7 @@ impl JsAnyBinaryLikeExpression {
     }
 }
 
-declare_union! {
+declare_node_union! {
     JsAnyBinaryLikeLeftExpression = JsAnyExpression | JsPrivateName
 }
 

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -8,6 +8,9 @@
 )]
 #![deny(unsafe_code)]
 
+#[doc(hidden)]
+pub mod macros;
+
 #[allow(unsafe_code)]
 pub mod cursor;
 #[allow(unsafe_code)]

--- a/crates/rome_rowan/src/macros.rs
+++ b/crates/rome_rowan/src/macros.rs
@@ -1,0 +1,116 @@
+use crate::{AstNode, Language};
+
+/// Declares a custom union AstNode type with an ungram-like syntax
+///
+/// # Example
+///
+/// ```ignore
+/// declare_union! {
+///     /// Matches an if statement or a conditional expression
+///     pub(crate) JsAnyConditional = JsIfStatement | JsConditionalExpression
+/// }
+/// ```
+#[macro_export]
+macro_rules! declare_union {
+    ( $( #[$attr:meta] )* $vis:vis $name:ident = $( $variant:ident )|* ) => {
+        $( #[$attr] )*
+        #[allow(clippy::enum_variant_names)]
+        #[derive(Clone, PartialEq, Eq, Hash)]
+        $vis enum $name {
+            $( $variant($variant), )*
+        }
+
+        impl AstNode for $name {
+            type Language = <( $( $variant, )* ) as $crate::macros::UnionLanguage>::Language;
+
+            fn can_cast(kind: <Self::Language as $crate::Language>::Kind) -> bool {
+                $( $variant::can_cast(kind) )||*
+            }
+
+            fn cast(syntax: $crate::SyntaxNode<Self::Language>) -> Option<Self>
+            where
+                Self: Sized,
+            {
+                $( if $variant::can_cast(syntax.kind()) {
+                    return Some(Self::$variant($variant::unwrap_cast(syntax)));
+                } )*
+
+                None
+            }
+
+            fn syntax(&self) -> &$crate::SyntaxNode<Self::Language> {
+                match self {
+                    $( Self::$variant(node) => node.syntax() ),*
+                }
+            }
+
+            fn into_syntax(self) -> $crate::SyntaxNode<Self::Language> {
+                match self {
+                    $( Self::$variant(node) => node.into_syntax() ),*
+                }
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    $( Self::$variant(it) => std::fmt::Debug::fmt(it, f), )*
+                }
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Display::fmt(self.syntax(), f)
+            }
+        }
+
+        $( impl From<$variant> for $name {
+            fn from(node: $variant) -> Self {
+                Self::$variant(node)
+            }
+        } )*
+
+        impl From<$name> for $crate::SyntaxNode<<$name as AstNode>::Language> {
+            fn from(n: $name) -> $crate::SyntaxNode<<$name as AstNode>::Language> {
+                match n {
+                    $( $name::$variant(it) => it.into(), )*
+                }
+            }
+        }
+
+        impl From<$name> for $crate::SyntaxElement<<$name as AstNode>::Language> {
+            fn from(n: $name) -> $crate::SyntaxElement<<$name as AstNode>::Language> {
+                $crate::SyntaxNode::<<$name as AstNode>::Language>::from(n).into()
+            }
+        }
+    };
+}
+
+/// This trait is implemented for tuples of AstNode types of size 1 to 9 if all
+/// node types share the same associated language (which is then aliased as the
+/// `Language` associated type on [UnionLanguage] itself)
+pub trait UnionLanguage {
+    type Language: Language;
+}
+
+macro_rules! impl_union_language {
+    ( $head:ident $( , $rest:ident )* ) => {
+        impl<$head $( , $rest )*> UnionLanguage for ($head, $( $rest ),*)
+        where
+            $head: AstNode $( , $rest: AstNode<Language = <$head as AstNode>::Language> )*
+        {
+            type Language = <$head as AstNode>::Language;
+        }
+    };
+}
+
+impl_union_language!(T1);
+impl_union_language!(T1, T2);
+impl_union_language!(T1, T2, T3);
+impl_union_language!(T1, T2, T3, T4);
+impl_union_language!(T1, T2, T3, T4, T5);
+impl_union_language!(T1, T2, T3, T4, T5, T6);
+impl_union_language!(T1, T2, T3, T4, T5, T6, T7);
+impl_union_language!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_union_language!(T1, T2, T3, T4, T5, T6, T7, T8, T9);

--- a/crates/rome_rowan/src/macros.rs
+++ b/crates/rome_rowan/src/macros.rs
@@ -5,13 +5,13 @@ use crate::{AstNode, Language};
 /// # Example
 ///
 /// ```ignore
-/// declare_union! {
+/// declare_node_union! {
 ///     /// Matches an if statement or a conditional expression
 ///     pub(crate) JsAnyConditional = JsIfStatement | JsConditionalExpression
 /// }
 /// ```
 #[macro_export]
-macro_rules! declare_union {
+macro_rules! declare_node_union {
     ( $( #[$attr:meta] )* $vis:vis $name:ident = $( $variant:ident )|* ) => {
         $( #[$attr] )*
         #[allow(clippy::enum_variant_names)]
@@ -87,9 +87,9 @@ macro_rules! declare_union {
     };
 }
 
-/// This trait is implemented for tuples of AstNode types of size 1 to 9 if all
-/// node types share the same associated language (which is then aliased as the
-/// `Language` associated type on [UnionLanguage] itself)
+/// This trait is implemented for tuples of AstNode types of size 1 to 12 if
+/// all node types share the same associated language (which is then aliased as
+/// the `Language` associated type on [UnionLanguage] itself)
 pub trait UnionLanguage {
     type Language: Language;
 }
@@ -102,15 +102,11 @@ macro_rules! impl_union_language {
         {
             type Language = <$head as AstNode>::Language;
         }
+
+        impl_union_language!( $( $rest ),* );
     };
+
+    () => {};
 }
 
-impl_union_language!(T1);
-impl_union_language!(T1, T2);
-impl_union_language!(T1, T2, T3);
-impl_union_language!(T1, T2, T3, T4);
-impl_union_language!(T1, T2, T3, T4, T5);
-impl_union_language!(T1, T2, T3, T4, T5, T6);
-impl_union_language!(T1, T2, T3, T4, T5, T6, T7);
-impl_union_language!(T1, T2, T3, T4, T5, T6, T7, T8);
-impl_union_language!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+impl_union_language!(T00, T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11);


### PR DESCRIPTION
## Summary

This PR add a new `declare_union` for creating union AST nodes scoped to a local module, without having to add them to `js.ungram` and `rome_js_syntax`. Its usage looks like the following example:

```rust
declare_union! {
    /// Documentation
    #[allow(dead_code)]
    pub(crate) UnionName = NodeType | OtherNodeType
}
```

The resulting union type is an enum with a variant for each node type in the union and implementing:
- the `AstNode` trait
- the `Debug` and `Display` traits
- the `Clone`, `PartialEq`, `Eq` and `Hash` traits with derive
- the `From` trait for each variants
- the `Into` trait for `SyntaxNode` and `SyntaxElement`

The macro is designed to fail to compile when the union would contain node types from different languages, as the `AstNode` trait must have a single `Language` associated type. I'm not really sure if and how this is a restriction we may lift in the future.

## Test Plan

This macro is now used to implement the `JsAnyBinaryLikeExpression` and `JsAnyBinaryLikeLeftExpression` types in the formatting of binary-like expressions
