### PR TITLE
refactor(rome_js_formatter): Introduce `format_parenthesize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1375,6 +1375,7 @@ name = "rome_formatter"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
+ "indexmap",
  "rome_rowan",
  "tracing",
 ]

--- a/crates/rome_formatter/Cargo.toml
+++ b/crates/rome_formatter/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 rome_rowan = { path = "../rome_rowan" }
 tracing = { version = "0.1.31", default-features = false, features = ["std"] }
 cfg-if = "1.0.0"
+indexmap = "1.8.2"

--- a/crates/rome_formatter/src/buffer.rs
+++ b/crates/rome_formatter/src/buffer.rs
@@ -182,7 +182,7 @@ impl<'a, Context> VecBuffer<'a, Context> {
 
     /// Consumes the buffer and returns its content as a [`FormatElement`]
     pub fn into_element(mut self) -> FormatElement {
-        self.take()
+        self.take_element()
     }
 
     /// Consumes the buffer and returns the written [`FormatElement]`s as a vector.
@@ -191,7 +191,7 @@ impl<'a, Context> VecBuffer<'a, Context> {
     }
 
     /// Takes the elements without consuming self
-    pub fn take(&mut self) -> FormatElement {
+    pub fn take_element(&mut self) -> FormatElement {
         if self.len() == 1 {
             // Safety: Guaranteed by len check above
             self.elements.pop().unwrap()

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -6,7 +6,6 @@ use crate::{Buffer, VecBuffer};
 use rome_rowan::{Language, SyntaxNode, SyntaxToken, SyntaxTokenText, TextLen};
 use std::borrow::Cow;
 use std::cell::Cell;
-use std::fmt::Debug;
 use std::marker::PhantomData;
 
 /// A line break that only gets printed if the enclosing `Group` doesn't fit on a single line.

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -1,11 +1,14 @@
 use crate::prelude::*;
+use crate::token::{FormatInserted, InsertedToken};
 use crate::{
-    format_element, write, Argument, Arguments, GroupId, PreambleBuffer, TextRange, TextSize,
+    format_element, write, Argument, Arguments, CommentStyle, GroupId, PreambleBuffer, TextRange,
+    TextSize,
 };
 use crate::{Buffer, VecBuffer};
 use rome_rowan::{Language, SyntaxNode, SyntaxToken, SyntaxTokenText, TextLen};
 use std::borrow::Cow;
 use std::cell::Cell;
+use std::fmt::Debug;
 use std::marker::PhantomData;
 
 /// A line break that only gets printed if the enclosing `Group` doesn't fit on a single line.
@@ -1255,6 +1258,105 @@ impl<Context> std::fmt::Debug for IfGroupBreaks<'_, Context> {
     }
 }
 
+/// Inserts parenthesizes around some content.
+#[derive(Copy, Clone)]
+pub struct FormatParenthesize<'inner, Context, S>
+where
+    S: CommentStyle,
+{
+    open_paren: InsertedToken<<S::Language as Language>::Kind>,
+    content: Argument<'inner, Context>,
+    close_paren: InsertedToken<<S::Language as Language>::Kind>,
+    style: S,
+    group: bool,
+}
+
+impl<'inner, Context, S> FormatParenthesize<'inner, Context, S>
+where
+    S: CommentStyle,
+{
+    pub fn new<Content>(
+        open_paren: InsertedToken<<S::Language as Language>::Kind>,
+        content: &'inner Content,
+        close_paren: InsertedToken<<S::Language as Language>::Kind>,
+        style: S,
+    ) -> Self
+    where
+        Content: Format<Context>,
+    {
+        Self {
+            open_paren,
+            content: Argument::new(content),
+            close_paren,
+            style,
+            group: false,
+        }
+    }
+
+    pub fn grouped(mut self) -> Self {
+        self.group = true;
+        self
+    }
+}
+
+impl<Context, S> Format<Context> for FormatParenthesize<'_, Context, S>
+where
+    S: CommentStyle + 'static,
+{
+    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
+        // This may look odd but it's important to first write the opening parenthesis
+        // before writing the content to ensure that the tokens are formatted in the right order.
+        let mut buffer = VecBuffer::new(f.state_mut());
+        write!(buffer, [FormatInserted::new(self.open_paren, self.style)])?;
+        let l_paren_element = buffer.take_element();
+
+        buffer.write_fmt(Arguments::from(&self.content))?;
+        let formatted_node = buffer.into_element();
+
+        let (leading, content, trailing) = formatted_node.split_trivia();
+
+        f.write_element(leading)?;
+
+        let inner = format_once(|f| {
+            f.write_element(l_paren_element)?;
+
+            if self.group {
+                write!(
+                    f,
+                    [soft_block_indent(
+                        &format_once(|f| f.write_element(content))
+                    )]
+                )?;
+            } else {
+                f.write_element(content)?;
+            }
+
+            FormatInserted::new(self.close_paren, self.style).fmt(f)
+        });
+
+        if self.group {
+            write!(f, [group_elements(&inner)])?;
+        } else {
+            write!(f, [inner])?;
+        }
+
+        f.write_element(trailing)
+    }
+}
+
+impl<Context, S> Debug for FormatParenthesize<'_, Context, S>
+where
+    S: CommentStyle,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FormatParenthesize")
+            .field("open_paren", &self.open_paren)
+            .field("content", &"{{content}}")
+            .field("close_paren", &self.close_paren)
+            .finish()
+    }
+}
+
 /// Utility for formatting some content with an inline lambda function.
 #[derive(Copy, Clone)]
 pub struct FormatWith<Context, T> {
@@ -1695,7 +1797,7 @@ impl<Context> Format<Context> for BestFitting<'_, Context> {
         for variant in variants {
             buffer.write_fmt(Arguments::from(&*variant))?;
 
-            formatted_variants.push(buffer.take());
+            formatted_variants.push(buffer.take_element());
         }
 
         // SAFETY: The constructor guarantees that there are always at least two variants. It's, therefore,

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -56,7 +56,7 @@ pub use builders::{
 pub use comments::{CommentKind, SourceComment};
 pub use format_element::{normalize_newlines, FormatElement, Token, Verbatim, LINE_TERMINATORS};
 pub use group_id::GroupId;
-use indexmap::IndexMap;
+use indexmap::IndexSet;
 use rome_rowan::{
     Language, RawSyntaxKind, SyntaxElement, SyntaxError, SyntaxKind, SyntaxNode, SyntaxResult,
     SyntaxToken, SyntaxTriviaPieceComments, TextRange, TextSize, TokenAtOffset,
@@ -1083,7 +1083,7 @@ pub struct FormatState<Context> {
     /// Storing the position is sufficient because comments are guaranteed to not be empty
     /// (all start with a specific comment sequence) and thus, no two comments can have the same
     /// absolute position.
-    manually_formatted_comments: IndexMap<TextSize, ()>,
+    manually_formatted_comments: IndexSet<TextSize>,
 
     // This is using a RefCell as it only exists in debug mode,
     // the Formatter is still completely immutable in release builds
@@ -1115,7 +1115,7 @@ impl<Context> FormatState<Context> {
             group_id_builder: Default::default(),
             last_content_inline_comment: false,
             last_token_kind: None,
-            manually_formatted_comments: IndexMap::default(),
+            manually_formatted_comments: IndexSet::default(),
             #[cfg(debug_assertions)]
             printed_tokens: Default::default(),
         }
@@ -1175,7 +1175,7 @@ impl<Context> FormatState<Context> {
         comment: &SyntaxTriviaPieceComments<L>,
     ) {
         self.manually_formatted_comments
-            .insert(comment.text_range().start(), ());
+            .insert(comment.text_range().start());
     }
 
     /// Returns `true` if this comment has already been formatted manually
@@ -1185,7 +1185,7 @@ impl<Context> FormatState<Context> {
         comment: &SyntaxTriviaPieceComments<L>,
     ) -> bool {
         self.manually_formatted_comments
-            .contains_key(&comment.text_range().start())
+            .contains(&comment.text_range().start())
     }
 
     /// Returns the context specifying how to format the current CST

--- a/crates/rome_formatter/src/token.rs
+++ b/crates/rome_formatter/src/token.rs
@@ -240,7 +240,7 @@ impl<S> FormatInsertedCloseParen<S>
 where
     S: CommentStyle,
 {
-    pub fn new<Context>(
+    pub fn after_token<Context>(
         after_token: &Option<SyntaxToken<S::Language>>,
         kind: <S::Language as Language>::Kind,
         text: &'static str,

--- a/crates/rome_formatter/src/token.rs
+++ b/crates/rome_formatter/src/token.rs
@@ -33,9 +33,16 @@ where
     }
 }
 
-struct InsertedToken<Kind> {
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct InsertedToken<Kind> {
     kind: Kind,
     text: &'static str,
+}
+
+impl<Kind> InsertedToken<Kind> {
+    pub fn new(kind: Kind, text: &'static str) -> Self {
+        Self { kind, text }
+    }
 }
 
 /// Formats a token that has been inserted by the formatter and isn't present in the source text.
@@ -52,11 +59,8 @@ impl<S> FormatInserted<S>
 where
     S: CommentStyle,
 {
-    pub fn new(kind: <S::Language as Language>::Kind, text: &'static str, style: S) -> Self {
-        Self {
-            token: InsertedToken { kind, text },
-            style,
-        }
+    pub fn new(token: InsertedToken<<S::Language as Language>::Kind>, style: S) -> Self {
+        Self { token, style }
     }
 }
 
@@ -360,14 +364,17 @@ where
         )?;
 
         let is_last_content_inline_comment = f.state_mut().is_last_content_inline_comment();
+
         if needs_space_between_comments_and_token(
             &leading_comments,
             self.token.kind(),
             is_last_content_inline_comment,
             self.style,
         ) {
-            comment(&space_token()).fmt(f)?;
+            space_token().fmt(f)?;
         }
+
+        f.state_mut().set_last_content_is_inline_comment(false);
 
         Ok(())
     }

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::{AsFormat, JsCommentStyle};
 use rome_formatter::token::{
     format_token_trailing_trivia, FormatInserted, FormatLeadingTrivia, FormatOnlyIfBreaks,
-    FormatRemoved, FormatReplaced, TriviaPrintMode,
+    FormatRemoved, FormatReplaced, InsertedToken, TriviaPrintMode,
 };
 use rome_formatter::{format_args, write, Argument, Arguments, GroupId, PreambleBuffer, VecBuffer};
 use rome_js_syntax::{JsLanguage, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
@@ -46,10 +46,37 @@ where
 
 pub fn format_inserted(kind: JsSyntaxKind) -> FormatInserted<JsCommentStyle> {
     FormatInserted::new(
-        kind,
-        kind.to_string().expect("Expected a punctuation token"),
+        InsertedToken::new(
+            kind,
+            kind.to_string().expect("Expected a punctuation token"),
+        ),
         JsCommentStyle,
     )
+}
+
+/// Adds parentheses around some content
+pub fn format_parenthesize<Content>(
+    open_paren: JsSyntaxKind,
+    content: &Content,
+    close_paren: JsSyntaxKind,
+) -> FormatParenthesize<JsFormatContext, JsCommentStyle>
+where
+    Content: Format<JsFormatContext>,
+{
+    let open_paren = InsertedToken::new(
+        open_paren,
+        open_paren
+            .to_string()
+            .expect("Expected a punctuation token as the open paren token."),
+    );
+    let close_paren = InsertedToken::new(
+        close_paren,
+        close_paren
+            .to_string()
+            .expect("Expected a punctuation token as the close paren token."),
+    );
+
+    FormatParenthesize::new(open_paren, content, close_paren, JsCommentStyle)
 }
 
 /// Formats the leading and trailing trivia of a removed token.

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -71,7 +71,7 @@ pub fn format_inserted_close_paren(
     kind: JsSyntaxKind,
     f: &mut JsFormatter,
 ) -> FormatInsertedCloseParen<JsCommentStyle> {
-    FormatInsertedCloseParen::new(
+    FormatInsertedCloseParen::after_token(
         after_token,
         kind,
         kind.to_string()
@@ -124,7 +124,9 @@ pub struct FormatParenthesize<'content> {
 }
 
 impl FormatParenthesize<'_> {
-    pub fn grouped(mut self) -> Self {
+    /// Groups the open parenthesis, the content, and the closing parenthesis inside of a group
+    /// and indents the content with a soft block indent.
+    pub fn grouped_with_soft_block_indent(mut self) -> Self {
         self.grouped = true;
         self
     }

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -54,7 +54,7 @@ pub fn format_inserted(kind: JsSyntaxKind) -> FormatInserted<JsCommentStyle> {
 }
 
 pub fn format_inserted_open_paren(
-    before_token: &JsSyntaxToken,
+    before_token: Option<JsSyntaxToken>,
     kind: JsSyntaxKind,
 ) -> FormatInsertedOpenParen<JsCommentStyle> {
     FormatInsertedOpenParen::new(
@@ -67,7 +67,7 @@ pub fn format_inserted_open_paren(
 }
 
 pub fn format_inserted_close_paren(
-    after_token: &JsSyntaxToken,
+    after_token: &Option<JsSyntaxToken>,
     kind: JsSyntaxKind,
     f: &mut JsFormatter,
 ) -> FormatInsertedCloseParen<JsCommentStyle> {
@@ -98,11 +98,11 @@ pub fn format_inserted_close_paren(
 /// ```javascript
 /// /* leading */ ("test") /* trailing */;
 /// ```
-pub fn format_parenthesize<'token, 'content, Content>(
-    first_content_token: &'token JsSyntaxToken,
-    content: &'content Content,
-    last_content_token: &'token JsSyntaxToken,
-) -> FormatParenthesize<'token, 'content>
+pub fn format_parenthesize<Content>(
+    first_content_token: Option<JsSyntaxToken>,
+    content: &Content,
+    last_content_token: Option<JsSyntaxToken>,
+) -> FormatParenthesize
 where
     Content: Format<JsFormatContext>,
 {
@@ -116,26 +116,26 @@ where
 
 /// Adds parentheses around an expression
 #[derive(Clone)]
-pub struct FormatParenthesize<'token, 'content> {
+pub struct FormatParenthesize<'content> {
     grouped: bool,
-    first_content_token: &'token JsSyntaxToken,
-    last_content_token: &'token JsSyntaxToken,
+    first_content_token: Option<JsSyntaxToken>,
     content: Argument<'content, JsFormatContext>,
+    last_content_token: Option<JsSyntaxToken>,
 }
 
-impl FormatParenthesize<'_, '_> {
+impl FormatParenthesize<'_> {
     pub fn grouped(mut self) -> Self {
         self.grouped = true;
         self
     }
 }
 
-impl Format<JsFormatContext> for FormatParenthesize<'_, '_> {
+impl Format<JsFormatContext> for FormatParenthesize<'_> {
     fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
         let format_open_paren =
-            format_inserted_open_paren(self.first_content_token, JsSyntaxKind::L_PAREN);
+            format_inserted_open_paren(self.first_content_token.clone(), JsSyntaxKind::L_PAREN);
         let format_close_paren =
-            format_inserted_close_paren(self.last_content_token, JsSyntaxKind::R_PAREN, f);
+            format_inserted_close_paren(&self.last_content_token, JsSyntaxKind::R_PAREN, f);
 
         if self.grouped {
             write!(

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -40,7 +40,7 @@ impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
                     &format_args![binding.format(), if_group_breaks(&token(",")),],
                     binding.syntax().last_token(),
                 )
-                .grouped()]
+                .grouped_with_soft_block_indent()]
             )?,
             JsAnyArrowFunctionParameters::JsParameters(params) => write![f, [params.format()]]?,
         }

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use crate::utils::is_simple_expression;
 use rome_formatter::{format_args, write};
 use rome_js_syntax::{
-    JsAnyArrowFunctionParameters, JsAnyExpression, JsAnyFunction, JsAnyFunctionBody, JsSyntaxKind,
+    JsAnyArrowFunctionParameters, JsAnyExpression, JsAnyFunction, JsAnyFunctionBody,
 };
 
 impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
@@ -36,12 +36,12 @@ impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
             JsAnyArrowFunctionParameters::JsAnyBinding(binding) => write!(
                 f,
                 [group_elements(&format_args![
-                    format_inserted(JsSyntaxKind::L_PAREN),
+                    token("("),
                     soft_block_indent(&format_args![
                         binding.format(),
-                        if_group_breaks(&format_inserted(JsSyntaxKind::COMMA)),
+                        if_group_breaks(&token(",")),
                     ]),
-                    format_inserted(JsSyntaxKind::R_PAREN),
+                    token(")"),
                 ])]
             )?,
             JsAnyArrowFunctionParameters::JsParameters(params) => write![f, [params.format()]]?,

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -36,10 +36,9 @@ impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
             JsAnyArrowFunctionParameters::JsAnyBinding(binding) => write!(
                 f,
                 [format_parenthesize(
-                    // SAFETY: A binding without any content wouldn't parse as an any binding, thus, it's safe to call unwrap
-                    &binding.syntax().first_token().unwrap(),
+                    binding.syntax().first_token(),
                     &format_args![binding.format(), if_group_breaks(&token(",")),],
-                    &binding.syntax().last_token().unwrap(),
+                    binding.syntax().last_token(),
                 )
                 .grouped()]
             )?,

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -35,14 +35,13 @@ impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
         match node.parameters()? {
             JsAnyArrowFunctionParameters::JsAnyBinding(binding) => write!(
                 f,
-                [group_elements(&format_args![
-                    token("("),
-                    soft_block_indent(&format_args![
-                        binding.format(),
-                        if_group_breaks(&token(",")),
-                    ]),
-                    token(")"),
-                ])]
+                [format_parenthesize(
+                    // SAFETY: A binding without any content wouldn't parse as an any binding, thus, it's safe to call unwrap
+                    &binding.syntax().first_token().unwrap(),
+                    &format_args![binding.format(), if_group_breaks(&token(",")),],
+                    &binding.syntax().last_token().unwrap(),
+                )
+                .grouped()]
             )?,
             JsAnyArrowFunctionParameters::JsParameters(params) => write![f, [params.format()]]?,
         }

--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -145,14 +145,7 @@ impl Format<JsFormatContext> for FormatMemberStaticExpression<'_> {
         });
 
         if is_member_number_literal && (object_has_trailing_trivia || operator_has_leading_trivia) {
-            // SAFETY: `is_member_number_literal` expression guarantees that the node contains a `NumberLiteral`
-            // which always has at least one token.
-            format_parenthesize(
-                &self.first_token().unwrap(),
-                &format_node,
-                &self.last_token().unwrap(),
-            )
-            .fmt(f)
+            format_parenthesize(self.first_token(), &format_node, self.last_token()).fmt(f)
         } else {
             write!(f, [format_node])
         }

--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -3,7 +3,7 @@ use crate::FormatNodeFields;
 use rome_formatter::{format_args, write};
 use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsAnyName, JsStaticMemberExpression,
-    JsStaticMemberExpressionFields, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
+    JsStaticMemberExpressionFields, JsSyntaxNode, JsSyntaxToken,
 };
 use rome_rowan::AstNode;
 use std::ops::Deref;
@@ -145,7 +145,14 @@ impl Format<JsFormatContext> for FormatMemberStaticExpression<'_> {
         });
 
         if is_member_number_literal && (object_has_trailing_trivia || operator_has_leading_trivia) {
-            format_parenthesize(JsSyntaxKind::L_PAREN, &format_node, JsSyntaxKind::R_PAREN).fmt(f)
+            // SAFETY: `is_member_number_literal` expression guarantees that the node contains a `NumberLiteral`
+            // which always has at least one token.
+            format_parenthesize(
+                &self.first_token().unwrap(),
+                &format_node,
+                &self.last_token().unwrap(),
+            )
+            .fmt(f)
         } else {
             write!(f, [format_node])
         }

--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::FormatNodeFields;
-use rome_formatter::{format_args, write, VecBuffer};
+use rome_formatter::{format_args, write};
 use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsAnyName, JsStaticMemberExpression,
     JsStaticMemberExpressionFields, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
@@ -145,17 +145,7 @@ impl Format<JsFormatContext> for FormatMemberStaticExpression<'_> {
         });
 
         if is_member_number_literal && (object_has_trailing_trivia || operator_has_leading_trivia) {
-            let mut buffer = VecBuffer::new(f.state_mut());
-            write!(buffer, [format_node])?;
-            let formatted_member = buffer.into_element();
-
-            let (object_leading, object_content, object_trailing) = formatted_member.split_trivia();
-
-            f.write_element(object_leading)?;
-            format_inserted(JsSyntaxKind::L_PAREN).fmt(f)?;
-            f.write_element(object_content)?;
-            format_inserted(JsSyntaxKind::R_PAREN).fmt(f)?;
-            f.write_element(object_trailing)
+            format_parenthesize(JsSyntaxKind::L_PAREN, &format_node, JsSyntaxKind::R_PAREN).fmt(f)
         } else {
             write!(f, [format_node])
         }

--- a/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -23,7 +23,12 @@ impl FormatNodeFields<JsStringLiteralExpression> for FormatNodeRule<JsStringLite
             .is_some();
 
         if needs_parenthesis {
-            format_parenthesize(&value_token, &formatted, &value_token).fmt(f)
+            format_parenthesize(
+                Some(value_token.clone()),
+                &formatted,
+                Some(value_token.clone()),
+            )
+            .fmt(f)
         } else {
             formatted.fmt(f)
         }

--- a/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use rome_formatter::{write, Buffer, VecBuffer};
+use rome_formatter::{write, Buffer};
 
 use crate::utils::{FormatLiteralStringToken, StringLiteralParentKind};
 use crate::FormatNodeFields;
@@ -19,24 +19,12 @@ impl FormatNodeFields<JsStringLiteralExpression> for FormatNodeRule<JsStringLite
         let needs_parenthesis = parent.and_then(JsExpressionStatement::cast).is_some();
 
         if needs_parenthesis {
-            let mut buffer = VecBuffer::new(f.state_mut());
-            write!(
-                buffer,
-                [FormatLiteralStringToken::new(
-                    &value_token,
-                    StringLiteralParentKind::Expression
-                )]
-            )?;
-
-            let formatted_element = buffer.into_element();
-
-            let (leading_trivia, content, trailing_trivia) = formatted_element.split_trivia();
-
-            f.write_element(leading_trivia)?;
-            format_inserted(JsSyntaxKind::L_PAREN).fmt(f)?;
-            f.write_element(content)?;
-            format_inserted(JsSyntaxKind::R_PAREN).fmt(f)?;
-            f.write_element(trailing_trivia)
+            format_parenthesize(
+                JsSyntaxKind::L_PAREN,
+                &FormatLiteralStringToken::new(&value_token, StringLiteralParentKind::Expression),
+                JsSyntaxKind::R_PAREN,
+            )
+            .fmt(f)
         } else {
             write!(
                 f,

--- a/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -1,11 +1,10 @@
 use crate::prelude::*;
-use rome_formatter::{write, Buffer};
 
 use crate::utils::{FormatLiteralStringToken, StringLiteralParentKind};
 use crate::FormatNodeFields;
+use rome_js_syntax::JsExpressionStatement;
 use rome_js_syntax::JsStringLiteralExpression;
 use rome_js_syntax::JsStringLiteralExpressionFields;
-use rome_js_syntax::{JsExpressionStatement, JsSyntaxKind};
 use rome_rowan::AstNode;
 
 impl FormatNodeFields<JsStringLiteralExpression> for FormatNodeRule<JsStringLiteralExpression> {
@@ -13,26 +12,20 @@ impl FormatNodeFields<JsStringLiteralExpression> for FormatNodeRule<JsStringLite
         let JsStringLiteralExpressionFields { value_token } = node.as_fields();
 
         let value_token = value_token?;
-        let syntax_node = node.syntax();
-        let parent = syntax_node.parent();
 
-        let needs_parenthesis = parent.and_then(JsExpressionStatement::cast).is_some();
+        let formatted =
+            FormatLiteralStringToken::new(&value_token, StringLiteralParentKind::Expression);
+
+        let needs_parenthesis = node
+            .syntax()
+            .parent()
+            .and_then(JsExpressionStatement::cast)
+            .is_some();
 
         if needs_parenthesis {
-            format_parenthesize(
-                JsSyntaxKind::L_PAREN,
-                &FormatLiteralStringToken::new(&value_token, StringLiteralParentKind::Expression),
-                JsSyntaxKind::R_PAREN,
-            )
-            .fmt(f)
+            format_parenthesize(&value_token, &formatted, &value_token).fmt(f)
         } else {
-            write!(
-                f,
-                [FormatLiteralStringToken::new(
-                    &value_token,
-                    StringLiteralParentKind::Expression
-                )]
-            )
+            formatted.fmt(f)
         }
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -56,13 +56,11 @@ impl FormatNodeFields<JsUnaryExpression> for FormatNodeRule<JsUnaryExpression> {
         if is_ambiguous_expression {
             operator_token.format().fmt(f)?;
 
-            // SAFETY: `is_ambiguous_expression` matches ont he argument, guaranteeing that it is an expression
-            // containing at least one token
-            let first_token = argument.syntax().first_token().unwrap();
-            let last_token = argument.syntax().last_token().unwrap();
+            let first_token = argument.syntax().first_token();
+            let last_token = argument.syntax().last_token();
             let format_argument = argument.format();
 
-            let parenthesize = format_parenthesize(&first_token, &format_argument, &last_token);
+            let parenthesize = format_parenthesize(first_token, &format_argument, last_token);
 
             if is_simple_expression(&argument)? {
                 parenthesize.fmt(f)

--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -65,7 +65,7 @@ impl FormatNodeFields<JsUnaryExpression> for FormatNodeRule<JsUnaryExpression> {
             if is_simple_expression(&argument)? {
                 parenthesize.fmt(f)
             } else {
-                parenthesize.grouped().fmt(f)
+                parenthesize.grouped_with_soft_block_indent().fmt(f)
             }
         } else {
             write![f, [operator_token.format(), argument.format(),]]

--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::utils::is_simple_expression;
-use rome_formatter::{format_args, write};
+use rome_formatter::write;
 
 use crate::FormatNodeFields;
 use rome_js_syntax::{JsAnyExpression, JsUnaryExpression};
@@ -54,28 +54,23 @@ impl FormatNodeFields<JsUnaryExpression> for FormatNodeRule<JsUnaryExpression> {
         };
 
         if is_ambiguous_expression {
+            operator_token.format().fmt(f)?;
+
             if is_simple_expression(&argument)? {
-                write![
-                    f,
-                    [
-                        operator_token.format(),
-                        format_inserted(JsSyntaxKind::L_PAREN),
-                        argument.format(),
-                        format_inserted(JsSyntaxKind::R_PAREN),
-                    ]
-                ]
+                format_parenthesize(
+                    JsSyntaxKind::L_PAREN,
+                    &argument.format(),
+                    JsSyntaxKind::R_PAREN,
+                )
+                .fmt(f)
             } else {
-                write![
-                    f,
-                    [
-                        operator_token.format(),
-                        group_elements(&format_args![
-                            format_inserted(JsSyntaxKind::L_PAREN),
-                            soft_block_indent(&argument.format()),
-                            format_inserted(JsSyntaxKind::R_PAREN),
-                        ]),
-                    ]
-                ]
+                format_parenthesize(
+                    JsSyntaxKind::L_PAREN,
+                    &argument.format(),
+                    JsSyntaxKind::R_PAREN,
+                )
+                .grouped()
+                .fmt(f)
             }
         } else {
             write![f, [operator_token.format(), argument.format(),]]

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -82,9 +82,11 @@ fn write_consequent_block(f: &mut JsFormatter, stmt: JsAnyStatement) -> FormatRe
         f,
         [
             space_token(),
-            format_inserted(JsSyntaxKind::L_CURLY),
-            block_indent(&stmt.format()),
-            format_inserted(JsSyntaxKind::R_CURLY),
+            format_parenthesize(
+                JsSyntaxKind::L_CURLY,
+                &block_indent(&stmt.format()),
+                JsSyntaxKind::R_CURLY
+            )
         ]
     ]
 }

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -82,11 +82,9 @@ fn write_consequent_block(f: &mut JsFormatter, stmt: JsAnyStatement) -> FormatRe
         f,
         [
             space_token(),
-            format_parenthesize(
-                JsSyntaxKind::L_CURLY,
-                &block_indent(&stmt.format()),
-                JsSyntaxKind::R_CURLY
-            )
+            format_inserted(JsSyntaxKind::L_CURLY),
+            block_indent(&stmt.format()),
+            format_inserted(JsSyntaxKind::R_CURLY)
         ]
     ]
 }

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::utils::FormatWithSemicolon;
 use crate::FormatNodeFields;
-use rome_formatter::{format_args, write};
+use rome_formatter::write;
 use rome_js_syntax::{JsAnyExpression, JsReturnStatement, JsReturnStatementFields, JsSyntaxKind};
 
 impl FormatNodeFields<JsReturnStatement> for FormatNodeRule<JsReturnStatement> {
@@ -24,11 +24,11 @@ impl FormatNodeFields<JsReturnStatement> for FormatNodeRule<JsReturnStatement> {
                         if let JsAnyExpression::JsSequenceExpression(_expression) = argument {
                             write![
                                 f,
-                                [group_elements(&format_args![
-                                    format_inserted(JsSyntaxKind::L_PAREN),
-                                    soft_block_indent(&argument.format()),
-                                    format_inserted(JsSyntaxKind::R_PAREN)
-                                ])]
+                                [group_elements(&format_parenthesize(
+                                    JsSyntaxKind::L_PAREN,
+                                    &soft_block_indent(&argument.format()),
+                                    JsSyntaxKind::R_PAREN
+                                ))]
                             ]?;
                         } else {
                             write![f, [argument.format()]]?;

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::utils::FormatWithSemicolon;
 use crate::FormatNodeFields;
 use rome_formatter::write;
-use rome_js_syntax::{JsAnyExpression, JsReturnStatement, JsReturnStatementFields, JsSyntaxKind};
+use rome_js_syntax::{JsAnyExpression, JsReturnStatement, JsReturnStatementFields};
 
 impl FormatNodeFields<JsReturnStatement> for FormatNodeRule<JsReturnStatement> {
     fn fmt_fields(node: &JsReturnStatement, f: &mut JsFormatter) -> FormatResult<()> {
@@ -22,14 +22,15 @@ impl FormatNodeFields<JsReturnStatement> for FormatNodeRule<JsReturnStatement> {
                         write!(f, [space_token()])?;
 
                         if let JsAnyExpression::JsSequenceExpression(_expression) = argument {
-                            write![
-                                f,
-                                [group_elements(&format_parenthesize(
-                                    JsSyntaxKind::L_PAREN,
-                                    &soft_block_indent(&argument.format()),
-                                    JsSyntaxKind::R_PAREN
-                                ))]
-                            ]?;
+                            // SAFETY: a sequence expression contains at least the `,` comma token. Therefore, it's safe
+                            // to call `unwrap` here
+                            format_parenthesize(
+                                &argument.syntax().first_token().unwrap(),
+                                &argument.format(),
+                                &argument.syntax().last_token().unwrap(),
+                            )
+                            .grouped()
+                            .fmt(f)?;
                         } else {
                             write![f, [argument.format()]]?;
                         }

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -22,12 +22,10 @@ impl FormatNodeFields<JsReturnStatement> for FormatNodeRule<JsReturnStatement> {
                         write!(f, [space_token()])?;
 
                         if let JsAnyExpression::JsSequenceExpression(_expression) = argument {
-                            // SAFETY: a sequence expression contains at least the `,` comma token. Therefore, it's safe
-                            // to call `unwrap` here
                             format_parenthesize(
-                                &argument.syntax().first_token().unwrap(),
+                                argument.syntax().first_token(),
                                 &argument.format(),
-                                &argument.syntax().last_token().unwrap(),
+                                argument.syntax().last_token(),
                             )
                             .grouped()
                             .fmt(f)?;

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -27,7 +27,7 @@ impl FormatNodeFields<JsReturnStatement> for FormatNodeRule<JsReturnStatement> {
                                 &argument.format(),
                                 argument.syntax().last_token(),
                             )
-                            .grouped()
+                            .grouped_with_soft_block_indent()
                             .fmt(f)?;
                         } else {
                             write![f, [argument.format()]]?;

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -8,9 +8,10 @@ pub use rome_formatter::prelude::*;
 pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
 
 pub use crate::builders::{
-    format_delimited, format_inserted, format_leading_trivia, format_only_if_breaks,
-    format_or_verbatim, format_parenthesize, format_removed, format_replaced,
-    format_suppressed_node, format_trailing_trivia, format_unknown_node, format_verbatim_node,
+    format_delimited, format_inserted, format_inserted_close_paren, format_inserted_open_paren,
+    format_leading_trivia, format_only_if_breaks, format_or_verbatim, format_parenthesize,
+    format_removed, format_replaced, format_suppressed_node, format_trailing_trivia,
+    format_unknown_node, format_verbatim_node,
 };
 
 pub use crate::separated::{

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -9,8 +9,8 @@ pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
 
 pub use crate::builders::{
     format_delimited, format_inserted, format_leading_trivia, format_only_if_breaks,
-    format_or_verbatim, format_removed, format_replaced, format_suppressed_node,
-    format_trailing_trivia, format_unknown_node, format_verbatim_node,
+    format_or_verbatim, format_parenthesize, format_removed, format_replaced,
+    format_suppressed_node, format_trailing_trivia, format_unknown_node, format_verbatim_node,
 };
 
 pub use crate::separated::{

--- a/crates/rome_js_formatter/src/ts/types/union_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/union_type.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::ts::types::intersection_type::FormatTypeSetLeadingSeparator;
 use crate::FormatNodeFields;
-use rome_formatter::{format_args, write, Buffer, VecBuffer};
+use rome_formatter::{format_args, write, Buffer};
 use rome_js_syntax::TsUnionTypeFields;
 use rome_js_syntax::{JsSyntaxKind, TsUnionType};
 
@@ -12,36 +12,16 @@ impl FormatNodeFields<TsUnionType> for FormatNodeRule<TsUnionType> {
             types,
         } = node.as_fields();
 
-        let mut buffer = VecBuffer::new(f.state_mut());
-        write!(
-            buffer,
-            [
+        write![
+            f,
+            [group_elements(&indent(&format_args![
+                soft_line_break(),
                 FormatTypeSetLeadingSeparator {
                     separator: JsSyntaxKind::PIPE,
                     leading_separator: leading_separator_token.as_ref()
                 },
                 types.format()
-            ]
-        )?;
-
-        let types = buffer.into_element();
-
-        // Push trailing comments for the union out of the group (and indent block),
-        // so any potential line break doesn't influence the formatting of the type itself
-        let (leading_comments, types, trailing_comments) = types.split_trivia();
-
-        write![
-            f,
-            [
-                group_elements(&indent(&format_args![
-                    soft_line_break(),
-                    format_once(|f| {
-                        f.write_element(leading_comments)?;
-                        f.write_element(types)
-                    })
-                ])),
-                format_once(|f| { f.write_element(trailing_comments) })
-            ]
+            ]))]
         ]
     }
 }

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -226,7 +226,7 @@ fn format_sub_expression<'a>(
                 &sub_expression,
                 sub_expression.syntax().last_token(),
             )
-            .grouped()
+            .grouped_with_soft_block_indent()
             .fmt(f)
         } else {
             write!(f, [sub_expression])
@@ -569,7 +569,7 @@ impl FlattenedBinaryExpressionPart {
                     let last_token = current.syntax().last_token();
 
                     format_parenthesize(first_token, &content, last_token)
-                        .grouped()
+                        .grouped_with_soft_block_indent()
                         .fmt(f)
                 } else {
                     write!(f, [content])

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -221,11 +221,10 @@ fn format_sub_expression<'a>(
 ) -> impl Format<JsFormatContext> + 'a {
     format_with(move |f| {
         if needs_parens(parent_operator, sub_expression)? {
-            // SAFETY: `needs_parens` guarantees that the sub expression isn't empty (has at least one token)
             format_parenthesize(
-                &sub_expression.syntax().first_token().unwrap(),
+                sub_expression.syntax().first_token(),
                 &sub_expression,
-                &sub_expression.syntax().last_token().unwrap(),
+                sub_expression.syntax().last_token(),
             )
             .grouped()
             .fmt(f)
@@ -566,11 +565,10 @@ impl FlattenedBinaryExpressionPart {
                 });
 
                 if *parenthesized {
-                    // SAFETY: Guaranteed that left hand side is not an empty expression (or the left hand side node would be missing completely)
-                    let first_token = current.syntax().first_token().unwrap();
-                    let last_token = current.syntax().last_token().unwrap();
+                    let first_token = current.syntax().first_token();
+                    let last_token = current.syntax().last_token();
 
-                    format_parenthesize(&first_token, &content, &last_token)
+                    format_parenthesize(first_token, &content, last_token)
                         .grouped()
                         .fmt(f)
                 } else {

--- a/crates/rome_js_formatter/tests/specs/js/module/comments.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/comments.js
@@ -70,4 +70,6 @@ function test /* spacing before parentheses*/ () {}
 a /* before member */.test;
 statement /* comment */;
 
+/* leading */ "test" /*trailing*/ ;
+
 /* EOF comment */

--- a/crates/rome_js_formatter/tests/specs/js/module/comments.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/comments.js
@@ -72,4 +72,7 @@ statement /* comment */;
 
 /* leading */ "test" /*trailing*/ ;
 
+/* leading */
+"test" /*trailing*/ ;
+
 /* EOF comment */

--- a/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -75,6 +75,8 @@ function test /* spacing before parentheses*/ () {}
 a /* before member */.test;
 statement /* comment */;
 
+/* leading */ "test" /*trailing*/ ;
+
 /* EOF comment */
 
 =============================
@@ -165,5 +167,7 @@ function test /* spacing before parentheses*/ () {}
 
 a /* before member */.test;
 statement /* comment */;
+
+/* leading */ ("test") /*trailing*/;
 /* EOF comment */
 

--- a/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -151,7 +151,7 @@ function name(
 ) /* comment */ {}
 
 4 + /* plus trailing */
-(3 * 2 /* 2 trailing */);
+(3 * 2) /* 2 trailing */;
 
 /* leading of opening */ (
 	/* trailing of opening */

--- a/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -77,6 +77,9 @@ statement /* comment */;
 
 /* leading */ "test" /*trailing*/ ;
 
+/* leading */
+"test" /*trailing*/ ;
+
 /* EOF comment */
 
 =============================
@@ -169,5 +172,8 @@ a /* before member */.test;
 statement /* comment */;
 
 /* leading */ ("test") /*trailing*/;
+
+/* leading */
+("test") /*trailing*/;
 /* EOF comment */
 


### PR DESCRIPTION
## Summary

This PR replaces the usages of `split_trivia` where it is used to move the leading and trailing trivia of a "to be parenthesised" expression with `format_parenthesize` that manually formats the leading / trailing comments as part of the parentheses. 

```javascript
/* leading */ "string" /* trailing */;

// Becomes
/* leading */ ("string") /* trailing */;
```

Formatting the comments of the content as part of the parentheses requires a way to signal to the formatter that these comments have already been formatted and that it shouldn't format the comments again when formatting the `"string"` token. This is done by storing the "manually" formatted comments inside of the `FormatState` and checking for every comment if the comment has already been formatted. 

The advantage of this approach is that it enables format rules to manually format comments if there's a need to do so without going over `split_trivia`. 

## New Dependencies

This PR adds a dependency on `indexmap` to `rome_formatter`. The reason to use `IndexMap` over `HashMap` is that the new map is part of the `FormatState` that supports taking and restoring snapshots. Thus, it is important that the data structure offers a cheap mechanism to restore the "manual comments" map to a previous state. 

`IndexMap` (or `IndexSet`) offers that because it's possible to truncate the `set` and by doing so, remove all elements that have been added since the snapshot was taken. The built-in `HashMap` doesn't provide this functionality. 

`indexmap` is only a new dependency for `rome_formatter`. It's already used by the parser, `lsp` crate and others.

## Next Steps

Remove the need for `split_trivia` inside of `group_elements`. 

## Test Plan

`cargo test`. I added a few new tests verifying the new behaviour.
