### PR TITLE
refactor(rome_js_analyze): use `js_string_literal` helper function

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/no_unused_template_literal.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_unused_template_literal.rs
@@ -2,11 +2,10 @@ use rome_analyze::{ActionCategory, Rule, RuleCategory, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
-use rome_js_syntax::JsSyntaxKind::*;
 use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsAnyRoot, JsAnyTemplateElement, JsTemplate,
 };
-use rome_rowan::{AstNode, AstNodeExt, AstNodeList, SyntaxToken};
+use rome_rowan::{AstNode, AstNodeExt, AstNodeList};
 
 use crate::JsRuleAction;
 
@@ -39,7 +38,7 @@ impl Rule for NoUnusedTemplateLiteral {
         let inner_content = node
             .elements()
             .iter()
-            .fold(String::from("\""), |mut acc, cur| {
+            .fold(String::from(""), |mut acc, cur| {
                 match cur {
                     JsAnyTemplateElement::JsTemplateChunkElement(ele) => {
                         // Safety: if `ele.template_chunk_token()` is `Err` variant, [can_convert_to_string_lit] should return false,
@@ -57,12 +56,7 @@ impl Rule for NoUnusedTemplateLiteral {
             JsAnyExpression::JsTemplate(node.clone()),
             JsAnyExpression::JsAnyLiteralExpression(
                 JsAnyLiteralExpression::JsStringLiteralExpression(
-                    make::js_string_literal_expression(SyntaxToken::new_detached(
-                        JS_STRING_LITERAL,
-                        &(inner_content + "\""),
-                        [],
-                        [],
-                    )),
+                    make::js_string_literal_expression(make::js_string_literal(&inner_content)),
                 ),
             ),
         )?;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
1. use `make::js_string_literal` instead construct a `SyntaxToken` by hand
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. cargo test 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
