### PR TITLE
refactor(rome_js_formatter): Delete `FormatMemberName`

### DIFF
--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use crate::utils::FormatMemberName;
 
 use rome_formatter::write;
 use rome_js_syntax::JsObjectBindingPatternProperty;
@@ -24,7 +23,7 @@ impl FormatNodeRule<JsObjectBindingPatternProperty> for FormatJsObjectBindingPat
         write![
             f,
             [
-                FormatMemberName::from(member?),
+                member.format(),
                 colon_token.format(),
                 space_token(),
                 pattern.format(),

--- a/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use crate::utils::FormatMemberName;
 
 use rome_formatter::write;
 use rome_js_syntax::JsConstructorClassMember;
@@ -22,7 +21,7 @@ impl FormatNodeRule<JsConstructorClassMember> for FormatJsConstructorClassMember
             [
                 modifiers.format(),
                 space_token(),
-                FormatMemberName::from(name?),
+                name.format(),
                 parameters.format(),
                 space_token(),
                 body.format()

--- a/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use crate::utils::FormatMemberName;
 
 use rome_formatter::write;
 use rome_js_syntax::JsGetterClassMember;
@@ -27,7 +26,7 @@ impl FormatNodeRule<JsGetterClassMember> for FormatJsGetterClassMember {
                 space_token(),
                 get_token.format(),
                 space_token(),
-                FormatMemberName::from(name?),
+                name.format(),
                 l_paren_token.format(),
                 r_paren_token.format(),
                 return_type.format(),

--- a/crates/rome_js_formatter/src/js/classes/method_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/method_class_member.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use crate::utils::FormatMemberName;
 
 use rome_formatter::write;
 use rome_js_syntax::JsMethodClassMember;
@@ -32,7 +31,7 @@ impl FormatNodeRule<JsMethodClassMember> for FormatJsMethodClassMember {
             f,
             [
                 star_token.format(),
-                FormatMemberName::from(name?),
+                name.format(),
                 question_mark_token.format(),
                 type_parameters.format(),
                 parameters.format(),

--- a/crates/rome_js_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/property_class_member.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use rome_formatter::{format_args, write};
 
-use crate::utils::{FormatMemberName, FormatWithSemicolon};
+use crate::utils::FormatWithSemicolon;
 
 use rome_js_syntax::JsPropertyClassMember;
 use rome_js_syntax::JsPropertyClassMemberFields;
@@ -25,7 +25,7 @@ impl FormatNodeRule<JsPropertyClassMember> for FormatJsPropertyClassMember {
                 &format_args!(
                     modifiers.format(),
                     space_token(),
-                    FormatMemberName::from(name?),
+                    name.format(),
                     property_annotation.format(),
                     value
                         .format()

--- a/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use crate::utils::FormatMemberName;
 
 use rome_formatter::write;
 use rome_js_syntax::JsSetterClassMember;
@@ -27,7 +26,7 @@ impl FormatNodeRule<JsSetterClassMember> for FormatJsSetterClassMember {
                 space_token(),
                 set_token.format(),
                 space_token(),
-                FormatMemberName::from(name?),
+                name.format(),
                 l_paren_token.format(),
                 parameter.format(),
                 r_paren_token.format(),

--- a/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<JsLiteralMemberName> for FormatJsLiteralMemberName {
                     f,
                     [FormatLiteralStringToken::new(
                         &value,
-                        StringLiteralParentKind::Expression
+                        StringLiteralParentKind::Member
                     )]
                 ]
             }

--- a/crates/rome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/property_signature_type_member.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::utils::{FormatMemberName, FormatTypeMemberSeparator};
+use crate::utils::FormatTypeMemberSeparator;
 
 use rome_formatter::write;
 use rome_js_syntax::{TsPropertySignatureTypeMember, TsPropertySignatureTypeMemberFields};
@@ -26,7 +26,7 @@ impl FormatNodeRule<TsPropertySignatureTypeMember> for FormatTsPropertySignature
             [
                 readonly_token.format(),
                 space_token(),
-                FormatMemberName::from(name?),
+                name.format(),
                 optional_token.format(),
                 type_annotation.format(),
                 FormatTypeMemberSeparator::new(separator_token.as_ref())

--- a/crates/rome_js_formatter/src/ts/classes/method_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/method_signature_class_member.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::utils::{FormatMemberName, FormatWithSemicolon};
+use crate::utils::FormatWithSemicolon;
 
 use rome_formatter::{format_args, write};
 use rome_js_syntax::{TsMethodSignatureClassMember, TsMethodSignatureClassMemberFields};
@@ -33,7 +33,7 @@ impl FormatNodeRule<TsMethodSignatureClassMember> for FormatTsMethodSignatureCla
                         .format()
                         .with_or_empty(|token, f| write![f, [token, space_token()]]),
                     space_token(),
-                    FormatMemberName::from(name?),
+                    name.format(),
                     question_mark_token.format(),
                     type_parameters.format(),
                     parameters.format(),

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -21,11 +21,9 @@ pub(crate) use member_chain::format_call_expression;
 pub(crate) use object_pattern_like::JsObjectPatternLike;
 use rome_formatter::{format_args, normalize_newlines, write, Buffer, VecBuffer};
 use rome_js_syntax::suppression::{has_suppressions_category, SuppressionCategory};
-use rome_js_syntax::JsSyntaxKind::JS_STRING_LITERAL;
 use rome_js_syntax::{
-    JsAnyClassMemberName, JsAnyExpression, JsAnyFunction, JsAnyObjectMemberName, JsAnyStatement,
-    JsComputedMemberName, JsInitializerClause, JsLanguage, JsLiteralMemberName,
-    JsPrivateClassMemberName, JsTemplateElement, Modifiers, TsTemplateElement, TsType,
+    JsAnyExpression, JsAnyFunction, JsAnyStatement, JsInitializerClause, JsLanguage,
+    JsTemplateElement, Modifiers, TsTemplateElement, TsType,
 };
 use rome_js_syntax::{JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, AstNodeList, Direction, SyntaxResult};
@@ -460,71 +458,6 @@ pub(crate) fn is_call_like_expression(expression: &JsAnyExpression) -> bool {
             | JsAnyExpression::JsImportCallExpression(_)
             | JsAnyExpression::JsCallExpression(_)
     )
-}
-
-/// Data structure used to merge into one the following nodes:
-///
-/// - [JsAnyObjectMemberName]
-/// - [JsAnyClassMemberName]
-/// - [JsLiteralMemberName]
-///
-/// Once merged, the enum is used to get specific members (the literal ones) and elide
-/// the quotes from them, when the algorithm sees fit
-pub(crate) enum FormatMemberName {
-    Computed(JsComputedMemberName),
-    Private(JsPrivateClassMemberName),
-    Literal(JsLiteralMemberName),
-}
-
-impl From<JsAnyClassMemberName> for FormatMemberName {
-    fn from(node: JsAnyClassMemberName) -> Self {
-        match node {
-            JsAnyClassMemberName::JsComputedMemberName(node) => Self::Computed(node),
-            JsAnyClassMemberName::JsLiteralMemberName(node) => Self::Literal(node),
-            JsAnyClassMemberName::JsPrivateClassMemberName(node) => Self::Private(node),
-        }
-    }
-}
-
-impl From<JsAnyObjectMemberName> for FormatMemberName {
-    fn from(node: JsAnyObjectMemberName) -> Self {
-        match node {
-            JsAnyObjectMemberName::JsComputedMemberName(node) => Self::Computed(node),
-            JsAnyObjectMemberName::JsLiteralMemberName(node) => Self::Literal(node),
-        }
-    }
-}
-
-impl From<JsLiteralMemberName> for FormatMemberName {
-    fn from(literal: JsLiteralMemberName) -> Self {
-        Self::Literal(literal)
-    }
-}
-
-impl Format<JsFormatContext> for FormatMemberName {
-    fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
-        match self {
-            FormatMemberName::Computed(node) => {
-                write![f, [node.format()]]
-            }
-            FormatMemberName::Private(node) => {
-                write![f, [node.format()]]
-            }
-            FormatMemberName::Literal(literal) => {
-                let value = literal.value()?;
-
-                if value.kind() == JS_STRING_LITERAL {
-                    FormatLiteralStringToken::new(
-                        &literal.value()?,
-                        StringLiteralParentKind::Member,
-                    )
-                    .fmt(f)
-                } else {
-                    value.format().fmt(f)
-                }
-            }
-        }
-    }
 }
 
 /// This function is in charge to format the call arguments.


### PR DESCRIPTION



## Summary

This PR deletes `FormatMemberName` because:

a) It doesn't call into the nodes formatting logic and, therefore, doesn't respect "rome ignore" comments
b) The `JsLiteralMemberName` formatter already takes care of normalizing the member name

## Test Plan

`cargo test`