### PR TITLE
feat(rome_js_formatter): apply existing layout strategy to assignments

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -17,6 +17,7 @@ impl FormatNodeFields<JsAssignmentExpression> for FormatNodeRule<JsAssignmentExp
         let left = left?;
         let layout = compute_expression_layout(f, None, &right)?;
 
+        dbg!(&layout);
         match layout {
             AssignmentLikeLayout::Fluid => {
                 let group_id = f.group_id("assignment");

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -2,8 +2,8 @@ use crate::prelude::*;
 use crate::utils::{compute_expression_layout, AssignmentLikeLayout};
 use crate::FormatNodeFields;
 use rome_formatter::{format_args, write};
+use rome_js_syntax::JsAssignmentExpression;
 use rome_js_syntax::JsAssignmentExpressionFields;
-use rome_js_syntax::{JsAnyAssignmentPattern, JsAssignmentExpression};
 
 impl FormatNodeFields<JsAssignmentExpression> for FormatNodeRule<JsAssignmentExpression> {
     fn fmt_fields(node: &JsAssignmentExpression, f: &mut JsFormatter) -> FormatResult<()> {
@@ -17,7 +17,6 @@ impl FormatNodeFields<JsAssignmentExpression> for FormatNodeRule<JsAssignmentExp
         let left = left?;
         let layout = compute_expression_layout(f, None, &right)?;
 
-        dbg!(&layout);
         match layout {
             AssignmentLikeLayout::Fluid => {
                 let group_id = f.group_id("assignment");

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -1,8 +1,9 @@
 use crate::prelude::*;
+use crate::utils::{compute_expression_layout, AssignmentLikeLayout};
 use crate::FormatNodeFields;
 use rome_formatter::{format_args, write};
-use rome_js_syntax::JsAssignmentExpression;
 use rome_js_syntax::JsAssignmentExpressionFields;
+use rome_js_syntax::{JsAnyAssignmentPattern, JsAssignmentExpression};
 
 impl FormatNodeFields<JsAssignmentExpression> for FormatNodeRule<JsAssignmentExpression> {
     fn fmt_fields(node: &JsAssignmentExpression, f: &mut JsFormatter) -> FormatResult<()> {
@@ -12,15 +13,60 @@ impl FormatNodeFields<JsAssignmentExpression> for FormatNodeRule<JsAssignmentExp
             right,
         } = node.as_fields();
 
-        write!(
-            f,
-            [group_elements(&format_args![
-                left.format(),
-                space_token(),
-                operator_token.format(),
-                line_suffix_boundary(),
-                group_elements(&soft_line_indent_or_space(&right.format())),
-            ])]
-        )
+        let right = right?;
+        let left = left?;
+        let layout = compute_expression_layout(f, None, &right)?;
+
+        match layout {
+            AssignmentLikeLayout::Fluid => {
+                let group_id = f.group_id("assignment");
+                let formatted_right = right.format().memoized();
+                write!(
+                    f,
+                    [&group_elements(&format_args![
+                        &group_elements(&left.format()),
+                        space_token(),
+                        operator_token.format(),
+                        group_elements(&if_group_breaks(&indent(&hard_line_break())))
+                            .with_group_id(Some(group_id)),
+                        line_suffix_boundary(),
+                        group_elements(&format_args![
+                            if_group_fits_on_line(&format_args![space_token(), &formatted_right]),
+                            if_group_breaks(&indent(&format_args![
+                                &soft_line_break(),
+                                formatted_right
+                            ]))
+                        ])
+                        .with_group_id(Some(group_id)),
+                    ])]
+                )
+            }
+            AssignmentLikeLayout::BreakAfterColon => {
+                write!(
+                    f,
+                    [&group_elements(&format_args![
+                        group_elements(&left.format()),
+                        space_token(),
+                        operator_token.format(),
+                        group_elements(&indent(&format_args![
+                            &soft_line_break_or_space(),
+                            &right.format()
+                        ]))
+                    ])]
+                )
+            }
+            AssignmentLikeLayout::NeverBreakAfterColon => {
+                write!(
+                    f,
+                    [&group_elements(&format_args![
+                        group_elements(&left.format()),
+                        space_token(),
+                        operator_token.format(),
+                        space_token(),
+                        &right.format(),
+                    ])]
+                )
+            }
+        }
     }
 }

--- a/crates/rome_js_formatter/src/js/objects/property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/property_object_member.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-use crate::utils::{property_object_member_layout, write_member_name, PropertyObjectMemberLayout};
+use crate::utils::{compute_expression_layout, write_member_name, AssignmentLikeLayout};
 use crate::FormatNodeFields;
 use rome_formatter::{format_args, write};
 use rome_js_syntax::JsPropertyObjectMember;
@@ -20,9 +20,9 @@ impl FormatNodeFields<JsPropertyObjectMember> for FormatNodeRule<JsPropertyObjec
             let name_width = write_member_name(&name, f)?;
             colon_token.format().fmt(f)?;
 
-            let layout = property_object_member_layout(f, name_width, &value)?;
+            let layout = compute_expression_layout(f, Some(name_width), &value)?;
             match layout {
-                PropertyObjectMemberLayout::Fluid => {
+                AssignmentLikeLayout::Fluid => {
                     let group_id = f.group_id("property_object_member");
 
                     let value = value.format().memoized();
@@ -38,7 +38,7 @@ impl FormatNodeFields<JsPropertyObjectMember> for FormatNodeRule<JsPropertyObjec
                         ]
                     ]
                 }
-                PropertyObjectMemberLayout::BreakAfterColon => {
+                AssignmentLikeLayout::BreakAfterColon => {
                     write![
                         f,
                         [
@@ -50,7 +50,7 @@ impl FormatNodeFields<JsPropertyObjectMember> for FormatNodeRule<JsPropertyObjec
                         ]
                     ]
                 }
-                PropertyObjectMemberLayout::NeverBreakAfterColon => {
+                AssignmentLikeLayout::NeverBreakAfterColon => {
                     write![f, [space_token(), value.format(),]]
                 }
             }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -526,7 +526,9 @@ mod test {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-        class S { constructor() { this.x = y } }
+        fn = 
+
+        a;
         "#;
         let syntax = SourceType::ts();
         let tree = parse(src, 0, syntax);

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -525,9 +525,9 @@ mod test {
     #[test]
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
-        let src = r#"type B8  = /*1*/ (& C);
-type B9  = (/*1*/ & C);
-type B10 = /*1*/ & /*2*/ C;"#;
+        let src = r#"
+        class S { constructor() { this.x = y } }
+        "#;
         let syntax = SourceType::ts();
         let tree = parse(src, 0, syntax);
         let result = format_node(JsFormatContext::default(), &tree.syntax())

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -1,12 +1,11 @@
 use crate::prelude::*;
-use rome_formatter::write;
-
-use crate::utils::{has_leading_newline, StringLiteralParentKind};
+use crate::utils::StringLiteralParentKind;
 use crate::utils::{FormatLiteralStringToken, JsAnyBinaryLikeExpression};
+use rome_formatter::write;
 use rome_js_syntax::JsSyntaxKind::JS_STRING_LITERAL;
-use rome_js_syntax::{JsAnyExpression, JsAnyObjectMemberName, JsLanguage};
+use rome_js_syntax::{JsAnyExpression, JsAnyObjectMemberName};
 use rome_js_syntax::{JsAnyLiteralExpression, JsSyntaxNode};
-use rome_rowan::{AstNode, SyntaxResult, SyntaxTriviaPiece};
+use rome_rowan::{AstNode, SyntaxResult};
 use unicode_width::UnicodeWidthStr;
 
 pub(crate) fn write_member_name(

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod array;
+mod assignment_like;
 mod binary_like_expression;
 mod format_conditional;
-mod object;
 mod simple;
 pub mod string_utils;
 
@@ -10,13 +10,12 @@ mod member_chain;
 mod quickcheck_utils;
 
 use crate::prelude::*;
+pub(crate) use assignment_like::{
+    compute_expression_layout, is_break_after_colon, write_member_name, AssignmentLikeLayout,
+};
 pub(crate) use binary_like_expression::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 pub(crate) use format_conditional::{format_conditional, Conditional};
 pub(crate) use member_chain::format_call_expression;
-pub(crate) use object::{
-    is_break_after_colon, property_object_member_layout, write_member_name,
-    PropertyObjectMemberLayout,
-};
 use rome_formatter::{normalize_newlines, write, Buffer, VecBuffer};
 use rome_js_syntax::suppression::{has_suppressions_category, SuppressionCategory};
 use rome_js_syntax::JsSyntaxKind::JS_STRING_LITERAL;

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js
@@ -24,3 +24,18 @@ a[ b ]  =  c[ d ]
 
 (s||(s=Object.create(null)))[i]=!0;
 (s||(s=Object.create(null))).test=!0;
+
+
+// fluid layout
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers = [1, 2, 3, 4, 5];
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers = { a: 10 };
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder = bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawderArrayNumbes = { a: 10 };
+fn =
+
+    fn()
+
+
+// break after operator
+fn =
+// something
+    fn()

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: assignment.js
 ---
 # Input
@@ -30,6 +31,20 @@ a[ b ]  =  c[ d ]
 (s||(s=Object.create(null)))[i]=!0;
 (s||(s=Object.create(null))).test=!0;
 
+
+// fluid layout
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers = [1, 2, 3, 4, 5];
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers = { a: 10 };
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder = bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawderArrayNumbes = { a: 10 };
+fn =
+
+    fn()
+
+
+// break after operator
+fn =
+// something
+    fn()
 =============================
 # Outputs
 ## Output 1
@@ -76,4 +91,19 @@ a[b] = c[d];
 
 (s || (s = Object.create(null)))[i] = !0;
 (s || (s = Object.create(null))).test = !0;
+
+// fluid layout
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers =
+	[1, 2, 3, 4, 5];
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers =
+	{ a: 10 };
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder =
+	bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawderArrayNumbes =
+		{ a: 10 };
+fn = fn();
+
+// break after operator
+fn =
+	// something
+	fn();
 

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: class.js
 ---
 # Input
@@ -121,11 +122,10 @@ x = class {};
 
 x = class foo extends Boar {};
 
-x =
-	class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {};
+x = class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {};
 
 
 ## Lines exceeding width of 80 characters
 
-   54: 	class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {};
+   53: x = class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {};
 

--- a/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: suppression.js
 ---
 # Input
@@ -62,7 +63,7 @@ const expr =
 
 const expr2 = {
 	key:
-	// rome-ignore format: only skip formatting the value
+		// rome-ignore format: only skip formatting the value
         'single quoted string',
 };
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/call.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: call.js
 ---
 # Input
@@ -21,8 +22,9 @@ if (true) {
     if (true) {
       if (true) {
         if (true) {
-          longVariableName1 = // @ts-ignore
-          (variable01 + veryLongVariableNameNumber2).method();
+          longVariableName1 =
+            // @ts-ignore
+            (variable01 + veryLongVariableNameNumber2).method();
         }
       }
     }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: function.js
 ---
 # Input
@@ -87,8 +88,9 @@ f3 =
     a = b, //comment
   ) => {};
 
-f4 = // Comment
-() => {};
+f4 =
+  // Comment
+  () => {};
 
 f5 =
   // Comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
@@ -54,28 +54,28 @@ var fnNumber = /* comments0 */
 # Output
 ```js
 fnNumber =
-// Comment
-3;
+  // Comment
+  3;
 
 fnNumber =
-// Comment
+  // Comment
 
-3;
+  3;
 
 fnNumber =
-// Comment0
-// Comment1
-3;
+  // Comment0
+  // Comment1
+  3;
 
 fnNumber = /* comment */ 3;
 
 fnNumber = /* comments0 */
-/* comments1 */
-3;
+  /* comments1 */
+  3;
 
 fnNumber =
-// Comment
-3;
+  // Comment
+  3;
 
 var fnNumber =
 // Comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: number.js
 ---
 # Input
@@ -53,28 +54,28 @@ var fnNumber = /* comments0 */
 # Output
 ```js
 fnNumber =
-  // Comment
-  3;
+// Comment
+3;
 
 fnNumber =
-  // Comment
+// Comment
 
-  3;
+3;
 
 fnNumber =
-  // Comment0
-  // Comment1
-  3;
+// Comment0
+// Comment1
+3;
 
 fnNumber = /* comment */ 3;
 
 fnNumber = /* comments0 */
-  /* comments1 */
-  3;
+/* comments1 */
+3;
 
 fnNumber =
-  // Comment
-  3;
+// Comment
+3;
 
 var fnNumber =
 // Comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/string.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: string.js
 ---
 # Input
@@ -116,12 +117,12 @@ fnString =
     "long" +
     "string";
 
-fnString = // Comment0
+fnString =
+  // Comment0
   // Comment1
   "some" + "long" + "string";
 
-fnString = // Comment
-"some" + "long" + "string";
+fnString = "some" + "long" + "string"; // Comment
 
 fnString =
   // Comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/classes/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/classes/assignment.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: assignment.js
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/js/classes/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/classes/assignment.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: assignment.js
 ---
 # Input
@@ -40,47 +41,44 @@ module.exports = class A extends B {
 
 # Output
 ```js
-aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 =
-  class extends (
-    aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
-  ) {
-    method() {
-      console.log("foo");
-    }
-  };
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
+) {
+  method() {
+    console.log("foo");
+  }
+};
 
-foo =
-  class extends bar {
-    method() {
-      console.log("foo");
-    }
-  };
+foo = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
 
-aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 =
-  class extends bar {
-    method() {
-      console.log("foo");
-    }
-  };
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
 
-foo =
-  class extends aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 {
-    method() {
-      console.log("foo");
-    }
-  };
+foo = class extends aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 {
+  method() {
+    console.log("foo");
+  }
+};
 
-module.exports =
-  class A extends B {
-    method() {
-      console.log("foo");
-    }
-  };
+module.exports = class A extends B {
+  method() {
+    console.log("foo");
+  }
+};
 
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-   25:   class extends aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 {
+    1: aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+   15: aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends bar {
+   21: foo = class extends aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 {
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-comments/comment-inside.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-comments/comment-inside.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: comment-inside.js
 ---
 # Input
@@ -125,15 +126,14 @@ ${
 `;
 
 // https://github.com/prettier/prettier/pull/9278#issuecomment-700589195
-expr1 =
-  html`
+expr1 = html`
   <div>
     ${
-    x(
-      foo, // fg
-      bar,
-    )
-  }</div>
+  x(
+    foo, // fg
+    bar,
+  )
+}</div>
 `;
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/template-literals/expressions.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/template-literals/expressions.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: expressions.js
 ---
 # Input
@@ -78,10 +79,9 @@ console.log(
   ),
 );
 
-x =
-  `mdl-textfield mdl-js-textfield ${className} ${
-    content.length > 0 ? "is-dirty" : ""
-  } combo-box__input`;
+x = `mdl-textfield mdl-js-textfield ${className} ${
+  content.length > 0 ? "is-dirty" : ""
+} combo-box__input`;
 
 function testing() {
   const p = {};
@@ -134,9 +134,9 @@ throw new Error(
    10: const foo = `such a long template string ${foo.bar.baz} that prettier will want to wrap it`;
    12: const shouldWrapForNow = `such a long template string ${foo().bar.baz} that prettier will want to wrap it`;
    20:     `Covered Lines below threshold: ${coverageSettings.lines}%. Actual: ${coverageSummary.total.lines.pct}%`,
-   34:       return `${process.env.OPENID_URL}/something/something/something?${Object.keys(
-   44:   `Trying update appcast for ${app.name} (${app.cask.appcast}) -> (${app.cask.appcastGenerated})`,
-   52:   `\nApparently jetbrains changed the release artifact for ${app.name}@${app.jetbrains.version}.\n`,
-   66:   `pretty-format: Option "theme" has a key "${key}" whose value "${value}" is undefined in ansi-styles.`,
+   33:       return `${process.env.OPENID_URL}/something/something/something?${Object.keys(
+   43:   `Trying update appcast for ${app.name} (${app.cask.appcast}) -> (${app.cask.appcastGenerated})`,
+   51:   `\nApparently jetbrains changed the release artifact for ${app.name}@${app.jetbrains.version}.\n`,
+   65:   `pretty-format: Option "theme" has a key "${key}" whose value "${value}" is undefined in ansi-styles.`,
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes https://github.com/rome/tools/issues/2410

Prettier uses the layout strategy for assignments, which was introduced to format object members. 

This PR changes their name to be more generic. I didn't add the other layouts because they were not needed to fix the cases highlighted in the issue. I will introduce the other layouts in next PRs.

This PR adds an additional check to the condition `is_break_after_colon`, which covers a really specific case which is:

```js
const a = 
	// coment
	something;
```

It checks if a leading trivia comment is lead by newlines.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new cases to cover the `Fluid` and `BreakAfterColon` cases.

PR:
**File Based Average Prettier Similarity**: 73.32%  
**Line Based Average Prettier Similarity**: 67.72%  

`main`
**File Based Average Prettier Similarity**: 73.25%  
**Line Based Average Prettier Similarity**: 67.60% 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
