### PR TITLE
feat(rome_analyze): improve the diagnostics builder in the analyzer

### DIFF
--- a/crates/rome_analyze/src/analyzers/no_compare_neg_zero.rs
+++ b/crates/rome_analyze/src/analyzers/no_compare_neg_zero.rs
@@ -49,12 +49,12 @@ impl Rule for NoCompareNegZero {
     }
 
     fn diagnostic(node: &Self::Query, state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(
-            RuleDiagnostic::warning(markup! {
+        Some(RuleDiagnostic::warning(
+            node.range(),
+            markup! {
                 "Do not use the "{state.operator_kind}" operator to compare against -0."
-            })
-            .primary(node.range(), ""),
-        )
+            },
+        ))
     }
     fn action(
         root: rome_js_syntax::JsAnyRoot,

--- a/crates/rome_analyze/src/analyzers/no_compare_neg_zero.rs
+++ b/crates/rome_analyze/src/analyzers/no_compare_neg_zero.rs
@@ -1,5 +1,5 @@
 use rome_console::markup;
-use rome_diagnostics::{Applicability, Severity};
+use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsBinaryExpression, JsSyntaxKind, JsUnaryOperator,
@@ -49,14 +49,12 @@ impl Rule for NoCompareNegZero {
     }
 
     fn diagnostic(node: &Self::Query, state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic {
-            severity: Severity::Warning,
-            range: node.syntax().text_trimmed_range(),
-            message: markup! {
+        Some(
+            RuleDiagnostic::warning(markup! {
                 "Do not use the "{state.operator_kind}" operator to compare against -0."
-            }
-            .to_owned(),
-        })
+            })
+            .primary(node.range(), ""),
+        )
     }
     fn action(
         root: rome_js_syntax::JsAnyRoot,

--- a/crates/rome_analyze/src/analyzers/no_delete.rs
+++ b/crates/rome_analyze/src/analyzers/no_delete.rs
@@ -32,10 +32,9 @@ impl Rule for NoDelete {
 
     fn diagnostic(node: &Self::Query, _state: &Self::State) -> Option<RuleDiagnostic> {
         Some(
-            RuleDiagnostic::warning(markup! {
+            RuleDiagnostic::warning(node.range(), markup! {
                 "This is an unexpected use of the "<Emphasis>"delete"</Emphasis>" operator."
             })
-            .primary(node.range(), "")
             .summary("This is an unexpected use of the `delete` operator.\nReplace this expression with an `undefined` assignment")
         )
     }

--- a/crates/rome_analyze/src/analyzers/no_delete.rs
+++ b/crates/rome_analyze/src/analyzers/no_delete.rs
@@ -1,5 +1,5 @@
 use rome_console::markup;
-use rome_diagnostics::{Applicability, Severity};
+use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyAssignment, JsAnyAssignmentPattern, JsAnyExpression, JsAnyRoot,
@@ -31,14 +31,13 @@ impl Rule for NoDelete {
     }
 
     fn diagnostic(node: &Self::Query, _state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic {
-            severity: Severity::Warning,
-            range: node.syntax().text_trimmed_range(),
-            message: markup! {
+        Some(
+            RuleDiagnostic::warning(markup! {
                 "This is an unexpected use of the "<Emphasis>"delete"</Emphasis>" operator."
-            }
-            .to_owned(),
-        })
+            })
+            .primary(node.range(), "")
+            .summary("This is an unexpected use of the `delete` operator.\nReplace this expression with an `undefined` assignment")
+        )
     }
 
     fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_analyze/src/analyzers/no_double_equals.rs
@@ -37,16 +37,16 @@ impl Rule for NoDoubleEquals {
         let suggestion = if op.kind() == EQ2 { "===" } else { "!==" };
 
         Some(
-            RuleDiagnostic::warning(markup! {
+            RuleDiagnostic::warning(op.text_trimmed_range(),markup! {
                 "Use "<Emphasis>{suggestion}</Emphasis>" instead of "<Emphasis>{text_trimmed}</Emphasis>
             })
-            .primary(op.text_trimmed_range(), markup! {
-                <Emphasis>{text_trimmed}</Emphasis>" is only allowed when comparing against null"
+            .primary( markup! {
+                <Emphasis>{text_trimmed}</Emphasis>" is only allowed when comparing against "<Emphasis>"null"</Emphasis>
             })
             .footer_note(markup! {
                 "Using "<Emphasis>{suggestion}</Emphasis>" may be unsafe if you are relying on type coercion"
             })
-            .summary(format!("Use {suggestion} instead of {text_trimmed}\n{text_trimmed} is only allowed when comparing against null"))
+            .summary(format!("Use {suggestion} instead of {text_trimmed}.\n{text_trimmed} is only allowed when comparing against `null`"))
         )
     }
 
@@ -57,6 +57,8 @@ impl Rule for NoDoubleEquals {
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,
             applicability: Applicability::MaybeIncorrect,
+            // SAFETY: `suggestion` can only be JsSyntaxKind::EQ3 or JsSyntaxKind::NEQ2,
+            // the implementation of `to_string` for these two variants always returns Some
             message: markup! { "Use "<Emphasis>{suggestion.to_string().unwrap()}</Emphasis> }
                 .to_owned(),
             root,

--- a/crates/rome_analyze/src/analyzers/no_negation_else.rs
+++ b/crates/rome_analyze/src/analyzers/no_negation_else.rs
@@ -1,7 +1,7 @@
 use crate::registry::{JsRuleAction, Rule, RuleAction, RuleDiagnostic};
 use crate::{ActionCategory, RuleCategory};
 use rome_console::markup;
-use rome_diagnostics::{Applicability, Severity};
+use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyExpression, JsAnyRoot, JsConditionalExpression, JsIfStatement, JsLanguage, JsSyntaxKind,
@@ -39,14 +39,12 @@ impl Rule for NoNegationElse {
     }
 
     fn diagnostic(node: &Self::Query, _state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic {
-            severity: Severity::Warning,
-            message: markup! {
+        Some(
+            RuleDiagnostic::warning(markup! {
                 "Invert blocks when performing a negation test."
-            }
-            .to_owned(),
-            range: node.range(),
-        })
+            })
+            .primary(node.range(), ""),
+        )
     }
 
     fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_analyze/src/analyzers/no_negation_else.rs
+++ b/crates/rome_analyze/src/analyzers/no_negation_else.rs
@@ -39,12 +39,12 @@ impl Rule for NoNegationElse {
     }
 
     fn diagnostic(node: &Self::Query, _state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(
-            RuleDiagnostic::warning(markup! {
+        Some(RuleDiagnostic::warning(
+            node.range(),
+            markup! {
                 "Invert blocks when performing a negation test."
-            })
-            .primary(node.range(), ""),
-        )
+            },
+        ))
     }
 
     fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
+++ b/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
@@ -31,12 +31,12 @@ impl Rule for UseSingleCaseStatement {
     }
 
     fn diagnostic(n: &Self::Query, _: &Self::State) -> Option<RuleDiagnostic> {
-        Some(
-            RuleDiagnostic::warning(markup! {
+        Some(RuleDiagnostic::warning(
+            n.consequent().range(),
+            markup! {
                 "A switch case should only have a single statement. If you want more, then wrap it in a block."
-            })
-            .primary(n.consequent().range(), "")
-        )
+            },
+        ))
     }
 
     fn action(root: JsAnyRoot, n: &Self::Query, _: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
+++ b/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use rome_console::markup;
-use rome_diagnostics::{Applicability, Severity};
+use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyRoot, JsAnyStatement, JsCaseClause, JsCaseClauseFields, JsSyntaxToken, TriviaPieceKind, T,
@@ -31,14 +31,12 @@ impl Rule for UseSingleCaseStatement {
     }
 
     fn diagnostic(n: &Self::Query, _: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic {
-            severity: Severity::Warning,
-            message: markup! {
-                "A switch case should only have a single statement."
-            }
-            .to_owned(),
-            range: n.consequent().syntax().text_trimmed_range(),
-        })
+        Some(
+            RuleDiagnostic::warning(markup! {
+                "A switch case should only have a single statement. If you want more, then wrap it in a block."
+            })
+            .primary(n.consequent().range(), "")
+        )
     }
 
     fn action(root: JsAnyRoot, n: &Self::Query, _: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_analyze/src/analyzers/use_single_var_declarator.rs
+++ b/crates/rome_analyze/src/analyzers/use_single_var_declarator.rs
@@ -44,7 +44,10 @@ impl Rule for UseSingleVarDeclarator {
     }
 
     fn diagnostic(node: &Self::Query, _state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic::warning("Declare variables separately").primary(node.range(), ""))
+        Some(RuleDiagnostic::warning(
+            node.range(),
+            "Declare variables separately",
+        ))
     }
 
     fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_analyze/src/analyzers/use_single_var_declarator.rs
+++ b/crates/rome_analyze/src/analyzers/use_single_var_declarator.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use rome_console::markup;
-use rome_diagnostics::{Applicability, Severity};
+use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyRoot, JsModuleItemList, JsStatementList, JsSyntaxToken, JsVariableDeclarationFields,
@@ -44,14 +44,7 @@ impl Rule for UseSingleVarDeclarator {
     }
 
     fn diagnostic(node: &Self::Query, _state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic {
-            severity: Severity::Warning,
-            range: node.syntax().text_trimmed_range(),
-            message: markup! {
-                "Declare variables separately."
-            }
-            .to_owned(),
-        })
+        Some(RuleDiagnostic::warning("Declare variables separately").primary(node.range(), ""))
     }
 
     fn action(root: JsAnyRoot, node: &Self::Query, state: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_analyze/src/analyzers/use_valid_typeof.rs
+++ b/crates/rome_analyze/src/analyzers/use_valid_typeof.rs
@@ -143,18 +143,15 @@ impl Rule for UseValidTypeof {
     }
 
     fn diagnostic(_: &Self::Query, (err, _): &Self::State) -> Option<RuleDiagnostic> {
-        let diag = RuleDiagnostic::warning("Invalid `typeof` comparison value");
+        const TITLE: &str = "Invalid `typeof` comparison value";
+
         Some(match err {
-            TypeofError::InvalidLiteral(range, literal) => diag
-                .primary(range, "not a valid type name")
-                .summary(format!(
-                    "Invalid `typeof` comparison value: \"{literal}\" is not a valid type name"
-                )),
-            TypeofError::InvalidExpression(range) => {
-                diag.primary(range, "not a string literal").summary(
-                    "Invalid `typeof` comparison value: this expression is not a string literal",
-                )
-            }
+            TypeofError::InvalidLiteral(range, literal) => RuleDiagnostic::warning(range, TITLE)
+                .primary("not a valid type name")
+                .summary(format!("{TITLE}: \"{literal}\" is not a valid type name")),
+            TypeofError::InvalidExpression(range) => RuleDiagnostic::warning(range, TITLE)
+                .primary("not a string literal")
+                .summary(format!("{TITLE}: this expression is not a string literal",)),
         })
     }
 

--- a/crates/rome_analyze/src/analyzers/use_valid_typeof.rs
+++ b/crates/rome_analyze/src/analyzers/use_valid_typeof.rs
@@ -1,9 +1,9 @@
 use rome_console::markup;
-use rome_diagnostics::{Applicability, Severity};
+use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsAnyRoot, JsBinaryExpression,
-    JsBinaryExpressionFields, JsBinaryOperator, JsUnaryOperator,
+    JsBinaryExpressionFields, JsBinaryOperator, JsUnaryOperator, TextRange,
 };
 use rome_rowan::{AstNode, AstNodeExt};
 
@@ -22,7 +22,7 @@ impl Rule for UseValidTypeof {
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsBinaryExpression;
-    type State = Option<(JsAnyExpression, JsTypeName)>;
+    type State = (TypeofError, Option<(JsAnyExpression, JsTypeName)>);
 
     fn run(n: &Self::Query) -> Option<Self::State> {
         let JsBinaryExpressionFields {
@@ -44,7 +44,7 @@ impl Rule for UseValidTypeof {
         let left = left.ok()?;
         let right = right.ok()?;
 
-        match (&left, &right) {
+        let range = match (&left, &right) {
             // Check for `typeof $expr == $lit` and `$lit == typeof $expr`
             (
                 JsAnyExpression::JsUnaryExpression(unary),
@@ -60,6 +60,8 @@ impl Rule for UseValidTypeof {
 
                 if let JsAnyLiteralExpression::JsStringLiteralExpression(literal) = literal {
                     let literal = literal.value_token().ok()?;
+                    let range = literal.text_trimmed_range();
+
                     let literal = literal
                         .text_trimmed()
                         .trim_start_matches(['"', '\''])
@@ -71,11 +73,14 @@ impl Rule for UseValidTypeof {
                     }
 
                     // Try to fix the casing of the literal eg. "String" -> "string"
-                    let literal = literal.to_lowercase();
-                    return Some(
-                        JsTypeName::from_str(&literal).map(|type_name| (lit.clone(), type_name)),
-                    );
+                    let suggestion = literal.to_lowercase();
+                    return Some((
+                        TypeofError::InvalidLiteral(range, literal),
+                        JsTypeName::from_str(&suggestion).map(|type_name| (lit.clone(), type_name)),
+                    ));
                 }
+
+                lit.range()
             }
 
             // Check for `typeof $expr == typeof $expr`
@@ -83,9 +88,14 @@ impl Rule for UseValidTypeof {
                 JsAnyExpression::JsUnaryExpression(left),
                 JsAnyExpression::JsUnaryExpression(right),
             ) => {
-                let is_typeof_left = left.operator().ok()? != JsUnaryOperator::Typeof;
-                let is_typeof_right = right.operator().ok()? != JsUnaryOperator::Typeof;
-                if (is_typeof_left && is_typeof_right) || (!is_typeof_left && !is_typeof_right) {
+                let is_typeof_left = left.operator().ok()? == JsUnaryOperator::Typeof;
+                let is_typeof_right = right.operator().ok()? == JsUnaryOperator::Typeof;
+
+                if is_typeof_left && !is_typeof_right {
+                    right.range()
+                } else if is_typeof_right && !is_typeof_left {
+                    left.range()
+                } else {
                     return None;
                 }
             }
@@ -104,43 +114,56 @@ impl Rule for UseValidTypeof {
                 }
 
                 // Try to convert the identifier to a string literal eg. String -> "string"
-                return Some(ident.name().ok().and_then(|name| {
+                let suggestion = ident.name().ok().and_then(|name| {
                     let value = name.value_token().ok()?;
 
                     let to_lower = value.text_trimmed().to_lowercase();
                     let as_type = JsTypeName::from_str(&to_lower)?;
 
                     Some((id.clone(), as_type))
-                }));
+                });
+
+                return Some((TypeofError::InvalidExpression(ident.range()), suggestion));
             }
 
             // Check for `typeof $expr == $expr`
-            (JsAnyExpression::JsUnaryExpression(unary), _)
-            | (_, JsAnyExpression::JsUnaryExpression(unary)) => {
+            (JsAnyExpression::JsUnaryExpression(unary), expr)
+            | (expr, JsAnyExpression::JsUnaryExpression(unary)) => {
                 if unary.operator().ok()? != JsUnaryOperator::Typeof {
                     return None;
                 }
+
+                expr.range()
             }
 
             _ => return None,
-        }
+        };
 
-        Some(None)
+        Some((TypeofError::InvalidExpression(range), None))
     }
 
-    fn diagnostic(node: &Self::Query, _: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic {
-            severity: Severity::Warning,
-            message: markup! {
-                "Invalid typeof comparison value"
+    fn diagnostic(_: &Self::Query, (err, _): &Self::State) -> Option<RuleDiagnostic> {
+        let diag = RuleDiagnostic::warning("Invalid `typeof` comparison value");
+        Some(match err {
+            TypeofError::InvalidLiteral(range, literal) => diag
+                .primary(range, "not a valid type name")
+                .summary(format!(
+                    "Invalid `typeof` comparison value: \"{literal}\" is not a valid type name"
+                )),
+            TypeofError::InvalidExpression(range) => {
+                diag.primary(range, "not a string literal").summary(
+                    "Invalid `typeof` comparison value: this expression is not a string literal",
+                )
             }
-            .to_owned(),
-            range: node.range(),
         })
     }
 
-    fn action(root: JsAnyRoot, _node: &Self::Query, state: &Self::State) -> Option<JsRuleAction> {
-        let (expr, type_name) = state.as_ref()?;
+    fn action(
+        root: JsAnyRoot,
+        _node: &Self::Query,
+        (_, suggestion): &Self::State,
+    ) -> Option<JsRuleAction> {
+        let (expr, type_name) = suggestion.as_ref()?;
 
         let root = root.replace_node(
             expr.clone(),
@@ -156,6 +179,11 @@ impl Rule for UseValidTypeof {
             root,
         })
     }
+}
+
+pub enum TypeofError {
+    InvalidLiteral(TextRange, String),
+    InvalidExpression(TextRange),
 }
 
 pub enum JsTypeName {

--- a/crates/rome_analyze/src/analyzers/use_while.rs
+++ b/crates/rome_analyze/src/analyzers/use_while.rs
@@ -1,8 +1,8 @@
 use rome_console::markup;
-use rome_diagnostics::{Applicability, Severity};
+use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{JsAnyRoot, JsAnyStatement, JsForStatement, JsForStatementFields, T};
-use rome_rowan::{AstNode, AstNodeExt};
+use rome_rowan::AstNodeExt;
 
 use crate::{
     registry::{JsRuleAction, Rule, RuleDiagnostic},
@@ -45,14 +45,16 @@ impl Rule for UseWhile {
     }
 
     fn diagnostic(node: &Self::Query, _: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic {
-            severity: Severity::Warning,
-            message: markup! {
-                "Use a while loop instead of a for loop"
-            }
-            .to_owned(),
-            range: node.range(),
-        })
+        // SAFETY: These tokens have been checked for errors in `run` already
+        let for_range = node.for_token().unwrap().text_trimmed_range();
+        let r_paren_range = node.r_paren_token().unwrap().text_trimmed_range();
+
+        Some(
+            RuleDiagnostic::warning(markup! {
+                "Use "<Emphasis>"while"</Emphasis>" loops instead of "<Emphasis>"for"</Emphasis>" loops."
+            })
+                .primary(for_range.cover(r_paren_range), ""),
+        )
     }
 
     fn action(root: JsAnyRoot, node: &Self::Query, _: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_analyze/src/analyzers/use_while.rs
+++ b/crates/rome_analyze/src/analyzers/use_while.rs
@@ -49,12 +49,12 @@ impl Rule for UseWhile {
         let for_range = node.for_token().unwrap().text_trimmed_range();
         let r_paren_range = node.r_paren_token().unwrap().text_trimmed_range();
 
-        Some(
-            RuleDiagnostic::warning(markup! {
+        Some(RuleDiagnostic::warning(
+            for_range.cover(r_paren_range),
+            markup! {
                 "Use "<Emphasis>"while"</Emphasis>" loops instead of "<Emphasis>"for"</Emphasis>" loops."
-            })
-                .primary(for_range.cover(r_paren_range), ""),
-        )
+            },
+        ))
     }
 
     fn action(root: JsAnyRoot, node: &Self::Query, _: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -1,5 +1,8 @@
-use rome_console::MarkupBuf;
+use rome_console::fmt::Display;
+use rome_console::{markup, MarkupBuf};
+use rome_diagnostics::file::FileSpan;
 use rome_diagnostics::{file::FileId, Applicability, Severity};
+use rome_diagnostics::{Diagnostic, DiagnosticTag, Footer, Span, SubDiagnostic};
 use rome_js_syntax::JsLanguage;
 use rome_js_syntax::TextRange;
 use rome_rowan::{AstNode, Language, SyntaxNode};
@@ -147,9 +150,166 @@ pub(crate) trait Rule {
 
 /// Diagnostic object returned by a single analysis rule
 pub struct RuleDiagnostic {
-    pub severity: Severity,
-    pub range: TextRange,
-    pub message: MarkupBuf,
+    severity: Severity,
+    title: MarkupBuf,
+    summary: Option<String>,
+    tag: Option<DiagnosticTag>,
+    primary: Option<(Severity, MarkupBuf, TextRange)>,
+    secondaries: Vec<(Severity, MarkupBuf, TextRange)>,
+    footers: Vec<Footer>,
+}
+
+// Some of these methods aren't used by anything yet
+#[allow(dead_code)]
+impl RuleDiagnostic {
+    /// Creates a new [`RuleDiagnostic`] with a severity and title that will be
+    /// used in a builder-like way to modify labels.
+    fn new(severity: Severity, title: impl Display) -> Self {
+        Self {
+            severity,
+            title: markup!({ title }).to_owned(),
+            summary: None,
+            tag: None,
+            primary: None,
+            secondaries: Vec::new(),
+            footers: Vec::new(),
+        }
+    }
+
+    /// Creates a new [`RuleDiagnostic`] with the `Error` severity.
+    pub(crate) fn error(title: impl Display) -> Self {
+        Self::new(Severity::Error, title)
+    }
+
+    /// Creates a new [`RuleDiagnostic`] with the `Warning` severity.
+    pub(crate) fn warning(title: impl Display) -> Self {
+        Self::new(Severity::Warning, title)
+    }
+
+    /// Creates a new [`RuleDiagnostic`] with the `Help` severity.
+    pub(crate) fn help(title: impl Display) -> Self {
+        Self::new(Severity::Help, title)
+    }
+
+    /// Creates a new [`RuleDiagnostic`] with the `Note` severity.
+    pub(crate) fn note(title: impl Display) -> Self {
+        Self::new(Severity::Note, title)
+    }
+
+    /// Set an explicit plain-text summary for this diagnostic.
+    pub fn summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
+
+    /// Marks this diagnostic as deprecated code, which will
+    /// be displayed in the language server.
+    ///
+    /// This does not have any influence on the diagnostic rendering.
+    pub fn deprecated(mut self) -> Self {
+        self.tag = if matches!(self.tag, Some(DiagnosticTag::Unnecessary)) {
+            Some(DiagnosticTag::Both)
+        } else {
+            Some(DiagnosticTag::Deprecated)
+        };
+        self
+    }
+
+    /// Marks this diagnostic as unnecessary code, which will
+    /// be displayed in the language server.
+    ///
+    /// This does not have any influence on the diagnostic rendering.
+    pub fn unnecessary(mut self) -> Self {
+        self.tag = if matches!(self.tag, Some(DiagnosticTag::Deprecated)) {
+            Some(DiagnosticTag::Both)
+        } else {
+            Some(DiagnosticTag::Unnecessary)
+        };
+        self
+    }
+
+    /// Attaches a label to this [`RuleDiagnostic`], that will point to another file
+    /// that is provided.
+    pub fn label_in_file(mut self, severity: Severity, span: impl Span, msg: impl Display) -> Self {
+        self.secondaries
+            .push((severity, markup!({ msg }).to_owned(), span.as_range()));
+        self
+    }
+
+    /// Attaches a label to this [`RuleDiagnostic`].
+    ///
+    /// The given span has to be in the file that was provided while creating this [`RuleDiagnostic`].
+    pub fn label(mut self, severity: Severity, span: impl Span, msg: impl Display) -> Self {
+        self.secondaries
+            .push((severity, markup!({ msg }).to_owned(), span.as_range()));
+        self
+    }
+
+    /// Attaches a primary label to this [`RuleDiagnostic`].
+    pub fn primary(mut self, span: impl Span, msg: impl Display) -> Self {
+        self.primary = Some((self.severity, markup!({ msg }).to_owned(), span.as_range()));
+        self
+    }
+
+    /// Attaches a secondary label to this [`RuleDiagnostic`].
+    pub fn secondary(self, span: impl Span, msg: impl Display) -> Self {
+        self.label(Severity::Note, span, msg)
+    }
+
+    /// Adds a footer to this [`RuleDiagnostic`], which will be displayed under the actual error.
+    pub fn footer(mut self, severity: Severity, msg: impl Display) -> Self {
+        self.footers.push(Footer {
+            msg: markup!({ msg }).to_owned(),
+            severity,
+        });
+        self
+    }
+
+    /// Adds a footer to this [`RuleDiagnostic`], with the `Help` severity.
+    pub fn footer_help(self, msg: impl Display) -> Self {
+        self.footer(Severity::Help, msg)
+    }
+
+    /// Adds a footer to this [`RuleDiagnostic`], with the `Note` severity.
+    pub fn footer_note(self, msg: impl Display) -> Self {
+        self.footer(Severity::Note, msg)
+    }
+
+    /// Convert this [`RuleDiagnostic`] into an instance of [`Diagnostic`] by
+    /// injecting the name of the rule that emitted it and the ID of the file
+    /// the rule was being run on
+    pub(crate) fn into_diagnostic(self, file_id: FileId, code: &'static str) -> Diagnostic {
+        Diagnostic {
+            file_id,
+            severity: self.severity,
+            code: Some(code.into()),
+            title: self.title,
+            summary: self.summary,
+            tag: self.tag,
+            primary: self.primary.map(|(severity, msg, range)| SubDiagnostic {
+                severity,
+                msg,
+                span: FileSpan {
+                    file: file_id,
+                    range,
+                },
+            }),
+            children: self
+                .secondaries
+                .into_iter()
+                .map(|(severity, msg, range)| SubDiagnostic {
+                    severity,
+                    msg,
+                    span: FileSpan {
+                        file: file_id,
+                        range,
+                    },
+                })
+                .collect(),
+            suggestions: Vec::new(),
+            footers: self.footers,
+        }
+    }
 }
 
 /// Code Action object returned by a single analysis rule

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use rome_console::MarkupBuf;
 use rome_diagnostics::{
     file::{FileId, FileSpan},
-    Applicability, CodeSuggestion, Diagnostic, SubDiagnostic, SuggestionChange, SuggestionStyle,
+    Applicability, CodeSuggestion, Diagnostic, SuggestionChange, SuggestionStyle,
 };
 use rome_js_syntax::TextRange;
 use rome_rowan::{AstNode, Direction, Language, SyntaxNode};
@@ -101,24 +101,8 @@ impl<'a, R: Rule + 'static> RuleSignal<'a, R> {
 
 impl<'a, R: Rule> AnalyzerSignal<RuleLanguage<R>> for RuleSignal<'a, R> {
     fn diagnostic(&self) -> Option<Diagnostic> {
-        R::diagnostic(&self.node, &self.state).map(|diag| Diagnostic {
-            file_id: self.file_id,
-            severity: diag.severity,
-            code: Some(R::NAME.into()),
-            title: diag.message.clone(),
-            tag: None,
-            primary: Some(SubDiagnostic {
-                severity: diag.severity,
-                msg: diag.message,
-                span: FileSpan {
-                    file: self.file_id,
-                    range: diag.range,
-                },
-            }),
-            children: Vec::new(),
-            suggestions: Vec::new(),
-            footers: Vec::new(),
-        })
+        R::diagnostic(&self.node, &self.state)
+            .map(|diag| diag.into_diagnostic(self.file_id, R::NAME))
     }
 
     fn action(&self) -> Option<AnalyzerAction<RuleLanguage<R>>> {

--- a/crates/rome_analyze/tests/specs/noCompareNegZero.js.snap
+++ b/crates/rome_analyze/tests/specs/noCompareNegZero.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_analyze/tests/spec_tests.rs
-assertion_line: 96
 expression: noCompareNegZero.js
 ---
 # Input
@@ -65,9 +64,9 @@ warning[noCompareNegZero]: Do not use the === operator to compare against -0.
    ┌─ noCompareNegZero.js:32:1
    │
 32 │ x === -0;
-   │ -------- Do not use the === operator to compare against -0.
+   │ --------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -29,7 +29,7 @@
 28 28 |   x || -0;
 29 29 |   x === +0;
@@ -86,9 +85,9 @@ warning[noCompareNegZero]: Do not use the == operator to compare against -0.
    ┌─ noCompareNegZero.js:33:1
    │
 33 │ x == -0;
-   │ ------- Do not use the == operator to compare against -0.
+   │ -------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -30,7 +30,7 @@
 29 29 |   x === +0;
 30 30 |   // invalid
@@ -107,9 +106,9 @@ warning[noCompareNegZero]: Do not use the == operator to compare against -0.
    ┌─ noCompareNegZero.js:34:1
    │
 34 │ -0 == x;
-   │ ------- Do not use the == operator to compare against -0.
+   │ -------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -31,7 +31,7 @@
 30 30 |   // invalid
 31 31 |   x === -0;
@@ -128,9 +127,9 @@ warning[noCompareNegZero]: Do not use the < operator to compare against -0.
    ┌─ noCompareNegZero.js:35:1
    │
 35 │ x < -0;
-   │ ------ Do not use the < operator to compare against -0.
+   │ ------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -32,7 +32,7 @@
 31 31 |   x === -0;
 32 32 |   x == -0;
@@ -149,9 +148,9 @@ warning[noCompareNegZero]: Do not use the < operator to compare against -0.
    ┌─ noCompareNegZero.js:36:1
    │
 36 │ -0 < x;
-   │ ------ Do not use the < operator to compare against -0.
+   │ ------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -33,7 +33,7 @@
 32 32 |   x == -0;
 33 33 |   -0 == x;
@@ -170,9 +169,9 @@ warning[noCompareNegZero]: Do not use the <= operator to compare against -0.
    ┌─ noCompareNegZero.js:37:1
    │
 37 │ x <= -0;
-   │ ------- Do not use the <= operator to compare against -0.
+   │ -------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -34,7 +34,7 @@
 33 33 |   -0 == x;
 34 34 |   x < -0;
@@ -191,9 +190,9 @@ warning[noCompareNegZero]: Do not use the <= operator to compare against -0.
    ┌─ noCompareNegZero.js:38:1
    │
 38 │ -0 <= x;
-   │ ------- Do not use the <= operator to compare against -0.
+   │ -------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -35,7 +35,7 @@
 34 34 |   x < -0;
 35 35 |   -0 < x;
@@ -212,9 +211,9 @@ warning[noCompareNegZero]: Do not use the > operator to compare against -0.
    ┌─ noCompareNegZero.js:39:1
    │
 39 │ x > -0;
-   │ ------ Do not use the > operator to compare against -0.
+   │ ------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -36,7 +36,7 @@
 35 35 |   -0 < x;
 36 36 |   x <= -0;
@@ -233,9 +232,9 @@ warning[noCompareNegZero]: Do not use the > operator to compare against -0.
    ┌─ noCompareNegZero.js:40:1
    │
 40 │ -0 > x;
-   │ ------ Do not use the > operator to compare against -0.
+   │ ------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -37,7 +37,7 @@
 36 36 |   x <= -0;
 37 37 |   -0 <= x;
@@ -254,9 +253,9 @@ warning[noCompareNegZero]: Do not use the >= operator to compare against -0.
    ┌─ noCompareNegZero.js:41:1
    │
 41 │ x >= -0;
-   │ ------- Do not use the >= operator to compare against -0.
+   │ -------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -38,7 +38,7 @@
 37 37 |   -0 <= x;
 38 38 |   x > -0;
@@ -275,9 +274,9 @@ warning[noCompareNegZero]: Do not use the >= operator to compare against -0.
    ┌─ noCompareNegZero.js:42:1
    │
 42 │ -0 >= x;
-   │ ------- Do not use the >= operator to compare against -0.
+   │ -------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -39,7 +39,7 @@
 38 38 |   x > -0;
 39 39 |   -0 > x;
@@ -296,9 +295,9 @@ warning[noCompareNegZero]: Do not use the != operator to compare against -0.
    ┌─ noCompareNegZero.js:43:1
    │
 43 │ x != -0;
-   │ ------- Do not use the != operator to compare against -0.
+   │ -------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -40,7 +40,7 @@
 39 39 |   -0 > x;
 40 40 |   x >= -0;
@@ -317,9 +316,9 @@ warning[noCompareNegZero]: Do not use the != operator to compare against -0.
    ┌─ noCompareNegZero.js:44:1
    │
 44 │ -0 != x;
-   │ ------- Do not use the != operator to compare against -0.
+   │ -------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -41,7 +41,7 @@
 40 40 |   x >= -0;
 41 41 |   -0 >= x;
@@ -338,9 +337,9 @@ warning[noCompareNegZero]: Do not use the !== operator to compare against -0.
    ┌─ noCompareNegZero.js:45:1
    │
 45 │ -0 !== x;
-   │ -------- Do not use the !== operator to compare against -0.
+   │ --------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -42,7 +42,7 @@
 41 41 |   -0 >= x;
 42 42 |   x != -0;
@@ -359,9 +358,9 @@ warning[noCompareNegZero]: Do not use the === operator to compare against -0.
    ┌─ noCompareNegZero.js:46:1
    │
 46 │ -0 === -0;
-   │ --------- Do not use the === operator to compare against -0.
+   │ ---------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -43,7 +43,7 @@
 42 42 |   x != -0;
 43 43 |   -0 != x;
@@ -380,9 +379,9 @@ warning[noCompareNegZero]: Do not use the === operator to compare against -0.
    ┌─ noCompareNegZero.js:47:1
    │
 47 │ -0 /** commnet **/ === 4;
-   │ ------------------------ Do not use the === operator to compare against -0.
+   │ ------------------------
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -44,7 +44,7 @@
 43 43 |   -0 != x;
 44 44 |   -0 !== x;
@@ -403,9 +402,9 @@ warning[noCompareNegZero]: Do not use the === operator to compare against -0.
 48 │ ┌ -0
 49 │ │ // comment
 50 │ │ === 4;
-   │ └─────' Do not use the === operator to compare against -0.
+   │ └─────'
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -45,7 +45,7 @@
 44 44 |   -0 !== x;
 45 45 |   -0 === -0;
@@ -425,9 +424,9 @@ warning[noCompareNegZero]: Do not use the === operator to compare against -0.
    │  
 51 │ ┌ 4 === // comment
 52 │ │ -0
-   │ └──' Do not use the === operator to compare against -0.
+   │ └──'
 
-Replace -0 with 0
+Safe fix: Replace -0 with 0
       | @@ -49,4 +49,4 @@
 48 48 |   // comment
 49 49 |   === 4;

--- a/crates/rome_analyze/tests/specs/noDelete.js.snap
+++ b/crates/rome_analyze/tests/specs/noDelete.js.snap
@@ -18,9 +18,9 @@ warning[noDelete]: This is an unexpected use of the delete operator.
   ┌─ noDelete.js:2:1
   │
 2 │ delete a.b;
-  │ ---------- This is an unexpected use of the delete operator.
+  │ ----------
 
-Replace with undefined assignment
+Suggested fix: Replace with undefined assignment
     | @@ -1,5 +1,5 @@
 0 0 |   delete a;
 1   | - delete a.b;
@@ -37,9 +37,9 @@ warning[noDelete]: This is an unexpected use of the delete operator.
   ┌─ noDelete.js:3:1
   │
 3 │ delete a?.b;
-  │ ----------- This is an unexpected use of the delete operator.
+  │ -----------
 
-Replace with undefined assignment
+Suggested fix: Replace with undefined assignment
     | @@ -1,5 +1,5 @@
 0 0 |   delete a;
 1 1 |   delete a.b;
@@ -56,9 +56,9 @@ warning[noDelete]: This is an unexpected use of the delete operator.
   ┌─ noDelete.js:4:1
   │
 4 │ delete a["b"];
-  │ ------------- This is an unexpected use of the delete operator.
+  │ -------------
 
-Replace with undefined assignment
+Suggested fix: Replace with undefined assignment
     | @@ -1,5 +1,5 @@
 0 0 |   delete a;
 1 1 |   delete a.b;

--- a/crates/rome_analyze/tests/specs/noDoubleEquals.js.snap
+++ b/crates/rome_analyze/tests/specs/noDoubleEquals.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_analyze/tests/spec_tests.rs
-assertion_line: 96
 expression: noDoubleEquals.js
 ---
 # Input
@@ -15,13 +14,13 @@ const isNonNull = a != null;
 
 # Diagnostics
 ```
-warning[noDoubleEquals]: Do not use the == operator
+warning[noDoubleEquals]: Use === instead of ==
   ┌─ noDoubleEquals.js:1:18
   │
 1 │ const isZero = a == 0;
-  │                  -- Do not use the == operator
+  │                  -- == is only allowed when comparing against null
 
-Replace with strict equality
+Suggested fix: Use ===
     | @@ -1,4 +1,4 @@
 0   | - const isZero = a == 0;
   0 | + const isZero = a === 0;
@@ -29,17 +28,19 @@ Replace with strict equality
 2 2 |   
 3 3 |   const isNull = a == null;
 
+=  note: Using === may be unsafe if you are relying on type coercion
+
 
 ```
 
 ```
-warning[noDoubleEquals]: Do not use the != operator
+warning[noDoubleEquals]: Use !== instead of !=
   ┌─ noDoubleEquals.js:2:21
   │
 2 │ const isNonZero = a != 0;
-  │                     -- Do not use the != operator
+  │                     -- != is only allowed when comparing against null
 
-Replace with strict equality
+Suggested fix: Use !==
     | @@ -1,5 +1,5 @@
 0 0 |   const isZero = a == 0;
 1   | - const isNonZero = a != 0;
@@ -47,6 +48,8 @@ Replace with strict equality
 2 2 |   
 3 3 |   const isNull = a == null;
 4 4 |   const isNonNull = a != null;
+
+=  note: Using !== may be unsafe if you are relying on type coercion
 
 
 ```

--- a/crates/rome_analyze/tests/specs/noNegationElse.js.snap
+++ b/crates/rome_analyze/tests/specs/noNegationElse.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_analyze/tests/spec_tests.rs
-assertion_line: 96
 expression: noNegationElse.js
 ---
 # Input
@@ -29,9 +28,9 @@ warning[noNegationElse]: Invert blocks when performing a negation test.
 7 │ │ } else {
 8 │ │   alternate;
 9 │ │ }
-  │ └─' Invert blocks when performing a negation test.
+  │ └─'
 
-Exchange alternate and consequent of the node
+Suggested fix: Exchange alternate and consequent of the node
     | @@ -2,10 +2,10 @@
 1 1 |   if (!true) {consequent;};
 2 2 |   true ? consequent : alternate;
@@ -55,9 +54,9 @@ warning[noNegationElse]: Invert blocks when performing a negation test.
    ┌─ noNegationElse.js:10:1
    │
 10 │ !condition ? consequent : alternate;
-   │ ----------------------------------- Invert blocks when performing a negation test.
+   │ -----------------------------------
 
-Exchange alternate and consequent of the node
+Suggested fix: Exchange alternate and consequent of the node
       | @@ -7,6 +7,6 @@
  6  6 |   } else {
  7  7 |     alternate;
@@ -75,9 +74,9 @@ warning[noNegationElse]: Invert blocks when performing a negation test.
    ┌─ noNegationElse.js:12:9
    │
 12 │ let a = !test ? c : d;
-   │         ------------- Invert blocks when performing a negation test.
+   │         -------------
 
-Exchange alternate and consequent of the node
+Suggested fix: Exchange alternate and consequent of the node
       | @@ -9,4 +9,4 @@
  8  8 |   }
  9  9 |   !condition ? consequent : alternate;

--- a/crates/rome_analyze/tests/specs/useSingleCaseStatement.js.snap
+++ b/crates/rome_analyze/tests/specs/useSingleCaseStatement.js.snap
@@ -51,14 +51,14 @@ switch (foo) {
 
 # Diagnostics
 ```
-warning[useSingleCaseStatement]: A switch case should only have a single statement.
+warning[useSingleCaseStatement]: A switch case should only have a single statement. If you want more, then wrap it in a block.
   ┌─ useSingleCaseStatement.js:4:9
   │  
 4 │ ┌         let foo = '';
 5 │ │         foo;
-  │ └────────────' A switch case should only have a single statement.
+  │ └────────────'
 
-Wrap the statements in a block
+Suggested fix: Wrap the statements in a block
     | @@ -1,8 +1,9 @@
 0 0 |   switch (foo) {
 1 1 |       case true:
@@ -75,14 +75,14 @@ Wrap the statements in a block
 ```
 
 ```
-warning[useSingleCaseStatement]: A switch case should only have a single statement.
+warning[useSingleCaseStatement]: A switch case should only have a single statement. If you want more, then wrap it in a block.
    ┌─ useSingleCaseStatement.js:11:9
    │  
 11 │ ┌         let foo = '';
 12 │ │         foo;
-   │ └────────────' A switch case should only have a single statement.
+   │ └────────────'
 
-Wrap the statements in a block
+Suggested fix: Wrap the statements in a block
       | @@ -7,9 +7,10 @@
  6  6 |   
  7  7 |   switch (foo) {
@@ -100,14 +100,14 @@ Wrap the statements in a block
 ```
 
 ```
-warning[useSingleCaseStatement]: A switch case should only have a single statement.
+warning[useSingleCaseStatement]: A switch case should only have a single statement. If you want more, then wrap it in a block.
    ┌─ useSingleCaseStatement.js:17:9
    │  
 17 │ ┌         let foo = '';
 18 │ │         foo;
-   │ └────────────' A switch case should only have a single statement.
+   │ └────────────'
 
-Wrap the statements in a block
+Suggested fix: Wrap the statements in a block
       | @@ -13,9 +13,10 @@
 12 12 |   }
 13 13 |   
@@ -125,14 +125,14 @@ Wrap the statements in a block
 ```
 
 ```
-warning[useSingleCaseStatement]: A switch case should only have a single statement.
+warning[useSingleCaseStatement]: A switch case should only have a single statement. If you want more, then wrap it in a block.
    ┌─ useSingleCaseStatement.js:24:9
    │  
 24 │ ┌         let foo = '';
 25 │ │         foo;
-   │ └────────────' A switch case should only have a single statement.
+   │ └────────────'
 
-Wrap the statements in a block
+Suggested fix: Wrap the statements in a block
       | @@ -20,9 +20,10 @@
 19 19 |   
 20 20 |   switch (foo) {

--- a/crates/rome_analyze/tests/specs/useSingleVarDeclarator.js.snap
+++ b/crates/rome_analyze/tests/specs/useSingleVarDeclarator.js.snap
@@ -13,13 +13,13 @@ function test() {
 
 # Diagnostics
 ```
-warning[useSingleVarDeclarator]: Declare variables separately.
+warning[useSingleVarDeclarator]: Declare variables separately
   ┌─ useSingleVarDeclarator.js:3:2
   │
 3 │     let foo, bar;
-  │     ------------- Declare variables separately.
+  │     -------------
 
-Break out into multiple declarations
+Safe fix: Break out into multiple declarations
     | @@ -1,4 +1,5 @@
 0 0 |   function test() {
 1 1 |   	// Comment

--- a/crates/rome_analyze/tests/specs/useValidTypeof.js.snap
+++ b/crates/rome_analyze/tests/specs/useValidTypeof.js.snap
@@ -26,53 +26,53 @@ typeof foo == -5
 
 # Diagnostics
 ```
-warning[useValidTypeof]: Invalid typeof comparison value
-  ┌─ useValidTypeof.js:7:1
+warning[useValidTypeof]: Invalid `typeof` comparison value
+  ┌─ useValidTypeof.js:7:16
   │
 7 │ typeof foo === "strnig"
-  │ ----------------------- Invalid typeof comparison value
+  │                -------- not a valid type name
 
 
 ```
 
 ```
-warning[useValidTypeof]: Invalid typeof comparison value
-  ┌─ useValidTypeof.js:8:1
+warning[useValidTypeof]: Invalid `typeof` comparison value
+  ┌─ useValidTypeof.js:8:15
   │
 8 │ typeof foo == "undefimed"
-  │ ------------------------- Invalid typeof comparison value
+  │               ----------- not a valid type name
 
 
 ```
 
 ```
-warning[useValidTypeof]: Invalid typeof comparison value
-  ┌─ useValidTypeof.js:9:1
+warning[useValidTypeof]: Invalid `typeof` comparison value
+  ┌─ useValidTypeof.js:9:15
   │
 9 │ typeof bar != "nunber"
-  │ ---------------------- Invalid typeof comparison value
+  │               -------- not a valid type name
 
 
 ```
 
 ```
-warning[useValidTypeof]: Invalid typeof comparison value
-   ┌─ useValidTypeof.js:10:1
+warning[useValidTypeof]: Invalid `typeof` comparison value
+   ┌─ useValidTypeof.js:10:16
    │
 10 │ typeof bar !== "fucntion"
-   │ ------------------------- Invalid typeof comparison value
+   │                ---------- not a valid type name
 
 
 ```
 
 ```
-warning[useValidTypeof]: Invalid typeof comparison value
-   ┌─ useValidTypeof.js:13:1
+warning[useValidTypeof]: Invalid `typeof` comparison value
+   ┌─ useValidTypeof.js:13:16
    │
 13 │ typeof foo === undefined
-   │ ------------------------ Invalid typeof comparison value
+   │                --------- not a string literal
 
-Compare the result of `typeof` with a valid type name
+Suggested fix: Compare the result of `typeof` with a valid type name
       | @@ -10,7 +10,7 @@
  9  9 |   typeof bar !== "fucntion"
 10 10 |   
@@ -87,13 +87,13 @@ Compare the result of `typeof` with a valid type name
 ```
 
 ```
-warning[useValidTypeof]: Invalid typeof comparison value
-   ┌─ useValidTypeof.js:14:1
+warning[useValidTypeof]: Invalid `typeof` comparison value
+   ┌─ useValidTypeof.js:14:15
    │
 14 │ typeof bar == Object
-   │ -------------------- Invalid typeof comparison value
+   │               ------ not a string literal
 
-Compare the result of `typeof` with a valid type name
+Suggested fix: Compare the result of `typeof` with a valid type name
       | @@ -11,7 +11,7 @@
 10 10 |   
 11 11 |   // Invalid expressions
@@ -108,31 +108,31 @@ Compare the result of `typeof` with a valid type name
 ```
 
 ```
-warning[useValidTypeof]: Invalid typeof comparison value
-   ┌─ useValidTypeof.js:15:1
+warning[useValidTypeof]: Invalid `typeof` comparison value
+   ┌─ useValidTypeof.js:15:16
    │
 15 │ typeof foo === baz
-   │ ------------------ Invalid typeof comparison value
+   │                --- not a string literal
 
 
 ```
 
 ```
-warning[useValidTypeof]: Invalid typeof comparison value
-   ┌─ useValidTypeof.js:16:1
+warning[useValidTypeof]: Invalid `typeof` comparison value
+   ┌─ useValidTypeof.js:16:15
    │
 16 │ typeof foo == 5
-   │ --------------- Invalid typeof comparison value
+   │               - not a string literal
 
 
 ```
 
 ```
-warning[useValidTypeof]: Invalid typeof comparison value
-   ┌─ useValidTypeof.js:17:1
+warning[useValidTypeof]: Invalid `typeof` comparison value
+   ┌─ useValidTypeof.js:17:15
    │
 17 │ typeof foo == -5
-   │ ---------------- Invalid typeof comparison value
+   │               -- not a string literal
 
 
 ```

--- a/crates/rome_analyze/tests/specs/useWhile.js.snap
+++ b/crates/rome_analyze/tests/specs/useWhile.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_analyze/tests/spec_tests.rs
-assertion_line: 96
 expression: useWhile.js
 ---
 # Input
@@ -13,13 +12,13 @@ for (; true; ) {}
 
 # Diagnostics
 ```
-warning[useWhile]: Use a while loop instead of a for loop
+warning[useWhile]: Use while loops instead of for loops.
   ┌─ useWhile.js:3:1
   │
 3 │ for (; true; ) {}
-  │ ----------------- Use a while loop instead of a for loop
+  │ --------------
 
-Use a while loop
+Suggested fix: Use a while loop
     | @@ -1,3 +1,3 @@
 0 0 |   for (let i = 0; i < 16; ++i) {}
 1 1 |   

--- a/crates/rome_diagnostics/src/diagnostic.rs
+++ b/crates/rome_diagnostics/src/diagnostic.rs
@@ -16,6 +16,7 @@ pub struct Diagnostic {
     pub severity: Severity,
     pub code: Option<String>,
     pub title: MarkupBuf,
+    pub summary: Option<String>,
     pub tag: Option<DiagnosticTag>,
 
     pub primary: Option<SubDiagnostic>,
@@ -64,6 +65,7 @@ impl Diagnostic {
             code,
             severity,
             title: markup!({ title }).to_owned(),
+            summary: None,
             primary: None,
             tag: None,
             children: vec![],
@@ -75,6 +77,12 @@ impl Diagnostic {
     /// Overwrites the severity of this diagnostic.
     pub fn severity(mut self, severity: Severity) -> Self {
         self.severity = severity;
+        self
+    }
+
+    /// Set an explicit plain-text summary for this diagnostic.
+    pub fn summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
         self
     }
 

--- a/crates/rome_diagnostics/src/lib.rs
+++ b/crates/rome_diagnostics/src/lib.rs
@@ -6,7 +6,7 @@ mod diagnostic;
 mod emit;
 mod suggestion;
 
-pub use diagnostic::{Diagnostic, SubDiagnostic};
+pub use diagnostic::{Diagnostic, Footer, SubDiagnostic};
 pub use emit::{DiagnosticHeader, Emitter};
 pub use file::Span;
 pub use suggestion::*;

--- a/crates/rome_lsp/src/utils.rs
+++ b/crates/rome_lsp/src/utils.rs
@@ -153,7 +153,9 @@ pub(crate) fn diagnostic_to_lsp(
         }),
         diagnostic.code.map(lsp::NumberOrString::String),
         Some("rome".into()),
-        print_markup(&diagnostic.title),
+        diagnostic
+            .summary
+            .unwrap_or_else(|| print_markup(&diagnostic.title)),
         related_information,
         diagnostic.tag.map(|tag| {
             let mut result = Vec::new();


### PR DESCRIPTION
## Summary

This PR replicates the builder pattern implemented on `rome_diagnostic::Diagnostic` for the `RuleDiagnostic` type used internally by the analyzer rules. It should expose all the capabilities of normal diagnostics (including multiple labels and footers) with the notable exception of:

- `file_id`: at the moment diagnostics are considered to belong to the file currently being analyzed
- `code`: this property has its value set to the name of the rule that emitted the diagnostic
- `suggestions`: rules that emit quick fix suggestions are expected to do so by emitting a code action

Additionally, it adds a new optional `summary` field to diagnostics containing a plain-text description of the issue, aimed at rendering contexts that don't support rich formatting (such as diagnostic popovers in editors)

## Test Plan

Existing rules have been modified to use the new methods, and snapshots were updated accordingly
