### PR TITLE
chore: Move Prettier compat metrics to the top

### DIFF
--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -483,23 +483,11 @@ impl DiffReport {
             .unwrap();
         }
         // extra two space force markdown render insert a new line
-        writeln!(
-            report,
-            "**File Based Average Prettier Similarity**: {:.2}%  ",
+        report = format!(
+            "**File Based Average Prettier Similarity**: {:.2}%  \n**Line Based Average Prettier Similarity**: {:.2}%  \nthe definition of similarity you could found here: https://github.com/rome/tools/issues/2555#issuecomment-1124787893\n",
             report_metric_data.file_based_average_prettier_similarity * 100_f64,
-        )
-        .unwrap();
-        writeln!(
-            report,
-            "**Line Based Average Prettier Similarity**: {:.2}%  ",
             report_metric_data.line_based_average_prettier_similarity * 100_f64
-        )
-        .unwrap();
-        writeln!(
-            report,
-            " the definition of similarity you could found here: https://github.com/rome/tools/issues/2555#issuecomment-1124787893",
-        ).unwrap();
-        // write report content to target file_name
+        ) + &report;
         write(report_filename, report).unwrap();
     }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
1.  Moving the overall metrics back to the top.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. No need to test, I guess?
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
