### PR TITLE
feat(xtask): automatically generate documentation pages for lint rules

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,7 @@
 lint = "clippy --workspace --all-targets --verbose -- --deny warnings"
 format = "fmt --all --verbose"
 codegen = "run -p xtask_codegen --"
+lintdoc = "run -p xtask_lintdoc --"
 bench_parser = "run -p xtask_bench --release -- --feature parser"
 bench_formatter = "run -p xtask_bench --release -- --feature formatter"
 bench_analyzer = "run -p xtask_bench --release -- --feature analyzer"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,3 +80,35 @@ jobs:
         with:
           command: test
           args: --workspace --verbose
+
+  codegen:
+    name: Codegen
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install toolchain
+        run: rustup show
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Run the grammar codegen
+        uses: actions-rs/cargo@v1
+        with:
+          command: codegen
+          args: grammar
+      - name: Run the analyzer codegen
+        uses: actions-rs/cargo@v1
+        with:
+          command: codegen
+          args: analyzer
+      - name: Run the website codegen
+        uses: actions-rs/cargo@v1
+        with:
+          command: lintdoc
+      - name: Check for git diff
+        run: |
+          if [[ `git status --porcelain` ]]; then
+            git status
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f197a544b0c9ab3ae46c359a7ec9cbbb5c7bf97054266fecb7ead794a181d6"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66be59c2fd880e3d76d1a6cf6d34114008f1d8af2748d4ad9d39ea712f14fda9"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,6 +2497,20 @@ dependencies = [
  "walkdir",
  "xtask",
  "yastl",
+]
+
+[[package]]
+name = "xtask_lintdoc"
+version = "0.0.0"
+dependencies = [
+ "pulldown-cmark",
+ "rome_analyze",
+ "rome_console",
+ "rome_diagnostics",
+ "rome_js_analyze",
+ "rome_js_parser",
+ "rome_js_syntax",
+ "xtask",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 	"xtask/bench",
 	"xtask/codegen",
 	"xtask/coverage",
+	"xtask/lintdoc",
 ]
 
 [profile.release-with-debug]

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -1,10 +1,12 @@
 mod categories;
 pub mod context;
 mod registry;
+mod rule;
 mod signals;
 
 pub use crate::categories::{ActionCategory, RuleCategories, RuleCategory};
-pub use crate::registry::{LanguageRoot, Rule, RuleAction, RuleDiagnostic, RuleRegistry};
+pub use crate::registry::{LanguageRoot, MetadataIter, RuleRegistry};
+pub use crate::rule::{Rule, RuleAction, RuleDiagnostic, RuleMeta};
 pub use crate::signals::{AnalyzerAction, AnalyzerSignal};
 use rome_diagnostics::file::FileId;
 use rome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -1,15 +1,12 @@
-use rome_console::fmt::Display;
-use rome_console::{markup, MarkupBuf};
-use rome_diagnostics::file::FileSpan;
-use rome_diagnostics::{file::FileId, Applicability, Severity};
-use rome_diagnostics::{Diagnostic, DiagnosticTag, Footer, Span, SubDiagnostic};
-use rome_rowan::{AstNode, Language, SyntaxNode, TextRange};
+use std::{iter::Map, vec::IntoIter};
 
-use crate::context::RuleContext;
+use rome_diagnostics::file::FileId;
+use rome_rowan::{AstNode, Language, SyntaxNode};
+
 use crate::{
-    categories::{ActionCategory, RuleCategory},
+    context::RuleContext,
     signals::{AnalyzerSignal, RuleSignal},
-    ControlFlow,
+    ControlFlow, Rule,
 };
 
 /// The rule registry holds type-erased instances of all active analysis rules
@@ -27,9 +24,18 @@ impl<L: Language> RuleRegistry<L> {
         R: Rule + 'static,
         R::Query: AstNode<Language = L>,
     {
-        self.rules.push(run::<R>);
+        self.rules.push(RegistryRule::of::<R>());
+    }
+
+    /// Returns an iterator over the name and documentation of all active rules
+    /// in this instance of the registry
+    pub fn metadata(self) -> MetadataIter<L> {
+        self.rules.into_iter().map(|rule| (rule.name, rule.docs))
     }
 }
+
+pub type MetadataIter<L> =
+    Map<IntoIter<RegistryRule<L>>, fn(RegistryRule<L>) -> (&'static str, &'static str)>;
 
 pub(crate) type RuleLanguage<R> = NodeLanguage<<R as Rule>::Query>;
 pub(crate) type NodeLanguage<N> = <N as AstNode>::Language;
@@ -50,7 +56,7 @@ where
         callback: &mut impl FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<B>,
     ) -> ControlFlow<B> {
         for rule in &self.rules {
-            if let Some(event) = (rule)(file_id, root, &node) {
+            if let Some(event) = (rule.run)(file_id, root, &node) {
                 if let ControlFlow::Break(b) = callback(&*event) {
                     return ControlFlow::Break(b);
                 }
@@ -61,251 +67,53 @@ where
     }
 }
 
-/// Representation of a single rule in the registry as a generic function pointer
-type RegistryRule<L> = for<'a> fn(
+/// Executor for rule as a generic function pointer
+type RuleExecutor<L> = for<'a> fn(
     FileId,
     &'a LanguageRoot<L>,
     &'a SyntaxNode<L>,
 ) -> Option<Box<dyn AnalyzerSignal<L> + 'a>>;
 
-/// Generic implementation of RegistryRule for any rule type R
-fn run<'a, R: Rule + 'static>(
-    file_id: FileId,
-    root: &'a RuleRoot<R>,
-    node: &'a SyntaxNode<<R::Query as AstNode>::Language>,
-) -> Option<Box<dyn AnalyzerSignal<RuleLanguage<R>> + 'a>> {
-    if !<R::Query>::can_cast(node.kind()) {
-        return None;
-    }
-
-    let query_result = <R::Query>::cast(node.clone())?;
-    let ctx = RuleContext::new(query_result.clone(), root.clone());
-
-    let result = R::run(&ctx)?;
-    Some(RuleSignal::<R>::new_boxed(
-        file_id,
-        root,
-        query_result,
-        result,
-    ))
+#[doc(hidden)]
+/// Internal representation of a single rule in the registry
+pub struct RegistryRule<L: Language> {
+    name: &'static str,
+    docs: &'static str,
+    run: RuleExecutor<L>,
 }
 
-/// Trait implemented by all analysis rules: declares interest to a certain AstNode type,
-/// and a callback function to be executed on all nodes matching the query to possibly
-/// raise an analysis event
-pub trait Rule {
-    /// The name of this rule, displayed in the diagnostics it emits
-    const NAME: &'static str;
-    /// The category this rule belong to, this is used for broadly filtering
-    /// rules when running the analyzer
-    const CATEGORY: RuleCategory;
+impl<L: Language> RegistryRule<L> {
+    const fn of<R>() -> Self
+    where
+        R: Rule + 'static,
+        R::Query: AstNode<Language = L>,
+    {
+        /// Generic implementation of RuleExecutor for any rule type R
+        fn run<'a, R: Rule + 'static>(
+            file_id: FileId,
+            root: &'a RuleRoot<R>,
+            node: &'a SyntaxNode<<R::Query as AstNode>::Language>,
+        ) -> Option<Box<dyn AnalyzerSignal<RuleLanguage<R>> + 'a>> {
+            if !<R::Query>::can_cast(node.kind()) {
+                return None;
+            }
 
-    /// The type of AstNode this rule is interested in
-    type Query: AstNode;
-    /// A generic type that will be kept in memory between a call to `run` and
-    /// subsequent executions of `diagnostic` or `action`, allows the rule to
-    /// hold some temporary state between the moment a signal is raised and
-    /// when a diagnostic or action needs to be built
-    type State;
+            let query_result = <R::Query>::cast(node.clone())?;
+            let ctx = RuleContext::new(query_result.clone(), root.clone());
 
-    /// This function is called once for each node matching `Query` in the tree
-    /// being analyzed. If it returns `Some` the state object will be wrapped
-    /// in a generic `AnalyzerSignal`, and the consumer of the analyzer may call
-    /// `diagnostic` or `action` on it
-    fn run(ctx: &RuleContext<Self>) -> Option<Self::State>;
+            let result = R::run(&ctx)?;
+            Some(RuleSignal::<R>::new_boxed(
+                file_id,
+                root,
+                query_result,
+                result,
+            ))
+        }
 
-    /// Called by the consumer of the analyzer to try to generate a diagnostic
-    /// from a signal raised by `run`
-    ///
-    /// The default implementation returns None
-    #[allow(unused)]
-    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
-        None
-    }
-
-    /// Called by the consumer of the analyzer to try to generate a code action
-    /// from a signal raised by `run`
-    ///
-    /// The default implementation returns None
-    #[allow(unused)]
-    fn action(
-        ctx: &RuleContext<Self>,
-        state: &Self::State,
-    ) -> Option<RuleAction<RuleLanguage<Self>>> {
-        None
-    }
-}
-
-/// Diagnostic object returned by a single analysis rule
-pub struct RuleDiagnostic {
-    severity: Severity,
-    span: TextRange,
-    title: MarkupBuf,
-    summary: Option<String>,
-    tag: Option<DiagnosticTag>,
-    primary: Option<MarkupBuf>,
-    secondaries: Vec<(Severity, MarkupBuf, TextRange)>,
-    footers: Vec<Footer>,
-}
-
-// Some of these methods aren't used by anything yet
-#[allow(dead_code)]
-impl RuleDiagnostic {
-    /// Creates a new [`RuleDiagnostic`] with a severity and title that will be
-    /// used in a builder-like way to modify labels.
-    fn new(severity: Severity, span: impl Span, title: impl Display) -> Self {
         Self {
-            severity,
-            span: span.as_range(),
-            title: markup!({ title }).to_owned(),
-            summary: None,
-            tag: None,
-            primary: None,
-            secondaries: Vec::new(),
-            footers: Vec::new(),
+            name: R::NAME,
+            docs: R::DOCS,
+            run: run::<R>,
         }
     }
-
-    /// Creates a new [`RuleDiagnostic`] with the `Error` severity.
-    pub fn error(span: impl Span, title: impl Display) -> Self {
-        Self::new(Severity::Error, span, title)
-    }
-
-    /// Creates a new [`RuleDiagnostic`] with the `Warning` severity.
-    pub fn warning(span: impl Span, title: impl Display) -> Self {
-        Self::new(Severity::Warning, span, title)
-    }
-
-    /// Creates a new [`RuleDiagnostic`] with the `Help` severity.
-    pub fn help(span: impl Span, title: impl Display) -> Self {
-        Self::new(Severity::Help, span, title)
-    }
-
-    /// Creates a new [`RuleDiagnostic`] with the `Note` severity.
-    pub fn note(span: impl Span, title: impl Display) -> Self {
-        Self::new(Severity::Note, span, title)
-    }
-
-    /// Set an explicit plain-text summary for this diagnostic.
-    pub fn summary(mut self, summary: impl Into<String>) -> Self {
-        self.summary = Some(summary.into());
-        self
-    }
-
-    /// Marks this diagnostic as deprecated code, which will
-    /// be displayed in the language server.
-    ///
-    /// This does not have any influence on the diagnostic rendering.
-    pub fn deprecated(mut self) -> Self {
-        self.tag = if matches!(self.tag, Some(DiagnosticTag::Unnecessary)) {
-            Some(DiagnosticTag::Both)
-        } else {
-            Some(DiagnosticTag::Deprecated)
-        };
-        self
-    }
-
-    /// Marks this diagnostic as unnecessary code, which will
-    /// be displayed in the language server.
-    ///
-    /// This does not have any influence on the diagnostic rendering.
-    pub fn unnecessary(mut self) -> Self {
-        self.tag = if matches!(self.tag, Some(DiagnosticTag::Deprecated)) {
-            Some(DiagnosticTag::Both)
-        } else {
-            Some(DiagnosticTag::Unnecessary)
-        };
-        self
-    }
-
-    /// Attaches a label to this [`RuleDiagnostic`], that will point to another file
-    /// that is provided.
-    pub fn label_in_file(mut self, severity: Severity, span: impl Span, msg: impl Display) -> Self {
-        self.secondaries
-            .push((severity, markup!({ msg }).to_owned(), span.as_range()));
-        self
-    }
-
-    /// Attaches a label to this [`RuleDiagnostic`].
-    ///
-    /// The given span has to be in the file that was provided while creating this [`RuleDiagnostic`].
-    pub fn label(mut self, severity: Severity, span: impl Span, msg: impl Display) -> Self {
-        self.secondaries
-            .push((severity, markup!({ msg }).to_owned(), span.as_range()));
-        self
-    }
-
-    /// Attaches a primary label to this [`RuleDiagnostic`].
-    pub fn primary(mut self, msg: impl Display) -> Self {
-        self.primary = Some(markup!({ msg }).to_owned());
-        self
-    }
-
-    /// Attaches a secondary label to this [`RuleDiagnostic`].
-    pub fn secondary(self, span: impl Span, msg: impl Display) -> Self {
-        self.label(Severity::Note, span, msg)
-    }
-
-    /// Adds a footer to this [`RuleDiagnostic`], which will be displayed under the actual error.
-    pub fn footer(mut self, severity: Severity, msg: impl Display) -> Self {
-        self.footers.push(Footer {
-            msg: markup!({ msg }).to_owned(),
-            severity,
-        });
-        self
-    }
-
-    /// Adds a footer to this [`RuleDiagnostic`], with the `Help` severity.
-    pub fn footer_help(self, msg: impl Display) -> Self {
-        self.footer(Severity::Help, msg)
-    }
-
-    /// Adds a footer to this [`RuleDiagnostic`], with the `Note` severity.
-    pub fn footer_note(self, msg: impl Display) -> Self {
-        self.footer(Severity::Note, msg)
-    }
-
-    /// Convert this [`RuleDiagnostic`] into an instance of [`Diagnostic`] by
-    /// injecting the name of the rule that emitted it and the ID of the file
-    /// the rule was being run on
-    pub(crate) fn into_diagnostic(self, file_id: FileId, code: &'static str) -> Diagnostic {
-        Diagnostic {
-            file_id,
-            severity: self.severity,
-            code: Some(code.into()),
-            title: self.title,
-            summary: self.summary,
-            tag: self.tag,
-            primary: Some(SubDiagnostic {
-                severity: self.severity,
-                msg: self.primary.unwrap_or_default(),
-                span: FileSpan {
-                    file: file_id,
-                    range: self.span,
-                },
-            }),
-            children: self
-                .secondaries
-                .into_iter()
-                .map(|(severity, msg, range)| SubDiagnostic {
-                    severity,
-                    msg,
-                    span: FileSpan {
-                        file: file_id,
-                        range,
-                    },
-                })
-                .collect(),
-            suggestions: Vec::new(),
-            footers: self.footers,
-        }
-    }
-}
-
-/// Code Action object returned by a single analysis rule
-pub struct RuleAction<L: Language> {
-    pub category: ActionCategory,
-    pub applicability: Applicability,
-    pub message: MarkupBuf,
-    pub root: LanguageRoot<L>,
 }

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -17,9 +17,66 @@ pub trait RuleMeta {
     const DOCS: &'static str;
 }
 
+/// This macro is used to declare an analyzer rule type, and implement the
+/// [RuleMeta] trait for it
+///
+/// # Example
+///
+/// The macro itself expect the following syntax:
+/// ```ignore
+/// declare_rule! {
+///     /// Documentation
+///     pub(crate) ExampleRule = "ruleName"
+/// }
+/// ```
+///
+/// # Documentation
+///
+/// The doc-comment for the rule is mandatory and is used to generate the
+/// documentation page for the rule on the website.
+///
+/// Importantly, the tool used to generate those pages also runs tests on the
+/// code blocks included in the documentation written in languages supported by
+/// the Rome toolchain (JavaScript, JSX, TypeScript, ...) similar to how
+/// `rustdoc` generates tests from code blocks written in Rust. Because code
+/// blocks in Rust doc-comments are assumed to be written in Rust by default
+/// the language of the test must be explicitly specified, for instance:
+///
+/// ```ignore
+/// declare_rule! {
+///     /// Disallow the use of `var`
+///     ///
+///     /// ### Valid
+///     ///
+///     /// ```js
+///     /// let a, b;
+///     /// ```
+///     pub(crate) NoVar = "noVar"
+/// }
+/// ```
+///
+/// Additionally, it's possible to declare that a test should emit a diagnostic
+/// by adding `expect_diagnostic` to the language metadata:
+///
+/// ```ignore
+/// declare_rule! {
+///     /// Disallow the use of `var`
+///     ///
+///     /// ### Invalid
+///     ///
+///     /// ```js,expect_diagnostic
+///     /// var a, b;
+///     /// ```
+///     pub(crate) NoVar = "noVar"
+/// }
+/// ```
+///
+/// This will cause the documentation generator to ensure the rule does emit
+/// exactly one diagnostic for this code, and to include a snapshot for the
+/// diagnostic in the resulting documentation page
 #[macro_export]
 macro_rules! declare_rule {
-    ( $( #[doc = $doc:literal] )* $vis:vis $id:ident = $name:literal ) => {
+    ( $( #[doc = $doc:literal] )+ $vis:vis $id:ident = $name:literal ) => {
         $( #[doc = $doc] )*
         $vis enum $id {}
 

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -1,0 +1,247 @@
+use rome_console::fmt::Display;
+use rome_console::{markup, MarkupBuf};
+use rome_diagnostics::file::FileSpan;
+use rome_diagnostics::{file::FileId, Applicability, Severity};
+use rome_diagnostics::{Diagnostic, DiagnosticTag, Footer, Span, SubDiagnostic};
+use rome_rowan::{AstNode, Language, TextRange};
+
+use crate::categories::{ActionCategory, RuleCategory};
+use crate::context::RuleContext;
+use crate::registry::RuleLanguage;
+use crate::LanguageRoot;
+
+pub trait RuleMeta {
+    /// The name of this rule, displayed in the diagnostics it emits
+    const NAME: &'static str;
+    /// The content of the documentation comments for this rule
+    const DOCS: &'static str;
+}
+
+#[macro_export]
+macro_rules! declare_rule {
+    ( $( #[doc = $doc:literal] )* $vis:vis $id:ident = $name:literal ) => {
+        $( #[doc = $doc] )*
+        $vis enum $id {}
+
+        impl $crate::RuleMeta for $id {
+            const NAME: &'static str = $name;
+            const DOCS: &'static str = concat!( $( $doc, "\n", )* );
+        }
+    };
+}
+
+/// Trait implemented by all analysis rules: declares interest to a certain AstNode type,
+/// and a callback function to be executed on all nodes matching the query to possibly
+/// raise an analysis event
+pub trait Rule: RuleMeta {
+    /// The category this rule belong to, this is used for broadly filtering
+    /// rules when running the analyzer
+    const CATEGORY: RuleCategory;
+
+    /// The type of AstNode this rule is interested in
+    type Query: AstNode;
+    /// A generic type that will be kept in memory between a call to `run` and
+    /// subsequent executions of `diagnostic` or `action`, allows the rule to
+    /// hold some temporary state between the moment a signal is raised and
+    /// when a diagnostic or action needs to be built
+    type State;
+
+    /// This function is called once for each node matching `Query` in the tree
+    /// being analyzed. If it returns `Some` the state object will be wrapped
+    /// in a generic `AnalyzerSignal`, and the consumer of the analyzer may call
+    /// `diagnostic` or `action` on it
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State>;
+
+    /// Called by the consumer of the analyzer to try to generate a diagnostic
+    /// from a signal raised by `run`
+    ///
+    /// The default implementation returns None
+    fn diagnostic(_ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
+        None
+    }
+
+    /// Called by the consumer of the analyzer to try to generate a code action
+    /// from a signal raised by `run`
+    ///
+    /// The default implementation returns None
+    fn action(
+        _ctx: &RuleContext<Self>,
+        _state: &Self::State,
+    ) -> Option<RuleAction<RuleLanguage<Self>>> {
+        None
+    }
+}
+
+/// Diagnostic object returned by a single analysis rule
+pub struct RuleDiagnostic {
+    severity: Severity,
+    span: TextRange,
+    title: MarkupBuf,
+    summary: Option<String>,
+    tag: Option<DiagnosticTag>,
+    primary: Option<MarkupBuf>,
+    secondaries: Vec<(Severity, MarkupBuf, TextRange)>,
+    footers: Vec<Footer>,
+}
+
+// Some of these methods aren't used by anything yet
+#[allow(dead_code)]
+impl RuleDiagnostic {
+    /// Creates a new [`RuleDiagnostic`] with a severity and title that will be
+    /// used in a builder-like way to modify labels.
+    fn new(severity: Severity, span: impl Span, title: impl Display) -> Self {
+        Self {
+            severity,
+            span: span.as_range(),
+            title: markup!({ title }).to_owned(),
+            summary: None,
+            tag: None,
+            primary: None,
+            secondaries: Vec::new(),
+            footers: Vec::new(),
+        }
+    }
+
+    /// Creates a new [`RuleDiagnostic`] with the `Error` severity.
+    pub fn error(span: impl Span, title: impl Display) -> Self {
+        Self::new(Severity::Error, span, title)
+    }
+
+    /// Creates a new [`RuleDiagnostic`] with the `Warning` severity.
+    pub fn warning(span: impl Span, title: impl Display) -> Self {
+        Self::new(Severity::Warning, span, title)
+    }
+
+    /// Creates a new [`RuleDiagnostic`] with the `Help` severity.
+    pub fn help(span: impl Span, title: impl Display) -> Self {
+        Self::new(Severity::Help, span, title)
+    }
+
+    /// Creates a new [`RuleDiagnostic`] with the `Note` severity.
+    pub fn note(span: impl Span, title: impl Display) -> Self {
+        Self::new(Severity::Note, span, title)
+    }
+
+    /// Set an explicit plain-text summary for this diagnostic.
+    pub fn summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
+
+    /// Marks this diagnostic as deprecated code, which will
+    /// be displayed in the language server.
+    ///
+    /// This does not have any influence on the diagnostic rendering.
+    pub fn deprecated(mut self) -> Self {
+        self.tag = if matches!(self.tag, Some(DiagnosticTag::Unnecessary)) {
+            Some(DiagnosticTag::Both)
+        } else {
+            Some(DiagnosticTag::Deprecated)
+        };
+        self
+    }
+
+    /// Marks this diagnostic as unnecessary code, which will
+    /// be displayed in the language server.
+    ///
+    /// This does not have any influence on the diagnostic rendering.
+    pub fn unnecessary(mut self) -> Self {
+        self.tag = if matches!(self.tag, Some(DiagnosticTag::Deprecated)) {
+            Some(DiagnosticTag::Both)
+        } else {
+            Some(DiagnosticTag::Unnecessary)
+        };
+        self
+    }
+
+    /// Attaches a label to this [`RuleDiagnostic`], that will point to another file
+    /// that is provided.
+    pub fn label_in_file(mut self, severity: Severity, span: impl Span, msg: impl Display) -> Self {
+        self.secondaries
+            .push((severity, markup!({ msg }).to_owned(), span.as_range()));
+        self
+    }
+
+    /// Attaches a label to this [`RuleDiagnostic`].
+    ///
+    /// The given span has to be in the file that was provided while creating this [`RuleDiagnostic`].
+    pub fn label(mut self, severity: Severity, span: impl Span, msg: impl Display) -> Self {
+        self.secondaries
+            .push((severity, markup!({ msg }).to_owned(), span.as_range()));
+        self
+    }
+
+    /// Attaches a primary label to this [`RuleDiagnostic`].
+    pub fn primary(mut self, msg: impl Display) -> Self {
+        self.primary = Some(markup!({ msg }).to_owned());
+        self
+    }
+
+    /// Attaches a secondary label to this [`RuleDiagnostic`].
+    pub fn secondary(self, span: impl Span, msg: impl Display) -> Self {
+        self.label(Severity::Note, span, msg)
+    }
+
+    /// Adds a footer to this [`RuleDiagnostic`], which will be displayed under the actual error.
+    pub fn footer(mut self, severity: Severity, msg: impl Display) -> Self {
+        self.footers.push(Footer {
+            msg: markup!({ msg }).to_owned(),
+            severity,
+        });
+        self
+    }
+
+    /// Adds a footer to this [`RuleDiagnostic`], with the `Help` severity.
+    pub fn footer_help(self, msg: impl Display) -> Self {
+        self.footer(Severity::Help, msg)
+    }
+
+    /// Adds a footer to this [`RuleDiagnostic`], with the `Note` severity.
+    pub fn footer_note(self, msg: impl Display) -> Self {
+        self.footer(Severity::Note, msg)
+    }
+
+    /// Convert this [`RuleDiagnostic`] into an instance of [`Diagnostic`] by
+    /// injecting the name of the rule that emitted it and the ID of the file
+    /// the rule was being run on
+    pub(crate) fn into_diagnostic(self, file_id: FileId, code: &'static str) -> Diagnostic {
+        Diagnostic {
+            file_id,
+            severity: self.severity,
+            code: Some(code.into()),
+            title: self.title,
+            summary: self.summary,
+            tag: self.tag,
+            primary: Some(SubDiagnostic {
+                severity: self.severity,
+                msg: self.primary.unwrap_or_default(),
+                span: FileSpan {
+                    file: file_id,
+                    range: self.span,
+                },
+            }),
+            children: self
+                .secondaries
+                .into_iter()
+                .map(|(severity, msg, range)| SubDiagnostic {
+                    severity,
+                    msg,
+                    span: FileSpan {
+                        file: file_id,
+                        range,
+                    },
+                })
+                .collect(),
+            suggestions: Vec::new(),
+            footers: self.footers,
+        }
+    }
+}
+
+/// Code Action object returned by a single analysis rule
+pub struct RuleAction<L: Language> {
+    pub category: ActionCategory,
+    pub applicability: Applicability,
+    pub message: MarkupBuf,
+    pub root: LanguageRoot<L>,
+}

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -10,7 +10,8 @@ use rome_rowan::{AstNode, Direction, Language, SyntaxNode, TextRange};
 use crate::{
     categories::ActionCategory,
     context::RuleContext,
-    registry::{LanguageRoot, Rule, RuleLanguage, RuleRoot},
+    registry::{LanguageRoot, RuleLanguage, RuleRoot},
+    rule::Rule,
 };
 
 /// Event raised by the analyzer when a [Rule](crate::registry::Rule)

--- a/crates/rome_console/src/fmt.rs
+++ b/crates/rome_console/src/fmt.rs
@@ -1,13 +1,6 @@
-use std::{
-    borrow::Cow,
-    fmt::{self, Write as _},
-    io,
-    time::Duration,
-};
+use std::{borrow::Cow, fmt, io, time::Duration};
 
-use termcolor::{ColorSpec, WriteColor};
-use unicode_width::UnicodeWidthChar;
-
+pub use crate::write::{Termcolor, Write, HTML};
 use crate::{markup, Markup, MarkupElement};
 
 /// A stack-allocated linked-list of [MarkupElement] slices
@@ -23,124 +16,6 @@ impl<'a> MarkupElements<'a> {
             parent.for_each(func);
             func(elem);
         }
-    }
-}
-
-pub trait Write {
-    fn write_str(&mut self, elements: &MarkupElements, content: &str) -> io::Result<()>;
-    fn write_fmt(&mut self, elements: &MarkupElements, content: fmt::Arguments) -> io::Result<()>;
-}
-
-/// Applies the current format in `state` to `writer`, calls `func` to
-/// print a piece of text, then reset the printing format
-fn with_format<W>(
-    writer: &mut W,
-    state: &MarkupElements,
-    func: impl FnOnce(&mut W) -> io::Result<()>,
-) -> io::Result<()>
-where
-    W: WriteColor,
-{
-    let mut color = ColorSpec::new();
-    state.for_each(&mut |elements| {
-        for element in elements {
-            element.update_color(&mut color);
-        }
-    });
-
-    if let Err(err) = writer.set_color(&color) {
-        writer.reset()?;
-        return Err(err);
-    }
-
-    let result = func(writer);
-    writer.reset()?;
-    result
-}
-
-/// Adapter struct implementing [Write] over types implementing [WriteColor]
-pub struct Termcolor<W>(pub W);
-
-impl<W> Write for Termcolor<W>
-where
-    W: WriteColor,
-{
-    fn write_str(&mut self, elements: &MarkupElements, content: &str) -> io::Result<()> {
-        with_format(&mut self.0, elements, |writer| {
-            let mut adapter = SanitizeAdapter {
-                writer,
-                error: Ok(()),
-            };
-
-            match adapter.write_str(content) {
-                Ok(()) => Ok(()),
-                Err(..) => {
-                    if adapter.error.is_err() {
-                        adapter.error
-                    } else {
-                        // SanitizeAdapter can only fail if the underlying
-                        // writer returns an error
-                        unreachable!()
-                    }
-                }
-            }
-        })
-    }
-
-    fn write_fmt(&mut self, elements: &MarkupElements, content: fmt::Arguments) -> io::Result<()> {
-        with_format(&mut self.0, elements, |writer| {
-            let mut adapter = SanitizeAdapter {
-                writer,
-                error: Ok(()),
-            };
-
-            match adapter.write_fmt(content) {
-                Ok(()) => Ok(()),
-                Err(..) => {
-                    if adapter.error.is_err() {
-                        adapter.error
-                    } else {
-                        Err(io::Error::new(
-                            io::ErrorKind::Other,
-                            "a Display formatter returned an error",
-                        ))
-                    }
-                }
-            }
-        })
-    }
-}
-
-/// Adapter [fmt::Write] calls to [io::Write] with sanitization,
-/// implemented as an internal struct to avoid exposing [fmt::Write] on
-/// [Termcolor]
-struct SanitizeAdapter<W> {
-    writer: W,
-    error: io::Result<()>,
-}
-
-impl<W: io::Write> fmt::Write for SanitizeAdapter<W> {
-    fn write_str(&mut self, content: &str) -> fmt::Result {
-        let mut buffer = [0; 4];
-
-        for item in content.chars() {
-            // Replace non-whitespace, zero-width characters with the Unicode replacement character
-            let is_whitespace = item.is_whitespace();
-            let is_zero_width = UnicodeWidthChar::width(item).map_or(true, |width| width == 0);
-            let item = if !is_whitespace && is_zero_width {
-                char::REPLACEMENT_CHARACTER
-            } else {
-                item
-            };
-
-            item.encode_utf8(&mut buffer);
-            if let Err(err) = self.writer.write_all(&buffer[..item.len_utf8()]) {
-                self.error = Err(err);
-                return Err(fmt::Error);
-            }
-        }
-
-        Ok(())
     }
 }
 
@@ -327,36 +202,5 @@ impl Display for Duration {
         fmt.write_markup(markup! {
             {nanos}<Dim>"ns"</Dim>
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{fmt::Write, str::from_utf8};
-
-    use super::SanitizeAdapter;
-
-    #[test]
-    fn test_sanitize() {
-        // Sanitization should leave whitespace control characters (space,
-        // tabs, newline, ...) and non-ASCII unicode characters as-is but
-        // redact zero-width characters (RTL override, null character, bell,
-        // zero-width space, ...)
-        const INPUT: &str = "t\tes t\r\n\u{202D}t\0es\x07t\u{202E}\nt\u{200B}es🐛t";
-        const OUTPUT: &str = "t\tes t\r\n\u{FFFD}t\u{FFFD}es\u{FFFD}t\u{FFFD}\nt\u{FFFD}es🐛t";
-
-        let mut buffer = Vec::new();
-
-        {
-            let mut adapter = SanitizeAdapter {
-                writer: &mut buffer,
-                error: Ok(()),
-            };
-
-            adapter.write_str(INPUT).unwrap();
-            adapter.error.unwrap();
-        }
-
-        assert_eq!(from_utf8(&buffer).unwrap(), OUTPUT);
     }
 }

--- a/crates/rome_console/src/lib.rs
+++ b/crates/rome_console/src/lib.rs
@@ -1,13 +1,14 @@
 use std::io::Write;
 use std::panic::RefUnwindSafe;
 
-use fmt::Termcolor;
 use termcolor::{ColorChoice, StandardStream};
+use write::Termcolor;
 
 pub mod codespan;
 pub mod diff;
 pub mod fmt;
 mod markup;
+mod write;
 
 pub use self::markup::{Markup, MarkupBuf, MarkupElement, MarkupNode};
 pub use rome_markup::markup;

--- a/crates/rome_console/src/write.rs
+++ b/crates/rome_console/src/write.rs
@@ -1,0 +1,13 @@
+mod html;
+mod termcolor;
+
+use std::{fmt, io};
+
+use crate::fmt::MarkupElements;
+
+pub use self::{html::HTML, termcolor::Termcolor};
+
+pub trait Write {
+    fn write_str(&mut self, elements: &MarkupElements, content: &str) -> io::Result<()>;
+    fn write_fmt(&mut self, elements: &MarkupElements, content: fmt::Arguments) -> io::Result<()>;
+}

--- a/crates/rome_console/src/write/html.rs
+++ b/crates/rome_console/src/write/html.rs
@@ -1,0 +1,108 @@
+use std::{fmt, io};
+
+use crate::{fmt::MarkupElements, MarkupElement};
+
+use super::Write;
+
+/// Adapter struct implementing [Write] over types implementing [io::Write],
+/// renders markup as UTF-8 strings of HTML code
+pub struct HTML<W>(pub W);
+
+impl<W> Write for HTML<W>
+where
+    W: io::Write,
+{
+    fn write_str(&mut self, elements: &MarkupElements, content: &str) -> io::Result<()> {
+        push_styles(&mut self.0, elements)?;
+        self.0.write_all(content.as_bytes())?;
+        pop_styles(&mut self.0, elements)
+    }
+
+    fn write_fmt(&mut self, elements: &MarkupElements, content: fmt::Arguments) -> io::Result<()> {
+        push_styles(&mut self.0, elements)?;
+        self.0.write_fmt(content)?;
+        pop_styles(&mut self.0, elements)
+    }
+}
+
+fn push_styles<W: io::Write>(fmt: &mut W, elements: &MarkupElements) -> io::Result<()> {
+    let mut result = Ok(());
+    elements.for_each(&mut |styles| {
+        if result.is_err() {
+            return;
+        }
+
+        for style in styles {
+            let res = match style {
+                MarkupElement::Emphasis => {
+                    write!(fmt, "<em>")
+                }
+                MarkupElement::Dim => {
+                    write!(fmt, "<span style=\"opacity: 0.8;\">")
+                }
+                MarkupElement::Italic => {
+                    write!(fmt, "<i>")
+                }
+                MarkupElement::Underline => {
+                    write!(fmt, "<u>")
+                }
+                MarkupElement::Error => {
+                    write!(fmt, "<span style=\"color: Tomato;\">")
+                }
+                MarkupElement::Success => {
+                    write!(fmt, "<span style=\"color: MediumSeaGreen;\">")
+                }
+                MarkupElement::Warn => {
+                    write!(fmt, "<span style=\"color: Orange;\">")
+                }
+                MarkupElement::Info => {
+                    write!(fmt, "<span style=\"color: rgb(38, 148, 255);\">")
+                }
+            };
+
+            if res.is_err() {
+                result = res;
+                return;
+            }
+        }
+    });
+
+    result
+}
+
+fn pop_styles<W: io::Write>(fmt: &mut W, elements: &MarkupElements) -> io::Result<()> {
+    let mut result = Ok(());
+    elements.for_each(&mut |styles| {
+        if result.is_err() {
+            return;
+        }
+
+        for style in styles {
+            let res = match style {
+                MarkupElement::Emphasis => {
+                    write!(fmt, "</em>")
+                }
+                MarkupElement::Italic => {
+                    write!(fmt, "</i>")
+                }
+                MarkupElement::Underline => {
+                    write!(fmt, "</u>")
+                }
+                MarkupElement::Dim
+                | MarkupElement::Error
+                | MarkupElement::Success
+                | MarkupElement::Warn
+                | MarkupElement::Info => {
+                    write!(fmt, "</span>")
+                }
+            };
+
+            if res.is_err() {
+                result = res;
+                return;
+            }
+        }
+    });
+
+    result
+}

--- a/crates/rome_console/src/write/termcolor.rs
+++ b/crates/rome_console/src/write/termcolor.rs
@@ -1,0 +1,155 @@
+use std::{
+    fmt::{self, Write as _},
+    io,
+};
+
+use termcolor::{ColorSpec, WriteColor};
+use unicode_width::UnicodeWidthChar;
+
+use crate::fmt::MarkupElements;
+
+use super::Write;
+
+/// Adapter struct implementing [Write] over types implementing [WriteColor]
+pub struct Termcolor<W>(pub W);
+
+impl<W> Write for Termcolor<W>
+where
+    W: WriteColor,
+{
+    fn write_str(&mut self, elements: &MarkupElements, content: &str) -> io::Result<()> {
+        with_format(&mut self.0, elements, |writer| {
+            let mut adapter = SanitizeAdapter {
+                writer,
+                error: Ok(()),
+            };
+
+            match adapter.write_str(content) {
+                Ok(()) => Ok(()),
+                Err(..) => {
+                    if adapter.error.is_err() {
+                        adapter.error
+                    } else {
+                        // SanitizeAdapter can only fail if the underlying
+                        // writer returns an error
+                        unreachable!()
+                    }
+                }
+            }
+        })
+    }
+
+    fn write_fmt(&mut self, elements: &MarkupElements, content: fmt::Arguments) -> io::Result<()> {
+        with_format(&mut self.0, elements, |writer| {
+            let mut adapter = SanitizeAdapter {
+                writer,
+                error: Ok(()),
+            };
+
+            match adapter.write_fmt(content) {
+                Ok(()) => Ok(()),
+                Err(..) => {
+                    if adapter.error.is_err() {
+                        adapter.error
+                    } else {
+                        Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            "a Display formatter returned an error",
+                        ))
+                    }
+                }
+            }
+        })
+    }
+}
+
+/// Applies the current format in `state` to `writer`, calls `func` to
+/// print a piece of text, then reset the printing format
+fn with_format<W>(
+    writer: &mut W,
+    state: &MarkupElements,
+    func: impl FnOnce(&mut W) -> io::Result<()>,
+) -> io::Result<()>
+where
+    W: WriteColor,
+{
+    let mut color = ColorSpec::new();
+    state.for_each(&mut |elements| {
+        for element in elements {
+            element.update_color(&mut color);
+        }
+    });
+
+    if let Err(err) = writer.set_color(&color) {
+        writer.reset()?;
+        return Err(err);
+    }
+
+    let result = func(writer);
+    writer.reset()?;
+    result
+}
+
+/// Adapter [fmt::Write] calls to [io::Write] with sanitization,
+/// implemented as an internal struct to avoid exposing [fmt::Write] on
+/// [Termcolor]
+struct SanitizeAdapter<W> {
+    writer: W,
+    error: io::Result<()>,
+}
+
+impl<W: io::Write> fmt::Write for SanitizeAdapter<W> {
+    fn write_str(&mut self, content: &str) -> fmt::Result {
+        let mut buffer = [0; 4];
+
+        for item in content.chars() {
+            // Replace non-whitespace, zero-width characters with the Unicode replacement character
+            let is_whitespace = item.is_whitespace();
+            let is_zero_width = UnicodeWidthChar::width(item).map_or(true, |width| width == 0);
+            let item = if !is_whitespace && is_zero_width {
+                char::REPLACEMENT_CHARACTER
+            } else {
+                item
+            };
+
+            item.encode_utf8(&mut buffer);
+            if let Err(err) = self.writer.write_all(&buffer[..item.len_utf8()]) {
+                self.error = Err(err);
+                return Err(fmt::Error);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fmt::Write, str::from_utf8};
+
+    use super::SanitizeAdapter;
+
+    #[test]
+    fn test_sanitize() {
+        // Sanitization should leave whitespace control characters (space,
+        // tabs, newline, ...) and non-ASCII unicode characters as-is but
+        // redact zero-width characters (RTL override, null character, bell,
+        // zero-width space, ...)
+        const INPUT: &str = "t\tes t\r\n\u{202D}t\0es\x07t\u{202E}\nt\u{200B}es🐛t";
+        const OUTPUT: &str = "t\tes t\r\n\u{FFFD}t\u{FFFD}es\u{FFFD}t\u{FFFD}\nt\u{FFFD}es🐛t";
+
+        let mut buffer = Vec::new();
+
+        {
+            let mut adapter = SanitizeAdapter {
+                writer: &mut buffer,
+                error: Ok(()),
+            };
+
+            adapter.write_str(INPUT).unwrap();
+            adapter.error.unwrap();
+        }
+
+        assert_eq!(from_utf8(&buffer).unwrap(), OUTPUT);
+    }
+}

--- a/crates/rome_js_analyze/src/analyzers/no_compare_neg_zero.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_compare_neg_zero.rs
@@ -1,4 +1,6 @@
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -14,10 +16,12 @@ pub struct NoCompareNegZeroState {
     left_need_replaced: bool,
     right_need_replaced: bool,
 }
-pub(crate) enum NoCompareNegZero {}
+
+declare_rule! {
+    pub(crate) NoCompareNegZero = "noCompareNegZero"
+}
 
 impl Rule for NoCompareNegZero {
-    const NAME: &'static str = "noCompareNegZero";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsBinaryExpression;

--- a/crates/rome_js_analyze/src/analyzers/no_compare_neg_zero.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_compare_neg_zero.rs
@@ -18,6 +18,21 @@ pub struct NoCompareNegZeroState {
 }
 
 declare_rule! {
+    /// Disallow comparing against `-0`
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// (1 >= -0)
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// (1 >= 0)
+    ///```
     pub(crate) NoCompareNegZero = "noCompareNegZero"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/no_debugger.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_debugger.rs
@@ -12,6 +12,22 @@ use rome_rowan::{AstNode, AstNodeExt};
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Disallow the use of `debugger`
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// debugger;
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// const test = { debugger: 1 };
+    /// test.debugger;
+    ///```
     pub(crate) NoDebugger = "noDebugger"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/no_debugger.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_debugger.rs
@@ -1,4 +1,6 @@
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -9,10 +11,11 @@ use rome_rowan::{AstNode, AstNodeExt};
 
 use crate::JsRuleAction;
 
-pub(crate) enum NoDebugger {}
+declare_rule! {
+    pub(crate) NoDebugger = "noDebugger"
+}
 
 impl Rule for NoDebugger {
-    const NAME: &'static str = "noDebugger";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsDebuggerStatement;

--- a/crates/rome_js_analyze/src/analyzers/no_delete.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_delete.rs
@@ -14,6 +14,28 @@ use rome_rowan::{AstNode, AstNodeExt};
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Disallow the use of the `delete` operator
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// const arr = [['a','b','c'], [1, 2, 3]];
+    /// delete arr[0][2];
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// const obj = {a: {b: {c: 123}}};
+    /// delete obj.a.b.c;
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// const foo = new Set([1,2,3]);
+    /// foo.delete(1);
+    ///```
     pub(crate) NoDelete = "noDelete"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/no_delete.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_delete.rs
@@ -1,4 +1,6 @@
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -11,10 +13,11 @@ use rome_rowan::{AstNode, AstNodeExt};
 
 use crate::JsRuleAction;
 
-pub(crate) enum NoDelete {}
+declare_rule! {
+    pub(crate) NoDelete = "noDelete"
+}
 
 impl Rule for NoDelete {
-    const NAME: &'static str = "noDelete";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsUnaryExpression;

--- a/crates/rome_js_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_double_equals.rs
@@ -1,5 +1,6 @@
-use rome_analyze::context::RuleContext;
-use rome_analyze::{ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -9,10 +10,11 @@ use rome_rowan::{AstNodeExt, SyntaxResult};
 
 use crate::JsRuleAction;
 
-pub(crate) enum NoDoubleEquals {}
+declare_rule! {
+    pub(crate) NoDoubleEquals = "noDoubleEquals"
+}
 
 impl Rule for NoDoubleEquals {
-    const NAME: &'static str = "noDoubleEquals";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsBinaryExpression;

--- a/crates/rome_js_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_double_equals.rs
@@ -11,6 +11,41 @@ use rome_rowan::{AstNodeExt, SyntaxResult};
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Require the use of `===` and `!==`
+    ///
+    /// It is generally bad practice to use `==` for comparison instead of
+    /// `===`. Double operators will triger implicit [type coercion](https://developer.mozilla.org/en-US/docs/Glossary/Type_coercion)
+    /// and are thus not prefered. Using strict equality operators is almost
+    /// always best practice.
+    ///
+    /// For ergonomic reasons, this rule makes an exception for `== null` for
+    /// comparing to both `null` and `undefined`.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// foo == bar
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// foo == null
+    ///```
+    ///
+    /// ```js
+    /// foo != null
+    ///```
+    ///
+    /// ```js
+    /// null == foo
+    ///```
+    ///
+    /// ```js
+    /// null != foo
+    ///```
     pub(crate) NoDoubleEquals = "noDoubleEquals"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/no_implicit_boolean.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_implicit_boolean.rs
@@ -1,4 +1,6 @@
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -9,10 +11,11 @@ use rome_rowan::{AstNode, AstNodeExt};
 
 use crate::JsRuleAction;
 
-pub(crate) enum NoImplicitBoolean {}
+declare_rule! {
+    pub(crate) NoImplicitBoolean = "noImplicitBoolean"
+}
 
 impl Rule for NoImplicitBoolean {
-    const NAME: &'static str = "noImplicitBoolean";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsxAttribute;

--- a/crates/rome_js_analyze/src/analyzers/no_implicit_boolean.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_implicit_boolean.rs
@@ -12,6 +12,37 @@ use rome_rowan::{AstNode, AstNodeExt};
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Disallow implicit `true` values on JSX boolean attributes
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <input disabled />
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```jsx
+    /// <input disabled={false} />
+    ///```
+    ///
+    /// ```jsx
+    /// <input disabled={''} />
+    ///```
+    ///
+    /// ```jsx
+    /// <input disabled={0} />
+    ///```
+    ///
+    /// ```jsx
+    /// <input disabled={undefined} />
+    ///```
+    ///
+    /// ```jsx
+    /// <input disabled='false' />
+    ///```
     pub(crate) NoImplicitBoolean = "noImplicitBoolean"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/no_negation_else.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_negation_else.rs
@@ -13,6 +13,29 @@ use rome_rowan::{AstNode, AstNodeExt};
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Disallow negation in the condition of an `if` statement if it has an `else` clause
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// if (!true) {consequent;} else {alternate;}
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// !true ? consequent : alternate
+    ///```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// if (!true) {consequent;}
+    ///```
+    ///
+    /// ```js
+    /// true ? consequent : alternate
+    ///```
     pub(crate) NoNegationElse = "noNegationElse"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/no_negation_else.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_negation_else.rs
@@ -1,4 +1,6 @@
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -10,10 +12,11 @@ use rome_rowan::{AstNode, AstNodeExt};
 
 use crate::JsRuleAction;
 
-pub(crate) enum NoNegationElse {}
+declare_rule! {
+    pub(crate) NoNegationElse = "noNegationElse"
+}
 
 impl Rule for NoNegationElse {
-    const NAME: &'static str = "noNegationElse";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsAnyCondition;

--- a/crates/rome_js_analyze/src/analyzers/no_sparse_array.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_sparse_array.rs
@@ -10,6 +10,15 @@ use rome_rowan::{AstNode, AstNodeExt, AstSeparatedList};
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Disallow sparse arrays
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// [1,,2]
+    /// ```
     pub(crate) NoSparseArray = "noSparseArray"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/no_sparse_array.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_sparse_array.rs
@@ -1,4 +1,6 @@
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -7,10 +9,11 @@ use rome_rowan::{AstNode, AstNodeExt, AstSeparatedList};
 
 use crate::JsRuleAction;
 
-pub(crate) enum NoSparseArray {}
+declare_rule! {
+    pub(crate) NoSparseArray = "noSparseArray"
+}
 
 impl Rule for NoSparseArray {
-    const NAME: &'static str = "noSparseArray";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsArrayExpression;

--- a/crates/rome_js_analyze/src/analyzers/no_unused_template_literal.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_unused_template_literal.rs
@@ -8,6 +8,34 @@ use rome_js_syntax::{JsAnyExpression, JsAnyLiteralExpression, JsAnyTemplateEleme
 use rome_rowan::{AstNode, AstNodeExt, AstNodeList};
 
 declare_rule! {
+    /// Disallow template literals if interpolation and special-character handling are not needed
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// const foo = `bar`
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// const foo = `bar `
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// const foo = `bar
+    /// has newline`;
+    /// ```
+    ///
+    /// ```js
+    /// const foo = `"bar"`
+    /// ```
+    ///
+    /// ```js
+    /// const foo = `'bar'`
+    /// ```
     pub(crate) NoUnusedTemplateLiteral = "noUnusedTemplateLiteral"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/no_unused_template_literal.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_unused_template_literal.rs
@@ -1,16 +1,17 @@
 use crate::JsRuleAction;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{JsAnyExpression, JsAnyLiteralExpression, JsAnyTemplateElement, JsTemplate};
 use rome_rowan::{AstNode, AstNodeExt, AstNodeList};
 
-pub(crate) enum NoUnusedTemplateLiteral {}
+declare_rule! {
+    pub(crate) NoUnusedTemplateLiteral = "noUnusedTemplateLiteral"
+}
 
 impl Rule for NoUnusedTemplateLiteral {
-    const NAME: &'static str = "noUnusedTemplateLiteral";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsTemplate;

--- a/crates/rome_js_analyze/src/analyzers/use_self_closing_elements.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_self_closing_elements.rs
@@ -1,13 +1,58 @@
-use rome_analyze::{declare_rule, context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
-use rome_js_syntax::{ JsSyntaxToken, JsxAnyTag, JsxElement, JsxOpeningElementFields, T};
+use rome_js_syntax::{JsSyntaxToken, JsxAnyTag, JsxElement, JsxOpeningElementFields, T};
 use rome_rowan::{AstNode, AstNodeExt, AstNodeList, TriviaPiece};
 
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Prevent extra closing tags for components without children
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// <div></div>
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// <Component></Component>
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// <Foo.bar></Foo.bar>
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// <div />
+    ///```
+    ///
+    /// ```js
+    /// <div>child</div>
+    ///```
+    ///
+    /// ```js
+    /// <Component />
+    ///```
+    ///
+    /// ```js
+    /// <Component>child</Component>
+    ///```
+    ///
+    /// ```js
+    /// <Foo.bar />
+    ///```
+    ///
+    /// ```js
+    /// <Foo.bar>child</Foo.bar>
+    ///```
     pub(crate) UseSelfClosingElements = "useSelfClosingElements"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/use_single_case_statement.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_single_case_statement.rs
@@ -1,6 +1,8 @@
 use std::iter;
 
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -11,12 +13,11 @@ use rome_rowan::{AstNode, AstNodeExt, AstNodeList, TriviaPiece};
 
 use crate::JsRuleAction;
 
-/// Enforces case clauses have a single statement, emits a quick fix wrapping
-/// the statements in a block
-pub(crate) enum UseSingleCaseStatement {}
+declare_rule! {
+    pub(crate) UseSingleCaseStatement = "useSingleCaseStatement"
+}
 
 impl Rule for UseSingleCaseStatement {
-    const NAME: &'static str = "useSingleCaseStatement";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsCaseClause;

--- a/crates/rome_js_analyze/src/analyzers/use_single_case_statement.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_single_case_statement.rs
@@ -14,6 +14,33 @@ use rome_rowan::{AstNode, AstNodeExt, AstNodeList, TriviaPiece};
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Enforces case clauses have a single statement, emits a quick fix wrapping
+    /// the statements in a block
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// switch (foo) {
+    ///     case true:
+    ///     case false:
+    ///         let foo = '';
+    ///         foo;
+    /// }
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// switch (foo) {
+    ///     case true:
+    ///     case false: {
+    ///         let foo = '';
+    ///         foo;
+    ///     }
+    /// }
+    /// ```
     pub(crate) UseSingleCaseStatement = "useSingleCaseStatement"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/use_single_var_declarator.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_single_var_declarator.rs
@@ -1,6 +1,8 @@
 use std::iter;
 
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -12,10 +14,11 @@ use rome_rowan::{AstNode, AstSeparatedList};
 
 use crate::JsRuleAction;
 
-pub(crate) enum UseSingleVarDeclarator {}
+declare_rule! {
+    pub(crate) UseSingleVarDeclarator = "useSingleVarDeclarator"
+}
 
 impl Rule for UseSingleVarDeclarator {
-    const NAME: &'static str = "useSingleVarDeclarator";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsVariableStatement;

--- a/crates/rome_js_analyze/src/analyzers/use_single_var_declarator.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_single_var_declarator.rs
@@ -15,6 +15,21 @@ use rome_rowan::{AstNode, AstSeparatedList};
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Disallow multiple variable declarations in the same variable statement
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// let foo, bar;
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// for (let i = 0, x = 1; i < arr.length; i++) {}
+    /// ```
     pub(crate) UseSingleVarDeclarator = "useSingleVarDeclarator"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/use_valid_typeof.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_valid_typeof.rs
@@ -1,4 +1,6 @@
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -10,13 +12,11 @@ use rome_rowan::{AstNode, AstNodeExt};
 
 use crate::JsRuleAction;
 
-/// This rule verifies the result of `typeof $expr` unary expressions is being
-/// compared to valid values, either string literals containing valid type
-/// names or other `typeof` expressions
-pub(crate) enum UseValidTypeof {}
+declare_rule! {
+    pub(crate) UseValidTypeof = "useValidTypeof"
+}
 
 impl Rule for UseValidTypeof {
-    const NAME: &'static str = "useValidTypeof";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsBinaryExpression;

--- a/crates/rome_js_analyze/src/analyzers/use_valid_typeof.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_valid_typeof.rs
@@ -13,6 +13,63 @@ use rome_rowan::{AstNode, AstNodeExt};
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// This rule verifies the result of `typeof $expr` unary expressions is being
+    /// compared to valid values, either string literals containing valid type
+    /// names or other `typeof` expressions
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// typeof foo === "strnig"
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// typeof foo == "undefimed"
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// typeof bar != "nunber"
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// typeof bar !== "fucntion"
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// typeof foo === undefined
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// typeof bar == Object
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// typeof foo === baz
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// typeof foo == 5
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// typeof foo == -5
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// typeof foo === "string"
+    /// ```
+    ///
+    /// ```js
+    /// typeof bar == "undefined"
+    /// ```
+    ///
+    /// ```js
+    /// typeof bar === typeof qux
+    /// ```
     pub(crate) UseValidTypeof = "useValidTypeof"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/use_while.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_while.rs
@@ -10,6 +10,18 @@ use rome_rowan::AstNodeExt;
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Enforce the use of `while` loops instead of `for` loops when the
+    /// initializer and update expressions are not needed
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// for (; x.running;) {
+    ///     x.step();
+    /// }
+    /// ```
     pub(crate) UseWhile = "useWhile"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/use_while.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_while.rs
@@ -1,14 +1,19 @@
-use crate::JsRuleAction;
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{JsAnyStatement, JsForStatement, JsForStatementFields, T};
 use rome_rowan::AstNodeExt;
-pub(crate) enum UseWhile {}
+
+use crate::JsRuleAction;
+
+declare_rule! {
+    pub(crate) UseWhile = "useWhile"
+}
 
 impl Rule for UseWhile {
-    const NAME: &'static str = "useWhile";
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
     type Query = JsForStatement;

--- a/crates/rome_js_analyze/src/assists/flip_bin_exp.rs
+++ b/crates/rome_js_analyze/src/assists/flip_bin_exp.rs
@@ -10,6 +10,13 @@ use rome_rowan::AstNodeExt;
 use crate::JsRuleAction;
 
 declare_rule! {
+    /// Provides a refactor to invert the left and right hand side of a binary expression
+    ///
+    /// ## Examples
+    ///
+    /// ```js
+    /// (a < b)
+    /// ```
     pub(crate) FlipBinExp = "flipBinExp"
 }
 

--- a/crates/rome_js_analyze/src/assists/flip_bin_exp.rs
+++ b/crates/rome_js_analyze/src/assists/flip_bin_exp.rs
@@ -1,4 +1,4 @@
-use rome_analyze::{context::RuleContext, ActionCategory, Rule, RuleCategory};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -9,10 +9,11 @@ use rome_rowan::AstNodeExt;
 
 use crate::JsRuleAction;
 
-pub(crate) enum FlipBinExp {}
+declare_rule! {
+    pub(crate) FlipBinExp = "flipBinExp"
+}
 
 impl Rule for FlipBinExp {
-    const NAME: &'static str = "flipBinExp";
     const CATEGORY: RuleCategory = RuleCategory::Action;
 
     type Query = JsBinaryExpression;

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -1,5 +1,5 @@
 use rome_analyze::{
-    AnalysisFilter, Analyzer, AnalyzerSignal, ControlFlow, LanguageRoot, RuleAction,
+    AnalysisFilter, Analyzer, AnalyzerSignal, ControlFlow, LanguageRoot, MetadataIter, RuleAction,
 };
 use rome_diagnostics::file::FileId;
 use rome_js_syntax::{
@@ -14,6 +14,12 @@ mod registry;
 use crate::registry::build_registry;
 
 pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
+
+/// Return an iterator over the name and documentation of all the rules
+/// implemented by the JS analyzer
+pub fn metadata() -> MetadataIter<JsLanguage> {
+    build_registry(&AnalysisFilter::default()).metadata()
+}
 
 /// Run the analyzer on the provided `root`: this process will use the given `filter`
 /// to selectively restrict analysis to specific rules / a specific source range,

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -17,8 +17,8 @@ pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
 
 /// Return an iterator over the name and documentation of all the rules
 /// implemented by the JS analyzer
-pub fn metadata() -> MetadataIter<JsLanguage> {
-    build_registry(&AnalysisFilter::default()).metadata()
+pub fn metadata(filter: AnalysisFilter) -> MetadataIter<JsLanguage> {
+    build_registry(&filter).metadata()
 }
 
 /// Run the analyzer on the provided `root`: this process will use the given `filter`

--- a/website/src/_includes/docs/linter.md
+++ b/website/src/_includes/docs/linter.md
@@ -5,16 +5,16 @@ You can use the linter via our [VS Code extension] or by downloading our CLI dir
 > WARNING: The CLI and VS Code extension are packaged with separate binaries, which means that if you don't
 > use our default options, you will have to **pass them to both the extension AND the CLI**.
 >
-> This is a temporary choice to allow people to play with our formatter. This will change in the near future.
+> This is a temporary choice to allow people to play with our linter. This will change in the near future.
 
 
-### Use the formatter via VSCode extension
+### Use the linter via VSCode extension
 
 The feature is opt-in, and you'd need to enable the following options:
 - `analysis.enableDiagnostics` 
 - `analysis.enableCodeActions` 
 
-### Use the formatter via CLI
+### Use the linter via CLI
 
 You can start by running the CLI with the `--help` flag:
 
@@ -31,6 +31,14 @@ USAGE:
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
 
 ```
+
+### Rules
+
+At the moment only a few rules are implemented as the linting / analysis infrastructure is being built.
+
+**See the full [list of rules](/docs/lint/rules).**
+
+All rules are enabled by default, and cannot be disabled. [Suppressions](#suppressions) can be used to hide specific lint errors.
 
 
 [VS Code extension]: https://marketplace.visualstudio.com/items?itemName=rome.rome

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -18,35 +18,35 @@ eleventyNavigation:
 	<a href="/docs/lint/rules/noCompareNegZero">noCompareNegZero</a>
 	<a class="header-anchor" href="#noCompareNegZero"></a>
 </h3>
-Disallow comparing against `-0`
+Disallow comparing against <code>-0</code>
 </div>
 <div class="rule">
 <h3 data-toc-exclude id="noDebugger">
 	<a href="/docs/lint/rules/noDebugger">noDebugger</a>
 	<a class="header-anchor" href="#noDebugger"></a>
 </h3>
-Disallow the use of `debugger`
+Disallow the use of <code>debugger</code>
 </div>
 <div class="rule">
 <h3 data-toc-exclude id="noDelete">
 	<a href="/docs/lint/rules/noDelete">noDelete</a>
 	<a class="header-anchor" href="#noDelete"></a>
 </h3>
-Disallow the use of the `delete` operator
+Disallow the use of the <code>delete</code> operator
 </div>
 <div class="rule">
 <h3 data-toc-exclude id="noDoubleEquals">
 	<a href="/docs/lint/rules/noDoubleEquals">noDoubleEquals</a>
 	<a class="header-anchor" href="#noDoubleEquals"></a>
 </h3>
-Require the use of `===` and `!==`
+Require the use of <code>===</code> and <code>!==</code>
 </div>
 <div class="rule">
 <h3 data-toc-exclude id="noImplicitBoolean">
 	<a href="/docs/lint/rules/noImplicitBoolean">noImplicitBoolean</a>
 	<a class="header-anchor" href="#noImplicitBoolean"></a>
 </h3>
-Disallow implicit `true` values on JSX boolean attributes
+Disallow implicit <code>true</code> values on JSX boolean attributes
 </div>
 <div class="rule">
 <h3 data-toc-exclude id="noMultipleSpacesInRegularExpressionLiterals">
@@ -60,7 +60,7 @@ Disallow unclear usage of multiple space characters in regular expression litera
 	<a href="/docs/lint/rules/noNegationElse">noNegationElse</a>
 	<a class="header-anchor" href="#noNegationElse"></a>
 </h3>
-Disallow negation in the condition of an `if` statement if it has an `else` clause
+Disallow negation in the condition of an <code>if</code> statement if it has an <code>else</code> clause
 </div>
 <div class="rule">
 <h3 data-toc-exclude id="noSparseArray">
@@ -103,16 +103,16 @@ Disallow multiple variable declarations in the same variable statement
 	<a href="/docs/lint/rules/useValidTypeof">useValidTypeof</a>
 	<a class="header-anchor" href="#useValidTypeof"></a>
 </h3>
-This rule verifies the result of `typeof $expr` unary expressions is being
+This rule verifies the result of <code>typeof $expr</code> unary expressions is being
 compared to valid values, either string literals containing valid type
-names or other `typeof` expressions
+names or other <code>typeof</code> expressions
 </div>
 <div class="rule">
 <h3 data-toc-exclude id="useWhile">
 	<a href="/docs/lint/rules/useWhile">useWhile</a>
 	<a class="header-anchor" href="#useWhile"></a>
 </h3>
-Enforce the use of `while` loops instead of `for` loops when the
+Enforce the use of <code>while</code> loops instead of <code>for</code> loops when the
 initializer and update expressions are not needed
 </div>
 </section>

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -1,0 +1,118 @@
+---
+title: Lint Rules
+layout: layouts/page.liquid
+layout-type: split
+main-class: rules
+eleventyNavigation:
+  key: lint-rules
+  parent: linting
+  title: Rules
+---
+
+# Rules
+
+<section>
+<h2>JavaScript</h2>
+<div class="rule">
+<h3 data-toc-exclude id="noCompareNegZero">
+	<a href="/docs/lint/rules/noCompareNegZero">noCompareNegZero</a>
+	<a class="header-anchor" href="#noCompareNegZero"></a>
+</h3>
+Disallow comparing against `-0`
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="noDebugger">
+	<a href="/docs/lint/rules/noDebugger">noDebugger</a>
+	<a class="header-anchor" href="#noDebugger"></a>
+</h3>
+Disallow the use of `debugger`
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="noDelete">
+	<a href="/docs/lint/rules/noDelete">noDelete</a>
+	<a class="header-anchor" href="#noDelete"></a>
+</h3>
+Disallow the use of the `delete` operator
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="noDoubleEquals">
+	<a href="/docs/lint/rules/noDoubleEquals">noDoubleEquals</a>
+	<a class="header-anchor" href="#noDoubleEquals"></a>
+</h3>
+Require the use of `===` and `!==`
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="noImplicitBoolean">
+	<a href="/docs/lint/rules/noImplicitBoolean">noImplicitBoolean</a>
+	<a class="header-anchor" href="#noImplicitBoolean"></a>
+</h3>
+Disallow implicit `true` values on JSX boolean attributes
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="noMultipleSpacesInRegularExpressionLiterals">
+	<a href="/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">noMultipleSpacesInRegularExpressionLiterals</a>
+	<a class="header-anchor" href="#noMultipleSpacesInRegularExpressionLiterals"></a>
+</h3>
+Disallow unclear usage of multiple space characters in regular expression literals
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="noNegationElse">
+	<a href="/docs/lint/rules/noNegationElse">noNegationElse</a>
+	<a class="header-anchor" href="#noNegationElse"></a>
+</h3>
+Disallow negation in the condition of an `if` statement if it has an `else` clause
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="noSparseArray">
+	<a href="/docs/lint/rules/noSparseArray">noSparseArray</a>
+	<a class="header-anchor" href="#noSparseArray"></a>
+</h3>
+Disallow sparse arrays
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="noUnusedTemplateLiteral">
+	<a href="/docs/lint/rules/noUnusedTemplateLiteral">noUnusedTemplateLiteral</a>
+	<a class="header-anchor" href="#noUnusedTemplateLiteral"></a>
+</h3>
+Disallow template literals if interpolation and special-character handling are not needed
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="useSelfClosingElements">
+	<a href="/docs/lint/rules/useSelfClosingElements">useSelfClosingElements</a>
+	<a class="header-anchor" href="#useSelfClosingElements"></a>
+</h3>
+Prevent extra closing tags for components without children
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="useSingleCaseStatement">
+	<a href="/docs/lint/rules/useSingleCaseStatement">useSingleCaseStatement</a>
+	<a class="header-anchor" href="#useSingleCaseStatement"></a>
+</h3>
+Enforces case clauses have a single statement, emits a quick fix wrapping
+the statements in a block
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="useSingleVarDeclarator">
+	<a href="/docs/lint/rules/useSingleVarDeclarator">useSingleVarDeclarator</a>
+	<a class="header-anchor" href="#useSingleVarDeclarator"></a>
+</h3>
+Disallow multiple variable declarations in the same variable statement
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="useValidTypeof">
+	<a href="/docs/lint/rules/useValidTypeof">useValidTypeof</a>
+	<a class="header-anchor" href="#useValidTypeof"></a>
+</h3>
+This rule verifies the result of `typeof $expr` unary expressions is being
+compared to valid values, either string literals containing valid type
+names or other `typeof` expressions
+</div>
+<div class="rule">
+<h3 data-toc-exclude id="useWhile">
+	<a href="/docs/lint/rules/useWhile">useWhile</a>
+	<a class="header-anchor" href="#useWhile"></a>
+</h3>
+Enforce the use of `while` loops instead of `for` loops when the
+initializer and update expressions are not needed
+</div>
+</section>

--- a/website/src/docs/lint/rules/noCompareNegZero.md
+++ b/website/src/docs/lint/rules/noCompareNegZero.md
@@ -15,16 +15,16 @@ Disallow comparing against `-0`
 (1 >= -0)
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noCompareNegZero</span><span style="color: Orange;">]</span><em>: </em><em>Do not use the >= operator to compare against -0.</em>
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noCompareNegZero</span><span style="color: Orange;">]</span><em>: </em><em>Do not use the &gt;= operator to compare against -0.</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noCompareNegZero.js:1:2
   <span style="color: rgb(38, 148, 255);">│</span>
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> (1 >= -0)
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> (1 &gt;= -0)
   <span style="color: rgb(38, 148, 255);">│</span>  <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
 
 <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace -0 with 0</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">(1 >= -0)</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">(1 >= 0)</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">(1 &gt;= -0)</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">(1 &gt;= 0)</span>
 
 </code></pre>{% endraw %}
 

--- a/website/src/docs/lint/rules/noCompareNegZero.md
+++ b/website/src/docs/lint/rules/noCompareNegZero.md
@@ -1,0 +1,36 @@
+---
+title: Lint Rule noCompareNegZero
+layout: layouts/rule.liquid
+---
+
+# noCompareNegZero
+
+Disallow comparing against `-0`
+
+## Examples
+
+### Invalid
+
+```jsx
+(1 >= -0)
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noCompareNegZero</span><span style="color: Orange;">]</span><em>: </em><em>Do not use the >= operator to compare against -0.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noCompareNegZero.js:1:2
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> (1 >= -0)
+  <span style="color: rgb(38, 148, 255);">│</span>  <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace -0 with 0</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">(1 >= -0)</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">(1 >= 0)</span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+(1 >= 0)
+```
+

--- a/website/src/docs/lint/rules/noDebugger.md
+++ b/website/src/docs/lint/rules/noDebugger.md
@@ -1,0 +1,37 @@
+---
+title: Lint Rule noDebugger
+layout: layouts/rule.liquid
+---
+
+# noDebugger
+
+Disallow the use of `debugger`
+
+## Examples
+
+### Invalid
+
+```jsx
+debugger;
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noDebugger</span><span style="color: Orange;">]</span><em>: </em><em>This is an unexpected use of the </em><em><em>debugger</em></em><em> statement.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noDebugger.js:1:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> debugger;
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove debugger statement</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">debugger;</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"></span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+const test = { debugger: 1 };
+test.debugger;
+```
+

--- a/website/src/docs/lint/rules/noDelete.md
+++ b/website/src/docs/lint/rules/noDelete.md
@@ -1,0 +1,58 @@
+---
+title: Lint Rule noDelete
+layout: layouts/rule.liquid
+---
+
+# noDelete
+
+Disallow the use of the `delete` operator
+
+## Examples
+
+### Invalid
+
+```jsx
+const arr = [['a','b','c'], [1, 2, 3]];
+delete arr[0][2];
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noDelete</span><span style="color: Orange;">]</span><em>: </em><em>This is an unexpected use of the </em><em><em>delete</em></em><em> operator.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noDelete.js:2:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">2</span> <span style="color: rgb(38, 148, 255);">│</span> delete arr[0][2];
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace with undefined assignment</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1,2 +1,2 @@</span>
+0 0 |   const arr = [['a','b','c'], [1, 2, 3]];
+1   | <span style="color: Tomato;">- </span><span style="color: Tomato;">delete arr[0][2];</span>
+  1 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">arr[0][2] = undefined;</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+const obj = {a: {b: {c: 123}}};
+delete obj.a.b.c;
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noDelete</span><span style="color: Orange;">]</span><em>: </em><em>This is an unexpected use of the </em><em><em>delete</em></em><em> operator.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noDelete.js:2:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">2</span> <span style="color: rgb(38, 148, 255);">│</span> delete obj.a.b.c;
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace with undefined assignment</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1,2 +1,2 @@</span>
+0 0 |   const obj = {a: {b: {c: 123}}};
+1   | <span style="color: Tomato;">- </span><span style="color: Tomato;">delete obj.a.b.c;</span>
+  1 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">obj.a.b.c = undefined;</span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+const foo = new Set([1,2,3]);
+foo.delete(1);
+```
+

--- a/website/src/docs/lint/rules/noDoubleEquals.md
+++ b/website/src/docs/lint/rules/noDoubleEquals.md
@@ -1,0 +1,58 @@
+---
+title: Lint Rule noDoubleEquals
+layout: layouts/rule.liquid
+---
+
+# noDoubleEquals
+
+Require the use of `===` and `!==`
+
+It is generally bad practice to use `==` for comparison instead of
+`===`. Double operators will triger implicit [type coercion](https://developer.mozilla.org/en-US/docs/Glossary/Type_coercion)
+and are thus not prefered. Using strict equality operators is almost
+always best practice.
+
+For ergonomic reasons, this rule makes an exception for `== null` for
+comparing to both `null` and `undefined`.
+
+## Examples
+
+### Invalid
+
+```jsx
+foo == bar
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noDoubleEquals</span><span style="color: Orange;">]</span><em>: </em><em>Use </em><em><em>===</em></em><em> instead of </em><em><em>==</em></em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noDoubleEquals.js:1:5
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> foo == bar
+  <span style="color: rgb(38, 148, 255);">│</span>     <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);"><em>==</span></em><span style="color: rgb(38, 148, 255);"> is only allowed when comparing against </span><span style="color: rgb(38, 148, 255);"><em>null</span></em>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><em>===</span></em>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">foo == bar</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">foo === bar</span>
+
+=  note: Using <em>===</em> may be unsafe if you are relying on type coercion
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+foo == null
+```
+
+```jsx
+foo != null
+```
+
+```jsx
+null == foo
+```
+
+```jsx
+null != foo
+```
+

--- a/website/src/docs/lint/rules/noImplicitBoolean.md
+++ b/website/src/docs/lint/rules/noImplicitBoolean.md
@@ -1,0 +1,52 @@
+---
+title: Lint Rule noImplicitBoolean
+layout: layouts/rule.liquid
+---
+
+# noImplicitBoolean
+
+Disallow implicit `true` values on JSX boolean attributes
+
+## Examples
+
+### Invalid
+
+```jsx
+<input disabled />
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noImplicitBoolean</span><span style="color: Orange;">]</span><em>: </em><em>Use explicit boolean values for boolean JSX props.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noImplicitBoolean.js:1:8
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> <input disabled />
+  <span style="color: rgb(38, 148, 255);">│</span>        <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Add explicit `true` literal for this attribute</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;"><input disabled /></span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"><input disabled={true} /></span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+<input disabled={false} />
+```
+
+```jsx
+<input disabled={''} />
+```
+
+```jsx
+<input disabled={0} />
+```
+
+```jsx
+<input disabled={undefined} />
+```
+
+```jsx
+<input disabled='false' />
+```
+

--- a/website/src/docs/lint/rules/noImplicitBoolean.md
+++ b/website/src/docs/lint/rules/noImplicitBoolean.md
@@ -18,13 +18,13 @@ Disallow implicit `true` values on JSX boolean attributes
 {% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noImplicitBoolean</span><span style="color: Orange;">]</span><em>: </em><em>Use explicit boolean values for boolean JSX props.</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noImplicitBoolean.js:1:8
   <span style="color: rgb(38, 148, 255);">│</span>
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> <input disabled />
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> &lt;input disabled /&gt;
   <span style="color: rgb(38, 148, 255);">│</span>        <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
 
 <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Add explicit `true` literal for this attribute</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;"><input disabled /></span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"><input disabled={true} /></span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">&lt;input disabled /&gt;</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">&lt;input disabled={true} /&gt;</span>
 
 </code></pre>{% endraw %}
 

--- a/website/src/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals.md
+++ b/website/src/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals.md
@@ -1,0 +1,133 @@
+---
+title: Lint Rule noMultipleSpacesInRegularExpressionLiterals
+layout: layouts/rule.liquid
+---
+
+# noMultipleSpacesInRegularExpressionLiterals
+
+Disallow unclear usage of multiple space characters in regular expression literals
+
+## Examples
+
+### Invalid
+
+```jsx
+/   /
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noMultipleSpacesInRegularExpressionLiterals</span><span style="color: Orange;">]</span><em>: </em><em>This regular expression contains unclear uses of multiple spaces.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noMultipleSpacesInRegularExpressionLiterals.js:1:2
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> /   /
+  <span style="color: rgb(38, 148, 255);">│</span>  <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {3}/</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">/   /</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">/ {3}/</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+/  foo/
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noMultipleSpacesInRegularExpressionLiterals</span><span style="color: Orange;">]</span><em>: </em><em>This regular expression contains unclear uses of multiple spaces.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noMultipleSpacesInRegularExpressionLiterals.js:1:2
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> /  foo/
+  <span style="color: rgb(38, 148, 255);">│</span>  <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {2}/</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">/  foo/</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">/ {2}foo/</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+/foo   /
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noMultipleSpacesInRegularExpressionLiterals</span><span style="color: Orange;">]</span><em>: </em><em>This regular expression contains unclear uses of multiple spaces.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noMultipleSpacesInRegularExpressionLiterals.js:1:5
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> /foo   /
+  <span style="color: rgb(38, 148, 255);">│</span>     <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {3}/</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">/foo   /</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">/foo {3}/</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+/foo  bar/
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noMultipleSpacesInRegularExpressionLiterals</span><span style="color: Orange;">]</span><em>: </em><em>This regular expression contains unclear uses of multiple spaces.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noMultipleSpacesInRegularExpressionLiterals.js:1:5
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> /foo  bar/
+  <span style="color: rgb(38, 148, 255);">│</span>     <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {2}/</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">/foo  bar/</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">/foo {2}bar/</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+/foo   bar    baz/
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noMultipleSpacesInRegularExpressionLiterals</span><span style="color: Orange;">]</span><em>: </em><em>This regular expression contains unclear uses of multiple spaces.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noMultipleSpacesInRegularExpressionLiterals.js:1:5
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> /foo   bar    baz/
+  <span style="color: rgb(38, 148, 255);">│</span>     <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {7}/</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">/foo   bar    baz/</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">/foo {3}bar {4}baz/</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+/foo [ba]r  b(a|z)/
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noMultipleSpacesInRegularExpressionLiterals</span><span style="color: Orange;">]</span><em>: </em><em>This regular expression contains unclear uses of multiple spaces.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noMultipleSpacesInRegularExpressionLiterals.js:1:11
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> /foo [ba]r  b(a|z)/
+  <span style="color: rgb(38, 148, 255);">│</span>           <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. eg / {2}/</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">/foo [ba]r  b(a|z)/</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">/foo [ba]r {2}b(a|z)/</span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+/foo {2}bar/
+```
+
+```jsx
+/foo bar baz/
+```
+
+```jsx
+/foo bar	baz/
+```
+
+```jsx
+/foo /
+```
+

--- a/website/src/docs/lint/rules/noNegationElse.md
+++ b/website/src/docs/lint/rules/noNegationElse.md
@@ -1,0 +1,57 @@
+---
+title: Lint Rule noNegationElse
+layout: layouts/rule.liquid
+---
+
+# noNegationElse
+
+Disallow negation in the condition of an `if` statement if it has an `else` clause
+
+## Examples
+
+### Invalid
+
+```jsx
+if (!true) {consequent;} else {alternate;}
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noNegationElse</span><span style="color: Orange;">]</span><em>: </em><em>Invert blocks when performing a negation test.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noNegationElse.js:1:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> if (!true) {consequent;} else {alternate;}
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Exchange alternate and consequent of the node</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">if (!true) {consequent;} else {alternate;}</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">if (true) {alternate;} else {consequent;}</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+!true ? consequent : alternate
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noNegationElse</span><span style="color: Orange;">]</span><em>: </em><em>Invert blocks when performing a negation test.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noNegationElse.js:1:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> !true ? consequent : alternate
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Exchange alternate and consequent of the node</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">!true ? consequent : alternate</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">true ? alternate : consequent</span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+if (!true) {consequent;}
+```
+
+```jsx
+true ? consequent : alternate
+```
+

--- a/website/src/docs/lint/rules/noSparseArray.md
+++ b/website/src/docs/lint/rules/noSparseArray.md
@@ -1,0 +1,30 @@
+---
+title: Lint Rule noSparseArray
+layout: layouts/rule.liquid
+---
+
+# noSparseArray
+
+Disallow sparse arrays
+
+## Examples
+
+### Invalid
+
+```jsx
+[1,,2]
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noSparseArray</span><span style="color: Orange;">]</span><em>: </em><em>This </em><em><em>array</em></em><em> contains an </em><em><em>empty slot</em></em><em>.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noSparseArray.js:1:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> [1,,2]
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace hole with undefined</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">[1,,2]</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">[1, undefined,2]</span>
+
+</code></pre>{% endraw %}
+

--- a/website/src/docs/lint/rules/noUnusedTemplateLiteral.md
+++ b/website/src/docs/lint/rules/noUnusedTemplateLiteral.md
@@ -1,0 +1,62 @@
+---
+title: Lint Rule noUnusedTemplateLiteral
+layout: layouts/rule.liquid
+---
+
+# noUnusedTemplateLiteral
+
+Disallow template literals if interpolation and special-character handling are not needed
+
+## Examples
+
+### Invalid
+
+```jsx
+const foo = `bar`
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noUnusedTemplateLiteral</span><span style="color: Orange;">]</span><em>: </em><em>Do not use template literals if interpolation and special-character handling are not needed.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noUnusedTemplateLiteral.js:1:13
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> const foo = `bar`
+  <span style="color: rgb(38, 148, 255);">│</span>             <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace with string literal</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">const foo = `bar`</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">const foo = "bar"</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+const foo = `bar `
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">noUnusedTemplateLiteral</span><span style="color: Orange;">]</span><em>: </em><em>Do not use template literals if interpolation and special-character handling are not needed.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> noUnusedTemplateLiteral.js:1:13
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> const foo = `bar `
+  <span style="color: rgb(38, 148, 255);">│</span>             <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace with string literal</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">const foo = `bar `</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">const foo = "bar "</span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+const foo = `bar
+has newline`;
+```
+
+```jsx
+const foo = `"bar"`
+```
+
+```jsx
+const foo = `'bar'`
+```
+

--- a/website/src/docs/lint/rules/noUnusedTemplateLiteral.md
+++ b/website/src/docs/lint/rules/noUnusedTemplateLiteral.md
@@ -24,7 +24,7 @@ const foo = `bar`
 <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace with string literal</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
 0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">const foo = `bar`</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">const foo = "bar"</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">const foo = &quot;bar&quot;</span>
 
 </code></pre>{% endraw %}
 
@@ -41,7 +41,7 @@ const foo = `bar `
 <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace with string literal</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
 0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">const foo = `bar `</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">const foo = "bar "</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">const foo = &quot;bar &quot;</span>
 
 </code></pre>{% endraw %}
 

--- a/website/src/docs/lint/rules/useSelfClosingElements.md
+++ b/website/src/docs/lint/rules/useSelfClosingElements.md
@@ -1,0 +1,90 @@
+---
+title: Lint Rule useSelfClosingElements
+layout: layouts/rule.liquid
+---
+
+# useSelfClosingElements
+
+Prevent extra closing tags for components without children
+
+## Examples
+
+### Invalid
+
+```jsx
+<div></div>
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useSelfClosingElements</span><span style="color: Orange;">]</span><em>: </em><em>JSX elements without children should be marked as self-closing. In JSX, it is valid for any element to be self-closing.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useSelfClosingElements.js:1:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> <div></div>
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a SelfClosingElement instead</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;"><div></div></span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"><div /></span>
+
+</code></pre>{% endraw %}
+
+```jsx
+<Component></Component>
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useSelfClosingElements</span><span style="color: Orange;">]</span><em>: </em><em>JSX elements without children should be marked as self-closing. In JSX, it is valid for any element to be self-closing.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useSelfClosingElements.js:1:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> <Component></Component>
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a SelfClosingElement instead</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;"><Component></Component></span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"><Component /></span>
+
+</code></pre>{% endraw %}
+
+```jsx
+<Foo.bar></Foo.bar>
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useSelfClosingElements</span><span style="color: Orange;">]</span><em>: </em><em>JSX elements without children should be marked as self-closing. In JSX, it is valid for any element to be self-closing.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useSelfClosingElements.js:1:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> <Foo.bar></Foo.bar>
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a SelfClosingElement instead</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;"><Foo.bar></Foo.bar></span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"><Foo.bar /></span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+<div />
+```
+
+```jsx
+<div>child</div>
+```
+
+```jsx
+<Component />
+```
+
+```jsx
+<Component>child</Component>
+```
+
+```jsx
+<Foo.bar />
+```
+
+```jsx
+<Foo.bar>child</Foo.bar>
+```
+

--- a/website/src/docs/lint/rules/useSelfClosingElements.md
+++ b/website/src/docs/lint/rules/useSelfClosingElements.md
@@ -18,13 +18,13 @@ Prevent extra closing tags for components without children
 {% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useSelfClosingElements</span><span style="color: Orange;">]</span><em>: </em><em>JSX elements without children should be marked as self-closing. In JSX, it is valid for any element to be self-closing.</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useSelfClosingElements.js:1:1
   <span style="color: rgb(38, 148, 255);">│</span>
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> <div></div>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> &lt;div&gt;&lt;/div&gt;
   <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
 
 <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a SelfClosingElement instead</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;"><div></div></span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"><div /></span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">&lt;div&gt;&lt;/div&gt;</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">&lt;div /&gt;</span>
 
 </code></pre>{% endraw %}
 
@@ -35,13 +35,13 @@ Prevent extra closing tags for components without children
 {% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useSelfClosingElements</span><span style="color: Orange;">]</span><em>: </em><em>JSX elements without children should be marked as self-closing. In JSX, it is valid for any element to be self-closing.</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useSelfClosingElements.js:1:1
   <span style="color: rgb(38, 148, 255);">│</span>
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> <Component></Component>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> &lt;Component&gt;&lt;/Component&gt;
   <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
 
 <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a SelfClosingElement instead</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;"><Component></Component></span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"><Component /></span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">&lt;Component&gt;&lt;/Component&gt;</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">&lt;Component /&gt;</span>
 
 </code></pre>{% endraw %}
 
@@ -52,13 +52,13 @@ Prevent extra closing tags for components without children
 {% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useSelfClosingElements</span><span style="color: Orange;">]</span><em>: </em><em>JSX elements without children should be marked as self-closing. In JSX, it is valid for any element to be self-closing.</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useSelfClosingElements.js:1:1
   <span style="color: rgb(38, 148, 255);">│</span>
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> <Foo.bar></Foo.bar>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> &lt;Foo.bar&gt;&lt;/Foo.bar&gt;
   <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
 
 <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a SelfClosingElement instead</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;"><Foo.bar></Foo.bar></span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"><Foo.bar /></span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">&lt;Foo.bar&gt;&lt;/Foo.bar&gt;</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">&lt;Foo.bar /&gt;</span>
 
 </code></pre>{% endraw %}
 

--- a/website/src/docs/lint/rules/useSingleCaseStatement.md
+++ b/website/src/docs/lint/rules/useSingleCaseStatement.md
@@ -1,0 +1,55 @@
+---
+title: Lint Rule useSingleCaseStatement
+layout: layouts/rule.liquid
+---
+
+# useSingleCaseStatement
+
+Enforces case clauses have a single statement, emits a quick fix wrapping
+the statements in a block
+
+## Examples
+
+### Invalid
+
+```jsx
+switch (foo) {
+    case true:
+    case false:
+        let foo = '';
+        foo;
+}
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useSingleCaseStatement</span><span style="color: Orange;">]</span><em>: </em><em>A switch case should only have a single statement. If you want more, then wrap it in a block.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useSingleCaseStatement.js:4:9
+  <span style="color: rgb(38, 148, 255);">│</span>  
+<span style="color: rgb(38, 148, 255);">4</span> <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">┌</span>         let foo = '';
+<span style="color: rgb(38, 148, 255);">5</span> <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">│</span>         foo;
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">└</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">'</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Wrap the statements in a block</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1,6 +1,7 @@</span>
+0 0 |   switch (foo) {
+1 1 |       case true:
+2   | <span style="color: Tomato;">- </span><span style="color: Tomato;">    case false:</span>
+  2 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">    case false: {</span>
+3 3 |           let foo = '';
+4 4 |           foo;
+  5 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">    }</span>
+5 6 |   }
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+switch (foo) {
+    case true:
+    case false: {
+        let foo = '';
+        foo;
+    }
+}
+```
+

--- a/website/src/docs/lint/rules/useSingleVarDeclarator.md
+++ b/website/src/docs/lint/rules/useSingleVarDeclarator.md
@@ -1,0 +1,36 @@
+---
+title: Lint Rule useSingleVarDeclarator
+layout: layouts/rule.liquid
+---
+
+# useSingleVarDeclarator
+
+Disallow multiple variable declarations in the same variable statement
+
+## Examples
+
+### Invalid
+
+```jsx
+let foo, bar;
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useSingleVarDeclarator</span><span style="color: Orange;">]</span><em>: </em><em>Declare variables separately</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useSingleVarDeclarator.js:1:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> let foo, bar;
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Break out into multiple declarations</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">let foo, bar;</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">let foo;let bar;</span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+for (let i = 0, x = 1; i < arr.length; i++) {}
+```
+

--- a/website/src/docs/lint/rules/useValidTypeof.md
+++ b/website/src/docs/lint/rules/useValidTypeof.md
@@ -20,7 +20,7 @@ typeof foo === "strnig"
 {% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:16
   <span style="color: rgb(38, 148, 255);">│</span>
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo === "strnig"
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo === &quot;strnig&quot;
   <span style="color: rgb(38, 148, 255);">│</span>                <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
 
 </code></pre>{% endraw %}
@@ -32,7 +32,7 @@ typeof foo == "undefimed"
 {% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:15
   <span style="color: rgb(38, 148, 255);">│</span>
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo == "undefimed"
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo == &quot;undefimed&quot;
   <span style="color: rgb(38, 148, 255);">│</span>               <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
 
 </code></pre>{% endraw %}
@@ -44,7 +44,7 @@ typeof bar != "nunber"
 {% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:15
   <span style="color: rgb(38, 148, 255);">│</span>
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof bar != "nunber"
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof bar != &quot;nunber&quot;
   <span style="color: rgb(38, 148, 255);">│</span>               <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
 
 </code></pre>{% endraw %}
@@ -56,7 +56,7 @@ typeof bar !== "fucntion"
 {% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:16
   <span style="color: rgb(38, 148, 255);">│</span>
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof bar !== "fucntion"
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof bar !== &quot;fucntion&quot;
   <span style="color: rgb(38, 148, 255);">│</span>                <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
 
 </code></pre>{% endraw %}
@@ -74,7 +74,7 @@ typeof foo === undefined
 <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Compare the result of `typeof` with a valid type name</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
 0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">typeof foo === undefined</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">typeof foo === "undefined"</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">typeof foo === &quot;undefined&quot;</span>
 
 </code></pre>{% endraw %}
 
@@ -91,7 +91,7 @@ typeof bar == Object
 <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Compare the result of `typeof` with a valid type name</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
 0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">typeof bar == Object</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">typeof bar == "object"</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">typeof bar == &quot;object&quot;</span>
 
 </code></pre>{% endraw %}
 

--- a/website/src/docs/lint/rules/useValidTypeof.md
+++ b/website/src/docs/lint/rules/useValidTypeof.md
@@ -1,0 +1,147 @@
+---
+title: Lint Rule useValidTypeof
+layout: layouts/rule.liquid
+---
+
+# useValidTypeof
+
+This rule verifies the result of `typeof $expr` unary expressions is being
+compared to valid values, either string literals containing valid type
+names or other `typeof` expressions
+
+## Examples
+
+### Invalid
+
+```jsx
+typeof foo === "strnig"
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:16
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo === "strnig"
+  <span style="color: rgb(38, 148, 255);">│</span>                <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+typeof foo == "undefimed"
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:15
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo == "undefimed"
+  <span style="color: rgb(38, 148, 255);">│</span>               <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+typeof bar != "nunber"
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:15
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof bar != "nunber"
+  <span style="color: rgb(38, 148, 255);">│</span>               <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+typeof bar !== "fucntion"
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:16
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof bar !== "fucntion"
+  <span style="color: rgb(38, 148, 255);">│</span>                <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+typeof foo === undefined
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:16
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo === undefined
+  <span style="color: rgb(38, 148, 255);">│</span>                <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a string literal</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Compare the result of `typeof` with a valid type name</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">typeof foo === undefined</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">typeof foo === "undefined"</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+typeof bar == Object
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:15
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof bar == Object
+  <span style="color: rgb(38, 148, 255);">│</span>               <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a string literal</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Compare the result of `typeof` with a valid type name</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">typeof bar == Object</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">typeof bar == "object"</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+typeof foo === baz
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:16
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo === baz
+  <span style="color: rgb(38, 148, 255);">│</span>                <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a string literal</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+typeof foo == 5
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:15
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo == 5
+  <span style="color: rgb(38, 148, 255);">│</span>               <span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a string literal</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+typeof foo == -5
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useValidTypeof</span><span style="color: Orange;">]</span><em>: </em><em>Invalid `typeof` comparison value</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useValidTypeof.js:1:15
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> typeof foo == -5
+  <span style="color: rgb(38, 148, 255);">│</span>               <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">not a string literal</span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+typeof foo === "string"
+```
+
+```jsx
+typeof bar == "undefined"
+```
+
+```jsx
+typeof bar === typeof qux
+```
+

--- a/website/src/docs/lint/rules/useWhile.md
+++ b/website/src/docs/lint/rules/useWhile.md
@@ -1,0 +1,35 @@
+---
+title: Lint Rule useWhile
+layout: layouts/rule.liquid
+---
+
+# useWhile
+
+Enforce the use of `while` loops instead of `for` loops when the
+initializer and update expressions are not needed
+
+## Examples
+
+### Invalid
+
+```jsx
+for (; x.running;) {
+    x.step();
+}
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">useWhile</span><span style="color: Orange;">]</span><em>: </em><em>Use </em><em><em>while</em></em><em> loops instead of </em><em><em>for</em></em><em> loops.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> useWhile.js:1:1
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> for (; x.running;) {
+  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use a while loop</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1,3 +1,3 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">for (; x.running;) {</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">while (x.running) {</span>
+1 1 |       x.step();
+2 2 |   }
+
+</code></pre>{% endraw %}
+

--- a/xtask/lintdoc/Cargo.toml
+++ b/xtask/lintdoc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xtask_lintdoc"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+xtask = { path = '../', version = "0.0" }
+rome_analyze = { path = "../../crates/rome_analyze" }
+rome_console = { path = "../../crates/rome_console" }
+rome_diagnostics = { path = "../../crates/rome_diagnostics" }
+rome_js_analyze = { path = "../../crates/rome_js_analyze" }
+rome_js_parser = { path = "../../crates/rome_js_parser" }
+rome_js_syntax = { path = "../../crates/rome_js_syntax" }
+pulldown-cmark = { version = "0.9", default-features = false }

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -1,0 +1,353 @@
+use std::{fmt::Write as _, io::Write as _, path::Path, slice};
+
+use pulldown_cmark::{escape::escape_html, CodeBlockKind, Event, LinkType, Options, Parser, Tag};
+use rome_console::{
+    fmt::{Formatter, HTML},
+    markup,
+};
+use rome_diagnostics::{file::SimpleFile, Diagnostic};
+use xtask::{glue::fs2, *};
+
+use rome_analyze::{AnalysisFilter, ControlFlow};
+use rome_js_analyze::{analyze, metadata};
+use rome_js_syntax::SourceType;
+
+fn main() -> Result<()> {
+    let root = project_root().join("website/src/docs/lint/rules");
+
+    // Clear the rules directory
+    fs2::remove_dir_all(&root)?;
+    fs2::create_dir_all(&root)?;
+
+    // Content of the index page
+    let mut index = String::new();
+    writeln!(index, "---")?;
+    writeln!(index, "title: Lint Rules")?;
+    writeln!(index, "layout: layouts/page.liquid")?;
+    writeln!(index, "layout-type: split")?;
+    writeln!(index, "main-class: rules")?;
+    writeln!(index, "eleventyNavigation:")?;
+    writeln!(index, "  key: lint-rules")?;
+    writeln!(index, "  parent: linting")?;
+    writeln!(index, "  title: Rules")?;
+    writeln!(index, "---")?;
+    writeln!(index)?;
+
+    writeln!(index, "# Rules")?;
+    writeln!(index)?;
+
+    writeln!(index, "<section>")?;
+    // TODO: Update this when rule groups are implemented
+    writeln!(index, "<h2>JavaScript</h2>")?;
+
+    // Accumulate errors for all lint rules to print all outstanding issues on
+    // failure instead of just the first one
+    let mut errors = Vec::new();
+
+    for (name, docs) in metadata() {
+        match generate_rule(&root, name, docs) {
+            Ok(summary) => {
+                writeln!(index, "<div class=\"rule\">")?;
+                writeln!(index, "<h3 data-toc-exclude id=\"{name}\">")?;
+                writeln!(index, "	<a href=\"/docs/lint/rules/{name}\">{name}</a>")?;
+                writeln!(index, "	<a class=\"header-anchor\" href=\"#{name}\"></a>")?;
+                writeln!(index, "</h3>")?;
+                escape_html(&mut index, &summary)?;
+                writeln!(index, "\n</div>")?;
+            }
+            Err(err) => {
+                errors.push((name, err));
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        bail!(
+            "failed to generate documentation pages for the following rules:\n{}",
+            errors
+                .into_iter()
+                .map(|(rule, err)| format!("- {rule}: {err:?}\n"))
+                .collect::<String>()
+        );
+    }
+
+    writeln!(index, "</section>")?;
+
+    fs2::write(root.join("index.md"), index)?;
+
+    Ok(())
+}
+
+/// Generates the documentation page for a single lint rule
+fn generate_rule(root: &Path, name: &'static str, docs: &'static str) -> Result<String> {
+    let mut content = Vec::new();
+
+    // Write the header for this lint rule
+    writeln!(content, "---")?;
+    writeln!(content, "title: Lint Rule {name}")?;
+    writeln!(content, "layout: layouts/rule.liquid")?;
+    writeln!(content, "---")?;
+    writeln!(content)?;
+
+    writeln!(content, "# {name}")?;
+    writeln!(content)?;
+
+    let summary = if !docs.is_empty() {
+        parse_documentation(name, docs, &mut content)?
+    } else {
+        // Default content if the rule has no documentation
+        writeln!(content, "MISSING DOCUMENTATION")?;
+        String::from("MISSING DOCUMENTATION")
+    };
+
+    fs2::write(root.join(format!("{name}.md")), content)?;
+
+    Ok(summary)
+}
+
+/// Parse the documentation fragment for a lint rule (in markdown) and generates
+/// the content for the corresponding documentation page
+fn parse_documentation(
+    name: &'static str,
+    docs: &'static str,
+    content: &mut Vec<u8>,
+) -> Result<String> {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_HEADING_ATTRIBUTES);
+    let parser = Parser::new_ext(docs, options);
+
+    // Content of the first paragraph of documentation, used as a short summary
+    // of what the rule does in the rules index
+    let mut summary = String::new();
+    let mut is_summary = true;
+
+    // Tracks the content of the current code block if it's using a
+    // language supported for analysis
+    let mut language = None;
+
+    // Tracks whether the current section of documentation is expected to
+    // contain failing or passing tests
+    let mut section = SectionKind::None;
+
+    enum SectionKind {
+        None,
+        Invalid,
+        Valid,
+    }
+
+    for event in parser {
+        match event {
+            // CodeBlock-specific handling
+            Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(meta))) => {
+                // If this is a `valid` or `invalid` section, track the content
+                // of code blocks to pass them through the analyzer
+                if !matches!(section, SectionKind::None) {
+                    match meta.as_ref() {
+                        "js" | "javascript" => {
+                            language = Some((SourceType::js_module(), String::new()));
+                        }
+                        "jsx" => {
+                            language = Some((SourceType::jsx(), String::new()));
+                        }
+
+                        // TODO: Should all language names be explicitly
+                        // supported, of silently ignore unknown languages ?
+                        other => bail!("unsupported code block language {other:?}"),
+                    }
+                }
+
+                writeln!(content, "```{meta}")?;
+            }
+
+            Event::End(Tag::CodeBlock(_)) => {
+                writeln!(content, "```")?;
+                writeln!(content)?;
+
+                if let Some((source_type, block)) = language.take() {
+                    let should_fail = matches!(section, SectionKind::Invalid);
+
+                    if should_fail {
+                        write!(
+                            content,
+                            "{{% raw %}}<pre class=\"language-text\"><code class=\"language-text\">"
+                        )?;
+                    }
+
+                    assert_lint(name, source_type, &block, should_fail, content)
+                        .context("snapshot test failed")?;
+
+                    if should_fail {
+                        writeln!(content, "</code></pre>{{% endraw %}}")?;
+                        writeln!(content)?;
+                    }
+                }
+            }
+
+            Event::Text(text) => {
+                if is_summary {
+                    write!(summary, "{text}")?;
+                }
+
+                if let Some((_, block)) = &mut language {
+                    write!(block, "{text}")?;
+                }
+
+                write!(content, "{text}")?;
+            }
+
+            // Other markdown events are emitted as-is
+            Event::Start(Tag::Heading(level, fragment, _)) => {
+                write!(content, "{} ", "#".repeat(level as usize))?;
+
+                match fragment {
+                    Some("valid") => {
+                        section = SectionKind::Valid;
+                    }
+                    Some("invalid") => {
+                        section = SectionKind::Invalid;
+                    }
+                    _ => {}
+                }
+            }
+            Event::End(Tag::Heading(..)) => {
+                writeln!(content)?;
+                writeln!(content)?;
+            }
+
+            Event::Start(Tag::Paragraph) => {}
+            Event::End(Tag::Paragraph) => {
+                // Stop the summary at the first paragraph end
+                is_summary = false;
+
+                writeln!(content)?;
+                writeln!(content)?;
+            }
+
+            Event::Code(text) => {
+                write!(content, "`{text}`")?;
+
+                if is_summary {
+                    write!(summary, "`{text}`")?;
+                }
+            }
+
+            Event::Start(Tag::Link(kind, _, _)) => {
+                assert_eq!(kind, LinkType::Inline, "unimplemented link type");
+                write!(content, "[")?;
+
+                if is_summary {
+                    write!(summary, "[")?;
+                }
+            }
+            Event::End(Tag::Link(_, url, title)) => {
+                write!(content, "]({url}")?;
+                if !title.is_empty() {
+                    write!(content, " \"{title}\"")?;
+                }
+                write!(content, ")")?;
+
+                if is_summary {
+                    write!(summary, "]({url}")?;
+                    if !title.is_empty() {
+                        write!(summary, " \"{title}\"")?;
+                    }
+                    write!(summary, ")")?;
+                }
+            }
+
+            Event::SoftBreak => {
+                if is_summary {
+                    writeln!(summary)?;
+                }
+
+                writeln!(content)?;
+            }
+
+            _ => {
+                // TODO: Implement remaining events as required
+                bail!("unimplemented event {event:?}")
+            }
+        }
+    }
+
+    Ok(summary)
+}
+
+/// Parse and analyze the provided code block, and asserts that it emits
+/// exactly zero or one diagnostic depending on the value of `should_fail`.
+/// That diagnostic is then emitted as text into the `content` buffer
+fn assert_lint(
+    name: &'static str,
+    source_type: SourceType,
+    code: &str,
+    should_fail: bool,
+    content: &mut Vec<u8>,
+) -> Result<()> {
+    let file = SimpleFile::new(format!("{name}.js"), code.into());
+
+    // TODO: Emit markup as HTML
+    let mut write = HTML(content);
+    let mut diagnostic_count = 0;
+
+    let mut write_diagnostic = |diag: Diagnostic| {
+        // Fail the test if the analysis returns more diagnostics than expected
+        if should_fail {
+            ensure!(
+                diagnostic_count == 0,
+                "analysis returned multiple diagnostics"
+            );
+        } else {
+            bail!("analysis returned an unexpected diagnostic");
+        }
+
+        Formatter::new(&mut write).write_markup(markup! {
+            {diag.display(&file)}
+        })?;
+
+        diagnostic_count += 1;
+        Ok(())
+    };
+
+    let parse = rome_js_parser::parse(code, 0, source_type);
+
+    if parse.has_errors() {
+        for diag in parse.into_diagnostics() {
+            write_diagnostic(diag)?;
+        }
+    } else {
+        let root = parse.tree();
+        let filter = AnalysisFilter {
+            rules: Some(slice::from_ref(&name)),
+            ..AnalysisFilter::default()
+        };
+
+        let result = analyze(0, &root, filter, |signal| {
+            if let Some(mut diag) = signal.diagnostic() {
+                if let Some(action) = signal.action() {
+                    diag.suggestions.push(action.into());
+                }
+
+                let res = write_diagnostic(diag);
+
+                // Abort the analysis on error
+                if let Err(err) = res {
+                    return ControlFlow::Break(err);
+                }
+            }
+
+            ControlFlow::Continue(())
+        });
+
+        // Result is Some(_) if analysis aborted with an error
+        if let Some(err) = result {
+            return Err(err);
+        }
+    }
+
+    if should_fail {
+        // Fail the test if the analysis didn't emit any diagnostic
+        ensure!(diagnostic_count == 1, "analysis returned no diagnostics");
+    }
+
+    Ok(())
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 
 pub use crate::glue::{pushd, pushenv};
 
-pub use anyhow::{bail, Context as _, Result};
+pub use anyhow::{anyhow, bail, ensure, Context as _, Result};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Mode {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 
 pub use crate::glue::{pushd, pushenv};
 
-pub use anyhow::{anyhow, bail, ensure, Context as _, Result};
+pub use anyhow::{anyhow, bail, ensure, Context as _, Error, Result};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Mode {


### PR DESCRIPTION
## Summary

This PR adds a new `cargo lintdoc` automatically generating markdown documentation pages on the website for all registered lint rules

Internally this command relies on the content of the doc-comments of each lint rule that's now available as a runtime metadata alongside the name of the rule itself. A new `metadata()` method is available on the `RuleRegistry` to get the name and documentation of each active rule, and this method is aliased as the plain function `rome_js_analyze::metadata()` for the default instance of the JS rule registry.

The `xtask_lintdoc` crate makes use of this metadata by parsing the content of the comments as markdown, running the detected code blocks through the analyzer (similar to the "doctest" feature of `rustdoc`), and inserting snapshots of the emitted diagnostics if the analysis returned errors (using a newly-introduced HTML printer for `rome_console` markup)

## Test Plan

At the moment I've only run the new generation command manually, but it will probably need to be integrated to the automated test suite to ensure the generated files are kept up to date
