### PR TITLE
feat(rome_js_formatter): assignment expressions with layout

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-
 use crate::utils::JsAnyAssignmentLike;
 use crate::FormatNodeFields;
 use rome_formatter::write;

--- a/crates/rome_js_formatter/src/js/objects/property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/property_object_member.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-
 use crate::utils::JsAnyAssignmentLike;
 use crate::FormatNodeFields;
 use rome_formatter::write;

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -526,8 +526,11 @@ mod test {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-bifornCringerMoshedPerplex = bifornCringerMoshedPerplexSawder = arrayOfNumb = a = "test"
-        "#;
+tt.parenR.updateContext = tt.braceR.updateContext = function () {
+  if (this.state.context.length === 1) {
+    return;
+  }
+}        "#;
         let syntax = SourceType::ts();
         let tree = parse(src, 0, syntax);
         let result = format_node(JsFormatContext::default(), &tree.syntax())

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -526,20 +526,9 @@ mod test {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-       app.get("/", (req, res): void => {
-         res.send("Hello World!");
-       });
-       
- export class Thing implements OtherThing {
-        do: (type: Type) => Provider<Prop> = memoize(
-          (type: ObjectType): Provider<Opts> => {}
-        );
-      }
- 
-"#;
-        // let src = r#"useEffect(() => { hey; }, [1, 4])"#;
-
-        let syntax = SourceType::tsx();
+bifornCringerMoshedPerplex = bifornCringerMoshedPerplexSawder = arrayOfNumb = a = "test"
+        "#;
+        let syntax = SourceType::ts();
         let tree = parse(src, 0, syntax);
         let result = format_node(JsFormatContext::default(), &tree.syntax())
             .unwrap()

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -526,11 +526,8 @@ mod test {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-tt.parenR.updateContext = tt.braceR.updateContext = function () {
-  if (this.state.context.length === 1) {
-    return;
-  }
-}        "#;
+bifornCringerMoshedPerplex =
+	bifornCringerMoshedPerplexSawder = arrayOfNumb = a = "test";       "#;
         let syntax = SourceType::ts();
         let tree = parse(src, 0, syntax);
         let result = format_node(JsFormatContext::default(), &tree.syntax())

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -159,7 +159,16 @@ impl JsAnyAssignmentLike {
             matches!(
                 parent_kind,
                 Some(JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION | JsSyntaxKind::JS_VARIABLE_DECLARATOR)
-            )
+            ) && {
+                !right_is_tail
+                    || (matches!(
+                        parent_kind,
+                        Some(
+                            JsSyntaxKind::JS_EXPRESSION_STATEMENT
+                                | JsSyntaxKind::JS_VARIABLE_DECLARATOR
+                        )
+                    ))
+            }
         };
         let result = if should_use_chain_formatting {
             if right_is_tail {
@@ -262,6 +271,7 @@ impl Format<JsFormatContext> for JsAnyAssignmentLike {
 
             let layout = self.layout(is_left_short)?;
 
+            dbg!(&layout);
             match layout {
                 AssignmentLikeLayout::Fluid => {
                     let group_id = f.group_id("assignment_like");

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -129,7 +129,7 @@ impl JsAnyAssignmentLike {
     /// [Prettier applies]: https://github.com/prettier/prettier/blob/main/src/language-js/print/assignment.js
     fn layout(&self, is_left_short: bool) -> FormatResult<AssignmentLikeLayout> {
         let right = self.right()?;
-        if let Some(layout) = self.is_chain_formatting()? {
+        if let Some(layout) = self.chain_formatting_layout()? {
             Ok(layout)
         } else if is_break_after_operator(&right)? {
             Ok(AssignmentLikeLayout::BreakAfterOperator)
@@ -151,12 +151,9 @@ impl JsAnyAssignmentLike {
 
     /// Checks if the right node is entitled of the chain formatting,
     /// and if so, it return the layout type
-    fn is_chain_formatting(&self) -> SyntaxResult<Option<AssignmentLikeLayout>> {
+    fn chain_formatting_layout(&self) -> SyntaxResult<Option<AssignmentLikeLayout>> {
         let right = self.right()?;
         let right_is_tail = !matches!(right, JsAnyExpression::JsAssignmentExpression(_));
-        // Here we surf the upper levels and make sure that the current node
-        // is eligible of chain formatting
-        //
         // The chain goes up two levels, by checking up to the great parent if all the conditions
         // are correctly met.
         let upper_chain_is_eligible =

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -1,64 +1,21 @@
 use crate::prelude::*;
-
 use crate::utils::object::write_member_name;
 use crate::utils::JsAnyBinaryLikeExpression;
 use rome_formatter::{format_args, write};
 use rome_js_syntax::{
-    JsAnyExpression, JsAnyLiteralExpression, JsAssignmentExpression, JsPropertyObjectMember,
-    JsSyntaxNode,
+    JsAnyAssignmentPattern, JsAnyExpression, JsAnyObjectMemberName, JsAssignmentExpression,
+    JsPropertyObjectMember, JsSyntaxKind,
 };
+use rome_js_syntax::{JsAnyLiteralExpression, JsSyntaxNode};
 use rome_rowan::{declare_node_union, AstNode, SyntaxResult};
-
-pub(crate) fn write_assignment_like(
-    assignment_like: &JsAnyAssignmentLike,
-    f: &mut JsFormatter,
-) -> FormatResult<()> {
-    let right = assignment_like.right()?;
-    let format_content = format_with(|f| {
-        // Compare name only if we are in a position of computing it.
-        // If not (for example, left is not an identifier), then let's fallback to false,
-        // so we can continue the chain of checks
-        let is_left_short = assignment_like.write_left(f)?;
-        assignment_like.write_operator(f)?;
-
-        let layout = assignment_like.layout(is_left_short)?;
-        match layout {
-            AssignmentLikeLayout::Fluid => {
-                let group_id = f.group_id("assignment_like");
-
-                let right = right.format().memoized();
-
-                write![
-                    f,
-                    [
-                        group_elements(&indent(&soft_line_break_or_space()),)
-                            .with_group_id(Some(group_id)),
-                        line_suffix_boundary(),
-                        if_group_breaks(&indent(&right)).with_group_id(Some(group_id)),
-                        if_group_fits_on_line(&right).with_group_id(Some(group_id)),
-                    ]
-                ]
-            }
-            AssignmentLikeLayout::BreakAfterOperator => {
-                write![
-                    f,
-                    [group_elements(&indent(&format_args![
-                        soft_line_break_or_space(),
-                        right.format()
-                    ])),]
-                ]
-            }
-            AssignmentLikeLayout::NeverBreakAfterOperator => {
-                write![f, [space_token(), right.format(),]]
-            }
-        }
-    });
-
-    write!(f, [group_elements(&format_content)])
-}
 
 declare_node_union! {
     pub(crate) JsAnyAssignmentLike = JsPropertyObjectMember | JsAssignmentExpression
+
+}
+
+declare_node_union! {
+    pub(crate) LeftAssignmentLike = JsAnyAssignmentPattern | JsAnyObjectMemberName
 }
 
 /// Determines how a assignment like be formatted
@@ -66,6 +23,7 @@ declare_node_union! {
 /// Assignment like are:
 /// - Assignment
 /// - Object property member
+#[derive(Debug)]
 pub(crate) enum AssignmentLikeLayout {
     /// First break right-hand side, then after operator.
     /// ```js
@@ -102,6 +60,28 @@ pub(crate) enum AssignmentLikeLayout {
     /// }
     /// ```
     NeverBreakAfterOperator,
+
+    /// This is a special layout usually used for long variable declarations or assignment expressions
+    /// This layout is hit, usually, when we are in the "middle" of the chain:
+    ///
+    /// ```js
+    /// var a =
+    ///     loreum =
+    ///     ipsum =
+    ///         "foo";
+    /// ```
+    ///
+    /// Given the previous snippet, then `loreum` and `ipsum` will be formatted using the [Chain] layout.
+    Chain,
+
+    /// This is a special layout usually used for long variable declarations or assignment expressions
+    /// This layout is hit, usually, when we are in the end of a chain:
+    /// ```js
+    /// var a = loreum = ipsum = "foo";
+    /// ```
+    ///
+    /// Given the previous snippet, then `"foo"` formatted  using the [ChainTail] layout.
+    ChainTail,
 }
 
 impl JsAnyAssignmentLike {
@@ -144,14 +124,14 @@ impl JsAnyAssignmentLike {
             }
         }
     }
-}
 
-impl JsAnyAssignmentLike {
     /// Returns the layout variant for an assignment like depending on right expression and left part length
     /// [Prettier applies]: https://github.com/prettier/prettier/blob/main/src/language-js/print/assignment.js
     fn layout(&self, is_left_short: bool) -> FormatResult<AssignmentLikeLayout> {
         let right = self.right()?;
-        if is_break_after_operator(&right)? {
+        if let Some(layout) = self.is_chain_formatting()? {
+            Ok(layout)
+        } else if is_break_after_operator(&right)? {
             Ok(AssignmentLikeLayout::BreakAfterOperator)
         } else if is_left_short {
             Ok(AssignmentLikeLayout::NeverBreakAfterOperator)
@@ -162,17 +142,76 @@ impl JsAnyAssignmentLike {
             )
         ) {
             Ok(AssignmentLikeLayout::BreakAfterOperator)
-        } else if is_never_break_after_operator(&right)? {
+        } else if self.is_never_break_after_operator()? {
             Ok(AssignmentLikeLayout::NeverBreakAfterOperator)
         } else {
             Ok(AssignmentLikeLayout::Fluid)
         }
     }
+
+    /// Checks if the right node is entitled of the chain formatting,
+    /// and if so, it return the layout type
+    fn is_chain_formatting(&self) -> SyntaxResult<Option<AssignmentLikeLayout>> {
+        let parent_kind = self.syntax().parent().map(|p| p.kind());
+        let right = self.right()?;
+        let right_is_tail = !matches!(right, JsAnyExpression::JsAssignmentExpression(_));
+        let should_use_chain_formatting = {
+            matches!(
+                parent_kind,
+                Some(JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION | JsSyntaxKind::JS_VARIABLE_DECLARATOR)
+            )
+        };
+        let result = if should_use_chain_formatting {
+            if right_is_tail {
+                Some(AssignmentLikeLayout::ChainTail)
+            } else {
+                Some(AssignmentLikeLayout::Chain)
+            }
+        } else {
+            None
+        };
+
+        Ok(result)
+    }
+
+    fn is_never_break_after_operator(&self) -> SyntaxResult<bool> {
+        let right = self.right()?;
+        if let JsAnyExpression::JsCallExpression(call_expression) = &right {
+            if call_expression.callee()?.syntax().text() == "require" {
+                return Ok(true);
+            }
+        }
+
+        if matches!(
+            right,
+            JsAnyExpression::JsClassExpression(_)
+                | JsAnyExpression::JsTemplate(_)
+                | JsAnyExpression::JsAnyLiteralExpression(
+                    JsAnyLiteralExpression::JsBooleanLiteralExpression(_),
+                )
+                | JsAnyExpression::JsAnyLiteralExpression(
+                    JsAnyLiteralExpression::JsNumberLiteralExpression(_)
+                )
+        ) {
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
 }
 
+/// Checks if the function is entitled to be printed with layout [AssignmentLikeLayout::BreakAfterOperator]
 pub(crate) fn is_break_after_operator(right: &JsAnyExpression) -> SyntaxResult<bool> {
     if has_new_line_before_comment(right.syntax()) {
         return Ok(true);
+    }
+
+    // head is a long chain, meaning that right -> right are both assignment expressions
+    if let JsAnyExpression::JsAssignmentExpression(assignment) = right {
+        let right = assignment.right()?;
+        if matches!(right, JsAnyExpression::JsAssignmentExpression(_)) {
+            return Ok(true);
+        }
     }
 
     if JsAnyBinaryLikeExpression::cast(right.syntax().clone())
@@ -195,7 +234,6 @@ pub(crate) fn is_break_after_operator(right: &JsAnyExpression) -> SyntaxResult<b
 
     Ok(false)
 }
-
 /// If checks if among leading trivias, we there's a sequence of [Newline, Comment]
 pub(crate) fn has_new_line_before_comment(node: &JsSyntaxNode) -> bool {
     if let Some(leading_trivia) = node.first_leading_trivia() {
@@ -212,32 +250,71 @@ pub(crate) fn has_new_line_before_comment(node: &JsSyntaxNode) -> bool {
     false
 }
 
-fn is_never_break_after_operator(right: &JsAnyExpression) -> SyntaxResult<bool> {
-    if let JsAnyExpression::JsCallExpression(call_expression) = &right {
-        if call_expression.callee()?.syntax().text() == "require" {
-            return Ok(true);
-        }
-    }
-
-    if matches!(
-        right,
-        JsAnyExpression::JsClassExpression(_)
-            | JsAnyExpression::JsTemplate(_)
-            | JsAnyExpression::JsAnyLiteralExpression(
-                JsAnyLiteralExpression::JsBooleanLiteralExpression(_),
-            )
-            | JsAnyExpression::JsAnyLiteralExpression(
-                JsAnyLiteralExpression::JsNumberLiteralExpression(_)
-            )
-    ) {
-        return Ok(true);
-    }
-
-    Ok(false)
-}
-
 impl Format<JsFormatContext> for JsAnyAssignmentLike {
     fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
-        write_assignment_like(self, f)
+        let right = self.right()?;
+        let format_content = format_with(|f| {
+            // Compare name only if we are in a position of computing it.
+            // If not (for example, left is not an identifier), then let's fallback to false,
+            // so we can continue the chain of checks
+            let is_left_short = self.write_left(f)?;
+            self.write_operator(f)?;
+
+            let layout = self.layout(is_left_short)?;
+
+            match layout {
+                AssignmentLikeLayout::Fluid => {
+                    let group_id = f.group_id("assignment_like");
+
+                    let right = right.format().memoized();
+
+                    write![
+                        f,
+                        [
+                            group_elements(&indent(&soft_line_break_or_space()),)
+                                .with_group_id(Some(group_id)),
+                            line_suffix_boundary(),
+                            if_group_breaks(&indent(&right)).with_group_id(Some(group_id)),
+                            if_group_fits_on_line(&right).with_group_id(Some(group_id)),
+                        ]
+                    ]
+                }
+                AssignmentLikeLayout::BreakAfterOperator => {
+                    write![
+                        f,
+                        [group_elements(&indent(&format_args![
+                            soft_line_break_or_space(),
+                            right.format()
+                        ])),]
+                    ]
+                }
+                AssignmentLikeLayout::NeverBreakAfterOperator => {
+                    write![f, [space_token(), right.format(),]]
+                }
+
+                AssignmentLikeLayout::Chain => {
+                    write!(f, [soft_line_break_or_space(), right.format()])
+                }
+
+                AssignmentLikeLayout::ChainTail => {
+                    write!(
+                        f,
+                        [&indent(&format_args![
+                            soft_line_break_or_space(),
+                            right.format()
+                        ])]
+                    )
+                }
+            }
+        });
+
+        match self {
+            JsAnyAssignmentLike::JsPropertyObjectMember(_) => {
+                write!(f, [group_elements(&format_content)])
+            }
+            JsAnyAssignmentLike::JsAssignmentExpression(_) => {
+                write!(f, [&format_content])
+            }
+        }
     }
 }

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -291,8 +291,7 @@ impl Format<JsFormatContext> for JsAnyAssignmentLike {
 
             let layout = self.layout(is_left_short)?;
 
-            dbg!(&layout);
-            match layout {
+            let inner_content = format_with(|f| match &layout {
                 AssignmentLikeLayout::Fluid => {
                     let group_id = f.group_id("assignment_like");
 
@@ -335,16 +334,19 @@ impl Format<JsFormatContext> for JsAnyAssignmentLike {
                         ])]
                     )
                 }
+            });
+
+            match layout {
+                // Layouts that don't need enclosing group
+                AssignmentLikeLayout::Chain | AssignmentLikeLayout::ChainTail => {
+                    write!(f, [&inner_content])
+                }
+                _ => {
+                    write!(f, [group_elements(&inner_content)])
+                }
             }
         });
 
-        match self {
-            JsAnyAssignmentLike::JsPropertyObjectMember(_) => {
-                write!(f, [group_elements(&format_content)])
-            }
-            JsAnyAssignmentLike::JsAssignmentExpression(_) => {
-                write!(f, [&format_content])
-            }
-        }
+        write!(f, [format_content])
     }
 }

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use rome_formatter::{write, Buffer};
-
 use rome_js_syntax::{
     JsAnyExpression, JsAnyInProperty, JsBinaryExpression, JsBinaryOperator, JsInExpression,
     JsInstanceofExpression, JsLogicalExpression, JsLogicalOperator, JsPrivateName, JsSyntaxKind,

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js
@@ -109,3 +109,10 @@ render =  withGraphQLQuery(
 loadNext = (stateIsOK && hasNext) || {
     skipNext: true,
 };
+
+// chain and chain tail where it breaks
+bifornCringerMoshedPerplex = bifornCringerMoshedPerplexSawder = arrayOfNumb = a = "test"
+
+// chain and chain tail where it doesn't break
+loreum = ipsum = arrayOfNumb = a = "test"
+

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -252,8 +252,9 @@ bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers = {
 	a: 10,
 };
 bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder =
-	bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawderArrayNumbes =
-		{ a: 10 };
+	bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawderArrayNumbes = {
+		a: 10,
+	};
 fn = fn();
 this_is_a_very_long_key_and_the_assignment_should_be_put_on_the_next_line =
 	orMaybeIAmMisunderstandingAndIHaveSetSomethingWrongInMyConfig();
@@ -292,8 +293,7 @@ loadNext = (stateIsOK && hasNext) || {
 bifornCringerMoshedPerplex =
 	bifornCringerMoshedPerplexSawder =
 	arrayOfNumb =
-	a =
-		"test";
+	a = "test";
 
 // chain and chain tail where it doesn't break
 loreum = ipsum = arrayOfNumb = a = "test";

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -293,7 +293,8 @@ loadNext = (stateIsOK && hasNext) || {
 bifornCringerMoshedPerplex =
 	bifornCringerMoshedPerplexSawder =
 	arrayOfNumb =
-	a = "test";
+	a =
+		"test";
 
 // chain and chain tail where it doesn't break
 loreum = ipsum = arrayOfNumb = a = "test";

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: assignment.js
 ---
 # Input
@@ -114,6 +115,14 @@ render =  withGraphQLQuery(
 loadNext = (stateIsOK && hasNext) || {
     skipNext: true,
 };
+
+// chain and chain tail where it breaks
+bifornCringerMoshedPerplex = bifornCringerMoshedPerplexSawder = arrayOfNumb = a = "test"
+
+// chain and chain tail where it doesn't break
+loreum = ipsum = arrayOfNumb = a = "test"
+
+
 =============================
 # Outputs
 ## Output 1
@@ -243,9 +252,8 @@ bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers = {
 	a: 10,
 };
 bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder =
-	bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawderArrayNumbes = {
-		a: 10,
-	};
+	bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawderArrayNumbes =
+		{ a: 10 };
 fn = fn();
 this_is_a_very_long_key_and_the_assignment_should_be_put_on_the_next_line =
 	orMaybeIAmMisunderstandingAndIHaveSetSomethingWrongInMyConfig();
@@ -279,6 +287,16 @@ render = withGraphQLQuery("node(1234567890){image{uri}}", function (
 loadNext = (stateIsOK && hasNext) || {
 	skipNext: true,
 };
+
+// chain and chain tail where it breaks
+bifornCringerMoshedPerplex =
+	bifornCringerMoshedPerplexSawder =
+	arrayOfNumb =
+	a =
+		"test";
+
+// chain and chain tail where it doesn't break
+loreum = ipsum = arrayOfNumb = a = "test";
 
 
 ## Lines exceeding width of 80 characters

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-expression/assignment_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-expression/assignment_expression.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: assignment_expression.js
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain-two-segments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain-two-segments.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: chain-two-segments.js
 ---
 # Input
@@ -14,11 +15,12 @@ tt.parenR.updateContext = tt.braceR.updateContext = function () {
 
 # Output
 ```js
-tt.parenR.updateContext = tt.braceR.updateContext = function () {
-  if (this.state.context.length === 1) {
-    return;
-  }
-};
+tt.parenR.updateContext = tt.braceR.updateContext =
+  function () {
+    if (this.state.context.length === 1) {
+      return;
+    }
+  };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain-two-segments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain-two-segments.js.snap
@@ -15,12 +15,11 @@ tt.parenR.updateContext = tt.braceR.updateContext = function () {
 
 # Output
 ```js
-tt.parenR.updateContext = tt.braceR.updateContext =
-  function () {
-    if (this.state.context.length === 1) {
-      return;
-    }
-  };
+tt.parenR.updateContext = tt.braceR.updateContext = function () {
+  if (this.state.context.length === 1) {
+    return;
+  }
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: chain.js
 ---
 # Input
@@ -37,22 +38,32 @@ a=b=c;
 # Output
 ```js
 let bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans =
-  glimseGlyphsHazardNoopsTieTie = averredBathersBoxroomBuggyNurl =
-    anodyneCondosMalateOverateRetinol = annularCooeedSplicesWalksWayWay =
-      kochabCooieGameOnOboleUnweave;
+  glimseGlyphsHazardNoopsTieTie =
+  averredBathersBoxroomBuggyNurl =
+  anodyneCondosMalateOverateRetinol =
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave;
 
-bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans =
-  glimseGlyphsHazardNoopsTieTie = x = averredBathersBoxroomBuggyNurl =
-    anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
-      annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans =
+  glimseGlyphsHazardNoopsTieTie =
+  x =
+  averredBathersBoxroomBuggyNurl =
+  anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave;
 
-bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans =
-  glimseGlyphsHazardNoopsTieTie = x = averredBathersBoxroomBuggyNurl =
-    anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
-      annularCooeedSplicesWalksWayWay =
-        kochabCooieGameOnOboleUnweave + kochabCooieGameOnOboleUnweave;
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans =
+  glimseGlyphsHazardNoopsTieTie =
+  x =
+  averredBathersBoxroomBuggyNurl =
+  anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave + kochabCooieGameOnOboleUnweave;
 
-a = b = c;
+a = b =
+  c;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
@@ -41,8 +41,7 @@ let bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans =
   glimseGlyphsHazardNoopsTieTie =
   averredBathersBoxroomBuggyNurl =
   anodyneCondosMalateOverateRetinol =
-  annularCooeedSplicesWalksWayWay =
-    kochabCooieGameOnOboleUnweave;
+  annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
 
 bifornCringerMoshedPerplexSawder =
   askTrovenaBeenaDependsRowans =
@@ -50,8 +49,7 @@ bifornCringerMoshedPerplexSawder =
   x =
   averredBathersBoxroomBuggyNurl =
   anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
-  annularCooeedSplicesWalksWayWay =
-    kochabCooieGameOnOboleUnweave;
+  annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
 
 bifornCringerMoshedPerplexSawder =
   askTrovenaBeenaDependsRowans =
@@ -62,8 +60,7 @@ bifornCringerMoshedPerplexSawder =
   annularCooeedSplicesWalksWayWay =
     kochabCooieGameOnOboleUnweave + kochabCooieGameOnOboleUnweave;
 
-a = b =
-  c;
+a = b = c;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
@@ -41,7 +41,8 @@ let bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans =
   glimseGlyphsHazardNoopsTieTie =
   averredBathersBoxroomBuggyNurl =
   anodyneCondosMalateOverateRetinol =
-  annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave;
 
 bifornCringerMoshedPerplexSawder =
   askTrovenaBeenaDependsRowans =
@@ -49,7 +50,8 @@ bifornCringerMoshedPerplexSawder =
   x =
   averredBathersBoxroomBuggyNurl =
   anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
-  annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave;
 
 bifornCringerMoshedPerplexSawder =
   askTrovenaBeenaDependsRowans =

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
@@ -21,8 +21,7 @@ this.someObject.someOtherNestedObject =
   this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
 
 this.isaverylongmethodexpression.withmultiplelevels =
-  this.isanotherverylongexpression.thatisalsoassigned =
-    0;
+  this.isanotherverylongexpression.thatisalsoassigned = 0;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-1966.js
 ---
 # Input
@@ -20,7 +21,8 @@ this.someObject.someOtherNestedObject =
   this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
 
 this.isaverylongmethodexpression.withmultiplelevels =
-  this.isanotherverylongexpression.thatisalsoassigned = 0;
+  this.isanotherverylongexpression.thatisalsoassigned =
+    0;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
@@ -28,10 +28,9 @@ this.dummy.type1.dummyPropertyFunction =
   this.dummy.type5.dummyPropertyFunction =
   this.dummy.type6.dummyPropertyFunction =
   this.dummy.type7.dummyPropertyFunction =
-  this.dummy.type8.dummyPropertyFunction =
-    () => {
-      return "dummy";
-    };
+  this.dummy.type8.dummyPropertyFunction = () => {
+    return "dummy";
+  };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
@@ -28,9 +28,10 @@ this.dummy.type1.dummyPropertyFunction =
   this.dummy.type5.dummyPropertyFunction =
   this.dummy.type6.dummyPropertyFunction =
   this.dummy.type7.dummyPropertyFunction =
-  this.dummy.type8.dummyPropertyFunction = () => {
-    return "dummy";
-  };
+  this.dummy.type8.dummyPropertyFunction =
+    () => {
+      return "dummy";
+    };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: issue-3819.js
 ---
 # Input
@@ -22,14 +23,15 @@ this.dummy.type1.dummyPropertyFunction
 ```js
 this.dummy.type1.dummyPropertyFunction =
   this.dummy.type2.dummyPropertyFunction =
-    this.dummy.type3.dummyPropertyFunction =
-      this.dummy.type4.dummyPropertyFunction =
-        this.dummy.type5.dummyPropertyFunction =
-          this.dummy.type6.dummyPropertyFunction =
-            this.dummy.type7.dummyPropertyFunction =
-              this.dummy.type8.dummyPropertyFunction = () => {
-                return "dummy";
-              };
+  this.dummy.type3.dummyPropertyFunction =
+  this.dummy.type4.dummyPropertyFunction =
+  this.dummy.type5.dummyPropertyFunction =
+  this.dummy.type6.dummyPropertyFunction =
+  this.dummy.type7.dummyPropertyFunction =
+  this.dummy.type8.dummyPropertyFunction =
+    () => {
+      return "dummy";
+    };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/import-meta.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/import-meta.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: import-meta.js
 ---
 # Input
@@ -41,7 +42,8 @@ expression: import-meta.js
 
   const image = new Image();
   image.src = URL.createObjectURL(blob);
-  image.width = image.height = size;
+  image.width = image.height =
+    size;
 
   document.body.appendChild(image);
 })();

--- a/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/import-meta.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/import-meta.js.snap
@@ -42,8 +42,7 @@ expression: import-meta.js
 
   const image = new Image();
   image.src = URL.createObjectURL(blob);
-  image.width = image.height =
-    size;
+  image.width = image.height = size;
 
   document.body.appendChild(image);
 })();

--- a/crates/rome_js_formatter/tests/specs/prettier/js/logical-assignment/logical-assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/logical-assignment/logical-assignment.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: logical-assignment.js
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
@@ -42,8 +42,10 @@ const defaultMaskGetter = $parse(attrs[directiveName]) as (
   scope: ng.IScope,
 ) => Mask;
 
-(this.configuration as any) = (this.editor as any) = (this.editorBody as any) =
-  undefined;
+(this.configuration as any) =
+  (this.editor as any) =
+  (this.editorBody as any) =
+    undefined;
 
 angular.module("foo").directive("formIsolator", () => {
   return {
@@ -54,8 +56,10 @@ angular.module("foo").directive("formIsolator", () => {
   };
 });
 
-(this.selectorElem as any) = this.multiselectWidget = this.initialValues =
-  undefined;
+(this.selectorElem as any) =
+  this.multiselectWidget =
+  this.initialValues =
+    undefined;
 
 const extraRendererAttrs = (
   (

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
@@ -44,8 +44,7 @@ const defaultMaskGetter = $parse(attrs[directiveName]) as (
 
 (this.configuration as any) =
   (this.editor as any) =
-  (this.editorBody as any) =
-    undefined;
+  (this.editorBody as any) = undefined;
 
 angular.module("foo").directive("formIsolator", () => {
   return {
@@ -58,8 +57,7 @@ angular.module("foo").directive("formIsolator", () => {
 
 (this.selectorElem as any) =
   this.multiselectWidget =
-  this.initialValues =
-    undefined;
+  this.initialValues = undefined;
 
 const extraRendererAttrs = (
   (

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
@@ -44,7 +44,8 @@ const defaultMaskGetter = $parse(attrs[directiveName]) as (
 
 (this.configuration as any) =
   (this.editor as any) =
-  (this.editorBody as any) = undefined;
+  (this.editorBody as any) =
+    undefined;
 
 angular.module("foo").directive("formIsolator", () => {
   return {
@@ -57,7 +58,8 @@ angular.module("foo").directive("formIsolator", () => {
 
 (this.selectorElem as any) =
   this.multiselectWidget =
-  this.initialValues = undefined;
+  this.initialValues =
+    undefined;
 
 const extraRendererAttrs = (
   (


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR closes #2416 

This PR adds `Chain` and `ChainTail` to the list of layouts and implements them. I left out on purpose `ChainTailArrowFunction` to not add too code, mostly because this PR moves code around and it might cause some confusion.

I moved the implementation of `write_assignment_like` inside the `format` function of `JsAnyAssignmentLike` for two important reasons:
- I needed access to `JsAnyAssignmentLike` variants in order to understand whether a group should be added or not;
- I needed access to the parent of `JsAnyAssignmentLike`, which was needed for the implementation of the new layout;

I also moved few functions inside the struct itself, because they needed to be exposed. The only loose function is used else where, so I kept there. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I created two new tests for the new layouts, one case where the groups breaks and on where it doesn't.

PR

**File Based Average Prettier Similarity**: 74.79%  
**Line Based Average Prettier Similarity**: 69.89% 

`main`
**File Based Average Prettier Similarity**: 74.65%  
**Line Based Average Prettier Similarity**: 69.75% 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
