### PR TITLE
fix(rome_js_semantic): remove dbg from semantic tests

### DIFF
--- a/crates/rome_js_semantic/src/tests/assertions.rs
+++ b/crates/rome_js_semantic/src/tests/assertions.rs
@@ -115,11 +115,6 @@ pub fn assert(code: &str, test_name: &str) {
 
     let assertions = SemanticAssertions::from_root(r.tree(), code, test_name);
 
-    // Print info to help debug when a test fail
-
-    dbg!(&events_by_pos);
-    dbg!(&assertions);
-
     // check
 
     assertions.check(code, test_name, events_by_pos);


### PR DESCRIPTION
Some tools seems to display ```dbg!(...)``` even when tests succeed (clion is an example). So this PR removes all printing of tests.