### PR TITLE
fix(xtask): enforce a stable ordering for the generated imports of lint rules

### DIFF
--- a/crates/rome_analyze/src/analyzers.rs
+++ b/crates/rome_analyze/src/analyzers.rs
@@ -1,16 +1,16 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-mod use_while;
-pub(crate) use use_while::UseWhile;
+mod no_compare_neg_zero;
+pub(crate) use no_compare_neg_zero::NoCompareNegZero;
 mod no_delete;
 pub(crate) use no_delete::NoDelete;
 mod no_double_equals;
 pub(crate) use no_double_equals::NoDoubleEquals;
 mod no_negation_else;
 pub(crate) use no_negation_else::NoNegationElse;
-mod no_compare_neg_zero;
-pub(crate) use no_compare_neg_zero::NoCompareNegZero;
-mod use_valid_typeof;
-pub(crate) use use_valid_typeof::UseValidTypeof;
 mod use_single_var_declarator;
 pub(crate) use use_single_var_declarator::UseSingleVarDeclarator;
+mod use_valid_typeof;
+pub(crate) use use_valid_typeof::UseValidTypeof;
+mod use_while;
+pub(crate) use use_while::UseWhile;

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -36,13 +36,13 @@ macro_rules! impl_registry_builders {
 
 impl_registry_builders!(
     // Analyzers
-    UseWhile,
+    NoCompareNegZero,
     NoDelete,
     NoDoubleEquals,
     NoNegationElse,
-    NoCompareNegZero,
-    UseValidTypeof,
     UseSingleVarDeclarator,
+    UseValidTypeof,
+    UseWhile,
     // Assists
     FlipBinExp,
 );

--- a/xtask/codegen/src/generate_analyzer.rs
+++ b/xtask/codegen/src/generate_analyzer.rs
@@ -42,15 +42,19 @@ fn generate_module(name: &'static str, entries: &mut Vec<String>) -> Result<()> 
             rule_name.push(char);
         }
 
-        entries.push(rule_name.clone());
+        let index = entries.binary_search(&rule_name).unwrap_err();
+        entries.insert(index, rule_name.clone());
 
         let module_name = format_ident!("{}", file_name);
         let rule_name = format_ident!("{}", rule_name);
 
-        rules.push(quote! {
-            mod #module_name;
-            pub(crate) use #module_name::#rule_name;
-        });
+        rules.insert(
+            index,
+            quote! {
+                mod #module_name;
+                pub(crate) use #module_name::#rule_name;
+            },
+        );
     }
 
     let tokens = xtask::reformat(quote! {


### PR DESCRIPTION
## Summary

The `cargo codegen analyzer` command automatically generates imports for all the files in the `analyzers` and `assists` directories, but the ordering of the imports in the generated files depends on the order they are returned by the underlying filesystem. This order isn't stable and may change depending on the operating system, which leads to unnecessary merge conflicts for pull requests that add lint rules as the auto-generated files get modified every time the codegen script is run. This PR fixes the issue by modifying the script to sort the lint rules by their name in the resulting generated code.
