### PR TITLE
fix(rome_formatter): `dbg_write` API compatibility with `write`

### DIFF
--- a/crates/rome_formatter/src/buffer.rs
+++ b/crates/rome_formatter/src/buffer.rs
@@ -391,7 +391,7 @@ pub struct Inspect<'inner, Context, Inspector> {
 }
 
 impl<'inner, Context, Inspector> Inspect<'inner, Context, Inspector> {
-    pub fn new(inner: &'inner mut dyn Buffer<Context = Context>, inspector: Inspector) -> Self {
+    fn new(inner: &'inner mut dyn Buffer<Context = Context>, inspector: Inspector) -> Self {
         Self { inner, inspector }
     }
 }
@@ -432,6 +432,18 @@ pub trait BufferExtensions: Buffer + Sized {
         F: FnMut(&FormatElement),
     {
         Inspect::new(self, inspector)
+    }
+
+    /// Writes a sequence of elements into this buffer.
+    fn write_elements<I>(&mut self, elements: I) -> FormatResult<()>
+    where
+        I: IntoIterator<Item = FormatElement>,
+    {
+        for element in elements {
+            self.write_element(element)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -84,7 +84,7 @@ macro_rules! write {
 /// let mut state = FormatState::new(SimpleFormatContext::default());
 /// let mut buffer = VecBuffer::new(&mut state);
 ///
-/// dbg_write!(&mut buffer, [token("Hello")]).unwrap();
+/// dbg_write!(buffer, [token("Hello")]).unwrap();
 /// // ^-- prints: [src/main.rs:7][0] = StaticToken("Hello")
 ///
 /// assert_eq!(buffer.into_element(), FormatElement::Token(Token::Static { text: "Hello" }));
@@ -96,8 +96,9 @@ macro_rules! write {
 #[macro_export]
 macro_rules! dbg_write {
     ($dst:expr, [$($arg:expr),+ $(,)?]) => {{
+        use $crate::BufferExtensions;
         let mut count = 0;
-        let mut inspect = $crate::Inspect::new($dst, |element: &FormatElement| {
+        let mut inspect = $dst.inspect(|element: &FormatElement| {
             std::eprintln!(
                 "[{}:{}][{}] = {element:#?}",
                 std::file!(), std::line!(), count


### PR DESCRIPTION
## Summary

This PR ensures that the `buffer` argument of `dbg_write!` is compatible with the `buffer` argument of `write!` so that the two can be swapped without any changes to the debugged code.

The current implementation hasn't been compatible because the `dbg_write!` macro called into `Inspect::new` that expected a `&mut Buffer` which requires the use of `&mut buffer` if an implementation uses a local `Buffer` variable.

This PR changes the macro implementation to use `Buffer.inspect` instead that works for any mutable `Buffer`.

## Test Plan

I changed the `dbg_write` macro test to pass in `buffer` without `&mut`. 