### PR TITLE
refactor(rome_formatter): `GroupElementsBuffer`

### DIFF
--- a/crates/rome_formatter/src/arguments.rs
+++ b/crates/rome_formatter/src/arguments.rs
@@ -144,10 +144,10 @@ mod tests {
                 FormatElement::Space,
                 FormatElement::Token(Token::Static { text: "a" }),
                 FormatElement::Space,
-                FormatElement::Group(Group::new(FormatElement::List(List::new(vec![
+                FormatElement::Group(Group::new(vec![
                     FormatElement::Token(Token::Static { text: "(" }),
                     FormatElement::Token(Token::Static { text: ")" }),
-                ]))))
+                ]))
             ]))
         );
     }

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -469,7 +469,7 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 ///     SimpleFormatContext::default(),
 ///     [
 ///         group_elements(&format_args![
-///             comments(&format_args![token("// test"), hard_line_break()]).leading(true),
+///             comments(&format_args![token("// test"), hard_line_break()], CommentPosition::Leading),
 ///             token("a"),
 ///             soft_line_break_or_space(),
 ///             token("b")
@@ -483,27 +483,23 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 /// );
 /// ```
 #[inline]
-pub fn comments<Content, Context>(content: &Content) -> FormatComments<Context>
+pub fn comments<Content, Context>(
+    content: &Content,
+    position: CommentPosition,
+) -> FormatComments<Context>
 where
     Content: Format<Context>,
 {
     FormatComments {
         content: Argument::new(content),
-        leading: false,
+        position,
     }
 }
 
 #[derive(Copy, Clone)]
 pub struct FormatComments<'a, Context> {
     content: Argument<'a, Context>,
-    leading: bool,
-}
-
-impl<Context> FormatComments<'_, Context> {
-    pub fn leading(mut self, leading: bool) -> Self {
-        self.leading = leading;
-        self
-    }
+    position: CommentPosition,
 }
 
 impl<Context> Format<Context> for FormatComments<'_, Context> {
@@ -515,7 +511,7 @@ impl<Context> Format<Context> for FormatComments<'_, Context> {
 
         f.write_element(FormatElement::Comments {
             content: content.into_boxed_slice(),
-            leading: self.leading,
+            position: self.position,
         })
     }
 }

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -8,6 +8,7 @@ use rome_rowan::{Language, SyntaxNode, SyntaxToken, SyntaxTokenText, TextLen};
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::marker::PhantomData;
+use std::ops::Deref;
 
 /// A line break that only gets printed if the enclosing `Group` doesn't fit on a single line.
 /// It's omitted if the enclosing `Group` fits on a single line.
@@ -463,7 +464,7 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{format, format_args};
+/// use rome_formatter::{format, write, format_args};
 /// use rome_formatter::prelude::*;
 ///
 /// let elements = format!(
@@ -471,15 +472,22 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 ///     [
 ///         group_elements(&format_args![
 ///             comment(&format_args![token("// test"), hard_line_break()]),
-///             token("a"),
+///             format_with(|f| {
+///                 write!(f, [
+///                     comment(&format_args![token("/* inline */"), hard_line_break()]).memoized(),
+///                     token("a"),
+///                     soft_line_break_or_space(),
+///                 ])
+///             }).memoized(),
+///             token("b"),
 ///             soft_line_break_or_space(),
-///             token("b")
+///             token("c")
 ///         ])
 ///     ]
 /// ).unwrap();
 ///
 /// assert_eq!(
-///     "// test\na b",
+///     "// test\n/* inline */\na b c",
 ///     elements.print().as_code()
 /// );
 /// ```
@@ -983,6 +991,60 @@ impl<'inner, Context> GroupElementsBuffer<'inner, Context> {
     fn into_vec(self) -> Vec<FormatElement> {
         self.content
     }
+
+    fn write_interned(&mut self, interned: Interned) -> FormatResult<()> {
+        debug_assert!(self.content.is_empty());
+
+        match interned.deref() {
+            FormatElement::Comment(_) => {
+                self.inner.write_element(FormatElement::Interned(interned))
+            }
+            FormatElement::List(list) => {
+                let mut content_start = 0;
+
+                for element in list.iter() {
+                    match element {
+                        element @ FormatElement::Comment(_) => {
+                            content_start += 1;
+                            // Cloning comments should be alright as they are rarely nested
+                            // and the case where all elements of an interned data structure are comments
+                            // are rare
+                            self.inner.write_element(element.clone())?;
+                        }
+                        FormatElement::Interned(interned) => {
+                            self.write_interned(interned.clone())?;
+                            content_start += 1;
+
+                            if !self.content.is_empty() {
+                                // Interned struct contained non-comment
+                                break;
+                            }
+                        }
+                        _ => {
+                            // Found the first non-comment / nested interned element
+                            break;
+                        }
+                    }
+                }
+
+                // No leading comments, this group has no comments
+                if content_start == 0 {
+                    self.content.push(FormatElement::Interned(interned));
+                    return Ok(());
+                }
+
+                let content = &list[content_start..];
+
+                // It is necessary to mutate the interned elements, write cloned elements
+                self.write_elements(content.iter().cloned())
+            }
+            FormatElement::Interned(interned) => self.write_interned(interned.clone()),
+            _ => {
+                self.content.push(FormatElement::Interned(interned));
+                Ok(())
+            }
+        }
+    }
 }
 
 impl<Context> Buffer for GroupElementsBuffer<'_, Context> {
@@ -994,6 +1056,10 @@ impl<Context> Buffer for GroupElementsBuffer<'_, Context> {
                 FormatElement::List(list) => {
                     self.write_elements(list.into_vec())?;
                 }
+                FormatElement::Interned(interned) => match Interned::try_unwrap(interned) {
+                    Ok(owned) => self.write_element(owned)?,
+                    Err(interned) => self.write_interned(interned)?,
+                },
                 comment @ FormatElement::Comment { .. } => {
                     self.inner.write_element(comment)?;
                 }

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -469,7 +469,7 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 ///     SimpleFormatContext::default(),
 ///     [
 ///         group_elements(&format_args![
-///             comment(&empty_line()),
+///             comments(&format_args![token("// test"), hard_line_break()]).leading(true),
 ///             token("a"),
 ///             soft_line_break_or_space(),
 ///             token("b")
@@ -478,39 +478,51 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 /// ).unwrap();
 ///
 /// assert_eq!(
-///     "\na b",
+///     "// test\na b",
 ///     elements.print().as_code()
 /// );
 /// ```
 #[inline]
-pub fn comment<Content, Context>(content: &Content) -> FormatComment<Context>
+pub fn comments<Content, Context>(content: &Content) -> FormatComments<Context>
 where
     Content: Format<Context>,
 {
-    FormatComment {
+    FormatComments {
         content: Argument::new(content),
+        leading: false,
     }
 }
 
 #[derive(Copy, Clone)]
-pub struct FormatComment<'a, Context> {
+pub struct FormatComments<'a, Context> {
     content: Argument<'a, Context>,
+    leading: bool,
 }
 
-impl<Context> Format<Context> for FormatComment<'_, Context> {
+impl<Context> FormatComments<'_, Context> {
+    pub fn leading(mut self, leading: bool) -> Self {
+        self.leading = leading;
+        self
+    }
+}
+
+impl<Context> Format<Context> for FormatComments<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         let mut buffer = VecBuffer::new(f.state_mut());
 
         buffer.write_fmt(Arguments::from(&self.content))?;
-        let content = buffer.into_element();
+        let content = buffer.into_vec();
 
-        f.write_element(FormatElement::Comment(Box::new(content)))
+        f.write_element(FormatElement::Comments {
+            content: content.into_boxed_slice(),
+            leading: self.leading,
+        })
     }
 }
 
-impl<Context> std::fmt::Debug for FormatComment<'_, Context> {
+impl<Context> std::fmt::Debug for FormatComments<'_, Context> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Comment").field(&"{{content}}").finish()
+        f.debug_tuple("Comments").field(&"{{content}}").finish()
     }
 }
 
@@ -930,25 +942,11 @@ impl<Context> Format<Context> for GroupElements<'_, Context> {
 
         buffer.write_fmt(Arguments::from(&self.content))?;
 
-        let mut content = buffer.into_vec();
+        let content = buffer.into_vec();
 
-        // Move the leading comments out of the group to prevent that a leading line comment expands the
-        // token's enclosing group.
-        //
-        // ```javascript
-        // /* a comment */
-        // [1]
-        // ```
-        //
-        // The `/* a comment */` belongs to the `[` group token that is part of a group wrapping the whole
-        // `[1]` expression. It's important that the comment `/* a comment */` gets moved out of the group element
-        // to avoid that the `[1]` group expands because of the line break inserted by the comment.
-        let leading_end = content
-            .iter()
-            .position(|element| !matches!(element, FormatElement::Comment(_)))
-            .unwrap_or(content.len());
-
-        f.write_elements(content.drain(..leading_end))?;
+        if content.is_empty() && self.group_id.is_none() {
+            return Ok(());
+        }
 
         let group = Group::new(content).with_id(self.group_id);
 

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -55,12 +55,12 @@ pub enum FormatElement {
     LineSuffixBoundary,
 
     /// Special semantic element letting the printer and formatter know this is
-    /// a trivia content, and it should only have a limited influence on the
+    /// a comment content block, and it should only have a limited influence on the
     /// formatting (for instance line breaks contained within will not cause
-    /// the parent group to break if this element is at the start of it)
+    /// the parent group to break if this element is at the start of a line).
     Comments {
         content: Box<[FormatElement]>,
-        leading: bool,
+        position: CommentPosition,
     },
 
     /// A token that tracks tokens/nodes that are printed using [`format_verbatim`](crate::Formatter::format_verbatim) API
@@ -73,6 +73,12 @@ pub enum FormatElement {
     /// Reference counted format element content. Useful when the same content must be emitted twice
     /// because it avoids deep cloning of the inner content and instead only requires bumping a ref counter.
     Rc(Rc<FormatElement>),
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum CommentPosition {
+    Leading,
+    Trailing,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
@@ -142,10 +148,10 @@ impl Debug for FormatElement {
                 fmt.debug_tuple("LineSuffix").field(content).finish()
             }
             FormatElement::LineSuffixBoundary => write!(fmt, "LineSuffixBoundary"),
-            FormatElement::Comments { content, leading } => fmt
+            FormatElement::Comments { content, position } => fmt
                 .debug_struct("Comments")
                 .field("content", content)
-                .field("leading", leading)
+                .field("position", position)
                 .finish(),
             FormatElement::Verbatim(verbatim) => fmt
                 .debug_tuple("Verbatim")
@@ -500,8 +506,8 @@ impl FormatElement {
             FormatElement::Fill(fill) => fill.list.content.iter().any(FormatElement::will_break),
             FormatElement::Token(token) => token.contains('\n'),
             FormatElement::LineSuffix(_) => false,
-            FormatElement::Comments { content, leading } => {
-                if *leading {
+            FormatElement::Comments { content, position } => {
+                if *position == CommentPosition::Leading {
                     false
                 } else {
                     content.iter().any(FormatElement::will_break)

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -55,13 +55,10 @@ pub enum FormatElement {
     LineSuffixBoundary,
 
     /// Special semantic element letting the printer and formatter know this is
-    /// a comment content block, and it should only have a limited influence on the
+    /// a comment content, and it should only have a limited influence on the
     /// formatting (for instance line breaks contained within will not cause
-    /// the parent group to break if this element is at the start of a line).
-    Comments {
-        content: Box<[FormatElement]>,
-        position: CommentPosition,
-    },
+    /// the parent group to break if this element is at the start of it).
+    Comment(Box<[FormatElement]>),
 
     /// A token that tracks tokens/nodes that are printed using [`format_verbatim`](crate::Formatter::format_verbatim) API
     Verbatim(Verbatim),
@@ -73,12 +70,6 @@ pub enum FormatElement {
     /// Reference counted format element content. Useful when the same content must be emitted twice
     /// because it avoids deep cloning of the inner content and instead only requires bumping a ref counter.
     Rc(Rc<FormatElement>),
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum CommentPosition {
-    Leading,
-    Trailing,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
@@ -148,11 +139,7 @@ impl Debug for FormatElement {
                 fmt.debug_tuple("LineSuffix").field(content).finish()
             }
             FormatElement::LineSuffixBoundary => write!(fmt, "LineSuffixBoundary"),
-            FormatElement::Comments { content, position } => fmt
-                .debug_struct("Comments")
-                .field("content", content)
-                .field("position", position)
-                .finish(),
+            FormatElement::Comment(content) => fmt.debug_tuple("Comment").field(content).finish(),
             FormatElement::Verbatim(verbatim) => fmt
                 .debug_tuple("Verbatim")
                 .field(&verbatim.element)
@@ -500,19 +487,14 @@ impl FormatElement {
             FormatElement::Space => false,
             FormatElement::Line(line_mode) => matches!(line_mode, LineMode::Hard | LineMode::Empty),
             FormatElement::Indent(content) => content.will_break(),
-            FormatElement::Group(group) => group.content.iter().any(FormatElement::will_break),
+            FormatElement::Group(Group { content, .. }) | FormatElement::Comment(content) => {
+                content.iter().any(FormatElement::will_break)
+            }
             FormatElement::ConditionalGroupContent(group) => group.content.will_break(),
             FormatElement::List(list) => list.content.iter().any(FormatElement::will_break),
             FormatElement::Fill(fill) => fill.list.content.iter().any(FormatElement::will_break),
             FormatElement::Token(token) => token.contains('\n'),
             FormatElement::LineSuffix(_) => false,
-            FormatElement::Comments { content, position } => {
-                if *position == CommentPosition::Leading {
-                    false
-                } else {
-                    content.iter().any(FormatElement::will_break)
-                }
-            }
             FormatElement::Verbatim(verbatim) => verbatim.element.will_break(),
             FormatElement::BestFitting(_) => false,
             FormatElement::LineSuffixBoundary => false,
@@ -534,7 +516,7 @@ impl FormatElement {
             FormatElement::List(list) => {
                 list.iter().rev().find_map(|element| element.last_element())
             }
-            FormatElement::Line(_) | FormatElement::Comments { .. } => None,
+            FormatElement::Line(_) | FormatElement::Comment(_) => None,
 
             FormatElement::Indent(indent) => indent.last_element(),
             FormatElement::Group(group) => group

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -334,7 +334,7 @@ pub struct Interned(Rc<FormatElement>);
 
 impl Interned {
     pub(crate) fn try_unwrap(this: Interned) -> Result<FormatElement, Interned> {
-        Rc::try_unwrap(this.0).map_err(|rc| Interned(rc))
+        Rc::try_unwrap(this.0).map_err(Interned)
     }
 }
 
@@ -493,7 +493,6 @@ impl FormatElement {
     pub fn is_empty(&self) -> bool {
         match self {
             FormatElement::List(list) => list.is_empty(),
-            FormatElement::Rc(inner) => inner.is_empty(),
             _ => false,
         }
     }

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -58,7 +58,10 @@ pub enum FormatElement {
     /// a trivia content, and it should only have a limited influence on the
     /// formatting (for instance line breaks contained within will not cause
     /// the parent group to break if this element is at the start of it)
-    Comment(Content),
+    Comments {
+        content: Box<[FormatElement]>,
+        leading: bool,
+    },
 
     /// A token that tracks tokens/nodes that are printed using [`format_verbatim`](crate::Formatter::format_verbatim) API
     Verbatim(Verbatim),
@@ -139,7 +142,11 @@ impl Debug for FormatElement {
                 fmt.debug_tuple("LineSuffix").field(content).finish()
             }
             FormatElement::LineSuffixBoundary => write!(fmt, "LineSuffixBoundary"),
-            FormatElement::Comment(content) => fmt.debug_tuple("Comment").field(content).finish(),
+            FormatElement::Comments { content, leading } => fmt
+                .debug_struct("Comments")
+                .field("content", content)
+                .field("leading", leading)
+                .finish(),
             FormatElement::Verbatim(verbatim) => fmt
                 .debug_tuple("Verbatim")
                 .field(&verbatim.element)
@@ -493,67 +500,18 @@ impl FormatElement {
             FormatElement::Fill(fill) => fill.list.content.iter().any(FormatElement::will_break),
             FormatElement::Token(token) => token.contains('\n'),
             FormatElement::LineSuffix(_) => false,
-            FormatElement::Comment(content) => content.will_break(),
+            FormatElement::Comments { content, leading } => {
+                if *leading {
+                    false
+                } else {
+                    content.iter().any(FormatElement::will_break)
+                }
+            }
             FormatElement::Verbatim(verbatim) => verbatim.element.will_break(),
             FormatElement::BestFitting(_) => false,
             FormatElement::LineSuffixBoundary => false,
             FormatElement::ExpandParent => true,
             FormatElement::Rc(inner) => inner.will_break(),
-        }
-    }
-
-    /// Splits off the leading and trailing trivias (comments) from this [FormatElement]
-    ///
-    /// For [FormatElement::HardGroup], the trailing trivia
-    /// is automatically moved  outside of the group. The group itself is then recreated around the
-    /// content itself.
-    pub fn split_trivia(self) -> (FormatElement, FormatElement, FormatElement) {
-        match self {
-            FormatElement::List(mut list) => {
-                // Find the index of the first non-comment element in the list
-                let content_start = list
-                    .content
-                    .iter()
-                    .position(|elem| !matches!(elem, FormatElement::Comment(_)));
-
-                // List contains at least one non trivia element.
-                if let Some(content_start) = content_start {
-                    let (leading, mut content) = if content_start > 0 {
-                        let content = list.content.split_off(content_start);
-                        (FormatElement::List(list), content)
-                    } else {
-                        // No leading trivia
-                        (FormatElement::List(List::default()), list.content)
-                    };
-
-                    let content_end = content
-                        .iter()
-                        .rposition(|elem| !matches!(elem, FormatElement::Comment(_)))
-                        .expect("List guaranteed to contain at least one non trivia element.");
-                    let trailing_start = content_end + 1;
-
-                    let trailing = if trailing_start < content.len() {
-                        FormatElement::List(List::new(content.split_off(trailing_start)))
-                    } else {
-                        FormatElement::List(List::default())
-                    };
-
-                    (leading, FormatElement::List(List::new(content)), trailing)
-                } else {
-                    // All leading trivia
-                    (
-                        FormatElement::List(list),
-                        FormatElement::List(List::default()),
-                        FormatElement::List(List::default()),
-                    )
-                }
-            }
-            // Non-list elements are returned directly
-            _ => (
-                FormatElement::List(List::default()),
-                self,
-                FormatElement::List(List::default()),
-            ),
         }
     }
 
@@ -570,7 +528,7 @@ impl FormatElement {
             FormatElement::List(list) => {
                 list.iter().rev().find_map(|element| element.last_element())
             }
-            FormatElement::Line(_) | FormatElement::Comment(_) => None,
+            FormatElement::Line(_) | FormatElement::Comments { .. } => None,
 
             FormatElement::Indent(indent) => indent.last_element(),
             FormatElement::Group(group) => group

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -222,7 +222,7 @@ impl Fill {
 /// but breaks the array cross multiple lines if it would exceed the specified `line_width`, if a child token is a hard line break or if a string contains a line break.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Group {
-    pub(crate) content: Content,
+    pub(crate) content: Box<[FormatElement]>,
     pub(crate) id: Option<GroupId>,
 }
 
@@ -240,9 +240,9 @@ impl Debug for Group {
 }
 
 impl Group {
-    pub fn new(content: FormatElement) -> Self {
+    pub fn new(content: Vec<FormatElement>) -> Self {
         Self {
-            content: Box::new(content),
+            content: content.into_boxed_slice(),
             id: None,
         }
     }
@@ -487,7 +487,7 @@ impl FormatElement {
             FormatElement::Space => false,
             FormatElement::Line(line_mode) => matches!(line_mode, LineMode::Hard | LineMode::Empty),
             FormatElement::Indent(content) => content.will_break(),
-            FormatElement::Group(group) => group.content.will_break(),
+            FormatElement::Group(group) => group.content.iter().any(FormatElement::will_break),
             FormatElement::ConditionalGroupContent(group) => group.content.will_break(),
             FormatElement::List(list) => list.content.iter().any(FormatElement::will_break),
             FormatElement::Fill(fill) => fill.list.content.iter().any(FormatElement::will_break),
@@ -573,7 +573,11 @@ impl FormatElement {
             FormatElement::Line(_) | FormatElement::Comment(_) => None,
 
             FormatElement::Indent(indent) => indent.last_element(),
-            FormatElement::Group(group) => group.content.last_element(),
+            FormatElement::Group(group) => group
+                .content
+                .iter()
+                .rev()
+                .find_map(FormatElement::last_element),
 
             _ => Some(self),
         }

--- a/crates/rome_formatter/src/format_extensions.rs
+++ b/crates/rome_formatter/src/format_extensions.rs
@@ -145,7 +145,7 @@ impl<T, Context> MemoizeFormat<Context> for T where T: Format<Context> {}
 #[derive(Debug)]
 pub struct Memoized<F, Context> {
     inner: F,
-    memory: RefCell<Option<FormatResult<Rc<FormatElement>>>>,
+    memory: RefCell<Option<FormatResult<FormatElement>>>,
     options: PhantomData<Context>,
 }
 
@@ -171,7 +171,7 @@ where
         if let Some(memory) = self.memory.borrow().as_ref() {
             return match memory {
                 Ok(elements) => {
-                    f.write_element(FormatElement::Rc(elements.clone()))?;
+                    f.write_element(elements.clone())?;
 
                     Ok(())
                 }
@@ -185,9 +185,11 @@ where
         match result {
             Ok(_) => {
                 let elements = buffer.into_element();
-                let reference = Rc::new(elements);
-                f.write_element(FormatElement::Rc(reference.clone()))?;
-                *self.memory.borrow_mut() = Some(Ok(reference));
+                let interned = elements.intern();
+
+                f.write_element(interned.clone())?;
+
+                *self.memory.borrow_mut() = Some(Ok(interned));
 
                 Ok(())
             }

--- a/crates/rome_formatter/src/format_extensions.rs
+++ b/crates/rome_formatter/src/format_extensions.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use std::cell::RefCell;
 use std::marker::PhantomData;
-use std::rc::Rc;
 
 use crate::{write, Buffer, VecBuffer};
 

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -48,7 +48,7 @@ use crate::printer::{Printer, PrinterOptions};
 pub use arguments::{Argument, Arguments};
 pub use buffer::{Buffer, BufferExtensions, BufferSnapshot, Inspect, PreambleBuffer, VecBuffer};
 pub use builders::{
-    block_indent, comments, empty_line, get_lines_before, group_elements, hard_line_break,
+    block_indent, comment, empty_line, get_lines_before, group_elements, hard_line_break,
     if_group_breaks, if_group_fits_on_line, indent, line_suffix, soft_block_indent,
     soft_line_break, soft_line_break_or_space, soft_line_indent_or_space, space_token, token,
     BestFitting,

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -48,7 +48,7 @@ use crate::printer::{Printer, PrinterOptions};
 pub use arguments::{Argument, Arguments};
 pub use buffer::{Buffer, BufferExtensions, BufferSnapshot, Inspect, PreambleBuffer, VecBuffer};
 pub use builders::{
-    block_indent, comment, empty_line, get_lines_before, group_elements, hard_line_break,
+    block_indent, comments, empty_line, get_lines_before, group_elements, hard_line_break,
     if_group_breaks, if_group_fits_on_line, indent, line_suffix, soft_block_indent,
     soft_line_break, soft_line_break_or_space, soft_line_indent_or_space, space_token, token,
     BestFitting,

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -298,7 +298,7 @@ impl<'a> Printer<'a> {
                     }
                 }
             }
-            FormatElement::Rc(content) => queue.enqueue(PrintElementCall::new(content, args)),
+            FormatElement::Interned(content) => queue.enqueue(PrintElementCall::new(content, args)),
         }
     }
 
@@ -813,7 +813,7 @@ fn fits_element_on_line<'a, 'rest>(
                 return Fits::No;
             }
         }
-        FormatElement::Rc(content) => queue.enqueue(PrintElementCall::new(content, args)),
+        FormatElement::Interned(content) => queue.enqueue(PrintElementCall::new(content, args)),
     }
 
     Fits::Maybe

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -129,7 +129,11 @@ impl<'a> Printer<'a> {
                     PrintMode::Flat if self.state.measured_group_fits => {
                         // A parent group has already verified that this group fits on a single line
                         // Thus, just continue in flat mode
-                        queue.enqueue(PrintElementCall::new(content.as_ref(), args));
+                        queue.extend(
+                            content
+                                .iter()
+                                .map(|element| PrintElementCall::new(element, args)),
+                        );
                         PrintMode::Flat
                     }
                     // The printer is either in expanded mode or it's necessary to re-measure if the group fits
@@ -139,15 +143,16 @@ impl<'a> Printer<'a> {
                         // print the group in "flat" mode, otherwise continue in expanded mode
 
                         let flat_args = args.with_print_mode(PrintMode::Flat);
-                        if fits_on_line(&[content], flat_args, queue, self) {
-                            queue.enqueue(PrintElementCall::new(content, flat_args));
+                        if fits_on_line(content.iter(), flat_args, queue, self) {
+                            queue.extend(
+                                content.iter().map(|e| PrintElementCall::new(e, flat_args)),
+                            );
                             self.state.measured_group_fits = true;
                             PrintMode::Flat
                         } else {
-                            queue.enqueue(PrintElementCall::new(
-                                content,
-                                args.with_print_mode(PrintMode::Expanded),
-                            ));
+                            queue.extend(content.iter().map(|e| {
+                                PrintElementCall::new(e, args.with_print_mode(PrintMode::Expanded))
+                            }));
                             PrintMode::Expanded
                         }
                     }
@@ -279,7 +284,7 @@ impl<'a> Printer<'a> {
                                     PrintMode::Expanded
                                 };
 
-                                if fits_on_line(&[variant], args.with_print_mode(mode), queue, self)
+                                if fits_on_line([variant], args.with_print_mode(mode), queue, self)
                                 {
                                     self.state.measured_group_fits = true;
                                     queue.enqueue(PrintElementCall::new(
@@ -362,7 +367,7 @@ impl<'a> Printer<'a> {
         };
 
         let mut current_fits = fits_on_line(
-            &[current_content],
+            [current_content],
             args.with_print_mode(PrintMode::Flat),
             &empty_rest,
             self,
@@ -384,7 +389,7 @@ impl<'a> Printer<'a> {
             // otherwise see if both contents fit on the line.
             let current_and_next_fit = current_fits
                 && fits_on_line(
-                    &[separator, next_item],
+                    [separator, next_item],
                     args.with_print_mode(PrintMode::Flat),
                     &empty_rest,
                     self,
@@ -406,7 +411,7 @@ impl<'a> Printer<'a> {
                 );
 
                 let next_fits = fits_on_line(
-                    &[next_item],
+                    [next_item],
                     args.with_print_mode(PrintMode::Flat),
                     &empty_rest,
                     self,
@@ -626,12 +631,16 @@ impl<'a> ElementCallQueue<'a> {
 /// Tests if it's possible to print the content of the queue up to the first hard line break
 /// or the end of the document on a single line without exceeding the line width.
 #[must_use = "Only determines if content fits on a single line but doesn't print it"]
-fn fits_on_line<'a>(
-    elements: &[&'a FormatElement],
+fn fits_on_line<'a, I>(
+    elements: I,
     args: PrintElementArgs,
     queue: &ElementCallQueue<'a>,
     printer: &mut Printer<'a>,
-) -> bool {
+) -> bool
+where
+    I: IntoIterator<Item = &'a FormatElement>,
+    I::IntoIter: DoubleEndedIterator,
+{
     let shared_buffer = std::mem::take(&mut printer.state.measure_queue);
     debug_assert!(shared_buffer.is_empty());
 
@@ -641,7 +650,7 @@ fn fits_on_line<'a>(
 
     measure_queue.extend(
         elements
-            .iter()
+            .into_iter()
             .map(|element| PrintElementCall::new(element, args)),
     );
 
@@ -726,7 +735,9 @@ fn fits_element_on_line<'a, 'rest>(
             args.with_incremented_indent(),
         )),
 
-        FormatElement::Group(group) => queue.enqueue(PrintElementCall::new(&group.content, args)),
+        FormatElement::Group(group) => {
+            queue.extend(group.content.iter().map(|e| PrintElementCall::new(e, args)))
+        }
 
         FormatElement::ConditionalGroupContent(conditional) => {
             if args.mode == conditional.mode {

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -223,7 +223,7 @@ impl<'a> Printer<'a> {
 
                     // Fit's only tests if groups up to the first line break fit.
                     // The next group must re-measure if it still fits.
-                    self.state.measured_group_fits = false;
+                    self.state.measured_group_fits = !args.in_leading_comment;
                 }
             }
 
@@ -237,8 +237,8 @@ impl<'a> Printer<'a> {
                 self.queue_line_suffixes(HARD_BREAK, args, queue);
             }
 
-            FormatElement::Comment(content) => {
-                queue.enqueue(PrintElementCall::new(content.as_ref(), args));
+            FormatElement::Comments { content, .. } => {
+                queue.extend(content.iter().map(|e| PrintElementCall::new(e, args)))
             }
 
             FormatElement::Verbatim(verbatim) => {
@@ -539,6 +539,32 @@ impl PrinterState<'_> {
 struct PrintElementArgs {
     indent: u16,
     mode: PrintMode,
+
+    /// `true` if the printer is inside of a leading comments block at the start of a line.
+    /// The information is necessary to avoid that a leading comment with a line break, breaks the group
+    /// of the token:
+    ///
+    /// ```javascript
+    /// /* This comment should not expand `[]` */
+    /// []
+    /// ```
+    ///
+    /// The IR for the code roughly is (assuming that `[]` doesn't use `FormatDelimited`):
+    ///
+    /// ```plain
+    /// group_elements(
+    ///   comments(token("/* This comment... "), hard_line_break()),
+    ///   token("["),
+    ///   token("]"),
+    /// )
+    /// ```
+    ///
+    /// The important part is that the `comments` are part of the `group_elements` because the comments
+    /// are formatted as part of the `[` token that is part of the group.
+    ///
+    /// The printer should ignore line breaks in leading comments at the start of the line when
+    /// deciding if a group fits on the line or not.
+    in_leading_comment: bool,
 }
 
 impl PrintElementArgs {
@@ -558,6 +584,11 @@ impl PrintElementArgs {
         self.mode = mode;
         self
     }
+
+    pub fn with_in_leading_comment(mut self, in_leading_comment: bool) -> Self {
+        self.in_leading_comment = in_leading_comment;
+        self
+    }
 }
 
 impl Default for PrintElementArgs {
@@ -565,6 +596,7 @@ impl Default for PrintElementArgs {
         Self {
             indent: 0,
             mode: PrintMode::Expanded,
+            in_leading_comment: false,
         }
     }
 }
@@ -718,7 +750,15 @@ fn fits_element_on_line<'a, 'rest>(
                     }
                     LineMode::Soft => {}
                     LineMode::Hard | LineMode::Empty => {
-                        return Fits::No;
+                        // Line breaks inside a multiline block comment are OK if this is a leading comment at
+                        // the beginning of the line.
+                        if args.in_leading_comment {
+                            state.pending_space = false;
+                            state.pending_indent = args.indent;
+                            state.line_width = 0;
+                        } else {
+                            return Fits::No;
+                        }
                     }
                 }
             } else {
@@ -756,6 +796,7 @@ fn fits_element_on_line<'a, 'rest>(
 
         FormatElement::Token(token) => {
             state.line_width += state.pending_indent as usize * options.indent_string.len();
+            state.pending_indent = 0;
 
             if state.pending_space {
                 state.line_width += 1;
@@ -764,12 +805,32 @@ fn fits_element_on_line<'a, 'rest>(
             for c in token.chars() {
                 let char_width = match c {
                     '\t' => options.tab_width,
-                    '\n' => {
-                        return match args.mode {
-                            PrintMode::Flat => Fits::No,
-                            PrintMode::Expanded => Fits::Yes,
+                    '\n' => match args.mode {
+                        PrintMode::Flat => {
+                            // Special handling for leading comments at the start of a new line.
+                            // Prevents that a leading line comment expands the token's enclosing group.
+                            //
+                            // ```javascript
+                            // /* a comment */
+                            // [1]
+                            // ```
+                            //
+                            // The `/* a comment */` belongs to the `[` group token that is part of a group wrapping the whole
+                            // `[1]` expression. This branch treats the `/* a comment */` as if it is outside of the group element
+                            // to avoid that the `[1]` group expands because of the line break at the end of the comment.
+                            if args.in_leading_comment {
+                                state.line_width = 0;
+                                state.pending_space = false;
+                                state.pending_indent = args.indent;
+                                continue;
+                            } else {
+                                return Fits::No;
+                            }
                         }
-                    }
+                        PrintMode::Expanded => {
+                            return Fits::Yes;
+                        }
+                    },
                     _ => 1,
                 };
                 state.line_width += char_width as usize;
@@ -780,7 +841,6 @@ fn fits_element_on_line<'a, 'rest>(
             }
 
             state.pending_space = false;
-            state.pending_indent = 0;
         }
 
         FormatElement::LineSuffix(_) => {
@@ -793,7 +853,12 @@ fn fits_element_on_line<'a, 'rest>(
             }
         }
 
-        FormatElement::Comment(content) => queue.enqueue(PrintElementCall::new(content, args)),
+        FormatElement::Comments { content, leading } => queue.extend(content.iter().map(|e| {
+            PrintElementCall::new(
+                e,
+                args.with_in_leading_comment(*leading && state.line_width == 0),
+            )
+        })),
 
         FormatElement::Verbatim(verbatim) => {
             queue.enqueue(PrintElementCall::new(&verbatim.element, args))
@@ -1171,7 +1236,7 @@ two lines`,
                 token("]")
             ]),
             token(";"),
-            comment(&line_suffix(&format_args![
+            comments(&line_suffix(&format_args![
                 space_token(),
                 token("// trailing"),
                 space_token()

--- a/crates/rome_formatter/src/token.rs
+++ b/crates/rome_formatter/src/token.rs
@@ -813,7 +813,7 @@ where
             Ok(())
         });
 
-        write!(f, [comments(&format_comments).leading(true)])
+        write!(f, [comments(&format_comments, CommentPosition::Leading)])
     }
 }
 
@@ -889,6 +889,10 @@ where
         let mut comments = comments.enumerate().peekable();
         let is_empty = comments.peek().is_none();
 
+        if is_empty {
+            return Ok(());
+        }
+
         let format_comments = format_once(|f| {
             for (index, comment) in comments {
                 if !self.skip_formatted_check && f.state().is_comment_formatted(comment.piece()) {
@@ -921,12 +925,9 @@ where
             Ok(())
         });
 
-        if !is_empty {
-            crate::comments(&format_comments).fmt(f)?;
-            f.state_mut()
-                .set_last_content_is_inline_comment(last_inline_comment);
-        }
-
+        crate::comments(&format_comments, CommentPosition::Trailing).fmt(f)?;
+        f.state_mut()
+            .set_last_content_is_inline_comment(last_inline_comment);
         Ok(())
     }
 }


### PR DESCRIPTION
It's necessary to move leading comments outside a group to prevent that the comments expand the enclosing group:

```javascript
/* a comment */
[1]
```

The `/* a comment */` belongs to the `[` group token that is part of a group wrapping the whole `[1]` expression. It's important that the comment `/* a comment */` gets moved out of the group element to avoid the `[1]` group expanding because of the line break inserted by the comment.

The `group_elements` implementation so far used `split_trivia` to accomplish this. This PR changes `group_elements` to use a custom buffer that splits the leading trivia while it's being written. 

I decided to change Group to store a Box<[FormatElement]> to avoid boxing List elements.

## Test Plan
`cargo test`
