### PR TITLE
feat(rome_js_formatter): variable declarator formatting

### DIFF
--- a/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
@@ -1,28 +1,13 @@
 use crate::prelude::*;
-use crate::utils::FormatInitializerClause;
-
+use crate::utils::JsAnyAssignmentLike;
 use rome_formatter::write;
 use rome_js_syntax::JsVariableDeclarator;
-use rome_js_syntax::JsVariableDeclaratorFields;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsVariableDeclarator;
 
 impl FormatNodeRule<JsVariableDeclarator> for FormatJsVariableDeclarator {
     fn fmt_fields(&self, node: &JsVariableDeclarator, f: &mut JsFormatter) -> FormatResult<()> {
-        let JsVariableDeclaratorFields {
-            id,
-            variable_annotation,
-            initializer,
-        } = node.as_fields();
-
-        write![
-            f,
-            [
-                id.format(),
-                variable_annotation.format(),
-                FormatInitializerClause::new(initializer.as_ref())
-            ]
-        ]
+        write![f, [JsAnyAssignmentLike::from(node.clone())]]
     }
 }

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -347,7 +347,7 @@ impl JsAnyAssignmentLike {
             JsAnyAssignmentLike::JsVariableDeclarator(variable_declarator) => {
                 let id = variable_declarator.id()?;
                 let variable_annotation = variable_declarator.variable_annotation();
-                write!(buffer, [&id.format(), variable_annotation.format()])?;
+                write!(buffer, [id.format(), variable_annotation.format()])?;
                 Ok(false)
             }
         }
@@ -409,7 +409,7 @@ impl JsAnyAssignmentLike {
     /// Returns the layout variant for an assignment like depending on right expression and left part length
     /// [Prettier applies]: https://github.com/prettier/prettier/blob/main/src/language-js/print/assignment.js
     fn layout(&self, is_left_short: bool) -> FormatResult<AssignmentLikeLayout> {
-        if self.should_only_left() {
+        if self.has_only_left_hand_side() {
             return Ok(AssignmentLikeLayout::OnlyLeft);
         }
 
@@ -450,7 +450,7 @@ impl JsAnyAssignmentLike {
 
     /// Checks that a [JsAnyAssignmentLike] consists only of the left part
     /// usually, when a [variable declarator](JsVariableDeclarator) doesn't have initializer
-    fn should_only_left(&self) -> bool {
+    fn has_only_left_hand_side(&self) -> bool {
         if let JsAnyAssignmentLike::JsVariableDeclarator(declarator) = self {
             declarator.initializer().is_none()
         } else {

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -14,7 +14,7 @@ mod object_pattern_like;
 mod quickcheck_utils;
 
 use crate::prelude::*;
-pub(crate) use assignment_like::{is_break_after_operator, JsAnyAssignmentLike};
+pub(crate) use assignment_like::{should_break_after_operator, JsAnyAssignmentLike};
 pub(crate) use binary_like_expression::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 pub(crate) use format_conditional::{format_conditional, Conditional};
 pub(crate) use member_chain::format_call_expression;

--- a/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js
@@ -1,0 +1,47 @@
+//break left-hand side layout
+{
+    const {
+        id,
+        static: isStatic,
+        method: isMethod,
+        methodId,
+        getId,
+        setId,
+    } = privateNamesMap.get(name);
+
+		// rome-ignore format: test
+		const {
+			id, static: isStatic, method: isMethod,
+			methodId, getId, setId,
+		} = privateNamesMap.get(name);
+
+    const { id1, method: isMethod1, methodId1 } = privateNamesMap.get(name);
+
+		const { id1, method: isMethod1, methodId1 } =
+			// rome-ignore format: test
+			privateNamesMap.get(name);
+
+    const {
+        id3,
+        method: isMethod3,
+        methodId3,
+    } = anodyneCondosMalateOverateRetinol.get(bifornCringerMoshedPerplexSawder);
+
+		// rome-ignore format: test
+		const {
+			id3, method: isMethod3,
+			methodId3,
+		} =
+			// rome-ignore format: test
+			anodyneCondosMalateOverateRetinol.get(
+			bifornCringerMoshedPerplexSawder
+		);
+}
+
+//fluid layout
+const otherBrandsWithThisAdjacencyCount123 = Object.values(edge.to.edges).length;
+let vgChannel = pointPositionDefaultRef({ model, defaultPos, channel })();
+const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(
+    `foo
+`,
+)("bar");

--- a/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
@@ -1,0 +1,111 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: variable_declaration.js
+---
+# Input
+//break left-hand side layout
+{
+    const {
+        id,
+        static: isStatic,
+        method: isMethod,
+        methodId,
+        getId,
+        setId,
+    } = privateNamesMap.get(name);
+
+		// rome-ignore format: test
+		const {
+			id, static: isStatic, method: isMethod,
+			methodId, getId, setId,
+		} = privateNamesMap.get(name);
+
+    const { id1, method: isMethod1, methodId1 } = privateNamesMap.get(name);
+
+		const { id1, method: isMethod1, methodId1 } =
+			// rome-ignore format: test
+			privateNamesMap.get(name);
+
+    const {
+        id3,
+        method: isMethod3,
+        methodId3,
+    } = anodyneCondosMalateOverateRetinol.get(bifornCringerMoshedPerplexSawder);
+
+		// rome-ignore format: test
+		const {
+			id3, method: isMethod3,
+			methodId3,
+		} =
+			// rome-ignore format: test
+			anodyneCondosMalateOverateRetinol.get(
+			bifornCringerMoshedPerplexSawder
+		);
+}
+
+//fluid layout
+const otherBrandsWithThisAdjacencyCount123 = Object.values(edge.to.edges).length;
+let vgChannel = pointPositionDefaultRef({ model, defaultPos, channel })();
+const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(
+    `foo
+`,
+)("bar");
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+-----
+//break left-hand side layout
+{
+	const {
+		id,
+		static: isStatic,
+		method: isMethod,
+		methodId,
+		getId,
+		setId,
+	} = privateNamesMap.get(name);
+
+	// rome-ignore format: test
+		const {
+			id, static: isStatic, method: isMethod,
+			methodId, getId, setId,
+		} = privateNamesMap.get(name);
+
+	const { id1, method: isMethod1, methodId1 } = privateNamesMap.get(name);
+
+	const { id1, method: isMethod1, methodId1 } =
+	// rome-ignore format: test
+			privateNamesMap.get(name);
+
+	const {
+		id3,
+		method: isMethod3,
+		methodId3,
+	} = anodyneCondosMalateOverateRetinol.get(bifornCringerMoshedPerplexSawder);
+
+	// rome-ignore format: test
+		const {
+			id3, method: isMethod3,
+			methodId3,
+		} =
+			// rome-ignore format: test
+			anodyneCondosMalateOverateRetinol.get(
+			bifornCringerMoshedPerplexSawder
+		);
+}
+
+//fluid layout
+const otherBrandsWithThisAdjacencyCount123 = Object.values(
+	edge.to.edges,
+).length;
+let vgChannel = pointPositionDefaultRef({ model, defaultPos, channel })();
+const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(
+	`foo
+`,
+)("bar");
+

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -247,23 +247,24 @@ const b = `${
 	veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar
 }`;
 
-const a = (
-	aa &&
-		bb &&
-		something &&
-		elsewhere &&
-		happy &&
-		thoughts &&
-		somethingsomethingsomethingsomething
-) || (
-	aa &&
-		bb &&
-		something &&
-		elsewhere &&
-		happy &&
-		thoughts &&
-		somethingsomethingsomethingsomething
-);
+const a =
+	(
+		aa &&
+			bb &&
+			something &&
+			elsewhere &&
+			happy &&
+			thoughts &&
+			somethingsomethingsomethingsomething
+	) || (
+		aa &&
+			bb &&
+			something &&
+			elsewhere &&
+			happy &&
+			thoughts &&
+			somethingsomethingsomethingsomething
+	);
 
 (
 	lorem && // foo

--- a/crates/rome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 257
 expression: properties_quotes.js
 ---
 # Input
@@ -84,10 +83,8 @@ let a = { "": 10, c_d: 30 };
 
 let b = { "'": 10, c_d: 30 };
 
-let {
-	_$_ff$_morning_not_quotes: test,
-	"_$_ff$_morning_yes_quotes_@": test,
-} = value;
+let { _$_ff$_morning_not_quotes: test, "_$_ff$_morning_yes_quotes_@": test } =
+	value;
 
 let { "_$_$_%": test } = value;
 
@@ -131,10 +128,8 @@ let a = { '': 10, c_d: 30 };
 
 let b = { "'": 10, c_d: 30 };
 
-let {
-	_$_ff$_morning_not_quotes: test,
-	'_$_ff$_morning_yes_quotes_@': test,
-} = value;
+let { _$_ff$_morning_not_quotes: test, '_$_ff$_morning_yes_quotes_@': test } =
+	value;
 
 let { '_$_$_%': test } = value;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -52,7 +52,7 @@ if (true) statement();
 if (true) statement();
 
 const expr =
-// rome-ignore format: the array should not be formatted
+	// rome-ignore format: the array should not be formatted
 [
     (2*n)/(r-l), 0,            (r+l)/(r-l),  0,
     0,           (2*n)/(t-b),  (t+b)/(t-b),  0,
@@ -67,6 +67,6 @@ const expr2 = {
 };
 
 let a =
-// rome-ignore format: test
+	// rome-ignore format: test
 function () {};
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/arrays/empty.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/arrays/empty.js.snap
@@ -11,14 +11,11 @@ const b = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {
 
 # Output
 ```js
-const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || [];
-const b = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};
+const a =
+  someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || [];
+const b =
+  someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};
 
 ```
 
-# Lines exceeding max width of 80 characters
-```
-    1: const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || [];
-    2: const b = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};
-```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/call2.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/call2.js.snap
@@ -11,10 +11,9 @@ const kochabCooieGameOnOboleUnweave = // ???
 
 # Output
 ```js
-const kochabCooieGameOnOboleUnweave = rhubarbRhubarb(
+const kochabCooieGameOnOboleUnweave =
   // ???
-  annularCooeedSplicesWalksWayWay,
-);
+  rhubarbRhubarb(annularCooeedSplicesWalksWayWay);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
@@ -112,17 +112,19 @@ let f3 = (
   a = b, //comment
 ) => {};
 
-let f4 = () => {}; // Comment
+let f4 =
+  // Comment
+  () => {};
 
 let f5 =
-// Comment
+  // Comment
 
-() => {};
+  () => {};
 
 let f6 = /* comment */
-// Comment
+  // Comment
 
-() => {};
+  () => {};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/identifier.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/identifier.js.snap
@@ -16,14 +16,18 @@ const bifornCringerMoshedPerplexSawder = // !!!
 
 # Output
 ```js
-const kochabCooieGameOnOboleUnweave = annularCooeedSplicesWalksWayWay; // ???
+const kochabCooieGameOnOboleUnweave =
+  // ???
+  annularCooeedSplicesWalksWayWay;
 
-const bifornCringerMoshedPerplexSawder = glimseGlyphsHazardNoopsTieTie + averredBathersBoxroomBuggyNurl - anodyneCondosMalateOverateRetinol; // !!!
+const bifornCringerMoshedPerplexSawder =
+  // !!!
+  glimseGlyphsHazardNoopsTieTie + averredBathersBoxroomBuggyNurl - anodyneCondosMalateOverateRetinol;
 
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-    3: const bifornCringerMoshedPerplexSawder = glimseGlyphsHazardNoopsTieTie + averredBathersBoxroomBuggyNurl - anodyneCondosMalateOverateRetinol; // !!!
+    7:   glimseGlyphsHazardNoopsTieTie + averredBathersBoxroomBuggyNurl - anodyneCondosMalateOverateRetinol;
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
@@ -77,20 +77,20 @@ fnNumber =
   3;
 
 var fnNumber =
-// Comment
+  // Comment
 
-3;
+  3;
 
 var fnNumber =
-// Comment0
-// Comment1
-3;
+  // Comment0
+  // Comment1
+  3;
 
 var fnNumber = /* comment */ 3;
 
 var fnNumber = /* comments0 */
-/* comments1 */
-3;
+  /* comments1 */
+  3;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/string.js.snap
@@ -166,9 +166,7 @@ var fnString =
   // Comment1
   "some" + "long" + "string";
 
-var fnString =
-  // Comment
-  "some" + "long" + "string";
+var fnString = "some" + "long" + "string"; // Comment
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: chain.js
 ---
 # Input
@@ -37,12 +36,13 @@ a=b=c;
 
 # Output
 ```js
-let bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans =
-  glimseGlyphsHazardNoopsTieTie =
-  averredBathersBoxroomBuggyNurl =
-  anodyneCondosMalateOverateRetinol =
-  annularCooeedSplicesWalksWayWay =
-    kochabCooieGameOnOboleUnweave;
+let bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans =
+    glimseGlyphsHazardNoopsTieTie =
+    averredBathersBoxroomBuggyNurl =
+    anodyneCondosMalateOverateRetinol =
+    annularCooeedSplicesWalksWayWay =
+      kochabCooieGameOnOboleUnweave;
 
 bifornCringerMoshedPerplexSawder =
   askTrovenaBeenaDependsRowans =

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/destructuring-array.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/destructuring-array.js.snap
@@ -14,11 +14,8 @@ const [
 
 # Output
 ```js
-const [
-  width = nextWidth,
-  height = nextHeight,
-  baseline = nextBaseline,
-] = measureText(nextText, getFontString(element));
+const [width = nextWidth, height = nextHeight, baseline = nextBaseline] =
+  measureText(nextText, getFontString(element));
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-10218.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-10218.js.snap
@@ -14,22 +14,21 @@ const {_id:id3} = data.createTestMessageWithAReallyLongName.someVeryLongProperty
 
 # Output
 ```js
-const _id1 = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty._id;
+const _id1 =
+  data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty._id;
 
-const {
-  _id2,
-} = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
+const { _id2 } =
+  data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
 
-const {
-  _id: id3,
-} = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
+const { _id: id3 } =
+  data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
 
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-    1: const _id1 = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty._id;
-    5: } = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
-    9: } = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
+    2:   data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty._id;
+    5:   data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
+    8:   data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: issue-1966.js
 ---
 # Input
@@ -15,7 +14,8 @@ this.isaverylongmethodexpression.withmultiplelevels = this.isanotherverylongexpr
 
 # Output
 ```js
-const aVeryLongNameThatGoesOnAndOn = this.someOtherObject.someOtherNestedObject.someLongFunctionName();
+const aVeryLongNameThatGoesOnAndOn =
+  this.someOtherObject.someOtherNestedObject.someLongFunctionName();
 
 this.someObject.someOtherNestedObject =
   this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
@@ -25,8 +25,4 @@ this.isaverylongmethodexpression.withmultiplelevels =
 
 ```
 
-# Lines exceeding max width of 80 characters
-```
-    1: const aVeryLongNameThatGoesOnAndOn = this.someOtherObject.someOtherNestedObject.someLongFunctionName();
-```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-2482-2.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-2482-2.js.snap
@@ -18,9 +18,10 @@ class foo {
 ```js
 class foo {
   bar() {
-    const median = dates.length % 2 ? dates[half].getTime() : (
-      dates[half - 1].getTime() + dates[half].getTime()
-    ) / 2.0;
+    const median =
+      dates.length % 2 ? dates[half].getTime() : (
+        dates[half - 1].getTime() + dates[half].getTime()
+      ) / 2.0;
   }
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-8218.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-8218.js.snap
@@ -13,15 +13,12 @@ const pendingIndicatorz =
 
 # Output
 ```js
-const pendingIndicators = shield.alarmGeneratorConfiguration.getPendingVersionColumnValues;
+const pendingIndicators =
+  shield.alarmGeneratorConfiguration.getPendingVersionColumnValues;
 
-const pendingIndicatorz = shield.alarmGeneratorConfiguration.getPendingVersionColumnValues();
+const pendingIndicatorz =
+  shield.alarmGeneratorConfiguration.getPendingVersionColumnValues();
 
 ```
 
-# Lines exceeding max width of 80 characters
-```
-    1: const pendingIndicators = shield.alarmGeneratorConfiguration.getPendingVersionColumnValues;
-    3: const pendingIndicatorz = shield.alarmGeneratorConfiguration.getPendingVersionColumnValues();
-```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/unary.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/unary.js.snap
@@ -17,26 +17,23 @@ const loooooooooooooooooooooooooong8 = !!"looooooooooooooooooooooooooooooooooooo
 
 # Output
 ```js
-const loooooooooooooooooooooooooong1 = void looooooooooooooong.looooooooooooooong.loooooong;
-const loooooooooooooooooooooooooong2 = void "looooooooooooooooooooooooooooooooooooooooooog";
-const loooooooooooooooooooooooooong3 = !looooooooooooooong.looooooooooooooong.loooooong;
-const loooooooooooooooooooooooooong4 = !"looooooooooooooooooooooooooooooooooooooooooog";
-const loooooooooooooooooooooooooong5 = void void looooooooooooooong.looooooooooooooong.loooooong;
-const loooooooooooooooooooooooooong6 = void void "looooooooooooooooooooooooooooooooooooooooooog";
-const loooooooooooooooooooooooooong7 = !!looooooooooooooong.looooooooooooooong.loooooong;
-const loooooooooooooooooooooooooong8 = !!"looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong1 =
+  void looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong2 =
+  void "looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong3 =
+  !looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong4 =
+  !"looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong5 =
+  void void looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong6 =
+  void void "looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong7 =
+  !!looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong8 =
+  !!"looooooooooooooooooooooooooooooooooooooooooog";
 
 ```
 
-# Lines exceeding max width of 80 characters
-```
-    1: const loooooooooooooooooooooooooong1 = void looooooooooooooong.looooooooooooooong.loooooong;
-    2: const loooooooooooooooooooooooooong2 = void "looooooooooooooooooooooooooooooooooooooooooog";
-    3: const loooooooooooooooooooooooooong3 = !looooooooooooooong.looooooooooooooong.loooooong;
-    4: const loooooooooooooooooooooooooong4 = !"looooooooooooooooooooooooooooooooooooooooooog";
-    5: const loooooooooooooooooooooooooong5 = void void looooooooooooooong.looooooooooooooong.loooooong;
-    6: const loooooooooooooooooooooooooong6 = void void "looooooooooooooooooooooooooooooooooooooooooog";
-    7: const loooooooooooooooooooooooooong7 = !!looooooooooooooong.looooooooooooooong.loooooong;
-    8: const loooooooooooooooooooooooooong8 = !!"looooooooooooooooooooooooooooooooooooooooooog";
-```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-record.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-record.js.snap
@@ -16,14 +16,14 @@ const record2 = #{...record1, b: 5};
 
 # Output
 ```js
-const record1 = #
+const record1 = #;
 {
   a: 1, b;
   : 2,
     c: 3,
 }
 
-const record2 = #
+const record2 = #;
 {
   ...record1, b: 5
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-tuple.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-tuple.js.snap
@@ -10,7 +10,7 @@ const tuple1 = #[1, 2, 3];
 
 # Output
 ```js
-const tuple1 = #
+const tuple1 = #;
 [1, 2, 3];
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-jsx.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-jsx.js.snap
@@ -16,21 +16,22 @@ const avatar2 = (hasAvatar || showPlaceholder) && <Gravatar user={author} size={
 
 # Output
 ```js
-const user = renderedUser || (
-  <div><User name={this.state.user.name} age={this.state.user.age} /></div>
-);
-
-const user2 = renderedUser || (
-  shouldRenderUser && (
+const user =
+  renderedUser || (
     <div><User name={this.state.user.name} age={this.state.user.age} /></div>
-  )
-);
+  );
+
+const user2 =
+  renderedUser || (
+    shouldRenderUser && (
+      <div><User name={this.state.user.name} age={this.state.user.age} /></div>
+    )
+  );
 
 const avatar = hasAvatar && <Gravatar user={author} size={size} />;
 
-const avatar2 = (hasAvatar || showPlaceholder) && (
-  <Gravatar user={author} size={size} />
-);
+const avatar2 =
+  (hasAvatar || showPlaceholder) && <Gravatar user={author} size={size} />;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/short-right.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/short-right.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: short-right.js
 ---
 # Input
@@ -39,9 +38,8 @@ foooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(
   aaaaaaaaaaaaaaaaaaa,
 ) + a;
 
-const isPartOfPackageJSON = dependenciesArray.indexOf(
-  dependencyWithOutRelativePath.split("/")[0],
-) !== -1;
+const isPartOfPackageJSON =
+  dependenciesArray.indexOf(dependencyWithOutRelativePath.split("/")[0]) !== -1;
 
 defaultContent.filter((defaultLocale) => {
   // ...

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/test.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/test.js.snap
@@ -32,13 +32,15 @@ foo(obj.property * new Class() && obj instanceof Class && longVariable ? number 
 // break them all at the same time.
 
 const x = longVariable + longVariable + longVariable;
-const x1 = longVariable +
+const x1 =
   longVariable +
+    longVariable +
+    longVariable +
+    longVariable - longVariable + longVariable;
+const x2 =
   longVariable +
-  longVariable - longVariable + longVariable;
-const x2 = longVariable +
-  (longVariable * longVariable) +
-  longVariable - longVariable + longVariable;
+    (longVariable * longVariable) +
+    longVariable - longVariable + longVariable;
 const x3 =
   longVariable +
   (longVariable * longVariable * longVariable / longVariable) +
@@ -63,17 +65,19 @@ const x7 =
   firstItemWithAVeryLongNameThatKeepsGoing ||
   firstItemWithAVeryLongNameThatKeepsGoing ||
   [];
-const x8 = call(
-  firstItemWithAVeryLongNameThatKeepsGoing,
-  firstItemWithAVeryLongNameThatKeepsGoing,
-) || [];
+const x8 =
+  call(
+    firstItemWithAVeryLongNameThatKeepsGoing,
+    firstItemWithAVeryLongNameThatKeepsGoing,
+  ) || [];
 
 const x9 =
   longVariable * longint && longVariable >> 0 && longVariable + longVariable;
 
-const x10 = longVariable > longint && longVariable === (
-  0 + (longVariable * longVariable)
-);
+const x10 =
+  longVariable > longint && longVariable === (
+    0 + (longVariable * longVariable)
+  );
 
 foo(
   obj.property * new Class() &&

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary_math/parens.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary_math/parens.js.snap
@@ -39,12 +39,14 @@ exponent = (((b[3] << 1) & 0xff) | (b[2] >> 7)) - 127;
 mantissa = ((b[2] & 0x7f) << 16) | (b[1] << 8) | b[0];
 
 (2 / 3 * 10 / 2) + 2;
-const rotateX = (
-  ((RANGE / rect.height) * refY) - (RANGE / 2)
-) * getXMultiplication(rect.width);
-const rotateY = (
-  ((RANGE / rect.width) * refX) - (RANGE / 2)
-) * getYMultiplication(rect.width);
+const rotateX =
+  (((RANGE / rect.height) * refY) - (RANGE / 2)) * getXMultiplication(
+    rect.width,
+  );
+const rotateY =
+  (((RANGE / rect.width) * refX) - (RANGE / 2)) * getYMultiplication(
+    rect.width,
+  );
 
 (a % 10) - 5;
 a * b % 10;

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/comment-in-the-middle.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/comment-in-the-middle.js.snap
@@ -21,15 +21,15 @@ console.log(a.foo());
 # Output
 ```js
 var a =
-/**
+  /**
  * bla bla bla
  * @type {string |
   * number
  * }
 * bla bla bla
  */
-//2
-((window["s"])).toString();
+  //2
+  ((window["s"])).toString();
 console.log(a.foo());
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/comment-placement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/comment-placement.js.snap
@@ -32,18 +32,18 @@ const foo5 =
 const foo1 = /** @type {string} */ (value);
 
 const foo2 =
-/** @type {string} */
-(value);
+  /** @type {string} */
+  (value);
 
 const foo3 =
-/** @type {string} */
-(value);
+  /** @type {string} */
+  (value);
 
 const foo4 =
-/** @type {string} */ (value);
+  /** @type {string} */ (value);
 
 const foo5 =
-/** @type {string} */ (value);
+  /** @type {string} */ (value);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-8045.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-8045.js.snap
@@ -30,9 +30,8 @@ function jsdocCastInReturn() {
 
 # Output
 ```js
-const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
-  fooBarBaz
-);
+const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+  (fooBarBaz);
 
 function jsdocCastInReturn() {
   return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
@@ -40,9 +39,8 @@ function jsdocCastInReturn() {
   );
 }
 
-const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
-  fooBarBaz
-);
+const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+  (fooBarBaz);
 
 function jsdocCastInReturn() {
   return (
@@ -51,9 +49,8 @@ function jsdocCastInReturn() {
   );
 }
 
-const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
-  fooBarBaz
-);
+const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+  (fooBarBaz);
 
 function jsdocCastInReturn() {
   return (
@@ -66,8 +63,8 @@ function jsdocCastInReturn() {
 
 # Lines exceeding max width of 80 characters
 ```
-    1: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
-   11: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
-   22: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
+    1: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+   10: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+   20: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-9358.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-9358.js.snap
@@ -12,17 +12,14 @@ const fooooba3 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems ||
 
 # Output
 ```js
-const fooooba1 = /** @type {Array.<fooo.barr.baaaaaaz>} */ fooobaarbazzItems || foo;
-const fooooba2 = /** @type {Array.<fooo.barr.baaaaaaz>} */ fooobaarbazzItems + foo;
+const fooooba1 = /** @type {Array.<fooo.barr.baaaaaaz>} */
+  fooobaarbazzItems || foo;
+const fooooba2 = /** @type {Array.<fooo.barr.baaaaaaz>} */
+  fooobaarbazzItems + foo;
 const fooooba3 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (
   fooobaarbazzItems || foo
 ) ? foo : bar;
 
 ```
 
-# Lines exceeding max width of 80 characters
-```
-    1: const fooooba1 = /** @type {Array.<fooo.barr.baaaaaaz>} */ fooobaarbazzItems || foo;
-    2: const fooooba2 = /** @type {Array.<fooo.barr.baaaaaaz>} */ fooobaarbazzItems + foo;
-```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/styled-components.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/styled-components.js.snap
@@ -20,8 +20,8 @@ top: ${p => p.overlap === 'next' && 0};
 # Output
 ```js
 const OverlapWrapper =
-/** @type {import('styled-components').ThemedStyledFunction<'div',null,{overlap: boolean}>} */
-(styled.div)`
+  /** @type {import('styled-components').ThemedStyledFunction<'div',null,{overlap: boolean}>} */
+  (styled.div)`
 position:relative;
     > {
   position: absolute;
@@ -34,6 +34,6 @@ top: ${(p) => p.overlap === "next" && 0};
 
 # Lines exceeding max width of 80 characters
 ```
-    2: /** @type {import('styled-components').ThemedStyledFunction<'div',null,{overlap: boolean}>} */
+    2:   /** @type {import('styled-components').ThemedStyledFunction<'div',null,{overlap: boolean}>} */
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/variable_declarator.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/variable_declarator.js.snap
@@ -75,15 +75,17 @@ const foo3 = 123
 
 # Output
 ```js
-let obj1 = {
+let obj1 =
   // Comment
-  key: "val",
-};
+  {
+    key: "val",
+  };
 
-let obj2 = {
+let obj2 =
   // Comment
-  key: "val",
-};
+  {
+    key: "val",
+  };
 
 let obj3 = {
   // Comment
@@ -95,9 +97,13 @@ let obj4 = {
   key: "val",
 };
 
-let obj5 = ["val"]; // Comment
+let obj5 =
+  // Comment
+  ["val"];
 
-let obj6 = ["val"]; // Comment
+let obj6 =
+  // Comment
+  ["val"];
 
 let obj7 = [
   // Comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/conditional/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/conditional/comments.js.snap
@@ -113,21 +113,23 @@ c */? foo : bar : bar;
 
 # Output
 ```js
-var inspect = 4 === util.inspect.length ? (function (v, colors) {
-  // node <= 0.8.x
-  return util.inspect(v, void 0, void 0, colors);
-}) : (function (v, colors) {
-  // node > 0.8.x
-  return util.inspect(v, { colors: colors });
-});
+var inspect =
+  4 === util.inspect.length ? (function (v, colors) {
+    // node <= 0.8.x
+    return util.inspect(v, void 0, void 0, colors);
+  }) : (function (v, colors) {
+    // node > 0.8.x
+    return util.inspect(v, { colors: colors });
+  });
 
-var inspect = 4 === util.inspect.length ? (function (v, colors) {
-  // node <= 0.8.x
-  return util.inspect(v, void 0, void 0, colors);
-}) : (function (v, colors) {
-  // node > 0.8.x
-  return util.inspect(v, { colors: colors });
-});
+var inspect =
+  4 === util.inspect.length ? (function (v, colors) {
+    // node <= 0.8.x
+    return util.inspect(v, void 0, void 0, colors);
+  }) : (function (v, colors) {
+    // node > 0.8.x
+    return util.inspect(v, { colors: colors });
+  });
 
 const extractTextPluginOptions = shouldUseRelativeAssetPaths
 // Making sure that the publicPath goes back to to build folder.
@@ -143,9 +145,10 @@ const extractTextPluginOptions3 = shouldUseRelativeAssetPaths ? {
   publicPath: Array(cssFilename.split("/").length).join("../"),
 } : {};
 
-const { configureStore } = process.env.NODE_ENV === "production" ? require(
-  "./configureProdStore",
-) : require("./configureDevStore"); // a // b
+const { configureStore } =
+  process.env.NODE_ENV === "production" ? require(
+    "./configureProdStore",
+  ) : require("./configureDevStore"); // a // b
 
 test /* comment
   comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/logical_expressions/issue-7024.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/logical_expressions/issue-7024.js.snap
@@ -13,11 +13,12 @@ const radioSelectedAttr =
 
 # Output
 ```js
-const radioSelectedAttr = (
-  isAnyValueSelected && node.getAttribute(
-    radioAttr.toLowerCase(),
-  ) === radioValue
-) || ((!isAnyValueSelected && values[a].default === true) || a === 0);
+const radioSelectedAttr =
+  (
+    isAnyValueSelected && node.getAttribute(
+      radioAttr.toLowerCase(),
+    ) === radioValue
+  ) || ((!isAnyValueSelected && values[a].default === true) || a === 0);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-member.js.snap
@@ -44,14 +44,8 @@ expect(
   ].style.paddingRight,
 ).toBe("1000px");
 
-const {
-  course,
-  conflicts = [],
-  index,
-  scheduleId,
-  studentId,
-  something,
-} = a.this.props;
+const { course, conflicts = [], index, scheduleId, studentId, something } =
+  a.this.props;
 
 const {
   course2,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/record/destructuring.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/record/destructuring.js.snap
@@ -18,7 +18,7 @@ assert(rest.c === 3);
 
 # Output
 ```js
-const { a, b } = #
+const { a, b } = #;
 {
   a: 1, b;
   : 2
@@ -26,7 +26,7 @@ const { a, b } = #
 assert(a === 1);
 assert(b === 2);
 
-const { a, ...rest } = #
+const { a, ...rest } = #;
 {
   a: 1, b;
   : 2, c: 3

--- a/crates/rome_js_formatter/tests/specs/prettier/js/record/record.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/record/record.js.snap
@@ -25,14 +25,14 @@ assert(record1.d?.a === undefined);
 
 # Output
 ```js
-const record1 = #
+const record1 = #;
 {
   a: 1, b;
   : 2,
     c: 3,
 }
 
-const record2 = #
+const record2 = #;
 {
   ...record1, b: 5
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/record/shorthand.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/record/shorthand.js.snap
@@ -13,7 +13,7 @@ console.log(record.url) // https://github.com/tc39/proposal-record-tuple
 # Output
 ```js
 const url = "https://github.com/tc39/proposal-record-tuple";
-const record = #
+const record = #;
 {
   url;
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/record/spread.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/record/spread.js.snap
@@ -15,16 +15,16 @@ assert(taskLater === #{ status: "DONE", title: formData.title, id: 42 })
 
 # Output
 ```js
-const formData = #
+const formData = #;
 {
   title: ("Implement all the things");
 }
-const taskNow = #
+const taskNow = #;
 {
   id: 42, status;
   : "WIP", ...formData
 }
-const taskLater = #
+const taskLater = #;
 {
   ...taskNow, status: "DONE"
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/binary.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/binary.js.snap
@@ -21,11 +21,10 @@ room = room.map((row, rowIndex) => (
 
 # Output
 ```js
-const funnelSnapshotCard = (
-  report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2
-) || (
-  report === COMPANY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2_company_metrics
-) ? <ReportMetricsFunnelSnapshotCard metrics={metrics} /> : null;
+const funnelSnapshotCard =
+  (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) || (
+    report === COMPANY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2_company_metrics
+  ) ? <ReportMetricsFunnelSnapshotCard metrics={metrics} /> : null;
 
 room = room.map(
   (row, rowIndex) => (
@@ -46,6 +45,6 @@ room = room.map(
 
 # Lines exceeding max width of 80 characters
 ```
-    4:   report === COMPANY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2_company_metrics
+    3:     report === COMPANY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2_company_metrics
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested.js.snap
@@ -104,9 +104,10 @@ a
 
 # Output
 ```js
-let icecream = what == "cone" ? (p) =>
-  !!p ? `here's your ${p} cone` : `just the empty cone for you` : (p) =>
-  `here's your ${p} ${what}`;
+let icecream =
+  what == "cone" ? (p) =>
+    !!p ? `here's your ${p} cone` : `just the empty cone for you` : (p) =>
+    `here's your ${p} ${what}`;
 
 const value = condition1
   ? value1
@@ -135,34 +136,37 @@ const StorybookLoader = ({ match }) => (
             )
 );
 
-const message = (i % 3) === 0 && (i % 5) === 0
-  ? "fizzbuzz"
-  : (i % 3) === 0
-    ? "fizz"
-    : (i % 5) === 0
-      ? "buzz"
-      : String(i);
+const message =
+  (i % 3) === 0 && (i % 5) === 0
+    ? "fizzbuzz"
+    : (i % 3) === 0
+      ? "fizz"
+      : (i % 5) === 0
+        ? "buzz"
+        : String(i);
 
-const paymentMessage = state == "success"
-  ? "Payment completed successfully"
-  : state == "processing"
-    ? "Payment processing"
-    : state == "invalid_cvc"
-      ? "There was an issue with your CVC number"
-      : state == "invalid_expiry"
-        ? "Expiry must be sometime in the past."
-        : "There was an issue with the payment.  Please contact support.";
+const paymentMessage =
+  state == "success"
+    ? "Payment completed successfully"
+    : state == "processing"
+      ? "Payment processing"
+      : state == "invalid_cvc"
+        ? "There was an issue with your CVC number"
+        : state == "invalid_expiry"
+          ? "Expiry must be sometime in the past."
+          : "There was an issue with the payment.  Please contact support.";
 
-const paymentMessage2 = state == "success"
-  ? 1 //'Payment completed successfully'
-  : state == "processing"
-    ? 2 //'Payment processing'
-    : state == "invalid_cvc"
-      ? 3 //'There was an issue with your CVC number'
-      : true
-        //state == 'invalid_expiry'
-        ? 4 //'Expiry must be sometime in the past.'
-        : 5; // 'There was an issue with the payment.  Please contact support.'
+const paymentMessage2 =
+  state == "success"
+    ? 1 //'Payment completed successfully'
+    : state == "processing"
+      ? 2 //'Payment processing'
+      : state == "invalid_cvc"
+        ? 3 //'There was an issue with your CVC number'
+        : true
+          //state == 'invalid_expiry'
+          ? 4 //'Expiry must be sometime in the past.'
+          : 5; // 'There was an issue with the payment.  Please contact support.'
 
 const foo = (
   <div
@@ -198,4 +202,8 @@ a
 
 ```
 
+# Lines exceeding max width of 80 characters
+```
+   63:           : 5; // 'There was an issue with the payment.  Please contact support.'
+```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/tuple/destructuring.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/tuple/destructuring.js.snap
@@ -18,12 +18,12 @@ assert(rest[1] === 3);
 
 # Output
 ```js
-const [a, b] = #
+const [a, b] = #;
 [1, 2];
 assert(a === 1);
 assert(b === 2);
 
-const [a, ...rest] = #
+const [a, ...rest] = #;
 [1, 2, 3];
 assert(a === 1);
 assert(Array.isArray(rest));

--- a/crates/rome_js_formatter/tests/specs/prettier/js/tuple/tuple.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/tuple/tuple.js.snap
@@ -26,7 +26,7 @@ assert(tuple5 === #[2, 2, 3, 4]);
 
 # Output
 ```js
-const tuple1 = #
+const tuple1 = #;
 [1, 2, 3];
 
 assert(tuple1[0] === 1);
@@ -35,7 +35,7 @@ const tuple2 = tuple1.with(0, 2);
 assert(tuple1 !== tuple2);
 assert(tuple2 === #[2, 2, 3]);
 
-const tuple3 = #
+const tuple3 = #;
 [1, ...tuple2];
 assert(tuple3 === #[1, 2, 2, 3]);
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: as.ts
 ---
 # Input
@@ -91,8 +90,10 @@ const state = JSON.stringify({
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;
 
-const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
-const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value1 =
+  thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 =
+  thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
 const value3 = thisIsAReallyLongIdentifier as (
   SomeInterface | SomeOtherInterface
 );
@@ -101,10 +102,11 @@ const value4 = thisIsAReallyLongIdentifier as {
   prop2: number;
   prop3: number;
 }[];
-const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
-  string,
-  number,
-];
+const value5 =
+  thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
+    string,
+    number,
+  ];
 
 const iter1 = createIterator(
   this.controller,
@@ -121,8 +123,7 @@ const iter2 = createIterator(
 
 # Lines exceeding max width of 80 characters
 ```
-   42: const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
-   43: const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
-   52: const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
+   45:   thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+   55:   thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/long-identifiers.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/long-identifiers.ts.snap
@@ -24,7 +24,8 @@ averredBathersBoxroomBuggyNurl(
 
 # Output
 ```js
-const bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
+const bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
 
 averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
   annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
@@ -42,7 +43,6 @@ averredBathersBoxroomBuggyNurl(
 
 # Lines exceeding max width of 80 characters
 ```
-    1: const bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
-   12:   anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
+   13:   anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10850.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10850.ts.snap
@@ -29,10 +29,8 @@ const map: Map<
   Condition extends Foo ? FooFooFoo : BarBarBar
 > = new Map();
 
-const map: Map<
-  Function,
-  FunctionFunctionFunctionFunctionffFunction
-> = new Map();
+const map: Map<Function, FunctionFunctionFunctionFunctionffFunction> =
+  new Map();
 
 const map: Map<Function, Foo<S>> = new Map();
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-2322.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-2322.ts.snap
@@ -10,12 +10,13 @@ export const listAuthorizedSitesForDefaultHandler: ListAuthorizedSitesForHandler
 
 # Output
 ```js
-export const listAuthorizedSitesForDefaultHandler: ListAuthorizedSitesForHandler = aListAuthorizedSitesForResponse;
+export const listAuthorizedSitesForDefaultHandler: ListAuthorizedSitesForHandler =
+  aListAuthorizedSitesForResponse;
 
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-    1: export const listAuthorizedSitesForDefaultHandler: ListAuthorizedSitesForHandler = aListAuthorizedSitesForResponse;
+    1: export const listAuthorizedSitesForDefaultHandler: ListAuthorizedSitesForHandler =
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-8619.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-8619.ts.snap
@@ -19,9 +19,8 @@ expression: issue-8619.ts
 {
   {
     {
-      const myLongVariableName:
-        | MyLongTypeName
-        | null = myLongFunctionCallHere();
+      const myLongVariableName: MyLongTypeName | null =
+        myLongFunctionCallHere();
     }
   }
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-9172.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-9172.ts.snap
@@ -10,9 +10,8 @@ const firestorePersonallyIdentifiablePaths: Array<Collections.Users.Entity> = so
 
 # Output
 ```js
-const firestorePersonallyIdentifiablePaths: Array<
-  Collections.Users.Entity
-> = somefunc();
+const firestorePersonallyIdentifiablePaths: Array<Collections.Users.Entity> =
+  somefunc();
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/typeParameters/variables.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/typeParameters/variables.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: variables.ts
 ---
 # Input
@@ -37,46 +36,35 @@ const fooo: SomeThing<
   }
 > = func();
 const baar: SomeThing<K extends T ? G : S> = func();
-const fooooooooooooooo: SomeThing<
-  boolean
-> = looooooooooooooooooooooooooooooongNameFunc();
-const baaaaaaaaaaaaaaaaaaaaar: SomeThing<
-  boolean,
-  boolean
-> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<boolean> =
+  looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaaaaaaaar: SomeThing<boolean, boolean> =
+  looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaar: SomeThing<
   {
     [P in "x" | "y"]: number;
   }
 > = looooooooooooooooooooooooooooooongNameFunc();
-const baaaaaaaaaaaaaaaar: SomeThing<
-  K extends T ? G : S
-> = looooooooooooooooooooooooooooooongNameFunc();
-const isAnySuccessfulAttempt$: Observable<
-  boolean
-> = this._quizService.isAnySuccessfulAttempt$().pipe(
-  tap((isAnySuccessfulAttempt: boolean) => {
-    this.isAnySuccessfulAttempt = isAnySuccessfulAttempt;
-  }),
-);
-const isAnySuccessfulAttempt2$: Observable<
-  boolean
-> = this._someMethodWithLongName();
-const fooooooooooooooo: SomeThing<
-  boolean | string
-> = looooooooooooooooooooooooooooooongNameFunc();
-const fooooooooooooooo: SomeThing<
-  boolean & string
-> = looooooooooooooooooooooooooooooongNameFunc();
-const fooooooooooooooo: SomeThing<
-  keyof string
-> = looooooooooooooooooooooooooooooongNameFunc();
-const fooooooooooooooo: SomeThing<
-  string[]
-> = looooooooooooooooooooooooooooooongNameFunc();
-const fooooooooooooooo: SomeThing<
-  string["anchor"]
-> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaaar: SomeThing<K extends T ? G : S> =
+  looooooooooooooooooooooooooooooongNameFunc();
+const isAnySuccessfulAttempt$: Observable<boolean> =
+  this._quizService.isAnySuccessfulAttempt$().pipe(
+    tap((isAnySuccessfulAttempt: boolean) => {
+      this.isAnySuccessfulAttempt = isAnySuccessfulAttempt;
+    }),
+  );
+const isAnySuccessfulAttempt2$: Observable<boolean> =
+  this._someMethodWithLongName();
+const fooooooooooooooo: SomeThing<boolean | string> =
+  looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<boolean & string> =
+  looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<keyof string> =
+  looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<string[]> =
+  looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<string["anchor"]> =
+  looooooooooooooooooooooooooooooongNameFunc();
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/non-null/member-chain.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/non-null/member-chain.ts.snap
@@ -16,15 +16,11 @@ foo!.bar().baz().what();
 
 # Output
 ```js
-const {
-  somePropThatHasAReallyLongName,
-  anotherPropThatHasALongName,
-} = this.props.imReallySureAboutThis!;
+const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } =
+  this.props.imReallySureAboutThis!;
 
-const {
-  somePropThatHasAReallyLongName2,
-  anotherPropThatHasALongName2,
-} = this.props.imReallySureAboutThis!.anotherObject;
+const { somePropThatHasAReallyLongName2, anotherPropThatHasALongName2 } =
+  this.props.imReallySureAboutThis!.anotherObject;
 
 this.foo.get("bar")!.doThings().more();
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/typeparams/consistent/issue-9501.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/typeparams/consistent/issue-9501.ts.snap
@@ -12,9 +12,8 @@ const name: SomeGeneric<
 
 # Output
 ```js
-const name: SomeGeneric<
-  Pick<Config, "ONE_LONG_PROP" | "ANOTHER_LONG_PROP">
-> = null;
+const name: SomeGeneric<Pick<Config, "ONE_LONG_PROP" | "ANOTHER_LONG_PROP">> =
+  null;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts
@@ -1,0 +1,47 @@
+//break left-hand side layout
+const map: Map<Function, Map<string | void, { value: UnloadedDescriptor }>> =
+    new Map();
+
+const map: Map<Function, Condition extends Foo ? FooFooFoo : BarBarBar> =
+    new Map();
+
+const map: Map<Function, Foo<S>> = new Map();
+
+//fluid layout
+
+const map: Map<Map<string | void, { value: UnloadedDescriptor }>> =
+    new Map();
+
+const map: Map<Function, FunctionFunctionFunctionFunctionffFunction> =
+    new Map();
+
+const map: Map<Foo<S>> =
+    new Map();
+
+const map: Map<Condition extends Foo ? FooFooFoo : BarBarBar> =
+    new Map();
+
+const {
+	id, static: isStatic, method: isMethod,
+	methodId, getId, setId,
+}:
+	Map<Function, Map<string | void, {
+		value: UnloadedDescriptor
+	}>> =
+	anodyneCondosMalateOverateRetinol.get(
+		bifornCringerMoshedPerplexSawder
+	);
+
+// rome-ignore format: test
+const {
+	id, static: isStatic, method: isMethod,
+	methodId, getId, setId,
+}:
+	// rome-ignore format: test
+	Map<Function, Map<string | void, {
+		value: UnloadedDescriptor
+	}>> =
+	// rome-ignore format: test
+	anodyneCondosMalateOverateRetinol.get(
+		bifornCringerMoshedPerplexSawder
+	);

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
@@ -1,0 +1,109 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: variable_declaration.ts
+---
+# Input
+//break left-hand side layout
+const map: Map<Function, Map<string | void, { value: UnloadedDescriptor }>> =
+    new Map();
+
+const map: Map<Function, Condition extends Foo ? FooFooFoo : BarBarBar> =
+    new Map();
+
+const map: Map<Function, Foo<S>> = new Map();
+
+//fluid layout
+
+const map: Map<Map<string | void, { value: UnloadedDescriptor }>> =
+    new Map();
+
+const map: Map<Function, FunctionFunctionFunctionFunctionffFunction> =
+    new Map();
+
+const map: Map<Foo<S>> =
+    new Map();
+
+const map: Map<Condition extends Foo ? FooFooFoo : BarBarBar> =
+    new Map();
+
+const {
+	id, static: isStatic, method: isMethod,
+	methodId, getId, setId,
+}:
+	Map<Function, Map<string | void, {
+		value: UnloadedDescriptor
+	}>> =
+	anodyneCondosMalateOverateRetinol.get(
+		bifornCringerMoshedPerplexSawder
+	);
+
+// rome-ignore format: test
+const {
+	id, static: isStatic, method: isMethod,
+	methodId, getId, setId,
+}:
+	// rome-ignore format: test
+	Map<Function, Map<string | void, {
+		value: UnloadedDescriptor
+	}>> =
+	// rome-ignore format: test
+	anodyneCondosMalateOverateRetinol.get(
+		bifornCringerMoshedPerplexSawder
+	);
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+-----
+//break left-hand side layout
+const map: Map<
+	Function,
+	Map<string | void, { value: UnloadedDescriptor }>
+> = new Map();
+
+const map: Map<
+	Function,
+	Condition extends Foo ? FooFooFoo : BarBarBar
+> = new Map();
+
+const map: Map<Function, Foo<S>> = new Map();
+
+//fluid layout
+
+const map: Map<Map<string | void, { value: UnloadedDescriptor }>> = new Map();
+
+const map: Map<Function, FunctionFunctionFunctionFunctionffFunction> =
+	new Map();
+
+const map: Map<Foo<S>> = new Map();
+
+const map: Map<Condition extends Foo ? FooFooFoo : BarBarBar> = new Map();
+
+const { id, static: isStatic, method: isMethod, methodId, getId, setId }: Map<
+	Function,
+	Map<
+		string | void,
+		{
+			value: UnloadedDescriptor;
+		}
+	>
+> = anodyneCondosMalateOverateRetinol.get(bifornCringerMoshedPerplexSawder);
+
+// rome-ignore format: test
+const {
+	id, static: isStatic, method: isMethod,
+	methodId, getId, setId,
+}:
+	// rome-ignore format: test
+	Map<Function, Map<string | void, {
+		value: UnloadedDescriptor
+	}>> =
+	// rome-ignore format: test
+	anodyneCondosMalateOverateRetinol.get(
+		bifornCringerMoshedPerplexSawder
+	);
+


### PR DESCRIPTION
## Summary

This PR partially implements https://github.com/rome/tools/issues/2423

Prev PR with discussion: https://github.com/rome/tools/pull/2737

current:
File Based Average Prettier Similarity: 76.28%
Line Based Average Prettier Similarity: 70.99%

main:
File Based Average Prettier Similarity: 75.24%
Line Based Average Prettier Similarity: 70.33%

This PR adds 
- `OnlyLeft` layout to the list of layouts. This layout is hit, usually, when variable declarator doesn't have initializer.
- New conditional branch for `should_break_left_hand_side` when variable declaration `has_complex_type_annotation`. Prettier [hasComplexTypeAnnotation](https://github.com/prettier/prettier/blob/fde0b49d7866e203ca748c306808a87b7c15548f/src/language-js/print/assignment.js#L278-L298).
- New conditional branch for `should_not_indent_if_parent_indents`. Don't indent if `great_parent` is `JS_VARIABLE_DECLARATOR`.

## Test Plan

Add new tests specs
