### PR TITLE
fix(rome_js_formatter): don't add trailing operator on rest arguments

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -106,7 +106,6 @@ impl FormatNodeRule<JsCallArguments> for FormatJsCallArguments {
                 // which means that if one is `false`, then the other is `true`.
                 // This means that in this branch we format the case where `should_group_first_argument`,
                 // in the else branch we format the case where `should_group_last_argument` is `true`.
-
                 write!(f, [l_leading_trivia, l_paren, l_trailing_trivia,])?;
                 if should_group_first_argument {
                     // special formatting of the first element
@@ -132,7 +131,6 @@ impl FormatNodeRule<JsCallArguments> for FormatJsCallArguments {
                         }))
                         .finish()?;
                 }
-
                 write!(f, [r_leading_trivia, r_paren, r_trailing_trivia])
             });
 

--- a/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use rome_js_syntax::{JsConstructorParameterList, JsSyntaxKind};
+use rome_js_syntax::{JsAnyConstructorParameter, JsConstructorParameterList, JsSyntaxKind};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsConstructorParameterList;
@@ -8,8 +8,22 @@ impl FormatRule<JsConstructorParameterList> for FormatJsConstructorParameterList
     type Context = JsFormatContext;
 
     fn fmt(&self, node: &JsConstructorParameterList, f: &mut JsFormatter) -> FormatResult<()> {
+        // The trailing separator is disallowed if the last element in the list is a rest parameter
+        let has_trailing_rest = match node.into_iter().last() {
+            Some(elem) => matches!(elem?, JsAnyConstructorParameter::JsRestParameter(_)),
+            None => false,
+        };
+
+        let trailing_separator = if has_trailing_rest {
+            TrailingSeparator::Disallowed
+        } else {
+            TrailingSeparator::Allowed
+        };
         f.join_with(&soft_line_break_or_space())
-            .entries(node.format_separated(JsSyntaxKind::COMMA))
+            .entries(
+                node.format_separated(JsSyntaxKind::COMMA)
+                    .with_trailing_separator(trailing_separator),
+            )
             .finish()
     }
 }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -511,9 +511,18 @@ mod test {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-({aaaaaaaaaa,bbbbbbbbbb=cccccccccc,dddddddddd:eeeeeeeeee,ffffffffff:gggggggggg=hhhhhhhhhh,...jjjjjjjjjj} = x)
+export class Task {
+    args: any[];
 
-           "#;
+    constructor(
+        public script: string,
+        public duration: number,
+        public threadCount: number,
+        ...args: any[]
+    ) {
+        this.args = args;
+    }
+}       "#;
         let syntax = SourceType::ts();
         let tree = parse(src, 0, syntax);
         let result = format_node(JsFormatContext::default(), &tree.syntax())

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class.js
@@ -55,3 +55,17 @@ x = class foo extends Boar {
 
 x = class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {
 }
+
+
+export class Task {
+
+
+	constructor(
+		script,
+		duration,
+		threadCount,
+		...args
+	) {
+		this.args = args;
+	}
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 257
 expression: class.js
 ---
 # Input
@@ -61,6 +62,19 @@ x = class foo extends Boar {
 x = class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {
 }
 
+
+export class Task {
+
+
+	constructor(
+		script,
+		duration,
+		threadCount,
+		...args
+	) {
+		this.args = args;
+	}
+}
 =============================
 # Outputs
 ## Output 1
@@ -122,6 +136,12 @@ x = class {};
 x = class foo extends Boar {};
 
 x = class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {};
+
+export class Task {
+	constructor(script, duration, threadCount, ...args) {
+		this.args = args;
+	}
+}
 
 
 ## Lines exceeding width of 80 characters

--- a/crates/rome_js_formatter/tests/specs/ts/call_expression.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/call_expression.ts
@@ -8,3 +8,17 @@ export class Thing implements OtherThing {
         (type: ObjectType): Provider<Opts> => {}
     );
 }
+
+// Issue https://github.com/rome/tools/issues/2756
+export class Task {
+    args: any[];
+
+    constructor(
+        public script: string,
+        public duration: number,
+        public threadCount: number,
+        ...args: any[]
+    ) {
+        this.args = args;
+    }
+}

--- a/crates/rome_js_formatter/tests/specs/ts/call_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/call_expression.ts.snap
@@ -14,6 +14,20 @@ export class Thing implements OtherThing {
         (type: ObjectType): Provider<Opts> => {}
     );
 }
+
+// Issue https://github.com/rome/tools/issues/2756
+export class Task {
+    args: any[];
+
+    constructor(
+        public script: string,
+        public duration: number,
+        public threadCount: number,
+        ...args: any[]
+    ) {
+        this.args = args;
+    }
+}
 =============================
 # Outputs
 ## Output 1
@@ -30,5 +44,19 @@ export class Thing implements OtherThing {
 	do: (type: Type) => Provider<Prop> = memoize(
 		(type: ObjectType): Provider<Opts> => {},
 	);
+}
+
+// Issue https://github.com/rome/tools/issues/2756
+export class Task {
+	args: any[];
+
+	constructor(
+		public script: string,
+		public duration: number,
+		public threadCount: number,
+		...args: any[]
+	) {
+		this.args = args;
+	}
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes #2756

It checks if the last argument is not a rest operator. And if so, it doesn't add the trailing separator.

FYI, I copied the exact same check we have in `parameters_list.rs`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added two new tests, one for TS and one for JS

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
