### PR TITLE
refactor(rome_formatter): Group leading comments

### DIFF
--- a/crates/rome_formatter/src/arguments.rs
+++ b/crates/rome_formatter/src/arguments.rs
@@ -144,10 +144,10 @@ mod tests {
                 FormatElement::Space,
                 FormatElement::Token(Token::Static { text: "a" }),
                 FormatElement::Space,
-                FormatElement::Group(Group::new(FormatElement::List(List::new(vec![
+                FormatElement::Group(Group::new(vec![
                     FormatElement::Token(Token::Static { text: "(" }),
                     FormatElement::Token(Token::Static { text: ")" }),
-                ]))))
+                ]))
             ]))
         );
     }

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -931,19 +931,29 @@ impl<Context> Format<Context> for GroupElements<'_, Context> {
 
         buffer.write_fmt(Arguments::from(&self.content))?;
 
-        let content = buffer.into_element();
+        let mut content = buffer.into_vec();
 
-        let (leading, content, trailing) = content.split_trivia();
+        // Move the leading comments out of the group to prevent that a leading line comment expands the
+        // token's enclosing group.
+        //
+        // ```javascript
+        // /* a comment */
+        // [1]
+        // ```
+        //
+        // The `/* a comment */` belongs to the `[` group token that is part of a group wrapping the whole
+        // `[1]` expression. It's important that the comment `/* a comment */` gets moved out of the group element
+        // to avoid that the `[1]` group expands because of the line break inserted by the comment.
+        let leading_end = content
+            .iter()
+            .position(|element| !matches!(element, FormatElement::Comment(_)))
+            .unwrap_or(content.len());
+
+        f.write_elements(content.drain(..leading_end))?;
+
         let group = Group::new(content).with_id(self.group_id);
 
-        if !leading.is_empty() {
-            f.write_element(leading)?;
-        }
         f.write_element(FormatElement::Group(group))?;
-
-        if !trailing.is_empty() {
-            f.write_element(trailing)?;
-        }
 
         Ok(())
     }

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -470,7 +470,7 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 ///     SimpleFormatContext::default(),
 ///     [
 ///         group_elements(&format_args![
-///             comments(&format_args![token("// test"), hard_line_break()]).leading(true),
+///             comments(&format_args![token("// test"), hard_line_break()], CommentPosition::Leading),
 ///             token("a"),
 ///             soft_line_break_or_space(),
 ///             token("b")
@@ -484,27 +484,23 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 /// );
 /// ```
 #[inline]
-pub fn comments<Content, Context>(content: &Content) -> FormatComments<Context>
+pub fn comments<Content, Context>(
+    content: &Content,
+    position: CommentPosition,
+) -> FormatComments<Context>
 where
     Content: Format<Context>,
 {
     FormatComments {
         content: Argument::new(content),
-        leading: false,
+        position,
     }
 }
 
 #[derive(Copy, Clone)]
 pub struct FormatComments<'a, Context> {
     content: Argument<'a, Context>,
-    leading: bool,
-}
-
-impl<Context> FormatComments<'_, Context> {
-    pub fn leading(mut self, leading: bool) -> Self {
-        self.leading = leading;
-        self
-    }
+    position: CommentPosition,
 }
 
 impl<Context> Format<Context> for FormatComments<'_, Context> {
@@ -516,7 +512,7 @@ impl<Context> Format<Context> for FormatComments<'_, Context> {
 
         f.write_element(FormatElement::Comments {
             content: content.into_boxed_slice(),
-            leading: self.leading,
+            position: self.position,
         })
     }
 }

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -48,7 +48,7 @@ use crate::printer::{Printer, PrinterOptions};
 pub use arguments::{Argument, Arguments};
 pub use buffer::{Buffer, BufferExtensions, BufferSnapshot, Inspect, PreambleBuffer, VecBuffer};
 pub use builders::{
-    block_indent, comment, empty_line, get_lines_before, group_elements, hard_line_break,
+    block_indent, comments, empty_line, get_lines_before, group_elements, hard_line_break,
     if_group_breaks, if_group_fits_on_line, indent, line_suffix, soft_block_indent,
     soft_line_break, soft_line_break_or_space, soft_line_indent_or_space, space_token, token,
     BestFitting,

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -129,7 +129,11 @@ impl<'a> Printer<'a> {
                     PrintMode::Flat if self.state.measured_group_fits => {
                         // A parent group has already verified that this group fits on a single line
                         // Thus, just continue in flat mode
-                        queue.enqueue(PrintElementCall::new(content.as_ref(), args));
+                        queue.extend(
+                            content
+                                .iter()
+                                .map(|element| PrintElementCall::new(element, args)),
+                        );
                         PrintMode::Flat
                     }
                     // The printer is either in expanded mode or it's necessary to re-measure if the group fits
@@ -139,15 +143,16 @@ impl<'a> Printer<'a> {
                         // print the group in "flat" mode, otherwise continue in expanded mode
 
                         let flat_args = args.with_print_mode(PrintMode::Flat);
-                        if fits_on_line(&[content], flat_args, queue, self) {
-                            queue.enqueue(PrintElementCall::new(content, flat_args));
+                        if fits_on_line(content.iter(), flat_args, queue, self) {
+                            queue.extend(
+                                content.iter().map(|e| PrintElementCall::new(e, flat_args)),
+                            );
                             self.state.measured_group_fits = true;
                             PrintMode::Flat
                         } else {
-                            queue.enqueue(PrintElementCall::new(
-                                content,
-                                args.with_print_mode(PrintMode::Expanded),
-                            ));
+                            queue.extend(content.iter().map(|e| {
+                                PrintElementCall::new(e, args.with_print_mode(PrintMode::Expanded))
+                            }));
                             PrintMode::Expanded
                         }
                     }
@@ -279,7 +284,7 @@ impl<'a> Printer<'a> {
                                     PrintMode::Expanded
                                 };
 
-                                if fits_on_line(&[variant], args.with_print_mode(mode), queue, self)
+                                if fits_on_line([variant], args.with_print_mode(mode), queue, self)
                                 {
                                     self.state.measured_group_fits = true;
 
@@ -362,7 +367,7 @@ impl<'a> Printer<'a> {
         };
 
         let mut current_fits = fits_on_line(
-            &[current_content],
+            [current_content],
             args.with_print_mode(PrintMode::Flat),
             &empty_rest,
             self,
@@ -384,7 +389,7 @@ impl<'a> Printer<'a> {
             // otherwise see if both contents fit on the line.
             let current_and_next_fit = current_fits
                 && fits_on_line(
-                    &[separator, next_item],
+                    [separator, next_item],
                     args.with_print_mode(PrintMode::Flat),
                     &empty_rest,
                     self,
@@ -406,7 +411,7 @@ impl<'a> Printer<'a> {
                 );
 
                 let next_fits = fits_on_line(
-                    &[next_item],
+                    [next_item],
                     args.with_print_mode(PrintMode::Flat),
                     &empty_rest,
                     self,
@@ -626,12 +631,16 @@ impl<'a> ElementCallQueue<'a> {
 /// Tests if it's possible to print the content of the queue up to the first hard line break
 /// or the end of the document on a single line without exceeding the line width.
 #[must_use = "Only determines if content fits on a single line but doesn't print it"]
-fn fits_on_line<'a>(
-    elements: &[&'a FormatElement],
+fn fits_on_line<'a, I>(
+    elements: I,
     args: PrintElementArgs,
     queue: &ElementCallQueue<'a>,
     printer: &mut Printer<'a>,
-) -> bool {
+) -> bool
+where
+    I: IntoIterator<Item = &'a FormatElement>,
+    I::IntoIter: DoubleEndedIterator,
+{
     let shared_buffer = std::mem::take(&mut printer.state.measure_queue);
     debug_assert!(shared_buffer.is_empty());
 
@@ -641,7 +650,7 @@ fn fits_on_line<'a>(
 
     measure_queue.extend(
         elements
-            .iter()
+            .into_iter()
             .map(|element| PrintElementCall::new(element, args)),
     );
 
@@ -726,7 +735,9 @@ fn fits_element_on_line<'a, 'rest>(
             args.with_incremented_indent(),
         )),
 
-        FormatElement::Group(group) => queue.enqueue(PrintElementCall::new(&group.content, args)),
+        FormatElement::Group(group) => {
+            queue.extend(group.content.iter().map(|e| PrintElementCall::new(e, args)))
+        }
 
         FormatElement::ConditionalGroupContent(conditional) => {
             if args.mode == conditional.mode {

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -8,6 +8,7 @@ use crate::format_element::{
 use crate::intersperse::Intersperse;
 use crate::{FormatElement, GroupId, Printed, SourceMarker, TextRange};
 
+use crate::prelude::CommentPosition;
 use rome_rowan::TextSize;
 use std::iter::{once, Rev};
 
@@ -853,10 +854,12 @@ fn fits_element_on_line<'a, 'rest>(
             }
         }
 
-        FormatElement::Comments { content, leading } => queue.extend(content.iter().map(|e| {
+        FormatElement::Comments { content, position } => queue.extend(content.iter().map(|e| {
             PrintElementCall::new(
                 e,
-                args.with_in_leading_comment(*leading && state.line_width == 0),
+                args.with_in_leading_comment(
+                    *position == CommentPosition::Leading && state.line_width == 0,
+                ),
             )
         })),
 
@@ -1235,11 +1238,14 @@ two lines`,
                 token("]")
             ]),
             token(";"),
-            comments(&line_suffix(&format_args![
-                space_token(),
-                token("// trailing"),
-                space_token()
-            ]))
+            comments(
+                &line_suffix(&format_args![
+                    space_token(),
+                    token("// trailing"),
+                    space_token()
+                ]),
+                CommentPosition::Trailing
+            )
         ]);
 
         assert_eq!(printed.as_code(), "[1, 2, 3]; // trailing")

--- a/crates/rome_formatter/src/token.rs
+++ b/crates/rome_formatter/src/token.rs
@@ -755,26 +755,31 @@ where
     S: CommentStyle,
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
-        for (index, comment) in self.comments.iter().enumerate() {
-            if f.state().is_comment_formatted(comment.piece()) {
-                continue;
-            }
+        if self.comments.is_empty() {
+            return Ok(());
+        }
 
-            let is_line_comment = self
-                .options
-                .style
-                .get_comment_kind(comment.piece())
-                .is_line();
-            let lines_after = self
-                .comments
-                .get(index + 1)
-                .map(|comment| comment.lines_before())
-                .unwrap_or_else(|| match self.options.trim_mode {
-                    TriviaPrintMode::Full => self.lines_before_token,
-                    TriviaPrintMode::Trim => 0,
-                });
+        let format_comments = format_with(|f| {
+            for (index, comment) in self.comments.iter().enumerate() {
+                if f.state().is_comment_formatted(comment.piece()) {
+                    continue;
+                }
 
-            let format_content = format_with(|f| {
+                let is_line_comment = self
+                    .options
+                    .style
+                    .get_comment_kind(comment.piece())
+                    .is_line();
+
+                let lines_after = self
+                    .comments
+                    .get(index + 1)
+                    .map(|comment| comment.lines_before())
+                    .unwrap_or_else(|| match self.options.trim_mode {
+                        TriviaPrintMode::Full => self.lines_before_token,
+                        TriviaPrintMode::Trim => 0,
+                    });
+
                 if comment.lines_before() > 0 && index == 0 {
                     write!(f, [hard_line_break()])?;
                 } else {
@@ -798,14 +803,11 @@ where
                         _ => write!(f, [empty_line()])?,
                     }
                 };
+            }
+            Ok(())
+        });
 
-                Ok(())
-            });
-
-            write!(f, [crate::comment(&format_content)])?;
-        }
-
-        Ok(())
+        write!(f, [comments(&format_comments).leading(true)])
     }
 }
 
@@ -878,16 +880,19 @@ where
         let comments = self.comments.clone();
         let mut last_inline_comment = false;
 
-        for (index, comment) in comments.enumerate() {
-            if !self.skip_formatted_check && f.state().is_comment_formatted(comment.piece()) {
-                continue;
-            }
+        let mut comments = comments.enumerate().peekable();
+        let is_empty = comments.peek().is_none();
 
-            let kind = self.style.get_comment_kind(comment.piece());
-            last_inline_comment = kind.is_inline();
-            let is_single_line = kind.is_line();
+        let format_comments = format_once(|f| {
+            for (index, comment) in comments {
+                if !self.skip_formatted_check && f.state().is_comment_formatted(comment.piece()) {
+                    continue;
+                }
 
-            let content = format_with(|f| {
+                let kind = self.style.get_comment_kind(comment.piece());
+                last_inline_comment = kind.is_inline();
+                let is_single_line = kind.is_line();
+
                 if !is_single_line {
                     match self.token_kind {
                         // Don't write a space if this is a group start token and it isn't the first trailing comment
@@ -905,15 +910,16 @@ where
                         ]
                     ]?;
                 }
+            }
 
-                Ok(())
-            });
+            Ok(())
+        });
 
-            crate::comment(&content).fmt(f)?;
+        if !is_empty {
+            crate::comments(&format_comments).fmt(f)?;
+            f.state_mut()
+                .set_last_content_is_inline_comment(last_inline_comment);
         }
-
-        f.state_mut()
-            .set_last_content_is_inline_comment(last_inline_comment);
 
         Ok(())
     }

--- a/crates/rome_formatter/src/token.rs
+++ b/crates/rome_formatter/src/token.rs
@@ -807,7 +807,7 @@ where
             Ok(())
         });
 
-        write!(f, [comments(&format_comments).leading(true)])
+        write!(f, [comments(&format_comments, CommentPosition::Leading)])
     }
 }
 
@@ -883,6 +883,10 @@ where
         let mut comments = comments.enumerate().peekable();
         let is_empty = comments.peek().is_none();
 
+        if is_empty {
+            return Ok(());
+        }
+
         let format_comments = format_once(|f| {
             for (index, comment) in comments {
                 if !self.skip_formatted_check && f.state().is_comment_formatted(comment.piece()) {
@@ -915,12 +919,9 @@ where
             Ok(())
         });
 
-        if !is_empty {
-            crate::comments(&format_comments).fmt(f)?;
-            f.state_mut()
-                .set_last_content_is_inline_comment(last_inline_comment);
-        }
-
+        crate::comments(&format_comments, CommentPosition::Trailing).fmt(f)?;
+        f.state_mut()
+            .set_last_content_is_inline_comment(last_inline_comment);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

It's necessary to move leading comments outside a group to prevent they expand the enclosing group:

```javascript
/* a comment */
[1]
```

The `/* a comment */` belongs to the `[` group token that is part of a group wrapping the whole `[1]` expression. It's important that the comment `/* a comment */` gets moved out of the group element to avoid the `[1]` group expanding because of the line break inserted by the comment.

The `group_elements` implementation so far used `split_trivia` to accomplish this.

This PR changes the semantics of the `Comment` IR if `leading: true` is set to ignore line breaks when considering if an element fits for all leading comments that appear at the beginning of the line. This gives us the same behaviour as with `split_trivia` but without the need to move elements around.

I decided to change `Group` to store a `Box<[FormatElement]>` to avoid boxing List elements.

## Test Plan

`cargo test` because this PR isn't adding any new functionality

### Performance

This change improves performance marginally (split2 is this branch)

```
group                                    split                                  split2
-----                                    -----                                  ------
formatter/checker.ts                     1.04    201.2±1.88ms    12.9 MB/sec    1.00    192.7±1.09ms    13.5 MB/sec
formatter/compiler.js                    1.04    123.7±2.43ms     8.5 MB/sec    1.00    118.5±1.12ms     8.8 MB/sec
formatter/d3.min.js                      1.03     90.0±1.61ms     2.9 MB/sec    1.00     87.6±0.83ms     3.0 MB/sec
formatter/dojo.js                        1.01      6.4±0.10ms    10.7 MB/sec    1.00      6.4±0.02ms    10.8 MB/sec
formatter/ios.d.ts                       1.02    140.4±1.06ms    13.3 MB/sec    1.00    137.6±0.86ms    13.6 MB/sec
formatter/jquery.min.js                  1.01     26.9±0.16ms     3.1 MB/sec    1.00     26.7±0.06ms     3.1 MB/sec
formatter/math.js                        1.03    207.2±1.93ms     3.1 MB/sec    1.00    200.4±3.35ms     3.2 MB/sec
formatter/parser.ts                      1.03      4.4±0.08ms    11.1 MB/sec    1.00      4.2±0.06ms    11.4 MB/sec
formatter/pixi.min.js                    1.05    102.0±1.04ms     4.3 MB/sec    1.00     97.3±0.69ms     4.5 MB/sec
formatter/react-dom.production.min.js    1.04     30.8±0.06ms     3.7 MB/sec    1.00     29.6±0.21ms     3.9 MB/sec
formatter/react.production.min.js        1.02  1518.1±28.17µs     4.1 MB/sec    1.00  1483.7±25.72µs     4.1 MB/sec
formatter/router.ts                      1.02      3.4±0.03ms    18.2 MB/sec    1.00      3.3±0.02ms    18.5 MB/sec
formatter/tex-chtml-full.js              1.03    272.8±6.15ms     3.3 MB/sec    1.00    265.3±3.47ms     3.4 MB/sec
formatter/three.min.js                   1.06    123.5±2.33ms     4.8 MB/sec    1.00    116.5±0.77ms     5.0 MB/sec
formatter/typescript.js                  1.00    783.9±7.12ms    12.1 MB/sec    1.01   790.1±11.15ms    12.0 MB/sec
formatter/vue.global.prod.js             1.02     39.1±0.72ms     3.1 MB/sec    1.00     38.3±0.26ms     3.1 MB/sec
```
