### PR TITLE
feat(rome_rowan): expose the kind of AstNode as a constant

### DIFF
--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -5,7 +5,7 @@ mod rule;
 mod signals;
 
 pub use crate::categories::{ActionCategory, RuleCategories, RuleCategory};
-pub use crate::registry::{LanguageRoot, MetadataIter, RuleRegistry};
+pub use crate::registry::{LanguageRoot, RuleRegistry};
 pub use crate::rule::{Rule, RuleAction, RuleDiagnostic, RuleMeta};
 pub use crate::signals::{AnalyzerAction, AnalyzerSignal};
 use rome_diagnostics::file::FileId;

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -1,7 +1,7 @@
-use std::{iter::Map, vec::IntoIter};
+use std::collections::HashSet;
 
 use rome_diagnostics::file::FileId;
-use rome_rowan::{AstNode, Language, SyntaxNode};
+use rome_rowan::{AstNode, Language, SyntaxKind, SyntaxNode};
 
 use crate::{
     context::RuleContext,
@@ -11,12 +11,12 @@ use crate::{
 
 /// The rule registry holds type-erased instances of all active analysis rules
 pub struct RuleRegistry<L: Language> {
-    rules: Vec<RegistryRule<L>>,
+    nodes: Vec<KindRules<L>>,
 }
 
 impl<L: Language> RuleRegistry<L> {
     pub fn empty() -> Self {
-        Self { rules: Vec::new() }
+        Self { nodes: Vec::new() }
     }
 
     pub fn push<R>(&mut self)
@@ -24,18 +24,39 @@ impl<L: Language> RuleRegistry<L> {
         R: Rule + 'static,
         R::Query: AstNode<Language = L>,
     {
-        self.rules.push(RegistryRule::of::<R>());
+        for kind in <R::Query as AstNode>::KIND_SET.iter() {
+            let index = usize::from(kind.to_raw().0);
+
+            if self.nodes.len() <= index {
+                self.nodes.resize_with(index + 1, KindRules::empty);
+            }
+
+            let node = &mut self.nodes[index];
+            node.rules.push(RegistryRule::of::<R>());
+        }
     }
 
     /// Returns an iterator over the name and documentation of all active rules
     /// in this instance of the registry
-    pub fn metadata(self) -> MetadataIter<L> {
-        self.rules.into_iter().map(|rule| (rule.name, rule.docs))
+    pub fn metadata(self) -> impl Iterator<Item = (&'static str, &'static str)> {
+        let mut unique = HashSet::new();
+        self.nodes
+            .into_iter()
+            .flat_map(|node| node.rules)
+            .map(|rule| (rule.name, rule.docs))
+            .filter(move |(name, _)| unique.insert(name.as_ptr() as u64))
     }
 }
 
-pub type MetadataIter<L> =
-    Map<IntoIter<RegistryRule<L>>, fn(RegistryRule<L>) -> (&'static str, &'static str)>;
+struct KindRules<L: Language> {
+    rules: Vec<RegistryRule<L>>,
+}
+
+impl<L: Language> KindRules<L> {
+    fn empty() -> Self {
+        Self { rules: Vec::new() }
+    }
+}
 
 pub(crate) type RuleLanguage<R> = NodeLanguage<<R as Rule>::Query>;
 pub(crate) type NodeLanguage<N> = <N as AstNode>::Language;
@@ -55,7 +76,12 @@ where
         node: SyntaxNode<L>,
         callback: &mut impl FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<B>,
     ) -> ControlFlow<B> {
-        for rule in &self.rules {
+        let kind = usize::from(node.kind().to_raw().0);
+        let rules = match self.nodes.get(kind) {
+            Some(entry) => &entry.rules,
+            None => return ControlFlow::Continue(()),
+        };
+        for rule in rules {
             if let Some(event) = (rule.run)(file_id, root, &node) {
                 if let ControlFlow::Break(b) = callback(&*event) {
                     return ControlFlow::Break(b);

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -9,18 +9,15 @@ use crate::{
     ControlFlow, Rule,
 };
 
+#[derive(Default)]
 /// The rule registry holds type-erased instances of all active analysis rules
 pub struct RuleRegistry<L: Language> {
     /// Holds a collection of rules for each [SyntaxKind] node type that has
     /// lint rules associated with it
-    nodes: Vec<KindRules<L>>,
+    nodes: Vec<SyntaxKindRules<L>>,
 }
 
 impl<L: Language> RuleRegistry<L> {
-    pub fn empty() -> Self {
-        Self { nodes: Vec::new() }
-    }
-
     /// Add the rule `R` to the list of rules stores in this registry instance
     pub fn push<R>(&mut self)
     where
@@ -35,12 +32,12 @@ impl<L: Language> RuleRegistry<L> {
             let index = usize::from(index);
 
             // Ensure the vector has enough capacity by inserting empty
-            // `KindRules` as required
+            // `SyntaxKindRules` as required
             if self.nodes.len() <= index {
-                self.nodes.resize_with(index + 1, KindRules::empty);
+                self.nodes.resize_with(index + 1, SyntaxKindRules::new);
             }
 
-            // Insert a handle to the rule `R` into the `KindRules` entry
+            // Insert a handle to the rule `R` into the `SyntaxKindRules` entry
             // corresponding to the SyntaxKind index
             let node = &mut self.nodes[index];
             node.rules.push(RegistryRule::of::<R>());
@@ -59,13 +56,13 @@ impl<L: Language> RuleRegistry<L> {
     }
 }
 
-/// [KindRules] holds a collection of [Rule]s that match a specific [SyntaxKind] value
-struct KindRules<L: Language> {
+/// [SyntaxKindRules] holds a collection of [Rule]s that match a specific [SyntaxKind] value
+struct SyntaxKindRules<L: Language> {
     rules: Vec<RegistryRule<L>>,
 }
 
-impl<L: Language> KindRules<L> {
-    fn empty() -> Self {
+impl<L: Language> SyntaxKindRules<L> {
+    fn new() -> Self {
         Self { rules: Vec::new() }
     }
 }

--- a/crates/rome_css_syntax/src/generated/nodes.rs
+++ b/crates/rome_css_syntax/src/generated/nodes.rs
@@ -9,7 +9,7 @@ use crate::{
     CssSyntaxKind::{self as SyntaxKind, *},
     CssSyntaxList as SyntaxList, CssSyntaxNode as SyntaxNode, CssSyntaxToken as SyntaxToken,
 };
-use rome_rowan::{support, AstNode, SyntaxResult};
+use rome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
 #[allow(unused)]
 use rome_rowan::{
     AstNodeList, AstNodeListIterator, AstSeparatedList, AstSeparatedListNodesIterator,
@@ -2044,6 +2044,8 @@ impl CssAnyValue {
 }
 impl AstNode for CssAnyFunction {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ANY_FUNCTION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ANY_FUNCTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2073,6 +2075,8 @@ impl From<CssAnyFunction> for SyntaxElement {
 }
 impl AstNode for CssAtKeyframes {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_KEYFRAMES as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_KEYFRAMES }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2106,6 +2110,8 @@ impl From<CssAtKeyframes> for SyntaxElement {
 }
 impl AstNode for CssAtKeyframesBody {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_KEYFRAMES_BODY as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_KEYFRAMES_BODY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2140,6 +2146,8 @@ impl From<CssAtKeyframesBody> for SyntaxElement {
 }
 impl AstNode for CssAtMedia {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2180,6 +2188,8 @@ impl From<CssAtMedia> for SyntaxElement {
 }
 impl AstNode for CssAtMediaQuery {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA_QUERY as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2219,6 +2229,8 @@ impl From<CssAtMediaQuery> for SyntaxElement {
 }
 impl AstNode for CssAtMediaQueryConsequent {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA_QUERY_CONSEQUENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_CONSEQUENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2250,6 +2262,8 @@ impl From<CssAtMediaQueryConsequent> for SyntaxElement {
 }
 impl AstNode for CssAtMediaQueryFeature {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA_QUERY_FEATURE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2284,6 +2298,8 @@ impl From<CssAtMediaQueryFeature> for SyntaxElement {
 }
 impl AstNode for CssAtMediaQueryFeatureBoolean {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA_QUERY_FEATURE_BOOLEAN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE_BOOLEAN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2313,6 +2329,8 @@ impl From<CssAtMediaQueryFeatureBoolean> for SyntaxElement {
 }
 impl AstNode for CssAtMediaQueryFeatureCompare {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA_QUERY_FEATURE_COMPARE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE_COMPARE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2341,6 +2359,8 @@ impl From<CssAtMediaQueryFeatureCompare> for SyntaxElement {
 }
 impl AstNode for CssAtMediaQueryFeaturePlain {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA_QUERY_FEATURE_PLAIN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE_PLAIN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2372,6 +2392,8 @@ impl From<CssAtMediaQueryFeaturePlain> for SyntaxElement {
 }
 impl AstNode for CssAtMediaQueryFeatureRange {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA_QUERY_FEATURE_RANGE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE_RANGE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2414,6 +2436,8 @@ impl From<CssAtMediaQueryFeatureRange> for SyntaxElement {
 }
 impl AstNode for CssAtMediaQueryRange {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA_QUERY_RANGE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_RANGE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2455,6 +2479,8 @@ impl From<CssAtMediaQueryRange> for SyntaxElement {
 }
 impl AstNode for CssAttribute {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ATTRIBUTE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2496,6 +2522,8 @@ impl From<CssAttribute> for SyntaxElement {
 }
 impl AstNode for CssAttributeMatcher {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ATTRIBUTE_MATCHER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_MATCHER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2550,6 +2578,8 @@ impl From<CssAttributeMatcher> for SyntaxElement {
 }
 impl AstNode for CssAttributeMeta {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ATTRIBUTE_META as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_META }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2583,6 +2613,8 @@ impl From<CssAttributeMeta> for SyntaxElement {
 }
 impl AstNode for CssAttributeModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ATTRIBUTE_MODIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2609,6 +2641,8 @@ impl From<CssAttributeModifier> for SyntaxElement {
 }
 impl AstNode for CssAttributeName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ATTRIBUTE_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2635,6 +2669,8 @@ impl From<CssAttributeName> for SyntaxElement {
 }
 impl AstNode for CssAttributeSelectorPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ATTRIBUTE_SELECTOR_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2662,6 +2698,8 @@ impl From<CssAttributeSelectorPattern> for SyntaxElement {
 }
 impl AstNode for CssBlock {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_BLOCK as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_BLOCK }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2696,6 +2734,8 @@ impl From<CssBlock> for SyntaxElement {
 }
 impl AstNode for CssClassSelectorPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_CLASS_SELECTOR_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_CLASS_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2723,6 +2763,8 @@ impl From<CssClassSelectorPattern> for SyntaxElement {
 }
 impl AstNode for CssCombinatorSelectorPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_COMBINATOR_SELECTOR_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_COMBINATOR_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2763,6 +2805,8 @@ impl From<CssCombinatorSelectorPattern> for SyntaxElement {
 }
 impl AstNode for CssCustomProperty {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_CUSTOM_PROPERTY as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_CUSTOM_PROPERTY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2792,6 +2836,8 @@ impl From<CssCustomProperty> for SyntaxElement {
 }
 impl AstNode for CssDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2831,6 +2877,8 @@ impl From<CssDeclaration> for SyntaxElement {
 }
 impl AstNode for CssDeclarationImportant {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_DECLARATION_IMPORTANT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_DECLARATION_IMPORTANT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2861,6 +2909,8 @@ impl From<CssDeclarationImportant> for SyntaxElement {
 }
 impl AstNode for CssDimension {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_DIMENSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_DIMENSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2888,6 +2938,8 @@ impl From<CssDimension> for SyntaxElement {
 }
 impl AstNode for CssIdSelectorPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ID_SELECTOR_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ID_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2915,6 +2967,8 @@ impl From<CssIdSelectorPattern> for SyntaxElement {
 }
 impl AstNode for CssIdentifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_IDENTIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_IDENTIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2944,6 +2998,8 @@ impl From<CssIdentifier> for SyntaxElement {
 }
 impl AstNode for CssKeyframesBlock {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_KEYFRAMES_BLOCK as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_KEYFRAMES_BLOCK }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2979,6 +3035,8 @@ impl From<CssKeyframesBlock> for SyntaxElement {
 }
 impl AstNode for CssKeyframesSelector {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_KEYFRAMES_SELECTOR as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_KEYFRAMES_SELECTOR }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3010,6 +3068,8 @@ impl From<CssKeyframesSelector> for SyntaxElement {
 }
 impl AstNode for CssNumber {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_NUMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_NUMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3039,6 +3099,8 @@ impl From<CssNumber> for SyntaxElement {
 }
 impl AstNode for CssParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_PARAMETER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3068,6 +3130,8 @@ impl From<CssParameter> for SyntaxElement {
 }
 impl AstNode for CssPercentage {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_PERCENTAGE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PERCENTAGE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3098,6 +3162,8 @@ impl From<CssPercentage> for SyntaxElement {
 }
 impl AstNode for CssPseudoClassSelectorPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_PSEUDO_CLASS_SELECTOR_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PSEUDO_CLASS_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3132,6 +3198,9 @@ impl From<CssPseudoClassSelectorPattern> for SyntaxElement {
 }
 impl AstNode for CssPseudoClassSelectorPatternParameters {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        CSS_PSEUDO_CLASS_SELECTOR_PATTERN_PARAMETERS as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PSEUDO_CLASS_SELECTOR_PATTERN_PARAMETERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3166,6 +3235,8 @@ impl From<CssPseudoClassSelectorPatternParameters> for SyntaxElement {
 }
 impl AstNode for CssRatio {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_RATIO as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_RATIO }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3196,6 +3267,8 @@ impl From<CssRatio> for SyntaxElement {
 }
 impl AstNode for CssRule {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_RULE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_RULE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3223,6 +3296,8 @@ impl From<CssRule> for SyntaxElement {
 }
 impl AstNode for CssSelector {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_SELECTOR as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_SELECTOR }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3249,6 +3324,8 @@ impl From<CssSelector> for SyntaxElement {
 }
 impl AstNode for CssSimpleFunction {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_SIMPLE_FUNCTION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_SIMPLE_FUNCTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3284,6 +3361,8 @@ impl From<CssSimpleFunction> for SyntaxElement {
 }
 impl AstNode for CssString {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_STRING as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_STRING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3313,6 +3392,8 @@ impl From<CssString> for SyntaxElement {
 }
 impl AstNode for CssTypeSelectorPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_TYPE_SELECTOR_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_TYPE_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3339,6 +3420,8 @@ impl From<CssTypeSelectorPattern> for SyntaxElement {
 }
 impl AstNode for CssUniversalSelectorPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_UNIVERSAL_SELECTOR_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_UNIVERSAL_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3365,6 +3448,8 @@ impl From<CssUniversalSelectorPattern> for SyntaxElement {
 }
 impl AstNode for CssVarFunction {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_VAR_FUNCTION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_VAR_FUNCTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3401,6 +3486,8 @@ impl From<CssVarFunction> for SyntaxElement {
 }
 impl AstNode for CssVarFunctionValue {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_VAR_FUNCTION_VALUE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_VAR_FUNCTION_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3451,6 +3538,10 @@ impl From<CssAtMediaQueryFeatureRange> for CssAnyAtMediaQueryFeatureType {
 }
 impl AstNode for CssAnyAtMediaQueryFeatureType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = CssAtMediaQueryFeatureBoolean::KIND_SET
+        .union(CssAtMediaQueryFeatureCompare::KIND_SET)
+        .union(CssAtMediaQueryFeaturePlain::KIND_SET)
+        .union(CssAtMediaQueryFeatureRange::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -3549,6 +3640,8 @@ impl From<CssIdentifier> for CssAnyAtMediaQueryType {
 }
 impl AstNode for CssAnyAtMediaQueryType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        CssAtMediaQueryFeature::KIND_SET.union(CssIdentifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, CSS_AT_MEDIA_QUERY_FEATURE | CSS_IDENTIFIER)
     }
@@ -3605,6 +3698,7 @@ impl From<CssAtMedia> for CssAnyAtRule {
 }
 impl AstNode for CssAnyAtRule {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = CssAtKeyframes::KIND_SET.union(CssAtMedia::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, CSS_AT_KEYFRAMES | CSS_AT_MEDIA) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -3654,6 +3748,7 @@ impl From<CssRule> for CssAnyRule {
 }
 impl AstNode for CssAnyRule {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = CssAnyAtRule::KIND_SET.union(CssRule::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             CSS_RULE => true,
@@ -3745,6 +3840,13 @@ impl From<CssUniversalSelectorPattern> for CssAnySelectorPattern {
 }
 impl AstNode for CssAnySelectorPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = CssAttributeSelectorPattern::KIND_SET
+        .union(CssClassSelectorPattern::KIND_SET)
+        .union(CssCombinatorSelectorPattern::KIND_SET)
+        .union(CssIdSelectorPattern::KIND_SET)
+        .union(CssPseudoClassSelectorPattern::KIND_SET)
+        .union(CssTypeSelectorPattern::KIND_SET)
+        .union(CssUniversalSelectorPattern::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -3870,6 +3972,13 @@ impl From<CssString> for CssAnyValue {
 }
 impl AstNode for CssAnyValue {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = CssAnyFunction::KIND_SET
+        .union(CssCustomProperty::KIND_SET)
+        .union(CssDimension::KIND_SET)
+        .union(CssIdentifier::KIND_SET)
+        .union(CssNumber::KIND_SET)
+        .union(CssRatio::KIND_SET)
+        .union(CssString::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -4213,6 +4322,8 @@ impl CssUnknown {
 }
 impl AstNode for CssUnknown {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_UNKNOWN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_UNKNOWN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -4256,6 +4367,8 @@ impl CssAnySelectorPatternList {
 }
 impl AstNode for CssAnySelectorPatternList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ANY_SELECTOR_PATTERN_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ANY_SELECTOR_PATTERN_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssAnySelectorPatternList> {
         if Self::can_cast(syntax.kind()) {
@@ -4323,6 +4436,8 @@ impl CssAtKeyframesItemList {
 }
 impl AstNode for CssAtKeyframesItemList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_KEYFRAMES_ITEM_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_KEYFRAMES_ITEM_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssAtKeyframesItemList> {
         if Self::can_cast(syntax.kind()) {
@@ -4390,6 +4505,8 @@ impl CssAtMediaQueryList {
 }
 impl AstNode for CssAtMediaQueryList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_AT_MEDIA_QUERY_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssAtMediaQueryList> {
         if Self::can_cast(syntax.kind()) {
@@ -4457,6 +4574,8 @@ impl CssAttributeList {
 }
 impl AstNode for CssAttributeList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ATTRIBUTE_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssAttributeList> {
         if Self::can_cast(syntax.kind()) {
@@ -4524,6 +4643,8 @@ impl CssDeclarationList {
 }
 impl AstNode for CssDeclarationList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_DECLARATION_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_DECLARATION_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssDeclarationList> {
         if Self::can_cast(syntax.kind()) {
@@ -4591,6 +4712,8 @@ impl CssKeyframesSelectorList {
 }
 impl AstNode for CssKeyframesSelectorList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_KEYFRAMES_SELECTOR_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_KEYFRAMES_SELECTOR_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssKeyframesSelectorList> {
         if Self::can_cast(syntax.kind()) {
@@ -4658,6 +4781,8 @@ impl CssParameterList {
 }
 impl AstNode for CssParameterList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_PARAMETER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssParameterList> {
         if Self::can_cast(syntax.kind()) {
@@ -4725,6 +4850,8 @@ impl CssRoot {
 }
 impl AstNode for CssRoot {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_ROOT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ROOT }
     fn cast(syntax: SyntaxNode) -> Option<CssRoot> {
         if Self::can_cast(syntax.kind()) {
@@ -4792,6 +4919,8 @@ impl CssSelectorList {
 }
 impl AstNode for CssSelectorList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(CSS_SELECTOR_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_SELECTOR_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssSelectorList> {
         if Self::can_cast(syntax.kind()) {

--- a/crates/rome_js_analyze/src/analyzers/no_negation_else.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_negation_else.rs
@@ -5,10 +5,9 @@ use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
-    JsAnyExpression, JsConditionalExpression, JsIfStatement, JsLanguage, JsSyntaxKind,
-    JsUnaryExpression, JsUnaryOperator,
+    JsAnyExpression, JsConditionalExpression, JsIfStatement, JsUnaryExpression, JsUnaryOperator,
 };
-use rome_rowan::{AstNode, AstNodeExt};
+use rome_rowan::{declare_node_union, AstNode, AstNodeExt};
 
 use crate::JsRuleAction;
 
@@ -134,48 +133,6 @@ fn is_negation(node: &JsAnyExpression) -> Option<bool> {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum JsAnyCondition {
-    JsConditionalExpression(JsConditionalExpression),
-    JsIfStatement(JsIfStatement),
-}
-
-impl AstNode for JsAnyCondition {
-    type Language = JsLanguage;
-
-    fn can_cast(kind: <Self::Language as rome_rowan::Language>::Kind) -> bool {
-        matches!(
-            kind,
-            JsSyntaxKind::JS_CONDITIONAL_EXPRESSION | JsSyntaxKind::JS_IF_STATEMENT
-        )
-    }
-
-    fn cast(syntax: rome_rowan::SyntaxNode<Self::Language>) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            JsSyntaxKind::JS_CONDITIONAL_EXPRESSION => {
-                JsConditionalExpression::cast(syntax).map(JsAnyCondition::JsConditionalExpression)
-            }
-            JsSyntaxKind::JS_IF_STATEMENT => {
-                JsIfStatement::cast(syntax).map(JsAnyCondition::JsIfStatement)
-            }
-            _ => None,
-        }
-    }
-
-    fn syntax(&self) -> &rome_rowan::SyntaxNode<Self::Language> {
-        match self {
-            JsAnyCondition::JsConditionalExpression(expr) => expr.syntax(),
-            JsAnyCondition::JsIfStatement(stmt) => stmt.syntax(),
-        }
-    }
-
-    fn into_syntax(self) -> rome_rowan::SyntaxNode<Self::Language> {
-        match self {
-            JsAnyCondition::JsConditionalExpression(expr) => expr.into_syntax(),
-            JsAnyCondition::JsIfStatement(stmt) => stmt.into_syntax(),
-        }
-    }
+declare_node_union! {
+    pub JsAnyCondition = JsConditionalExpression | JsIfStatement
 }

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -1,5 +1,5 @@
 use rome_analyze::{
-    AnalysisFilter, Analyzer, AnalyzerSignal, ControlFlow, LanguageRoot, MetadataIter, RuleAction,
+    AnalysisFilter, Analyzer, AnalyzerSignal, ControlFlow, LanguageRoot, RuleAction,
 };
 use rome_diagnostics::file::FileId;
 use rome_js_syntax::{
@@ -17,7 +17,7 @@ pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
 
 /// Return an iterator over the name and documentation of all the rules
 /// implemented by the JS analyzer
-pub fn metadata(filter: AnalysisFilter) -> MetadataIter<JsLanguage> {
+pub fn metadata(filter: AnalysisFilter) -> impl Iterator<Item = (&'static str, &'static str)> {
     build_registry(&filter).metadata()
 }
 

--- a/crates/rome_js_analyze/src/registry.rs
+++ b/crates/rome_js_analyze/src/registry.rs
@@ -4,7 +4,7 @@ use crate::{analyzers::*, assists::*};
 use rome_analyze::{AnalysisFilter, RuleRegistry};
 use rome_js_syntax::JsLanguage;
 pub(crate) fn build_registry(filter: &AnalysisFilter) -> RuleRegistry<JsLanguage> {
-    let mut rules = RuleRegistry::empty();
+    let mut rules = RuleRegistry::default();
     if filter.match_rule::<NoAsyncPromiseExecutor>() {
         rules.push::<NoAsyncPromiseExecutor>();
     }

--- a/crates/rome_js_syntax/src/generated/nodes.rs
+++ b/crates/rome_js_syntax/src/generated/nodes.rs
@@ -9,7 +9,7 @@ use crate::{
     JsSyntaxKind::{self as SyntaxKind, *},
     JsSyntaxList as SyntaxList, JsSyntaxNode as SyntaxNode, JsSyntaxToken as SyntaxToken,
 };
-use rome_rowan::{support, AstNode, SyntaxResult};
+use rome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
 #[allow(unused)]
 use rome_rowan::{
     AstNodeList, AstNodeListIterator, AstSeparatedList, AstSeparatedListNodesIterator,
@@ -14752,6 +14752,8 @@ impl TsType {
 }
 impl AstNode for ImportMeta {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(IMPORT_META as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_META }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14783,6 +14785,8 @@ impl From<ImportMeta> for SyntaxElement {
 }
 impl AstNode for JsArrayAssignmentPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ARRAY_ASSIGNMENT_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_ASSIGNMENT_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14817,6 +14821,9 @@ impl From<JsArrayAssignmentPattern> for SyntaxElement {
 }
 impl AstNode for JsArrayAssignmentPatternRestElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        JS_ARRAY_ASSIGNMENT_PATTERN_REST_ELEMENT as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_ASSIGNMENT_PATTERN_REST_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14847,6 +14854,8 @@ impl From<JsArrayAssignmentPatternRestElement> for SyntaxElement {
 }
 impl AstNode for JsArrayBindingPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ARRAY_BINDING_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_BINDING_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14881,6 +14890,8 @@ impl From<JsArrayBindingPattern> for SyntaxElement {
 }
 impl AstNode for JsArrayBindingPatternRestElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ARRAY_BINDING_PATTERN_REST_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_BINDING_PATTERN_REST_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14911,6 +14922,8 @@ impl From<JsArrayBindingPatternRestElement> for SyntaxElement {
 }
 impl AstNode for JsArrayExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ARRAY_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14945,6 +14958,8 @@ impl From<JsArrayExpression> for SyntaxElement {
 }
 impl AstNode for JsArrayHole {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ARRAY_HOLE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_HOLE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14969,6 +14984,8 @@ impl From<JsArrayHole> for SyntaxElement {
 }
 impl AstNode for JsArrowFunctionExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ARROW_FUNCTION_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARROW_FUNCTION_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15012,6 +15029,8 @@ impl From<JsArrowFunctionExpression> for SyntaxElement {
 }
 impl AstNode for JsAssignmentExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ASSIGNMENT_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ASSIGNMENT_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15043,6 +15062,8 @@ impl From<JsAssignmentExpression> for SyntaxElement {
 }
 impl AstNode for JsAssignmentWithDefault {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ASSIGNMENT_WITH_DEFAULT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ASSIGNMENT_WITH_DEFAULT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15071,6 +15092,8 @@ impl From<JsAssignmentWithDefault> for SyntaxElement {
 }
 impl AstNode for JsAwaitExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_AWAIT_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_AWAIT_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15101,6 +15124,8 @@ impl From<JsAwaitExpression> for SyntaxElement {
 }
 impl AstNode for JsBigIntLiteralExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_BIG_INT_LITERAL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BIG_INT_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15130,6 +15155,8 @@ impl From<JsBigIntLiteralExpression> for SyntaxElement {
 }
 impl AstNode for JsBinaryExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_BINARY_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BINARY_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15161,6 +15188,8 @@ impl From<JsBinaryExpression> for SyntaxElement {
 }
 impl AstNode for JsBindingPatternWithDefault {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_BINDING_PATTERN_WITH_DEFAULT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BINDING_PATTERN_WITH_DEFAULT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15189,6 +15218,8 @@ impl From<JsBindingPatternWithDefault> for SyntaxElement {
 }
 impl AstNode for JsBlockStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_BLOCK_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BLOCK_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15223,6 +15254,8 @@ impl From<JsBlockStatement> for SyntaxElement {
 }
 impl AstNode for JsBooleanLiteralExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_BOOLEAN_LITERAL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BOOLEAN_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15252,6 +15285,8 @@ impl From<JsBooleanLiteralExpression> for SyntaxElement {
 }
 impl AstNode for JsBreakStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_BREAK_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BREAK_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15289,6 +15324,8 @@ impl From<JsBreakStatement> for SyntaxElement {
 }
 impl AstNode for JsCallArguments {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CALL_ARGUMENTS as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CALL_ARGUMENTS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15323,6 +15360,8 @@ impl From<JsCallArguments> for SyntaxElement {
 }
 impl AstNode for JsCallExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CALL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CALL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15358,6 +15397,8 @@ impl From<JsCallExpression> for SyntaxElement {
 }
 impl AstNode for JsCaseClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CASE_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CASE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15390,6 +15431,8 @@ impl From<JsCaseClause> for SyntaxElement {
 }
 impl AstNode for JsCatchClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CATCH_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15424,6 +15467,8 @@ impl From<JsCatchClause> for SyntaxElement {
 }
 impl AstNode for JsCatchDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CATCH_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15462,6 +15507,8 @@ impl From<JsCatchDeclaration> for SyntaxElement {
 }
 impl AstNode for JsClassDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CLASS_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15517,6 +15564,8 @@ impl From<JsClassDeclaration> for SyntaxElement {
 }
 impl AstNode for JsClassExportDefaultDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CLASS_EXPORT_DEFAULT_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_EXPORT_DEFAULT_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15572,6 +15621,8 @@ impl From<JsClassExportDefaultDeclaration> for SyntaxElement {
 }
 impl AstNode for JsClassExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CLASS_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15623,6 +15674,8 @@ impl From<JsClassExpression> for SyntaxElement {
 }
 impl AstNode for JsComputedMemberAssignment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_COMPUTED_MEMBER_ASSIGNMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15658,6 +15711,8 @@ impl From<JsComputedMemberAssignment> for SyntaxElement {
 }
 impl AstNode for JsComputedMemberExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_COMPUTED_MEMBER_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15697,6 +15752,8 @@ impl From<JsComputedMemberExpression> for SyntaxElement {
 }
 impl AstNode for JsComputedMemberName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_COMPUTED_MEMBER_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15731,6 +15788,8 @@ impl From<JsComputedMemberName> for SyntaxElement {
 }
 impl AstNode for JsConditionalExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CONDITIONAL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONDITIONAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15767,6 +15826,8 @@ impl From<JsConditionalExpression> for SyntaxElement {
 }
 impl AstNode for JsConstructorClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CONSTRUCTOR_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15796,6 +15857,8 @@ impl From<JsConstructorClassMember> for SyntaxElement {
 }
 impl AstNode for JsConstructorParameters {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CONSTRUCTOR_PARAMETERS as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_PARAMETERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15830,6 +15893,8 @@ impl From<JsConstructorParameters> for SyntaxElement {
 }
 impl AstNode for JsContinueStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CONTINUE_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONTINUE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15867,6 +15932,8 @@ impl From<JsContinueStatement> for SyntaxElement {
 }
 impl AstNode for JsDebuggerStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_DEBUGGER_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEBUGGER_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15900,6 +15967,8 @@ impl From<JsDebuggerStatement> for SyntaxElement {
 }
 impl AstNode for JsDefaultClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_DEFAULT_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEFAULT_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15934,6 +16003,8 @@ impl From<JsDefaultClause> for SyntaxElement {
 }
 impl AstNode for JsDefaultImportSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_DEFAULT_IMPORT_SPECIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEFAULT_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15964,6 +16035,8 @@ impl From<JsDefaultImportSpecifier> for SyntaxElement {
 }
 impl AstNode for JsDirective {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_DIRECTIVE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DIRECTIVE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15997,6 +16070,8 @@ impl From<JsDirective> for SyntaxElement {
 }
 impl AstNode for JsDoWhileStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_DO_WHILE_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DO_WHILE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16041,6 +16116,8 @@ impl From<JsDoWhileStatement> for SyntaxElement {
 }
 impl AstNode for JsElseClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ELSE_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ELSE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16068,6 +16145,8 @@ impl From<JsElseClause> for SyntaxElement {
 }
 impl AstNode for JsEmptyClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EMPTY_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16097,6 +16176,8 @@ impl From<JsEmptyClassMember> for SyntaxElement {
 }
 impl AstNode for JsEmptyStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EMPTY_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16126,6 +16207,8 @@ impl From<JsEmptyStatement> for SyntaxElement {
 }
 impl AstNode for JsExport {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16159,6 +16242,8 @@ impl From<JsExport> for SyntaxElement {
 }
 impl AstNode for JsExportAsClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_AS_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_AS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16189,6 +16274,8 @@ impl From<JsExportAsClause> for SyntaxElement {
 }
 impl AstNode for JsExportDefaultDeclarationClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_DEFAULT_DECLARATION_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_DEFAULT_DECLARATION_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16226,6 +16313,8 @@ impl From<JsExportDefaultDeclarationClause> for SyntaxElement {
 }
 impl AstNode for JsExportDefaultExpressionClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16260,6 +16349,8 @@ impl From<JsExportDefaultExpressionClause> for SyntaxElement {
 }
 impl AstNode for JsExportFromClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_FROM_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_FROM_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16300,6 +16391,8 @@ impl From<JsExportFromClause> for SyntaxElement {
 }
 impl AstNode for JsExportNamedClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_NAMED_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16342,6 +16435,8 @@ impl From<JsExportNamedClause> for SyntaxElement {
 }
 impl AstNode for JsExportNamedFromClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_NAMED_FROM_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_FROM_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16390,6 +16485,8 @@ impl From<JsExportNamedFromClause> for SyntaxElement {
 }
 impl AstNode for JsExportNamedFromSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_NAMED_FROM_SPECIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_FROM_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16427,6 +16524,8 @@ impl From<JsExportNamedFromSpecifier> for SyntaxElement {
 }
 impl AstNode for JsExportNamedShorthandSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_NAMED_SHORTHAND_SPECIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_SHORTHAND_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16457,6 +16556,8 @@ impl From<JsExportNamedShorthandSpecifier> for SyntaxElement {
 }
 impl AstNode for JsExportNamedSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_NAMED_SPECIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16492,6 +16593,8 @@ impl From<JsExportNamedSpecifier> for SyntaxElement {
 }
 impl AstNode for JsExpressionSnipped {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPRESSION_SNIPPED as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPRESSION_SNIPPED }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16519,6 +16622,8 @@ impl From<JsExpressionSnipped> for SyntaxElement {
 }
 impl AstNode for JsExpressionStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPRESSION_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPRESSION_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16549,6 +16654,8 @@ impl From<JsExpressionStatement> for SyntaxElement {
 }
 impl AstNode for JsExtendsClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXTENDS_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXTENDS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16586,6 +16693,8 @@ impl From<JsExtendsClause> for SyntaxElement {
 }
 impl AstNode for JsFinallyClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FINALLY_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FINALLY_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16616,6 +16725,8 @@ impl From<JsFinallyClause> for SyntaxElement {
 }
 impl AstNode for JsForInStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FOR_IN_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FOR_IN_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16657,6 +16768,8 @@ impl From<JsForInStatement> for SyntaxElement {
 }
 impl AstNode for JsForOfStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FOR_OF_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FOR_OF_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16702,6 +16815,8 @@ impl From<JsForOfStatement> for SyntaxElement {
 }
 impl AstNode for JsForStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FOR_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FOR_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16751,6 +16866,8 @@ impl From<JsForStatement> for SyntaxElement {
 }
 impl AstNode for JsForVariableDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FOR_VARIABLE_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FOR_VARIABLE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16778,6 +16895,8 @@ impl From<JsForVariableDeclaration> for SyntaxElement {
 }
 impl AstNode for JsFormalParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FORMAL_PARAMETER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FORMAL_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16816,6 +16935,8 @@ impl From<JsFormalParameter> for SyntaxElement {
 }
 impl AstNode for JsFunctionBody {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FUNCTION_BODY as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_BODY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16851,6 +16972,8 @@ impl From<JsFunctionBody> for SyntaxElement {
 }
 impl AstNode for JsFunctionDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FUNCTION_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16899,6 +17022,8 @@ impl From<JsFunctionDeclaration> for SyntaxElement {
 }
 impl AstNode for JsFunctionExportDefaultDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FUNCTION_EXPORT_DEFAULT_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_EXPORT_DEFAULT_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16947,6 +17072,8 @@ impl From<JsFunctionExportDefaultDeclaration> for SyntaxElement {
 }
 impl AstNode for JsFunctionExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_FUNCTION_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16995,6 +17122,8 @@ impl From<JsFunctionExpression> for SyntaxElement {
 }
 impl AstNode for JsGetterClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_GETTER_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17036,6 +17165,8 @@ impl From<JsGetterClassMember> for SyntaxElement {
 }
 impl AstNode for JsGetterObjectMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_GETTER_OBJECT_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17076,6 +17207,8 @@ impl From<JsGetterObjectMember> for SyntaxElement {
 }
 impl AstNode for JsIdentifierAssignment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IDENTIFIER_ASSIGNMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17102,6 +17235,8 @@ impl From<JsIdentifierAssignment> for SyntaxElement {
 }
 impl AstNode for JsIdentifierBinding {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IDENTIFIER_BINDING as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_BINDING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17128,6 +17263,8 @@ impl From<JsIdentifierBinding> for SyntaxElement {
 }
 impl AstNode for JsIdentifierExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IDENTIFIER_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17154,6 +17291,8 @@ impl From<JsIdentifierExpression> for SyntaxElement {
 }
 impl AstNode for JsIfStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IF_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IF_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17194,6 +17333,8 @@ impl From<JsIfStatement> for SyntaxElement {
 }
 impl AstNode for JsImport {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IMPORT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17231,6 +17372,8 @@ impl From<JsImport> for SyntaxElement {
 }
 impl AstNode for JsImportAssertion {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IMPORT_ASSERTION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_ASSERTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17269,6 +17412,8 @@ impl From<JsImportAssertion> for SyntaxElement {
 }
 impl AstNode for JsImportAssertionEntry {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IMPORT_ASSERTION_ENTRY as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_ASSERTION_ENTRY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17303,6 +17448,8 @@ impl From<JsImportAssertionEntry> for SyntaxElement {
 }
 impl AstNode for JsImportBareClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IMPORT_BARE_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_BARE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17333,6 +17480,8 @@ impl From<JsImportBareClause> for SyntaxElement {
 }
 impl AstNode for JsImportCallExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IMPORT_CALL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_CALL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17363,6 +17512,8 @@ impl From<JsImportCallExpression> for SyntaxElement {
 }
 impl AstNode for JsImportDefaultClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IMPORT_DEFAULT_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_DEFAULT_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17399,6 +17550,8 @@ impl From<JsImportDefaultClause> for SyntaxElement {
 }
 impl AstNode for JsImportNamedClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IMPORT_NAMED_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_NAMED_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17442,6 +17595,8 @@ impl From<JsImportNamedClause> for SyntaxElement {
 }
 impl AstNode for JsImportNamespaceClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IMPORT_NAMESPACE_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_NAMESPACE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17480,6 +17635,8 @@ impl From<JsImportNamespaceClause> for SyntaxElement {
 }
 impl AstNode for JsInExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IN_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IN_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17508,6 +17665,8 @@ impl From<JsInExpression> for SyntaxElement {
 }
 impl AstNode for JsInitializerClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_INITIALIZER_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_INITIALIZER_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17535,6 +17694,8 @@ impl From<JsInitializerClause> for SyntaxElement {
 }
 impl AstNode for JsInstanceofExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_INSTANCEOF_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_INSTANCEOF_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17566,6 +17727,8 @@ impl From<JsInstanceofExpression> for SyntaxElement {
 }
 impl AstNode for JsLabeledStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_LABELED_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LABELED_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17600,6 +17763,8 @@ impl From<JsLabeledStatement> for SyntaxElement {
 }
 impl AstNode for JsLiteralExportName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_LITERAL_EXPORT_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LITERAL_EXPORT_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17626,6 +17791,8 @@ impl From<JsLiteralExportName> for SyntaxElement {
 }
 impl AstNode for JsLiteralMemberName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_LITERAL_MEMBER_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LITERAL_MEMBER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17652,6 +17819,8 @@ impl From<JsLiteralMemberName> for SyntaxElement {
 }
 impl AstNode for JsLogicalExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_LOGICAL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LOGICAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17683,6 +17852,8 @@ impl From<JsLogicalExpression> for SyntaxElement {
 }
 impl AstNode for JsMethodClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_METHOD_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17732,6 +17903,8 @@ impl From<JsMethodClassMember> for SyntaxElement {
 }
 impl AstNode for JsMethodObjectMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_METHOD_OBJECT_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17776,6 +17949,8 @@ impl From<JsMethodObjectMember> for SyntaxElement {
 }
 impl AstNode for JsModule {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_MODULE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_MODULE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17808,6 +17983,8 @@ impl From<JsModule> for SyntaxElement {
 }
 impl AstNode for JsModuleSource {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_MODULE_SOURCE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_MODULE_SOURCE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17837,6 +18014,8 @@ impl From<JsModuleSource> for SyntaxElement {
 }
 impl AstNode for JsName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17866,6 +18045,8 @@ impl From<JsName> for SyntaxElement {
 }
 impl AstNode for JsNamedImportSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_NAMED_IMPORT_SPECIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAMED_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17898,6 +18079,8 @@ impl From<JsNamedImportSpecifier> for SyntaxElement {
 }
 impl AstNode for JsNamedImportSpecifiers {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_NAMED_IMPORT_SPECIFIERS as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAMED_IMPORT_SPECIFIERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17932,6 +18115,8 @@ impl From<JsNamedImportSpecifiers> for SyntaxElement {
 }
 impl AstNode for JsNamespaceImportSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_NAMESPACE_IMPORT_SPECIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAMESPACE_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17960,6 +18145,8 @@ impl From<JsNamespaceImportSpecifier> for SyntaxElement {
 }
 impl AstNode for JsNewExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_NEW_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NEW_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17995,6 +18182,8 @@ impl From<JsNewExpression> for SyntaxElement {
 }
 impl AstNode for JsNullLiteralExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_NULL_LITERAL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NULL_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18024,6 +18213,8 @@ impl From<JsNullLiteralExpression> for SyntaxElement {
 }
 impl AstNode for JsNumberLiteralExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_NUMBER_LITERAL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NUMBER_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18053,6 +18244,8 @@ impl From<JsNumberLiteralExpression> for SyntaxElement {
 }
 impl AstNode for JsObjectAssignmentPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_OBJECT_ASSIGNMENT_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_ASSIGNMENT_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18087,6 +18280,8 @@ impl From<JsObjectAssignmentPattern> for SyntaxElement {
 }
 impl AstNode for JsObjectAssignmentPatternProperty {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18119,6 +18314,8 @@ impl From<JsObjectAssignmentPatternProperty> for SyntaxElement {
 }
 impl AstNode for JsObjectAssignmentPatternRest {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_OBJECT_ASSIGNMENT_PATTERN_REST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_ASSIGNMENT_PATTERN_REST }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18149,6 +18346,9 @@ impl From<JsObjectAssignmentPatternRest> for SyntaxElement {
 }
 impl AstNode for JsObjectAssignmentPatternShorthandProperty {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        JS_OBJECT_ASSIGNMENT_PATTERN_SHORTHAND_PROPERTY as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool {
         kind == JS_OBJECT_ASSIGNMENT_PATTERN_SHORTHAND_PROPERTY
     }
@@ -18178,6 +18378,8 @@ impl From<JsObjectAssignmentPatternShorthandProperty> for SyntaxElement {
 }
 impl AstNode for JsObjectBindingPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_OBJECT_BINDING_PATTERN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18212,6 +18414,8 @@ impl From<JsObjectBindingPattern> for SyntaxElement {
 }
 impl AstNode for JsObjectBindingPatternProperty {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_OBJECT_BINDING_PATTERN_PROPERTY as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN_PROPERTY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18244,6 +18448,8 @@ impl From<JsObjectBindingPatternProperty> for SyntaxElement {
 }
 impl AstNode for JsObjectBindingPatternRest {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_OBJECT_BINDING_PATTERN_REST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN_REST }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18274,6 +18480,9 @@ impl From<JsObjectBindingPatternRest> for SyntaxElement {
 }
 impl AstNode for JsObjectBindingPatternShorthandProperty {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18301,6 +18510,8 @@ impl From<JsObjectBindingPatternShorthandProperty> for SyntaxElement {
 }
 impl AstNode for JsObjectExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_OBJECT_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18335,6 +18546,8 @@ impl From<JsObjectExpression> for SyntaxElement {
 }
 impl AstNode for JsParameters {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PARAMETERS as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARAMETERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18369,6 +18582,8 @@ impl From<JsParameters> for SyntaxElement {
 }
 impl AstNode for JsParenthesizedAssignment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PARENTHESIZED_ASSIGNMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARENTHESIZED_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18403,6 +18618,8 @@ impl From<JsParenthesizedAssignment> for SyntaxElement {
 }
 impl AstNode for JsParenthesizedExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PARENTHESIZED_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARENTHESIZED_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18437,6 +18654,8 @@ impl From<JsParenthesizedExpression> for SyntaxElement {
 }
 impl AstNode for JsPostUpdateExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_POST_UPDATE_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_POST_UPDATE_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18467,6 +18686,8 @@ impl From<JsPostUpdateExpression> for SyntaxElement {
 }
 impl AstNode for JsPreUpdateExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PRE_UPDATE_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRE_UPDATE_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18497,6 +18718,8 @@ impl From<JsPreUpdateExpression> for SyntaxElement {
 }
 impl AstNode for JsPrivateClassMemberName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PRIVATE_CLASS_MEMBER_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRIVATE_CLASS_MEMBER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18524,6 +18747,8 @@ impl From<JsPrivateClassMemberName> for SyntaxElement {
 }
 impl AstNode for JsPrivateName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PRIVATE_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRIVATE_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18554,6 +18779,8 @@ impl From<JsPrivateName> for SyntaxElement {
 }
 impl AstNode for JsPropertyClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PROPERTY_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18590,6 +18817,8 @@ impl From<JsPropertyClassMember> for SyntaxElement {
 }
 impl AstNode for JsPropertyObjectMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PROPERTY_OBJECT_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18621,6 +18850,8 @@ impl From<JsPropertyObjectMember> for SyntaxElement {
 }
 impl AstNode for JsReferenceIdentifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_REFERENCE_IDENTIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18650,6 +18881,8 @@ impl From<JsReferenceIdentifier> for SyntaxElement {
 }
 impl AstNode for JsRegexLiteralExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_REGEX_LITERAL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REGEX_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18679,6 +18912,8 @@ impl From<JsRegexLiteralExpression> for SyntaxElement {
 }
 impl AstNode for JsRestParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_REST_PARAMETER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REST_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18713,6 +18948,8 @@ impl From<JsRestParameter> for SyntaxElement {
 }
 impl AstNode for JsReturnStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_RETURN_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_RETURN_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18747,6 +18984,8 @@ impl From<JsReturnStatement> for SyntaxElement {
 }
 impl AstNode for JsScript {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SCRIPT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SCRIPT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18779,6 +19018,8 @@ impl From<JsScript> for SyntaxElement {
 }
 impl AstNode for JsSequenceExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SEQUENCE_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SEQUENCE_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18810,6 +19051,8 @@ impl From<JsSequenceExpression> for SyntaxElement {
 }
 impl AstNode for JsSetterClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SETTER_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18848,6 +19091,8 @@ impl From<JsSetterClassMember> for SyntaxElement {
 }
 impl AstNode for JsSetterObjectMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SETTER_OBJECT_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18885,6 +19130,8 @@ impl From<JsSetterObjectMember> for SyntaxElement {
 }
 impl AstNode for JsShorthandNamedImportSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SHORTHAND_NAMED_IMPORT_SPECIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SHORTHAND_NAMED_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18915,6 +19162,8 @@ impl From<JsShorthandNamedImportSpecifier> for SyntaxElement {
 }
 impl AstNode for JsShorthandPropertyObjectMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SHORTHAND_PROPERTY_OBJECT_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18941,6 +19190,8 @@ impl From<JsShorthandPropertyObjectMember> for SyntaxElement {
 }
 impl AstNode for JsSpread {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SPREAD as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SPREAD }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18971,6 +19222,9 @@ impl From<JsSpread> for SyntaxElement {
 }
 impl AstNode for JsStaticInitializationBlockClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        JS_STATIC_INITIALIZATION_BLOCK_CLASS_MEMBER as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_INITIALIZATION_BLOCK_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19009,6 +19263,8 @@ impl From<JsStaticInitializationBlockClassMember> for SyntaxElement {
 }
 impl AstNode for JsStaticMemberAssignment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_STATIC_MEMBER_ASSIGNMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MEMBER_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19037,6 +19293,8 @@ impl From<JsStaticMemberAssignment> for SyntaxElement {
 }
 impl AstNode for JsStaticMemberExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_STATIC_MEMBER_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MEMBER_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19068,6 +19326,8 @@ impl From<JsStaticMemberExpression> for SyntaxElement {
 }
 impl AstNode for JsStaticModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_STATIC_MODIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19097,6 +19357,8 @@ impl From<JsStaticModifier> for SyntaxElement {
 }
 impl AstNode for JsStringLiteralExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_STRING_LITERAL_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STRING_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19126,6 +19388,8 @@ impl From<JsStringLiteralExpression> for SyntaxElement {
 }
 impl AstNode for JsSuperExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SUPER_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SUPER_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19155,6 +19419,8 @@ impl From<JsSuperExpression> for SyntaxElement {
 }
 impl AstNode for JsSwitchStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SWITCH_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SWITCH_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19205,6 +19471,8 @@ impl From<JsSwitchStatement> for SyntaxElement {
 }
 impl AstNode for JsTemplate {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_TEMPLATE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TEMPLATE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19244,6 +19512,8 @@ impl From<JsTemplate> for SyntaxElement {
 }
 impl AstNode for JsTemplateChunkElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_TEMPLATE_CHUNK_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TEMPLATE_CHUNK_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19273,6 +19543,8 @@ impl From<JsTemplateChunkElement> for SyntaxElement {
 }
 impl AstNode for JsTemplateElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_TEMPLATE_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TEMPLATE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19307,6 +19579,8 @@ impl From<JsTemplateElement> for SyntaxElement {
 }
 impl AstNode for JsThisExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_THIS_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THIS_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19333,6 +19607,8 @@ impl From<JsThisExpression> for SyntaxElement {
 }
 impl AstNode for JsThrowStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_THROW_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THROW_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19367,6 +19643,8 @@ impl From<JsThrowStatement> for SyntaxElement {
 }
 impl AstNode for JsTryFinallyStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_TRY_FINALLY_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_FINALLY_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19402,6 +19680,8 @@ impl From<JsTryFinallyStatement> for SyntaxElement {
 }
 impl AstNode for JsTryStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_TRY_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19433,6 +19713,8 @@ impl From<JsTryStatement> for SyntaxElement {
 }
 impl AstNode for JsUnaryExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNARY_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNARY_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19463,6 +19745,8 @@ impl From<JsUnaryExpression> for SyntaxElement {
 }
 impl AstNode for JsVariableDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_VARIABLE_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19490,6 +19774,8 @@ impl From<JsVariableDeclaration> for SyntaxElement {
 }
 impl AstNode for JsVariableDeclarationClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_VARIABLE_DECLARATION_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19523,6 +19809,8 @@ impl From<JsVariableDeclarationClause> for SyntaxElement {
 }
 impl AstNode for JsVariableDeclarator {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_VARIABLE_DECLARATOR as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATOR }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19557,6 +19845,8 @@ impl From<JsVariableDeclarator> for SyntaxElement {
 }
 impl AstNode for JsVariableStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_VARIABLE_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19590,6 +19880,8 @@ impl From<JsVariableStatement> for SyntaxElement {
 }
 impl AstNode for JsWhileStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_WHILE_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WHILE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19629,6 +19921,8 @@ impl From<JsWhileStatement> for SyntaxElement {
 }
 impl AstNode for JsWithStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_WITH_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WITH_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19665,6 +19959,8 @@ impl From<JsWithStatement> for SyntaxElement {
 }
 impl AstNode for JsYieldArgument {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_YIELD_ARGUMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_YIELD_ARGUMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19695,6 +19991,8 @@ impl From<JsYieldArgument> for SyntaxElement {
 }
 impl AstNode for JsYieldExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_YIELD_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_YIELD_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19725,6 +20023,8 @@ impl From<JsYieldExpression> for SyntaxElement {
 }
 impl AstNode for JsxAttribute {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_ATTRIBUTE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_ATTRIBUTE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19755,6 +20055,8 @@ impl From<JsxAttribute> for SyntaxElement {
 }
 impl AstNode for JsxAttributeInitializerClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_ATTRIBUTE_INITIALIZER_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_ATTRIBUTE_INITIALIZER_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19782,6 +20084,8 @@ impl From<JsxAttributeInitializerClause> for SyntaxElement {
 }
 impl AstNode for JsxClosingElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_CLOSING_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_CLOSING_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19820,6 +20124,8 @@ impl From<JsxClosingElement> for SyntaxElement {
 }
 impl AstNode for JsxClosingFragment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_CLOSING_FRAGMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_CLOSING_FRAGMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19857,6 +20163,8 @@ impl From<JsxClosingFragment> for SyntaxElement {
 }
 impl AstNode for JsxElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19891,6 +20199,8 @@ impl From<JsxElement> for SyntaxElement {
 }
 impl AstNode for JsxExpressionAttributeValue {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_EXPRESSION_ATTRIBUTE_VALUE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_EXPRESSION_ATTRIBUTE_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19925,6 +20235,8 @@ impl From<JsxExpressionAttributeValue> for SyntaxElement {
 }
 impl AstNode for JsxExpressionChild {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_EXPRESSION_CHILD as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_EXPRESSION_CHILD }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19962,6 +20274,8 @@ impl From<JsxExpressionChild> for SyntaxElement {
 }
 impl AstNode for JsxFragment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_FRAGMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_FRAGMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -19996,6 +20310,8 @@ impl From<JsxFragment> for SyntaxElement {
 }
 impl AstNode for JsxMemberName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_MEMBER_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_MEMBER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20024,6 +20340,8 @@ impl From<JsxMemberName> for SyntaxElement {
 }
 impl AstNode for JsxName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20053,6 +20371,8 @@ impl From<JsxName> for SyntaxElement {
 }
 impl AstNode for JsxNamespaceName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_NAMESPACE_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_NAMESPACE_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20084,6 +20404,8 @@ impl From<JsxNamespaceName> for SyntaxElement {
 }
 impl AstNode for JsxOpeningElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_OPENING_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_OPENING_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20123,6 +20445,8 @@ impl From<JsxOpeningElement> for SyntaxElement {
 }
 impl AstNode for JsxOpeningFragment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_OPENING_FRAGMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_OPENING_FRAGMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20156,6 +20480,8 @@ impl From<JsxOpeningFragment> for SyntaxElement {
 }
 impl AstNode for JsxReferenceIdentifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_REFERENCE_IDENTIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_REFERENCE_IDENTIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20185,6 +20511,8 @@ impl From<JsxReferenceIdentifier> for SyntaxElement {
 }
 impl AstNode for JsxSelfClosingElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_SELF_CLOSING_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_SELF_CLOSING_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20228,6 +20556,8 @@ impl From<JsxSelfClosingElement> for SyntaxElement {
 }
 impl AstNode for JsxSpreadAttribute {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_SPREAD_ATTRIBUTE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_SPREAD_ATTRIBUTE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20266,6 +20596,8 @@ impl From<JsxSpreadAttribute> for SyntaxElement {
 }
 impl AstNode for JsxSpreadChild {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_SPREAD_CHILD as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_SPREAD_CHILD }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20304,6 +20636,8 @@ impl From<JsxSpreadChild> for SyntaxElement {
 }
 impl AstNode for JsxString {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_STRING as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_STRING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20333,6 +20667,8 @@ impl From<JsxString> for SyntaxElement {
 }
 impl AstNode for JsxTagExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_TAG_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_TAG_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20359,6 +20695,8 @@ impl From<JsxTagExpression> for SyntaxElement {
 }
 impl AstNode for JsxText {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_TEXT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_TEXT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20388,6 +20726,8 @@ impl From<JsxText> for SyntaxElement {
 }
 impl AstNode for NewTarget {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(NEW_TARGET as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_TARGET }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20419,6 +20759,8 @@ impl From<NewTarget> for SyntaxElement {
 }
 impl AstNode for TsAbstractModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_ABSTRACT_MODIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ABSTRACT_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20448,6 +20790,8 @@ impl From<TsAbstractModifier> for SyntaxElement {
 }
 impl AstNode for TsAccessibilityModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_ACCESSIBILITY_MODIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ACCESSIBILITY_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20477,6 +20821,8 @@ impl From<TsAccessibilityModifier> for SyntaxElement {
 }
 impl AstNode for TsAnyType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_ANY_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ANY_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20503,6 +20849,8 @@ impl From<TsAnyType> for SyntaxElement {
 }
 impl AstNode for TsArrayType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_ARRAY_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ARRAY_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20540,6 +20888,8 @@ impl From<TsArrayType> for SyntaxElement {
 }
 impl AstNode for TsAsAssignment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_AS_ASSIGNMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_AS_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20568,6 +20918,8 @@ impl From<TsAsAssignment> for SyntaxElement {
 }
 impl AstNode for TsAsExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_AS_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_AS_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20596,6 +20948,8 @@ impl From<TsAsExpression> for SyntaxElement {
 }
 impl AstNode for TsAssertsCondition {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_ASSERTS_CONDITION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ASSERTS_CONDITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20623,6 +20977,8 @@ impl From<TsAssertsCondition> for SyntaxElement {
 }
 impl AstNode for TsAssertsReturnType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_ASSERTS_RETURN_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ASSERTS_RETURN_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20660,6 +21016,8 @@ impl From<TsAssertsReturnType> for SyntaxElement {
 }
 impl AstNode for TsBigIntLiteralType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_BIG_INT_LITERAL_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BIG_INT_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20693,6 +21051,8 @@ impl From<TsBigIntLiteralType> for SyntaxElement {
 }
 impl AstNode for TsBigintType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_BIGINT_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BIGINT_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20722,6 +21082,8 @@ impl From<TsBigintType> for SyntaxElement {
 }
 impl AstNode for TsBooleanLiteralType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_BOOLEAN_LITERAL_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BOOLEAN_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20748,6 +21110,8 @@ impl From<TsBooleanLiteralType> for SyntaxElement {
 }
 impl AstNode for TsBooleanType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_BOOLEAN_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BOOLEAN_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20777,6 +21141,8 @@ impl From<TsBooleanType> for SyntaxElement {
 }
 impl AstNode for TsCallSignatureTypeMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_CALL_SIGNATURE_TYPE_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CALL_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20815,6 +21181,8 @@ impl From<TsCallSignatureTypeMember> for SyntaxElement {
 }
 impl AstNode for TsConditionalType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_CONDITIONAL_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONDITIONAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20859,6 +21227,8 @@ impl From<TsConditionalType> for SyntaxElement {
 }
 impl AstNode for TsConstructSignatureTypeMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_CONSTRUCT_SIGNATURE_TYPE_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCT_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20898,6 +21268,8 @@ impl From<TsConstructSignatureTypeMember> for SyntaxElement {
 }
 impl AstNode for TsConstructorSignatureClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_CONSTRUCTOR_SIGNATURE_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20930,6 +21302,8 @@ impl From<TsConstructorSignatureClassMember> for SyntaxElement {
 }
 impl AstNode for TsConstructorType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_CONSTRUCTOR_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -20973,6 +21347,8 @@ impl From<TsConstructorType> for SyntaxElement {
 }
 impl AstNode for TsDeclareFunctionDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_DECLARE_FUNCTION_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DECLARE_FUNCTION_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21020,6 +21396,8 @@ impl From<TsDeclareFunctionDeclaration> for SyntaxElement {
 }
 impl AstNode for TsDeclareModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_DECLARE_MODIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DECLARE_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21049,6 +21427,8 @@ impl From<TsDeclareModifier> for SyntaxElement {
 }
 impl AstNode for TsDeclareStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_DECLARE_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DECLARE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21082,6 +21462,8 @@ impl From<TsDeclareStatement> for SyntaxElement {
 }
 impl AstNode for TsDefaultTypeClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_DEFAULT_TYPE_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFAULT_TYPE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21109,6 +21491,8 @@ impl From<TsDefaultTypeClause> for SyntaxElement {
 }
 impl AstNode for TsDefinitePropertyAnnotation {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_DEFINITE_PROPERTY_ANNOTATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFINITE_PROPERTY_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21139,6 +21523,8 @@ impl From<TsDefinitePropertyAnnotation> for SyntaxElement {
 }
 impl AstNode for TsDefiniteVariableAnnotation {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_DEFINITE_VARIABLE_ANNOTATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFINITE_VARIABLE_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21169,6 +21555,9 @@ impl From<TsDefiniteVariableAnnotation> for SyntaxElement {
 }
 impl AstNode for TsEmptyExternalModuleDeclarationBody {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        TS_EMPTY_EXTERNAL_MODULE_DECLARATION_BODY as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EMPTY_EXTERNAL_MODULE_DECLARATION_BODY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21198,6 +21587,8 @@ impl From<TsEmptyExternalModuleDeclarationBody> for SyntaxElement {
 }
 impl AstNode for TsEnumDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_ENUM_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21238,6 +21629,8 @@ impl From<TsEnumDeclaration> for SyntaxElement {
 }
 impl AstNode for TsEnumMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_ENUM_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21268,6 +21661,8 @@ impl From<TsEnumMember> for SyntaxElement {
 }
 impl AstNode for TsExportAsNamespaceClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_EXPORT_AS_NAMESPACE_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_AS_NAMESPACE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21303,6 +21698,8 @@ impl From<TsExportAsNamespaceClause> for SyntaxElement {
 }
 impl AstNode for TsExportAssignmentClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_EXPORT_ASSIGNMENT_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_ASSIGNMENT_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21334,6 +21731,8 @@ impl From<TsExportAssignmentClause> for SyntaxElement {
 }
 impl AstNode for TsExportDeclareClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_EXPORT_DECLARE_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_DECLARE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21367,6 +21766,8 @@ impl From<TsExportDeclareClause> for SyntaxElement {
 }
 impl AstNode for TsExtendsClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_EXTENDS_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTENDS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21397,6 +21798,8 @@ impl From<TsExtendsClause> for SyntaxElement {
 }
 impl AstNode for TsExternalModuleDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_EXTERNAL_MODULE_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTERNAL_MODULE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21428,6 +21831,8 @@ impl From<TsExternalModuleDeclaration> for SyntaxElement {
 }
 impl AstNode for TsExternalModuleReference {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_EXTERNAL_MODULE_REFERENCE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTERNAL_MODULE_REFERENCE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21466,6 +21871,8 @@ impl From<TsExternalModuleReference> for SyntaxElement {
 }
 impl AstNode for TsFunctionType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_FUNCTION_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_FUNCTION_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21504,6 +21911,8 @@ impl From<TsFunctionType> for SyntaxElement {
 }
 impl AstNode for TsGetterSignatureClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_GETTER_SIGNATURE_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_GETTER_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21548,6 +21957,8 @@ impl From<TsGetterSignatureClassMember> for SyntaxElement {
 }
 impl AstNode for TsGetterSignatureTypeMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_GETTER_SIGNATURE_TYPE_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_GETTER_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21591,6 +22002,8 @@ impl From<TsGetterSignatureTypeMember> for SyntaxElement {
 }
 impl AstNode for TsGlobalDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_GLOBAL_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_GLOBAL_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21621,6 +22034,8 @@ impl From<TsGlobalDeclaration> for SyntaxElement {
 }
 impl AstNode for TsIdentifierBinding {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_IDENTIFIER_BINDING as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IDENTIFIER_BINDING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21647,6 +22062,8 @@ impl From<TsIdentifierBinding> for SyntaxElement {
 }
 impl AstNode for TsImplementsClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_IMPLEMENTS_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPLEMENTS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21677,6 +22094,8 @@ impl From<TsImplementsClause> for SyntaxElement {
 }
 impl AstNode for TsImportEqualsDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_IMPORT_EQUALS_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_EQUALS_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21720,6 +22139,8 @@ impl From<TsImportEqualsDeclaration> for SyntaxElement {
 }
 impl AstNode for TsImportType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_IMPORT_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21773,6 +22194,8 @@ impl From<TsImportType> for SyntaxElement {
 }
 impl AstNode for TsImportTypeQualifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_IMPORT_TYPE_QUALIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_TYPE_QUALIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21800,6 +22223,8 @@ impl From<TsImportTypeQualifier> for SyntaxElement {
 }
 impl AstNode for TsIndexSignatureClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_INDEX_SIGNATURE_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21843,6 +22268,8 @@ impl From<TsIndexSignatureClassMember> for SyntaxElement {
 }
 impl AstNode for TsIndexSignatureParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_INDEX_SIGNATURE_PARAMETER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21873,6 +22300,8 @@ impl From<TsIndexSignatureParameter> for SyntaxElement {
 }
 impl AstNode for TsIndexSignatureTypeMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_INDEX_SIGNATURE_TYPE_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21919,6 +22348,8 @@ impl From<TsIndexSignatureTypeMember> for SyntaxElement {
 }
 impl AstNode for TsIndexedAccessType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_INDEXED_ACCESS_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEXED_ACCESS_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21957,6 +22388,8 @@ impl From<TsIndexedAccessType> for SyntaxElement {
 }
 impl AstNode for TsInferType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_INFER_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INFER_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -21990,6 +22423,8 @@ impl From<TsInferType> for SyntaxElement {
 }
 impl AstNode for TsInterfaceDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_INTERFACE_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERFACE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22037,6 +22472,8 @@ impl From<TsInterfaceDeclaration> for SyntaxElement {
 }
 impl AstNode for TsIntersectionType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_INTERSECTION_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERSECTION_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22067,6 +22504,8 @@ impl From<TsIntersectionType> for SyntaxElement {
 }
 impl AstNode for TsMappedType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_MAPPED_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22134,6 +22573,8 @@ impl From<TsMappedType> for SyntaxElement {
 }
 impl AstNode for TsMappedTypeAsClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_MAPPED_TYPE_AS_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_AS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22161,6 +22602,9 @@ impl From<TsMappedTypeAsClause> for SyntaxElement {
 }
 impl AstNode for TsMappedTypeOptionalModifierClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        TS_MAPPED_TYPE_OPTIONAL_MODIFIER_CLAUSE as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_OPTIONAL_MODIFIER_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22194,6 +22638,9 @@ impl From<TsMappedTypeOptionalModifierClause> for SyntaxElement {
 }
 impl AstNode for TsMappedTypeReadonlyModifierClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        TS_MAPPED_TYPE_READONLY_MODIFIER_CLAUSE as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_READONLY_MODIFIER_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22227,6 +22674,8 @@ impl From<TsMappedTypeReadonlyModifierClause> for SyntaxElement {
 }
 impl AstNode for TsMethodSignatureClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_METHOD_SIGNATURE_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22275,6 +22724,8 @@ impl From<TsMethodSignatureClassMember> for SyntaxElement {
 }
 impl AstNode for TsMethodSignatureTypeMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_METHOD_SIGNATURE_TYPE_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22318,6 +22769,8 @@ impl From<TsMethodSignatureTypeMember> for SyntaxElement {
 }
 impl AstNode for TsModuleBlock {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_MODULE_BLOCK as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_BLOCK }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22352,6 +22805,8 @@ impl From<TsModuleBlock> for SyntaxElement {
 }
 impl AstNode for TsModuleDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_MODULE_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22383,6 +22838,8 @@ impl From<TsModuleDeclaration> for SyntaxElement {
 }
 impl AstNode for TsNameWithTypeArguments {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_NAME_WITH_TYPE_ARGUMENTS as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAME_WITH_TYPE_ARGUMENTS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22413,6 +22870,8 @@ impl From<TsNameWithTypeArguments> for SyntaxElement {
 }
 impl AstNode for TsNamedTupleTypeElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_NAMED_TUPLE_TYPE_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMED_TUPLE_TYPE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22452,6 +22911,8 @@ impl From<TsNamedTupleTypeElement> for SyntaxElement {
 }
 impl AstNode for TsNeverType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_NEVER_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NEVER_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22481,6 +22942,8 @@ impl From<TsNeverType> for SyntaxElement {
 }
 impl AstNode for TsNonNullAssertionAssignment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_NON_NULL_ASSERTION_ASSIGNMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_NULL_ASSERTION_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22508,6 +22971,8 @@ impl From<TsNonNullAssertionAssignment> for SyntaxElement {
 }
 impl AstNode for TsNonNullAssertionExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_NON_NULL_ASSERTION_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_NULL_ASSERTION_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22535,6 +23000,8 @@ impl From<TsNonNullAssertionExpression> for SyntaxElement {
 }
 impl AstNode for TsNonPrimitiveType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_NON_PRIMITIVE_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_PRIMITIVE_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22564,6 +23031,8 @@ impl From<TsNonPrimitiveType> for SyntaxElement {
 }
 impl AstNode for TsNullLiteralType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_NULL_LITERAL_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NULL_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22593,6 +23062,8 @@ impl From<TsNullLiteralType> for SyntaxElement {
 }
 impl AstNode for TsNumberLiteralType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_NUMBER_LITERAL_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NUMBER_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22626,6 +23097,8 @@ impl From<TsNumberLiteralType> for SyntaxElement {
 }
 impl AstNode for TsNumberType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_NUMBER_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NUMBER_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22655,6 +23128,8 @@ impl From<TsNumberType> for SyntaxElement {
 }
 impl AstNode for TsObjectType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_OBJECT_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22689,6 +23164,8 @@ impl From<TsObjectType> for SyntaxElement {
 }
 impl AstNode for TsOptionalPropertyAnnotation {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_OPTIONAL_PROPERTY_ANNOTATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OPTIONAL_PROPERTY_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22722,6 +23199,8 @@ impl From<TsOptionalPropertyAnnotation> for SyntaxElement {
 }
 impl AstNode for TsOptionalTupleTypeElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_OPTIONAL_TUPLE_TYPE_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OPTIONAL_TUPLE_TYPE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22752,6 +23231,8 @@ impl From<TsOptionalTupleTypeElement> for SyntaxElement {
 }
 impl AstNode for TsOverrideModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_OVERRIDE_MODIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OVERRIDE_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22781,6 +23262,8 @@ impl From<TsOverrideModifier> for SyntaxElement {
 }
 impl AstNode for TsParenthesizedType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_PARENTHESIZED_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PARENTHESIZED_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22815,6 +23298,8 @@ impl From<TsParenthesizedType> for SyntaxElement {
 }
 impl AstNode for TsPredicateReturnType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_PREDICATE_RETURN_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PREDICATE_RETURN_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22846,6 +23331,8 @@ impl From<TsPredicateReturnType> for SyntaxElement {
 }
 impl AstNode for TsPropertyParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_PROPERTY_PARAMETER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22876,6 +23363,8 @@ impl From<TsPropertyParameter> for SyntaxElement {
 }
 impl AstNode for TsPropertySignatureClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_PROPERTY_SIGNATURE_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22911,6 +23400,8 @@ impl From<TsPropertySignatureClassMember> for SyntaxElement {
 }
 impl AstNode for TsPropertySignatureTypeMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_PROPERTY_SIGNATURE_TYPE_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22953,6 +23444,8 @@ impl From<TsPropertySignatureTypeMember> for SyntaxElement {
 }
 impl AstNode for TsQualifiedModuleName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_QUALIFIED_MODULE_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_QUALIFIED_MODULE_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -22981,6 +23474,8 @@ impl From<TsQualifiedModuleName> for SyntaxElement {
 }
 impl AstNode for TsQualifiedName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_QUALIFIED_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_QUALIFIED_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23009,6 +23504,8 @@ impl From<TsQualifiedName> for SyntaxElement {
 }
 impl AstNode for TsReadonlyModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_READONLY_MODIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_READONLY_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23038,6 +23535,8 @@ impl From<TsReadonlyModifier> for SyntaxElement {
 }
 impl AstNode for TsReferenceType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_REFERENCE_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_REFERENCE_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23068,6 +23567,8 @@ impl From<TsReferenceType> for SyntaxElement {
 }
 impl AstNode for TsRestTupleTypeElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_REST_TUPLE_TYPE_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_REST_TUPLE_TYPE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23098,6 +23599,8 @@ impl From<TsRestTupleTypeElement> for SyntaxElement {
 }
 impl AstNode for TsReturnTypeAnnotation {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_RETURN_TYPE_ANNOTATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_RETURN_TYPE_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23128,6 +23631,8 @@ impl From<TsReturnTypeAnnotation> for SyntaxElement {
 }
 impl AstNode for TsSetterSignatureClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_SETTER_SIGNATURE_CLASS_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SETTER_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23169,6 +23674,8 @@ impl From<TsSetterSignatureClassMember> for SyntaxElement {
 }
 impl AstNode for TsSetterSignatureTypeMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_SETTER_SIGNATURE_TYPE_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SETTER_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23209,6 +23716,8 @@ impl From<TsSetterSignatureTypeMember> for SyntaxElement {
 }
 impl AstNode for TsStringLiteralType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_STRING_LITERAL_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_STRING_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23238,6 +23747,8 @@ impl From<TsStringLiteralType> for SyntaxElement {
 }
 impl AstNode for TsStringType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_STRING_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_STRING_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23267,6 +23778,8 @@ impl From<TsStringType> for SyntaxElement {
 }
 impl AstNode for TsSymbolType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_SYMBOL_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SYMBOL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23296,6 +23809,8 @@ impl From<TsSymbolType> for SyntaxElement {
 }
 impl AstNode for TsTemplateChunkElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TEMPLATE_CHUNK_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_CHUNK_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23325,6 +23840,8 @@ impl From<TsTemplateChunkElement> for SyntaxElement {
 }
 impl AstNode for TsTemplateElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TEMPLATE_ELEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23359,6 +23876,8 @@ impl From<TsTemplateElement> for SyntaxElement {
 }
 impl AstNode for TsTemplateLiteralType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TEMPLATE_LITERAL_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23393,6 +23912,8 @@ impl From<TsTemplateLiteralType> for SyntaxElement {
 }
 impl AstNode for TsThisParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_THIS_PARAMETER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_THIS_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23423,6 +23944,8 @@ impl From<TsThisParameter> for SyntaxElement {
 }
 impl AstNode for TsThisType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_THIS_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_THIS_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23449,6 +23972,8 @@ impl From<TsThisType> for SyntaxElement {
 }
 impl AstNode for TsTupleType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TUPLE_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23483,6 +24008,8 @@ impl From<TsTupleType> for SyntaxElement {
 }
 impl AstNode for TsTypeAliasDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_ALIAS_DECLARATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ALIAS_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23523,6 +24050,8 @@ impl From<TsTypeAliasDeclaration> for SyntaxElement {
 }
 impl AstNode for TsTypeAnnotation {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_ANNOTATION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23553,6 +24082,8 @@ impl From<TsTypeAnnotation> for SyntaxElement {
 }
 impl AstNode for TsTypeArguments {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_ARGUMENTS as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ARGUMENTS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23587,6 +24118,8 @@ impl From<TsTypeArguments> for SyntaxElement {
 }
 impl AstNode for TsTypeAssertionAssignment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_ASSERTION_ASSIGNMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ASSERTION_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23622,6 +24155,8 @@ impl From<TsTypeAssertionAssignment> for SyntaxElement {
 }
 impl AstNode for TsTypeAssertionExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_ASSERTION_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ASSERTION_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23657,6 +24192,8 @@ impl From<TsTypeAssertionExpression> for SyntaxElement {
 }
 impl AstNode for TsTypeConstraintClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_CONSTRAINT_CLAUSE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_CONSTRAINT_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23687,6 +24224,8 @@ impl From<TsTypeConstraintClause> for SyntaxElement {
 }
 impl AstNode for TsTypeOperatorType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_OPERATOR_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_OPERATOR_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23717,6 +24256,8 @@ impl From<TsTypeOperatorType> for SyntaxElement {
 }
 impl AstNode for TsTypeParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_PARAMETER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23748,6 +24289,8 @@ impl From<TsTypeParameter> for SyntaxElement {
 }
 impl AstNode for TsTypeParameterName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_PARAMETER_NAME as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMETER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23777,6 +24320,8 @@ impl From<TsTypeParameterName> for SyntaxElement {
 }
 impl AstNode for TsTypeParameters {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_PARAMETERS as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMETERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23811,6 +24356,8 @@ impl From<TsTypeParameters> for SyntaxElement {
 }
 impl AstNode for TsTypeofType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPEOF_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPEOF_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23844,6 +24391,8 @@ impl From<TsTypeofType> for SyntaxElement {
 }
 impl AstNode for TsUndefinedType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_UNDEFINED_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNDEFINED_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23873,6 +24422,8 @@ impl From<TsUndefinedType> for SyntaxElement {
 }
 impl AstNode for TsUnionType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_UNION_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNION_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23903,6 +24454,8 @@ impl From<TsUnionType> for SyntaxElement {
 }
 impl AstNode for TsUnknownType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_UNKNOWN_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNKNOWN_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23932,6 +24485,8 @@ impl From<TsUnknownType> for SyntaxElement {
 }
 impl AstNode for TsVoidType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_VOID_TYPE as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_VOID_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -23973,6 +24528,10 @@ impl From<JsAssignmentWithDefault> for JsAnyArrayAssignmentPatternElement {
 }
 impl AstNode for JsAnyArrayAssignmentPatternElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyAssignmentPattern::KIND_SET
+        .union(JsArrayAssignmentPatternRestElement::KIND_SET)
+        .union(JsArrayHole::KIND_SET)
+        .union(JsAssignmentWithDefault::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_ASSIGNMENT_PATTERN_REST_ELEMENT
@@ -24080,6 +24639,10 @@ impl From<JsBindingPatternWithDefault> for JsAnyArrayBindingPatternElement {
 }
 impl AstNode for JsAnyArrayBindingPatternElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyBindingPattern::KIND_SET
+        .union(JsArrayBindingPatternRestElement::KIND_SET)
+        .union(JsArrayHole::KIND_SET)
+        .union(JsBindingPatternWithDefault::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_BINDING_PATTERN_REST_ELEMENT
@@ -24168,6 +24731,9 @@ impl From<JsSpread> for JsAnyArrayElement {
 }
 impl AstNode for JsAnyArrayElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyExpression::KIND_SET
+        .union(JsArrayHole::KIND_SET)
+        .union(JsSpread::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_HOLE | JS_SPREAD => true,
@@ -24234,6 +24800,7 @@ impl From<JsParameters> for JsAnyArrowFunctionParameters {
 }
 impl AstNode for JsAnyArrowFunctionParameters {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyBinding::KIND_SET.union(JsParameters::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_PARAMETERS => true,
@@ -24328,6 +24895,14 @@ impl From<TsTypeAssertionAssignment> for JsAnyAssignment {
 }
 impl AstNode for JsAnyAssignment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsComputedMemberAssignment::KIND_SET
+        .union(JsIdentifierAssignment::KIND_SET)
+        .union(JsParenthesizedAssignment::KIND_SET)
+        .union(JsStaticMemberAssignment::KIND_SET)
+        .union(JsUnknownAssignment::KIND_SET)
+        .union(TsAsAssignment::KIND_SET)
+        .union(TsNonNullAssertionAssignment::KIND_SET)
+        .union(TsTypeAssertionAssignment::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -24442,6 +25017,9 @@ impl From<JsObjectAssignmentPattern> for JsAnyAssignmentPattern {
 }
 impl AstNode for JsAnyAssignmentPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyAssignment::KIND_SET
+        .union(JsArrayAssignmentPattern::KIND_SET)
+        .union(JsObjectAssignmentPattern::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_ASSIGNMENT_PATTERN | JS_OBJECT_ASSIGNMENT_PATTERN => true,
@@ -24517,6 +25095,8 @@ impl From<JsUnknownBinding> for JsAnyBinding {
 }
 impl AstNode for JsAnyBinding {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsIdentifierBinding::KIND_SET.union(JsUnknownBinding::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_IDENTIFIER_BINDING | JS_UNKNOWN_BINDING)
     }
@@ -24577,6 +25157,9 @@ impl From<JsObjectBindingPattern> for JsAnyBindingPattern {
 }
 impl AstNode for JsAnyBindingPattern {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyBinding::KIND_SET
+        .union(JsArrayBindingPattern::KIND_SET)
+        .union(JsObjectBindingPattern::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_BINDING_PATTERN | JS_OBJECT_BINDING_PATTERN => true,
@@ -24645,6 +25228,7 @@ impl From<JsSpread> for JsAnyCallArgument {
 }
 impl AstNode for JsAnyCallArgument {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyExpression::KIND_SET.union(JsSpread::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_SPREAD => true,
@@ -24712,6 +25296,9 @@ impl From<JsClassExpression> for JsAnyClass {
 }
 impl AstNode for JsAnyClass {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsClassDeclaration::KIND_SET
+        .union(JsClassExportDefaultDeclaration::KIND_SET)
+        .union(JsClassExpression::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -24840,6 +25427,20 @@ impl From<TsSetterSignatureClassMember> for JsAnyClassMember {
 }
 impl AstNode for JsAnyClassMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsConstructorClassMember::KIND_SET
+        .union(JsEmptyClassMember::KIND_SET)
+        .union(JsGetterClassMember::KIND_SET)
+        .union(JsMethodClassMember::KIND_SET)
+        .union(JsPropertyClassMember::KIND_SET)
+        .union(JsSetterClassMember::KIND_SET)
+        .union(JsStaticInitializationBlockClassMember::KIND_SET)
+        .union(JsUnknownMember::KIND_SET)
+        .union(TsConstructorSignatureClassMember::KIND_SET)
+        .union(TsGetterSignatureClassMember::KIND_SET)
+        .union(TsIndexSignatureClassMember::KIND_SET)
+        .union(TsMethodSignatureClassMember::KIND_SET)
+        .union(TsPropertySignatureClassMember::KIND_SET)
+        .union(TsSetterSignatureClassMember::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -25021,6 +25622,9 @@ impl From<JsPrivateClassMemberName> for JsAnyClassMemberName {
 }
 impl AstNode for JsAnyClassMemberName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsComputedMemberName::KIND_SET
+        .union(JsLiteralMemberName::KIND_SET)
+        .union(JsPrivateClassMemberName::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -25093,6 +25697,9 @@ impl From<TsPropertyParameter> for JsAnyConstructorParameter {
 }
 impl AstNode for JsAnyConstructorParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyFormalParameter::KIND_SET
+        .union(JsRestParameter::KIND_SET)
+        .union(TsPropertyParameter::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_REST_PARAMETER | TS_PROPERTY_PARAMETER => true,
@@ -25215,6 +25822,17 @@ impl From<TsTypeAliasDeclaration> for JsAnyDeclaration {
 }
 impl AstNode for JsAnyDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsClassDeclaration::KIND_SET
+        .union(JsFunctionDeclaration::KIND_SET)
+        .union(JsVariableDeclaration::KIND_SET)
+        .union(TsDeclareFunctionDeclaration::KIND_SET)
+        .union(TsEnumDeclaration::KIND_SET)
+        .union(TsExternalModuleDeclaration::KIND_SET)
+        .union(TsGlobalDeclaration::KIND_SET)
+        .union(TsImportEqualsDeclaration::KIND_SET)
+        .union(TsInterfaceDeclaration::KIND_SET)
+        .union(TsModuleDeclaration::KIND_SET)
+        .union(TsTypeAliasDeclaration::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -25402,6 +26020,17 @@ impl From<TsTypeAliasDeclaration> for JsAnyDeclarationClause {
 }
 impl AstNode for JsAnyDeclarationClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsClassDeclaration::KIND_SET
+        .union(JsFunctionDeclaration::KIND_SET)
+        .union(JsVariableDeclarationClause::KIND_SET)
+        .union(TsDeclareFunctionDeclaration::KIND_SET)
+        .union(TsEnumDeclaration::KIND_SET)
+        .union(TsExternalModuleDeclaration::KIND_SET)
+        .union(TsGlobalDeclaration::KIND_SET)
+        .union(TsImportEqualsDeclaration::KIND_SET)
+        .union(TsInterfaceDeclaration::KIND_SET)
+        .union(TsModuleDeclaration::KIND_SET)
+        .union(TsTypeAliasDeclaration::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -25578,6 +26207,15 @@ impl From<TsExportDeclareClause> for JsAnyExportClause {
 }
 impl AstNode for JsAnyExportClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyDeclarationClause::KIND_SET
+        .union(JsExportDefaultDeclarationClause::KIND_SET)
+        .union(JsExportDefaultExpressionClause::KIND_SET)
+        .union(JsExportFromClause::KIND_SET)
+        .union(JsExportNamedClause::KIND_SET)
+        .union(JsExportNamedFromClause::KIND_SET)
+        .union(TsExportAsNamespaceClause::KIND_SET)
+        .union(TsExportAssignmentClause::KIND_SET)
+        .union(TsExportDeclareClause::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_EXPORT_DEFAULT_DECLARATION_CLAUSE
@@ -25718,6 +26356,10 @@ impl From<TsInterfaceDeclaration> for JsAnyExportDefaultDeclaration {
 }
 impl AstNode for JsAnyExportDefaultDeclaration {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsClassExportDefaultDeclaration::KIND_SET
+        .union(JsFunctionExportDefaultDeclaration::KIND_SET)
+        .union(TsDeclareFunctionDeclaration::KIND_SET)
+        .union(TsInterfaceDeclaration::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -25816,6 +26458,8 @@ impl From<JsExportNamedSpecifier> for JsAnyExportNamedSpecifier {
 }
 impl AstNode for JsAnyExportNamedSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsExportNamedShorthandSpecifier::KIND_SET.union(JsExportNamedSpecifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -26015,6 +26659,41 @@ impl From<TsTypeAssertionExpression> for JsAnyExpression {
 }
 impl AstNode for JsAnyExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = ImportMeta::KIND_SET
+        .union(JsAnyLiteralExpression::KIND_SET)
+        .union(JsArrayExpression::KIND_SET)
+        .union(JsArrowFunctionExpression::KIND_SET)
+        .union(JsAssignmentExpression::KIND_SET)
+        .union(JsAwaitExpression::KIND_SET)
+        .union(JsBinaryExpression::KIND_SET)
+        .union(JsCallExpression::KIND_SET)
+        .union(JsClassExpression::KIND_SET)
+        .union(JsComputedMemberExpression::KIND_SET)
+        .union(JsConditionalExpression::KIND_SET)
+        .union(JsFunctionExpression::KIND_SET)
+        .union(JsIdentifierExpression::KIND_SET)
+        .union(JsImportCallExpression::KIND_SET)
+        .union(JsInExpression::KIND_SET)
+        .union(JsInstanceofExpression::KIND_SET)
+        .union(JsLogicalExpression::KIND_SET)
+        .union(JsNewExpression::KIND_SET)
+        .union(JsObjectExpression::KIND_SET)
+        .union(JsParenthesizedExpression::KIND_SET)
+        .union(JsPostUpdateExpression::KIND_SET)
+        .union(JsPreUpdateExpression::KIND_SET)
+        .union(JsSequenceExpression::KIND_SET)
+        .union(JsStaticMemberExpression::KIND_SET)
+        .union(JsSuperExpression::KIND_SET)
+        .union(JsTemplate::KIND_SET)
+        .union(JsThisExpression::KIND_SET)
+        .union(JsUnaryExpression::KIND_SET)
+        .union(JsUnknownExpression::KIND_SET)
+        .union(JsYieldExpression::KIND_SET)
+        .union(JsxTagExpression::KIND_SET)
+        .union(NewTarget::KIND_SET)
+        .union(TsAsExpression::KIND_SET)
+        .union(TsNonNullAssertionExpression::KIND_SET)
+        .union(TsTypeAssertionExpression::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             IMPORT_META
@@ -26316,6 +26995,8 @@ impl From<JsForVariableDeclaration> for JsAnyForInOrOfInitializer {
 }
 impl AstNode for JsAnyForInOrOfInitializer {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsAnyAssignmentPattern::KIND_SET.union(JsForVariableDeclaration::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_FOR_VARIABLE_DECLARATION => true,
@@ -26383,6 +27064,8 @@ impl From<JsVariableDeclaration> for JsAnyForInitializer {
 }
 impl AstNode for JsAnyForInitializer {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsAnyExpression::KIND_SET.union(JsVariableDeclaration::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_VARIABLE_DECLARATION => true,
@@ -26451,6 +27134,8 @@ impl From<JsUnknownParameter> for JsAnyFormalParameter {
 }
 impl AstNode for JsAnyFormalParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsFormalParameter::KIND_SET.union(JsUnknownParameter::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_FORMAL_PARAMETER | JS_UNKNOWN_PARAMETER)
     }
@@ -26523,6 +27208,10 @@ impl From<JsFunctionExpression> for JsAnyFunction {
 }
 impl AstNode for JsAnyFunction {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsArrowFunctionExpression::KIND_SET
+        .union(JsFunctionDeclaration::KIND_SET)
+        .union(JsFunctionExportDefaultDeclaration::KIND_SET)
+        .union(JsFunctionExpression::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -26600,6 +27289,8 @@ impl From<JsFunctionBody> for JsAnyFunctionBody {
 }
 impl AstNode for JsAnyFunctionBody {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsAnyExpression::KIND_SET.union(JsFunctionBody::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_FUNCTION_BODY => true,
@@ -26666,6 +27357,8 @@ impl From<JsUnknownImportAssertionEntry> for JsAnyImportAssertionEntry {
 }
 impl AstNode for JsAnyImportAssertionEntry {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsImportAssertionEntry::KIND_SET.union(JsUnknownImportAssertionEntry::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -26745,6 +27438,10 @@ impl From<JsImportNamespaceClause> for JsAnyImportClause {
 }
 impl AstNode for JsAnyImportClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsImportBareClause::KIND_SET
+        .union(JsImportDefaultClause::KIND_SET)
+        .union(JsImportNamedClause::KIND_SET)
+        .union(JsImportNamespaceClause::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -26820,6 +27517,8 @@ impl From<JsPrivateName> for JsAnyInProperty {
 }
 impl AstNode for JsAnyInProperty {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsAnyExpression::KIND_SET.union(JsPrivateName::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_PRIVATE_NAME => true,
@@ -26906,6 +27605,12 @@ impl From<JsStringLiteralExpression> for JsAnyLiteralExpression {
 }
 impl AstNode for JsAnyLiteralExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsBigIntLiteralExpression::KIND_SET
+        .union(JsBooleanLiteralExpression::KIND_SET)
+        .union(JsNullLiteralExpression::KIND_SET)
+        .union(JsNumberLiteralExpression::KIND_SET)
+        .union(JsRegexLiteralExpression::KIND_SET)
+        .union(JsStringLiteralExpression::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -27019,6 +27724,9 @@ impl From<TsOverrideModifier> for JsAnyMethodModifier {
 }
 impl AstNode for JsAnyMethodModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsStaticModifier::KIND_SET
+        .union(TsAccessibilityModifier::KIND_SET)
+        .union(TsOverrideModifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -27087,6 +27795,9 @@ impl From<JsImport> for JsAnyModuleItem {
 }
 impl AstNode for JsAnyModuleItem {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyStatement::KIND_SET
+        .union(JsExport::KIND_SET)
+        .union(JsImport::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_EXPORT | JS_IMPORT => true,
@@ -27154,6 +27865,7 @@ impl From<JsPrivateName> for JsAnyName {
 }
 impl AstNode for JsAnyName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsName::KIND_SET.union(JsPrivateName::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_NAME | JS_PRIVATE_NAME) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -27210,6 +27922,8 @@ impl From<JsNamespaceImportSpecifier> for JsAnyNamedImport {
 }
 impl AstNode for JsAnyNamedImport {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsNamedImportSpecifiers::KIND_SET.union(JsNamespaceImportSpecifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -27280,6 +27994,9 @@ impl From<JsUnknownNamedImportSpecifier> for JsAnyNamedImportSpecifier {
 }
 impl AstNode for JsAnyNamedImportSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsNamedImportSpecifier::KIND_SET
+        .union(JsShorthandNamedImportSpecifier::KIND_SET)
+        .union(JsUnknownNamedImportSpecifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -27374,6 +28091,10 @@ impl From<JsUnknownAssignment> for JsAnyObjectAssignmentPatternMember {
 }
 impl AstNode for JsAnyObjectAssignmentPatternMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsObjectAssignmentPatternProperty::KIND_SET
+        .union(JsObjectAssignmentPatternRest::KIND_SET)
+        .union(JsObjectAssignmentPatternShorthandProperty::KIND_SET)
+        .union(JsUnknownAssignment::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -27493,6 +28214,11 @@ impl From<JsUnknownBinding> for JsAnyObjectBindingPatternMember {
 }
 impl AstNode for JsAnyObjectBindingPatternMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsIdentifierBinding::KIND_SET
+        .union(JsObjectBindingPatternProperty::KIND_SET)
+        .union(JsObjectBindingPatternRest::KIND_SET)
+        .union(JsObjectBindingPatternShorthandProperty::KIND_SET)
+        .union(JsUnknownBinding::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -27622,6 +28348,13 @@ impl From<JsUnknownMember> for JsAnyObjectMember {
 }
 impl AstNode for JsAnyObjectMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsGetterObjectMember::KIND_SET
+        .union(JsMethodObjectMember::KIND_SET)
+        .union(JsPropertyObjectMember::KIND_SET)
+        .union(JsSetterObjectMember::KIND_SET)
+        .union(JsShorthandPropertyObjectMember::KIND_SET)
+        .union(JsSpread::KIND_SET)
+        .union(JsUnknownMember::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -27726,6 +28459,8 @@ impl From<JsLiteralMemberName> for JsAnyObjectMemberName {
 }
 impl AstNode for JsAnyObjectMemberName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsComputedMemberName::KIND_SET.union(JsLiteralMemberName::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_COMPUTED_MEMBER_NAME | JS_LITERAL_MEMBER_NAME)
     }
@@ -27784,6 +28519,9 @@ impl From<TsThisParameter> for JsAnyParameter {
 }
 impl AstNode for JsAnyParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsAnyFormalParameter::KIND_SET
+        .union(JsRestParameter::KIND_SET)
+        .union(TsThisParameter::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_REST_PARAMETER | TS_THIS_PARAMETER => true,
@@ -27867,6 +28605,10 @@ impl From<TsReadonlyModifier> for JsAnyPropertyModifier {
 }
 impl AstNode for JsAnyPropertyModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsStaticModifier::KIND_SET
+        .union(TsAccessibilityModifier::KIND_SET)
+        .union(TsOverrideModifier::KIND_SET)
+        .union(TsReadonlyModifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -27948,6 +28690,9 @@ impl From<JsScript> for JsAnyRoot {
 }
 impl AstNode for JsAnyRoot {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsExpressionSnipped::KIND_SET
+        .union(JsModule::KIND_SET)
+        .union(JsScript::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_EXPRESSION_SNIPPED | JS_MODULE | JS_SCRIPT)
     }
@@ -28123,6 +28868,38 @@ impl From<TsTypeAliasDeclaration> for JsAnyStatement {
 }
 impl AstNode for JsAnyStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsBlockStatement::KIND_SET
+        .union(JsBreakStatement::KIND_SET)
+        .union(JsClassDeclaration::KIND_SET)
+        .union(JsContinueStatement::KIND_SET)
+        .union(JsDebuggerStatement::KIND_SET)
+        .union(JsDoWhileStatement::KIND_SET)
+        .union(JsEmptyStatement::KIND_SET)
+        .union(JsExpressionStatement::KIND_SET)
+        .union(JsForInStatement::KIND_SET)
+        .union(JsForOfStatement::KIND_SET)
+        .union(JsForStatement::KIND_SET)
+        .union(JsFunctionDeclaration::KIND_SET)
+        .union(JsIfStatement::KIND_SET)
+        .union(JsLabeledStatement::KIND_SET)
+        .union(JsReturnStatement::KIND_SET)
+        .union(JsSwitchStatement::KIND_SET)
+        .union(JsThrowStatement::KIND_SET)
+        .union(JsTryFinallyStatement::KIND_SET)
+        .union(JsTryStatement::KIND_SET)
+        .union(JsUnknownStatement::KIND_SET)
+        .union(JsVariableStatement::KIND_SET)
+        .union(JsWhileStatement::KIND_SET)
+        .union(JsWithStatement::KIND_SET)
+        .union(TsDeclareFunctionDeclaration::KIND_SET)
+        .union(TsDeclareStatement::KIND_SET)
+        .union(TsEnumDeclaration::KIND_SET)
+        .union(TsExternalModuleDeclaration::KIND_SET)
+        .union(TsGlobalDeclaration::KIND_SET)
+        .union(TsImportEqualsDeclaration::KIND_SET)
+        .union(TsInterfaceDeclaration::KIND_SET)
+        .union(TsModuleDeclaration::KIND_SET)
+        .union(TsTypeAliasDeclaration::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -28399,6 +29176,8 @@ impl From<JsDefaultClause> for JsAnySwitchClause {
 }
 impl AstNode for JsAnySwitchClause {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsCaseClause::KIND_SET.union(JsDefaultClause::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -28455,6 +29234,8 @@ impl From<JsTemplateElement> for JsAnyTemplateElement {
 }
 impl AstNode for JsAnyTemplateElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsTemplateChunkElement::KIND_SET.union(JsTemplateElement::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_TEMPLATE_CHUNK_ELEMENT | JS_TEMPLATE_ELEMENT)
     }
@@ -28515,6 +29296,8 @@ impl From<JsxSpreadAttribute> for JsxAnyAttribute {
 }
 impl AstNode for JsxAnyAttribute {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsxAttribute::KIND_SET.union(JsxSpreadAttribute::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JSX_ATTRIBUTE | JSX_SPREAD_ATTRIBUTE) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -28571,6 +29354,7 @@ impl From<JsxNamespaceName> for JsxAnyAttributeName {
 }
 impl AstNode for JsxAnyAttributeName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsxName::KIND_SET.union(JsxNamespaceName::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JSX_NAME | JSX_NAMESPACE_NAME) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -28627,6 +29411,9 @@ impl From<JsxString> for JsxAnyAttributeValue {
 }
 impl AstNode for JsxAnyAttributeValue {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsxAnyTag::KIND_SET
+        .union(JsxExpressionAttributeValue::KIND_SET)
+        .union(JsxString::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JSX_EXPRESSION_ATTRIBUTE_VALUE | JSX_STRING => true,
@@ -28710,6 +29497,12 @@ impl From<JsxText> for JsxAnyChild {
 }
 impl AstNode for JsxAnyChild {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsxElement::KIND_SET
+        .union(JsxExpressionChild::KIND_SET)
+        .union(JsxFragment::KIND_SET)
+        .union(JsxSelfClosingElement::KIND_SET)
+        .union(JsxSpreadChild::KIND_SET)
+        .union(JsxText::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -28804,6 +29597,10 @@ impl From<JsxReferenceIdentifier> for JsxAnyElementName {
 }
 impl AstNode for JsxAnyElementName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsxMemberName::KIND_SET
+        .union(JsxName::KIND_SET)
+        .union(JsxNamespaceName::KIND_SET)
+        .union(JsxReferenceIdentifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -28873,6 +29670,7 @@ impl From<JsxNamespaceName> for JsxAnyName {
 }
 impl AstNode for JsxAnyName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsxName::KIND_SET.union(JsxNamespaceName::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JSX_NAME | JSX_NAMESPACE_NAME) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -28930,6 +29728,9 @@ impl From<JsxReferenceIdentifier> for JsxAnyObjectName {
 }
 impl AstNode for JsxAnyObjectName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsxMemberName::KIND_SET
+        .union(JsxNamespaceName::KIND_SET)
+        .union(JsxReferenceIdentifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -28997,6 +29798,9 @@ impl From<JsxSelfClosingElement> for JsxAnyTag {
 }
 impl AstNode for JsxAnyTag {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsxElement::KIND_SET
+        .union(JsxFragment::KIND_SET)
+        .union(JsxSelfClosingElement::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JSX_ELEMENT | JSX_FRAGMENT | JSX_SELF_CLOSING_ELEMENT)
     }
@@ -29062,6 +29866,8 @@ impl From<TsModuleBlock> for TsAnyExternalModuleDeclarationBody {
 }
 impl AstNode for TsAnyExternalModuleDeclarationBody {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        TsEmptyExternalModuleDeclarationBody::KIND_SET.union(TsModuleBlock::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -29137,6 +29943,8 @@ impl From<TsReadonlyModifier> for TsAnyIndexSignatureModifier {
 }
 impl AstNode for TsAnyIndexSignatureModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsStaticModifier::KIND_SET.union(TsReadonlyModifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_STATIC_MODIFIER | TS_READONLY_MODIFIER)
     }
@@ -29209,6 +30017,10 @@ impl From<TsOverrideModifier> for TsAnyMethodSignatureModifier {
 }
 impl AstNode for TsAnyMethodSignatureModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsStaticModifier::KIND_SET
+        .union(TsAbstractModifier::KIND_SET)
+        .union(TsAccessibilityModifier::KIND_SET)
+        .union(TsOverrideModifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -29295,6 +30107,8 @@ impl From<TsQualifiedModuleName> for TsAnyModuleName {
 }
 impl AstNode for TsAnyModuleName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        TsIdentifierBinding::KIND_SET.union(TsQualifiedModuleName::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, TS_IDENTIFIER_BINDING | TS_QUALIFIED_MODULE_NAME)
     }
@@ -29352,6 +30166,8 @@ impl From<TsExternalModuleReference> for TsAnyModuleReference {
 }
 impl AstNode for TsAnyModuleReference {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        TsAnyName::KIND_SET.union(TsExternalModuleReference::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             TS_EXTERNAL_MODULE_REFERENCE => true,
@@ -29418,6 +30234,8 @@ impl From<TsQualifiedName> for TsAnyName {
 }
 impl AstNode for TsAnyName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsReferenceIdentifier::KIND_SET.union(TsQualifiedName::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_REFERENCE_IDENTIFIER | TS_QUALIFIED_NAME)
     }
@@ -29483,6 +30301,9 @@ impl From<TsTypeAnnotation> for TsAnyPropertyAnnotation {
 }
 impl AstNode for TsAnyPropertyAnnotation {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = TsDefinitePropertyAnnotation::KIND_SET
+        .union(TsOptionalPropertyAnnotation::KIND_SET)
+        .union(TsTypeAnnotation::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -29568,6 +30389,9 @@ impl From<TsReadonlyModifier> for TsAnyPropertyParameterModifier {
 }
 impl AstNode for TsAnyPropertyParameterModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = TsAccessibilityModifier::KIND_SET
+        .union(TsOverrideModifier::KIND_SET)
+        .union(TsReadonlyModifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -29644,6 +30468,8 @@ impl From<TsTypeAnnotation> for TsAnyPropertySignatureAnnotation {
 }
 impl AstNode for TsAnyPropertySignatureAnnotation {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        TsOptionalPropertyAnnotation::KIND_SET.union(TsTypeAnnotation::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, TS_OPTIONAL_PROPERTY_ANNOTATION | TS_TYPE_ANNOTATION)
     }
@@ -29730,6 +30556,12 @@ impl From<TsReadonlyModifier> for TsAnyPropertySignatureModifier {
 }
 impl AstNode for TsAnyPropertySignatureModifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsStaticModifier::KIND_SET
+        .union(TsAbstractModifier::KIND_SET)
+        .union(TsAccessibilityModifier::KIND_SET)
+        .union(TsDeclareModifier::KIND_SET)
+        .union(TsOverrideModifier::KIND_SET)
+        .union(TsReadonlyModifier::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -29832,6 +30664,9 @@ impl From<TsPredicateReturnType> for TsAnyReturnType {
 }
 impl AstNode for TsAnyReturnType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = TsAssertsReturnType::KIND_SET
+        .union(TsPredicateReturnType::KIND_SET)
+        .union(TsType::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             TS_ASSERTS_RETURN_TYPE | TS_PREDICATE_RETURN_TYPE => true,
@@ -29907,6 +30742,8 @@ impl From<TsTemplateElement> for TsAnyTemplateElement {
 }
 impl AstNode for TsAnyTemplateElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        TsTemplateChunkElement::KIND_SET.union(TsTemplateElement::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, TS_TEMPLATE_CHUNK_ELEMENT | TS_TEMPLATE_ELEMENT)
     }
@@ -29974,6 +30811,10 @@ impl From<TsRestTupleTypeElement> for TsAnyTupleTypeElement {
 }
 impl AstNode for TsAnyTupleTypeElement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = TsNamedTupleTypeElement::KIND_SET
+        .union(TsOptionalTupleTypeElement::KIND_SET)
+        .union(TsRestTupleTypeElement::KIND_SET)
+        .union(TsType::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             TS_NAMED_TUPLE_TYPE_ELEMENT
@@ -30088,6 +30929,14 @@ impl From<TsSetterSignatureTypeMember> for TsAnyTypeMember {
 }
 impl AstNode for TsAnyTypeMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsUnknownMember::KIND_SET
+        .union(TsCallSignatureTypeMember::KIND_SET)
+        .union(TsConstructSignatureTypeMember::KIND_SET)
+        .union(TsGetterSignatureTypeMember::KIND_SET)
+        .union(TsIndexSignatureTypeMember::KIND_SET)
+        .union(TsMethodSignatureTypeMember::KIND_SET)
+        .union(TsPropertySignatureTypeMember::KIND_SET)
+        .union(TsSetterSignatureTypeMember::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -30204,6 +31053,8 @@ impl From<TsThisType> for TsAnyTypePredicateParameterName {
 }
 impl AstNode for TsAnyTypePredicateParameterName {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        JsReferenceIdentifier::KIND_SET.union(TsThisType::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_REFERENCE_IDENTIFIER | TS_THIS_TYPE) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -30266,6 +31117,8 @@ impl From<TsTypeAnnotation> for TsAnyVariableAnnotation {
 }
 impl AstNode for TsAnyVariableAnnotation {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        TsDefiniteVariableAnnotation::KIND_SET.union(TsTypeAnnotation::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, TS_DEFINITE_VARIABLE_ANNOTATION | TS_TYPE_ANNOTATION)
     }
@@ -30424,6 +31277,40 @@ impl From<TsVoidType> for TsType {
 }
 impl AstNode for TsType {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = TsAnyType::KIND_SET
+        .union(TsArrayType::KIND_SET)
+        .union(TsBigIntLiteralType::KIND_SET)
+        .union(TsBigintType::KIND_SET)
+        .union(TsBooleanLiteralType::KIND_SET)
+        .union(TsBooleanType::KIND_SET)
+        .union(TsConditionalType::KIND_SET)
+        .union(TsConstructorType::KIND_SET)
+        .union(TsFunctionType::KIND_SET)
+        .union(TsImportType::KIND_SET)
+        .union(TsIndexedAccessType::KIND_SET)
+        .union(TsInferType::KIND_SET)
+        .union(TsIntersectionType::KIND_SET)
+        .union(TsMappedType::KIND_SET)
+        .union(TsNeverType::KIND_SET)
+        .union(TsNonPrimitiveType::KIND_SET)
+        .union(TsNullLiteralType::KIND_SET)
+        .union(TsNumberLiteralType::KIND_SET)
+        .union(TsNumberType::KIND_SET)
+        .union(TsObjectType::KIND_SET)
+        .union(TsParenthesizedType::KIND_SET)
+        .union(TsReferenceType::KIND_SET)
+        .union(TsStringLiteralType::KIND_SET)
+        .union(TsStringType::KIND_SET)
+        .union(TsSymbolType::KIND_SET)
+        .union(TsTemplateLiteralType::KIND_SET)
+        .union(TsThisType::KIND_SET)
+        .union(TsTupleType::KIND_SET)
+        .union(TsTypeOperatorType::KIND_SET)
+        .union(TsTypeofType::KIND_SET)
+        .union(TsUndefinedType::KIND_SET)
+        .union(TsUnionType::KIND_SET)
+        .union(TsUnknownType::KIND_SET)
+        .union(TsVoidType::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -32398,6 +33285,8 @@ impl JsUnknown {
 }
 impl AstNode for JsUnknown {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNKNOWN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -32440,6 +33329,8 @@ impl JsUnknownAssignment {
 }
 impl AstNode for JsUnknownAssignment {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNKNOWN_ASSIGNMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -32482,6 +33373,8 @@ impl JsUnknownBinding {
 }
 impl AstNode for JsUnknownBinding {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNKNOWN_BINDING as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_BINDING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -32524,6 +33417,8 @@ impl JsUnknownExpression {
 }
 impl AstNode for JsUnknownExpression {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNKNOWN_EXPRESSION as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -32566,6 +33461,8 @@ impl JsUnknownImportAssertionEntry {
 }
 impl AstNode for JsUnknownImportAssertionEntry {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNKNOWN_IMPORT_ASSERTION_ENTRY as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_IMPORT_ASSERTION_ENTRY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -32608,6 +33505,8 @@ impl JsUnknownMember {
 }
 impl AstNode for JsUnknownMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNKNOWN_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -32650,6 +33549,8 @@ impl JsUnknownNamedImportSpecifier {
 }
 impl AstNode for JsUnknownNamedImportSpecifier {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNKNOWN_NAMED_IMPORT_SPECIFIER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_NAMED_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -32692,6 +33593,8 @@ impl JsUnknownParameter {
 }
 impl AstNode for JsUnknownParameter {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNKNOWN_PARAMETER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -32734,6 +33637,8 @@ impl JsUnknownStatement {
 }
 impl AstNode for JsUnknownStatement {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_UNKNOWN_STATEMENT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -32777,6 +33682,9 @@ impl JsArrayAssignmentPatternElementList {
 }
 impl AstNode for JsArrayAssignmentPatternElementList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsArrayAssignmentPatternElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -32844,6 +33752,8 @@ impl JsArrayBindingPatternElementList {
 }
 impl AstNode for JsArrayBindingPatternElementList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsArrayBindingPatternElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -32911,6 +33821,8 @@ impl JsArrayElementList {
 }
 impl AstNode for JsArrayElementList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_ARRAY_ELEMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsArrayElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -32978,6 +33890,8 @@ impl JsCallArgumentList {
 }
 impl AstNode for JsCallArgumentList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CALL_ARGUMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CALL_ARGUMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsCallArgumentList> {
         if Self::can_cast(syntax.kind()) {
@@ -33045,6 +33959,8 @@ impl JsClassMemberList {
 }
 impl AstNode for JsClassMemberList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CLASS_MEMBER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_MEMBER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsClassMemberList> {
         if Self::can_cast(syntax.kind()) {
@@ -33112,6 +34028,8 @@ impl JsConstructorModifierList {
 }
 impl AstNode for JsConstructorModifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CONSTRUCTOR_MODIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsConstructorModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -33179,6 +34097,8 @@ impl JsConstructorParameterList {
 }
 impl AstNode for JsConstructorParameterList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_CONSTRUCTOR_PARAMETER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsConstructorParameterList> {
         if Self::can_cast(syntax.kind()) {
@@ -33246,6 +34166,8 @@ impl JsDirectiveList {
 }
 impl AstNode for JsDirectiveList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_DIRECTIVE_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DIRECTIVE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsDirectiveList> {
         if Self::can_cast(syntax.kind()) {
@@ -33313,6 +34235,8 @@ impl JsExportNamedFromSpecifierList {
 }
 impl AstNode for JsExportNamedFromSpecifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_NAMED_FROM_SPECIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_FROM_SPECIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsExportNamedFromSpecifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -33380,6 +34304,8 @@ impl JsExportNamedSpecifierList {
 }
 impl AstNode for JsExportNamedSpecifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_EXPORT_NAMED_SPECIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_SPECIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsExportNamedSpecifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -33447,6 +34373,8 @@ impl JsImportAssertionEntryList {
 }
 impl AstNode for JsImportAssertionEntryList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_IMPORT_ASSERTION_ENTRY_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_ASSERTION_ENTRY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsImportAssertionEntryList> {
         if Self::can_cast(syntax.kind()) {
@@ -33514,6 +34442,8 @@ impl JsMethodModifierList {
 }
 impl AstNode for JsMethodModifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_METHOD_MODIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsMethodModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -33581,6 +34511,8 @@ impl JsModuleItemList {
 }
 impl AstNode for JsModuleItemList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_MODULE_ITEM_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_MODULE_ITEM_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsModuleItemList> {
         if Self::can_cast(syntax.kind()) {
@@ -33648,6 +34580,8 @@ impl JsNamedImportSpecifierList {
 }
 impl AstNode for JsNamedImportSpecifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_NAMED_IMPORT_SPECIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAMED_IMPORT_SPECIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsNamedImportSpecifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -33715,6 +34649,9 @@ impl JsObjectAssignmentPatternPropertyList {
 }
 impl AstNode for JsObjectAssignmentPatternPropertyList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsObjectAssignmentPatternPropertyList> {
         if Self::can_cast(syntax.kind()) {
@@ -33782,6 +34719,9 @@ impl JsObjectBindingPatternPropertyList {
 }
 impl AstNode for JsObjectBindingPatternPropertyList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
+        JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST as u16,
+    ));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsObjectBindingPatternPropertyList> {
         if Self::can_cast(syntax.kind()) {
@@ -33849,6 +34789,8 @@ impl JsObjectMemberList {
 }
 impl AstNode for JsObjectMemberList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_OBJECT_MEMBER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_MEMBER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsObjectMemberList> {
         if Self::can_cast(syntax.kind()) {
@@ -33916,6 +34858,8 @@ impl JsParameterList {
 }
 impl AstNode for JsParameterList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PARAMETER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsParameterList> {
         if Self::can_cast(syntax.kind()) {
@@ -33983,6 +34927,8 @@ impl JsPropertyModifierList {
 }
 impl AstNode for JsPropertyModifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_PROPERTY_MODIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsPropertyModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -34050,6 +34996,8 @@ impl JsStatementList {
 }
 impl AstNode for JsStatementList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_STATEMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsStatementList> {
         if Self::can_cast(syntax.kind()) {
@@ -34117,6 +35065,8 @@ impl JsSwitchCaseList {
 }
 impl AstNode for JsSwitchCaseList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_SWITCH_CASE_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SWITCH_CASE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsSwitchCaseList> {
         if Self::can_cast(syntax.kind()) {
@@ -34184,6 +35134,8 @@ impl JsTemplateElementList {
 }
 impl AstNode for JsTemplateElementList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_TEMPLATE_ELEMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TEMPLATE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsTemplateElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -34251,6 +35203,8 @@ impl JsVariableDeclaratorList {
 }
 impl AstNode for JsVariableDeclaratorList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JS_VARIABLE_DECLARATOR_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATOR_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsVariableDeclaratorList> {
         if Self::can_cast(syntax.kind()) {
@@ -34318,6 +35272,8 @@ impl JsxAttributeList {
 }
 impl AstNode for JsxAttributeList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_ATTRIBUTE_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_ATTRIBUTE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsxAttributeList> {
         if Self::can_cast(syntax.kind()) {
@@ -34385,6 +35341,8 @@ impl JsxChildList {
 }
 impl AstNode for JsxChildList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSX_CHILD_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_CHILD_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsxChildList> {
         if Self::can_cast(syntax.kind()) {
@@ -34452,6 +35410,8 @@ impl TsEnumMemberList {
 }
 impl AstNode for TsEnumMemberList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_ENUM_MEMBER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_MEMBER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsEnumMemberList> {
         if Self::can_cast(syntax.kind()) {
@@ -34519,6 +35479,8 @@ impl TsIndexSignatureModifierList {
 }
 impl AstNode for TsIndexSignatureModifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_INDEX_SIGNATURE_MODIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsIndexSignatureModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -34586,6 +35548,8 @@ impl TsIntersectionTypeElementList {
 }
 impl AstNode for TsIntersectionTypeElementList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_INTERSECTION_TYPE_ELEMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERSECTION_TYPE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsIntersectionTypeElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -34653,6 +35617,8 @@ impl TsMethodSignatureModifierList {
 }
 impl AstNode for TsMethodSignatureModifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_METHOD_SIGNATURE_MODIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsMethodSignatureModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -34720,6 +35686,8 @@ impl TsPropertyParameterModifierList {
 }
 impl AstNode for TsPropertyParameterModifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_PROPERTY_PARAMETER_MODIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_PARAMETER_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsPropertyParameterModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -34787,6 +35755,8 @@ impl TsPropertySignatureModifierList {
 }
 impl AstNode for TsPropertySignatureModifierList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_PROPERTY_SIGNATURE_MODIFIER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsPropertySignatureModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -34854,6 +35824,8 @@ impl TsTemplateElementList {
 }
 impl AstNode for TsTemplateElementList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TEMPLATE_ELEMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTemplateElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -34921,6 +35893,8 @@ impl TsTupleTypeElementList {
 }
 impl AstNode for TsTupleTypeElementList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TUPLE_TYPE_ELEMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE_TYPE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTupleTypeElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -34988,6 +35962,8 @@ impl TsTypeArgumentList {
 }
 impl AstNode for TsTypeArgumentList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_ARGUMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ARGUMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeArgumentList> {
         if Self::can_cast(syntax.kind()) {
@@ -35055,6 +36031,8 @@ impl TsTypeList {
 }
 impl AstNode for TsTypeList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeList> {
         if Self::can_cast(syntax.kind()) {
@@ -35122,6 +36100,8 @@ impl TsTypeMemberList {
 }
 impl AstNode for TsTypeMemberList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_MEMBER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_MEMBER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeMemberList> {
         if Self::can_cast(syntax.kind()) {
@@ -35189,6 +36169,8 @@ impl TsTypeParameterList {
 }
 impl AstNode for TsTypeParameterList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_TYPE_PARAMETER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeParameterList> {
         if Self::can_cast(syntax.kind()) {
@@ -35256,6 +36238,8 @@ impl TsUnionTypeVariantList {
 }
 impl AstNode for TsUnionTypeVariantList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(TS_UNION_TYPE_VARIANT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNION_TYPE_VARIANT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsUnionTypeVariantList> {
         if Self::can_cast(syntax.kind()) {

--- a/crates/rome_json_syntax/src/generated/nodes.rs
+++ b/crates/rome_json_syntax/src/generated/nodes.rs
@@ -9,7 +9,7 @@ use crate::{
     JsonSyntaxKind::{self as SyntaxKind, *},
     JsonSyntaxList as SyntaxList, JsonSyntaxNode as SyntaxNode, JsonSyntaxToken as SyntaxToken,
 };
-use rome_rowan::{support, AstNode, SyntaxResult};
+use rome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
 #[allow(unused)]
 use rome_rowan::{
     AstNodeList, AstNodeListIterator, AstSeparatedList, AstSeparatedListNodesIterator,
@@ -376,6 +376,8 @@ impl JsonValue {
 }
 impl AstNode for JsonArray {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_ARRAY as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_ARRAY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -410,6 +412,8 @@ impl From<JsonArray> for SyntaxElement {
 }
 impl AstNode for JsonBoolean {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_BOOLEAN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_BOOLEAN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -440,6 +444,8 @@ impl From<JsonBoolean> for SyntaxElement {
 }
 impl AstNode for JsonMember {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_MEMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -471,6 +477,8 @@ impl From<JsonMember> for SyntaxElement {
 }
 impl AstNode for JsonNull {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_NULL as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_NULL }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -497,6 +505,8 @@ impl From<JsonNull> for SyntaxElement {
 }
 impl AstNode for JsonNumber {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_NUMBER as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_NUMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -526,6 +536,8 @@ impl From<JsonNumber> for SyntaxElement {
 }
 impl AstNode for JsonObject {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_OBJECT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_OBJECT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -560,6 +572,8 @@ impl From<JsonObject> for SyntaxElement {
 }
 impl AstNode for JsonRoot {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_ROOT as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_ROOT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -586,6 +600,8 @@ impl From<JsonRoot> for SyntaxElement {
 }
 impl AstNode for JsonString {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_STRING as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_STRING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -636,6 +652,13 @@ impl From<JsonUnknown> for JsonValue {
 }
 impl AstNode for JsonValue {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> = JsonArray::KIND_SET
+        .union(JsonBoolean::KIND_SET)
+        .union(JsonNull::KIND_SET)
+        .union(JsonNumber::KIND_SET)
+        .union(JsonObject::KIND_SET)
+        .union(JsonString::KIND_SET)
+        .union(JsonUnknown::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -779,6 +802,8 @@ impl JsonUnknown {
 }
 impl AstNode for JsonUnknown {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_UNKNOWN as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_UNKNOWN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -822,6 +847,8 @@ impl JsonArrayElementList {
 }
 impl AstNode for JsonArrayElementList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_ARRAY_ELEMENT_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_ARRAY_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsonArrayElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -889,6 +916,8 @@ impl JsonMemberList {
 }
 impl AstNode for JsonMemberList {
     type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(JSON_MEMBER_LIST as u16));
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSON_MEMBER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsonMemberList> {
         if Self::can_cast(syntax.kind()) {

--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -15,8 +15,70 @@ use text_size::TextRange;
 mod mutation;
 
 use crate::syntax::{SyntaxSlot, SyntaxSlots};
-use crate::{Language, SyntaxList, SyntaxNode, SyntaxToken};
+use crate::{Language, RawSyntaxKind, SyntaxKind, SyntaxList, SyntaxNode, SyntaxToken};
 pub use mutation::{AstNodeExt, AstNodeListExt, AstSeparatedListExt};
+
+/// Represents a set of [SyntaxKind] as a bitfield, with each bit representing
+/// whether the corresponding [RawSyntaxKind] value is contained in the set
+///
+/// This is similar to the `TokenSet` struct in `rome_js_parser`, with the
+/// bitfield here being twice as large as it needs to cover all nodes as well
+/// as all token kinds
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SyntaxKindSet<L: ?Sized + Language>([u128; 4], PhantomData<L>);
+
+impl<L> SyntaxKindSet<L>
+where
+    L: Language,
+{
+    /// Create a new [SyntaxKindSet] containing only the provided [SyntaxKind]
+    pub fn of(kind: L::Kind) -> Self {
+        Self::from_raw(kind.to_raw())
+    }
+
+    /// Create a new [SyntaxKindSet] containing only the provided [RawSyntaxKind]
+    pub const fn from_raw(kind: RawSyntaxKind) -> Self {
+        Self(kind.as_bits(), PhantomData)
+    }
+
+    /// Returns the union of the two sets `self` and `other`
+    pub const fn union(self, other: Self) -> Self {
+        Self(
+            [
+                self.0[0] | other.0[0],
+                self.0[1] | other.0[1],
+                self.0[2] | other.0[2],
+                self.0[3] | other.0[3],
+            ],
+            PhantomData,
+        )
+    }
+
+    /// Returns true if `kind` is contained in this set
+    pub fn matches(self, kind: L::Kind) -> bool {
+        let bits = kind.to_raw().as_bits();
+        (self.0[0] & bits[0]) != 0
+            || (self.0[1] & bits[1]) != 0
+            || (self.0[2] & bits[2]) != 0
+            || (self.0[3] & bits[3]) != 0
+    }
+
+    /// Returns an iterator over all the [SyntaxKind] contained in this set
+    pub fn iter(self) -> impl Iterator<Item = L::Kind> {
+        self.0.into_iter().enumerate().flat_map(|(index, item)| {
+            let index = index as u16 * 128;
+            (0..u128::BITS).filter_map(move |bit| {
+                if (item & (1 << bit)) != 0 {
+                    let raw = index + bit as u16;
+                    let raw = RawSyntaxKind(raw);
+                    Some(<L::Kind as SyntaxKind>::from_raw(raw))
+                } else {
+                    None
+                }
+            })
+        })
+    }
+}
 
 /// The main trait to go from untyped `SyntaxNode`  to a typed ast. The
 /// conversion itself has zero runtime cost: ast and syntax nodes have exactly
@@ -24,6 +86,8 @@ pub use mutation::{AstNodeExt, AstNodeListExt, AstSeparatedListExt};
 /// node itself.
 pub trait AstNode: Clone {
     type Language: Language;
+
+    const KIND_SET: SyntaxKindSet<Self::Language>;
 
     /// Returns `true` if a node with the given kind can be cased to this AST node.
     fn can_cast(kind: <Self::Language as Language>::Kind) -> bool;
@@ -859,6 +923,10 @@ mod tests {
         struct RawRoot(SyntaxNode<RawLanguage>);
         impl AstNode for RawRoot {
             type Language = RawLanguage;
+
+            const KIND_SET: SyntaxKindSet<Self::Language> =
+                SyntaxKindSet::from_raw(RawSyntaxKind(RawLanguageKind::ROOT as u16));
+
             fn can_cast(_: <Self::Language as Language>::Kind) -> bool {
                 todo!()
             }

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -18,20 +18,6 @@ pub(crate) use self::node_cache::NodeCacheNodeEntryMut;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RawSyntaxKind(pub u16);
 
-impl RawSyntaxKind {
-    pub(crate) const fn as_bits(self) -> [u128; 4] {
-        if self.0 < 128 {
-            [1u128 << self.0, 0, 0, 0]
-        } else if self.0 < 256 {
-            [0, 1u128 << (self.0 - 128), 0, 0]
-        } else if self.0 < 384 {
-            [0, 0, 1u128 << (self.0 - 256), 0]
-        } else {
-            [0, 0, 0, 1u128 << (self.0 - 384)]
-        }
-    }
-}
-
 pub(crate) fn has_live() -> bool {
     node::has_live() || token::has_live() || trivia::has_live()
 }

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -18,6 +18,20 @@ pub(crate) use self::node_cache::NodeCacheNodeEntryMut;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RawSyntaxKind(pub u16);
 
+impl RawSyntaxKind {
+    pub(crate) const fn as_bits(self) -> [u128; 4] {
+        if self.0 < 128 {
+            [1u128 << self.0, 0, 0, 0]
+        } else if self.0 < 256 {
+            [0, 1u128 << (self.0 - 128), 0, 0]
+        } else if self.0 < 384 {
+            [0, 0, 1u128 << (self.0 - 256), 0]
+        } else {
+            [0, 0, 0, 1u128 << (self.0 - 384)]
+        }
+    }
+}
+
 pub(crate) fn has_live() -> bool {
     node::has_live() || token::has_live() || trivia::has_live()
 }

--- a/crates/rome_rowan/src/raw_language.rs
+++ b/crates/rome_rowan/src/raw_language.rs
@@ -2,7 +2,7 @@ use crate::raw_language::RawLanguageKind::{COMMA_TOKEN, LITERAL_EXPRESSION, ROOT
 ///! Provides a sample language implementation that is useful in API explanation or tests
 use crate::{
     AstNode, AstSeparatedList, Language, ParsedChildren, RawNodeSlots, RawSyntaxKind,
-    RawSyntaxNode, SyntaxFactory, SyntaxKind, SyntaxList, SyntaxNode, TreeBuilder,
+    RawSyntaxNode, SyntaxFactory, SyntaxKind, SyntaxKindSet, SyntaxList, SyntaxNode, TreeBuilder,
 };
 
 #[doc(hidden)]
@@ -69,6 +69,9 @@ pub struct RawLanguageRoot {
 impl AstNode for RawLanguageRoot {
     type Language = RawLanguage;
 
+    const KIND_SET: SyntaxKindSet<RawLanguage> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(ROOT as u16));
+
     fn can_cast(kind: RawLanguageKind) -> bool {
         kind == ROOT
     }
@@ -101,6 +104,9 @@ pub struct LiteralExpression {
 
 impl AstNode for LiteralExpression {
     type Language = RawLanguage;
+
+    const KIND_SET: SyntaxKindSet<RawLanguage> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(LITERAL_EXPRESSION as u16));
 
     fn can_cast(kind: RawLanguageKind) -> bool {
         kind == LITERAL_EXPRESSION

--- a/xtask/codegen/src/generate_analyzer.rs
+++ b/xtask/codegen/src/generate_analyzer.rs
@@ -92,7 +92,7 @@ fn update_registry_builder(analyzers: Vec<String>, assists: Vec<String>) -> Resu
         use crate::{analyzers::*, assists::*};
 
         pub(crate) fn build_registry(filter: &AnalysisFilter) -> RuleRegistry<JsLanguage> {
-            let mut rules = RuleRegistry::empty();
+            let mut rules = RuleRegistry::default();
             #( #rules )*
             rules
         }

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -65,7 +65,11 @@ fn main() -> Result<()> {
         ..AnalysisFilter::default()
     };
 
-    for (name, docs) in metadata(filter) {
+    // Ensure the list of rules is stored alphabetically
+    let mut rules: Vec<_> = metadata(filter).collect();
+    rules.sort_unstable_by_key(|(name, _)| *name);
+
+    for (name, docs) in rules {
         match generate_rule(&root, name, docs) {
             Ok(summary) => {
                 writeln!(index, "<div class=\"rule\">")?;


### PR DESCRIPTION
## Summary

This PR adds a new `KIND_SET` associated constant to the `AstNode`, representing the set of `SyntaxKind` values that can be cast into this node (the `can_cast` function would return true for these values). This allows code to statically list out all node types that match a certain node type, to optimize query matching in the analyzer for instance.

## Example

This code uses the new feature to list the variants of `JsSyntaxKind` that can be cast into `JsAnyRoot`:

```rust
let root_kinds: Vec<_> = JsAnyRoot::KIND_SET.iter().collect();
assert_eq!(root_kinds.as_slice(), &[
    JsSyntaxKind::JS_MODULE,
    JsSyntaxKind::JS_SCRIPT,
    JsSyntaxKind::JS_EXPRESSION_SNIPPED,
]);
```

## Test Plan

This is mostly a codegen change, and with most operations on `SyntaxKindSet` being `const` almost all these operations are checked at compile time (adding enough variants to `JsSyntaxKind` to make it overflow the 64 bytes of the bitfield would cause a compilation error for instance).
The changes to the rule registry are tested indirectly through the integration tests of the analyzer, ensuring that queries are still matched correctly
