### PR TITLE
refactor(rome_js_formatter): Remove `Copy` from `JsFormatContext`

### DIFF
--- a/crates/rome_js_formatter/src/check_reformat.rs
+++ b/crates/rome_js_formatter/src/check_reformat.rs
@@ -19,7 +19,7 @@ pub fn check_reformat(params: CheckReformatParams) {
         text,
         source_type,
         file_name,
-        format_context: format_options,
+        format_context: context,
     } = params;
 
     let re_parse = parse(text, 0, source_type);
@@ -44,11 +44,11 @@ pub fn check_reformat(params: CheckReformatParams) {
         )
     }
 
-    let formatted = format_node(format_options, &re_parse.syntax()).unwrap();
+    let formatted = format_node(context.clone(), &re_parse.syntax()).unwrap();
     let printed = formatted.print();
 
     if text != printed.as_code() {
-        let input_formatted = format_node(format_options, root).unwrap();
+        let input_formatted = format_node(context, root).unwrap();
 
         // Print a diff of the Formatter IR emitted for the input and the output
         let diff =

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -322,10 +322,7 @@ while(
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatContext {
-                indent_style: IndentStyle::Space(4),
-                ..JsFormatContext::default()
-            },
+            JsFormatContext::default().with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -357,10 +354,7 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatContext {
-                indent_style: IndentStyle::Space(4),
-                ..JsFormatContext::default()
-            },
+            JsFormatContext::default().with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -391,10 +385,7 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatContext {
-                indent_style: IndentStyle::Space(4),
-                ..JsFormatContext::default()
-            },
+            JsFormatContext::default().with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -413,10 +404,7 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatContext {
-                indent_style: IndentStyle::Space(4),
-                ..JsFormatContext::default()
-            },
+            JsFormatContext::default().with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -438,10 +426,7 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatContext {
-                indent_style: IndentStyle::Space(4),
-                ..JsFormatContext::default()
-            },
+            JsFormatContext::default().with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -472,7 +457,7 @@ mod test {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-        
+
 it(`does something really long and complicated so I have to write a very long name for the test`, function () {
   console.log("hello!");
  });

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -330,7 +330,7 @@ impl JsAnyAssignmentLike {
             JsAnyAssignmentLike::JsPropertyObjectMember(property) => {
                 let width = write_member_name(&property.name()?, f)?;
                 let text_width_for_break =
-                    (f.context().tab_width() + MIN_OVERLAP_FOR_BREAK) as usize;
+                    (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
                 Ok(width < text_width_for_break)
             }
             JsAnyAssignmentLike::JsAssignmentExpression(assignment) => {
@@ -341,7 +341,7 @@ impl JsAnyAssignmentLike {
             JsAnyAssignmentLike::JsObjectAssignmentPatternProperty(property) => {
                 let width = write_member_name(&property.member()?, f)?;
                 let text_width_for_break =
-                    (f.context().tab_width() + MIN_OVERLAP_FOR_BREAK) as usize;
+                    (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
                 Ok(width < text_width_for_break)
             }
             JsAnyAssignmentLike::JsVariableDeclarator(variable_declarator) => {

--- a/crates/rome_js_formatter/src/utils/member_chain/flatten_item.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/flatten_item.rs
@@ -1,3 +1,4 @@
+use crate::context::TabWidth;
 use crate::prelude::*;
 use rome_formatter::write;
 use rome_js_syntax::{
@@ -123,14 +124,14 @@ impl FlattenItem {
         }
     }
 
-    pub(crate) fn has_short_name(&self, tab_width: u8) -> SyntaxResult<bool> {
+    pub(crate) fn has_short_name(&self, tab_width: TabWidth) -> SyntaxResult<bool> {
         if let FlattenItem::StaticMember(static_member, ..) = self {
             if let JsAnyExpression::JsIdentifierExpression(identifier_expression) =
                 static_member.object()?
             {
                 let value_token = identifier_expression.name()?.value_token()?;
                 let text = value_token.text_trimmed();
-                Ok(text.len() <= tab_width as usize)
+                Ok(text.len() <= u8::from(tab_width) as usize)
             } else {
                 Ok(false)
             }

--- a/crates/rome_js_formatter/src/utils/member_chain/groups.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/groups.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use crate::utils::member_chain::flatten_item::FlattenItem;
 use crate::utils::member_chain::simple_argument::SimpleArgument;
 
+use crate::context::TabWidth;
 use rome_js_syntax::JsCallExpression;
 use rome_rowan::{AstSeparatedList, SyntaxResult};
 use std::mem;
@@ -23,17 +24,17 @@ pub(crate) struct Groups {
     /// By default, it's 2, meaning that we start breaking after the second group.
     cutoff: u8,
 
-    context: JsFormatContext,
+    tab_width: TabWidth,
 }
 
 impl Groups {
-    pub fn new(in_expression_statement: bool, context: JsFormatContext) -> Self {
+    pub fn new(in_expression_statement: bool, tab_width: TabWidth) -> Self {
         Self {
             in_expression_statement,
             groups: Vec::new(),
             current_group: Vec::new(),
             cutoff: 2,
-            context,
+            tab_width,
         }
     }
 
@@ -145,7 +146,7 @@ impl Groups {
     /// This is an heuristic needed to check when the first element of the group
     /// Should be part of the "head" or the "tail".
     fn should_not_wrap(&self, first_group: &HeadGroup) -> SyntaxResult<bool> {
-        let tab_with = self.context.tab_width();
+        let tab_with = self.tab_width;
         let has_computed_property = if self.groups.len() > 1 {
             // SAFETY: guarded by the previous check
             let group = &self.groups[0];

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -238,7 +238,7 @@ fn compute_groups(
     f: &JsFormatter,
 ) -> FormatResult<Groups> {
     let mut has_seen_call_expression = false;
-    let mut groups = Groups::new(in_expression_statement, *f.context());
+    let mut groups = Groups::new(in_expression_statement, f.context().tab_width());
     for item in flatten_items {
         let has_trailing_comments = item.as_syntax().has_trailing_comments();
 

--- a/crates/rome_js_formatter/src/utils/string_utils.rs
+++ b/crates/rome_js_formatter/src/utils/string_utils.rs
@@ -79,7 +79,7 @@ impl<'token> FormatLiteralStringToken<'token> {
         let chosen_quote_style = context.quote_style();
         let mut string_cleaner = LiteralStringNormaliser::new(self, chosen_quote_style);
 
-        let content = string_cleaner.normalise_text(context.source_type.into());
+        let content = string_cleaner.normalise_text(context.source_type().into());
         let normalized_text_width = content.width();
 
         CleanedStringLiteralText {

--- a/crates/rome_js_formatter/tests/check_reformat.rs
+++ b/crates/rome_js_formatter/tests/check_reformat.rs
@@ -20,7 +20,7 @@ pub fn check_reformat(params: CheckReformatParams) {
         text,
         source_type,
         file_name,
-        format_context: format_options,
+        format_context: context,
     } = params;
 
     let re_parse = parse(text, 0, source_type);
@@ -45,11 +45,11 @@ pub fn check_reformat(params: CheckReformatParams) {
         )
     }
 
-    let formatted = format_node(format_options, &re_parse.syntax()).unwrap();
+    let formatted = format_node(context.clone(), &re_parse.syntax()).unwrap();
     let printed = formatted.print();
 
     if text != printed.as_code() {
-        let input_format_element = format_node(format_options, root).unwrap();
+        let input_format_element = format_node(context, root).unwrap();
 
         // Print a diff of the Formatter IR emitted for the input and the output
         let diff =

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -60,10 +60,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
     let has_errors = parsed.has_errors();
     let syntax = parsed.syntax();
 
-    let context = JsFormatContext {
-        indent_style: IndentStyle::Space(2),
-        ..JsFormatContext::default()
-    };
+    let context = JsFormatContext::default().with_indent_style(IndentStyle::Space(2));
 
     let result = match (range_start_index, range_end_index) {
         (Some(start), Some(end)) => {
@@ -74,7 +71,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
             }
 
             rome_js_formatter::format_range(
-                context,
+                context.clone(),
                 &syntax,
                 TextRange::new(
                     TextSize::try_from(start).unwrap(),
@@ -82,7 +79,8 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
                 ),
             )
         }
-        _ => rome_js_formatter::format_node(context, &syntax).map(|formatted| formatted.print()),
+        _ => rome_js_formatter::format_node(context.clone(), &syntax)
+            .map(|formatted| formatted.print()),
     };
 
     let formatted = result.expect("formatting failed");
@@ -106,7 +104,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
                     text: &result,
                     source_type,
                     file_name,
-                    format_context: context,
+                    format_context: context.clone(),
                 });
             }
 
@@ -155,7 +153,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
         writeln!(snapshot).unwrap();
     }
 
-    let max_width = context.line_width.value() as usize;
+    let max_width = context.line_width().value() as usize;
     let mut lines_exceeding_max_width = formatted
         .lines()
         .enumerate()

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -3,7 +3,7 @@ use rome_diagnostics::{Applicability, Diagnostic};
 use rome_formatter::{IndentStyle, LineWidth, Printed};
 use rome_fs::RomePath;
 use rome_js_analyze::analyze;
-use rome_js_formatter::context::{JsFormatOptions, QuoteStyle};
+use rome_js_formatter::context::QuoteStyle;
 use rome_js_formatter::{context::JsFormatContext, format_node};
 use rome_js_parser::Parse;
 use rome_js_syntax::{JsAnyRoot, JsLanguage, SourceType, TextRange, TextSize, TokenAtOffset};
@@ -40,20 +40,20 @@ impl Language for JsLanguage {
         editor: IndentStyle,
         path: &RomePath,
     ) -> JsFormatContext {
-        JsFormatContext {
-            indent_style: language
-                .indent_style
-                .or(global.indent_style)
-                .unwrap_or(editor),
-            line_width: language
-                .line_width
-                .or(global.line_width)
-                .unwrap_or_default(),
-            options: JsFormatOptions {
-                quote_style: language.quote_style.unwrap_or_default(),
-            },
-            source_type: path.as_path().try_into().unwrap_or_default(),
-        }
+        JsFormatContext::new(path.as_path().try_into().unwrap_or_default())
+            .with_indent_style(
+                language
+                    .indent_style
+                    .or(global.indent_style)
+                    .unwrap_or(editor),
+            )
+            .with_line_width(
+                language
+                    .line_width
+                    .or(global.line_width)
+                    .unwrap_or_default(),
+            )
+            .with_quote_style(language.quote_style.unwrap_or_default())
     }
 }
 

--- a/website/playground/src/lib.rs
+++ b/website/playground/src/lib.rs
@@ -5,7 +5,7 @@ use rome_diagnostics::file::SimpleFiles;
 use rome_diagnostics::termcolor::{ColorSpec, WriteColor};
 use rome_diagnostics::Emitter;
 use rome_formatter::IndentStyle;
-use rome_js_formatter::context::{JsFormatContext, JsFormatOptions};
+use rome_js_formatter::context::JsFormatContext;
 use rome_js_formatter::format_node;
 use rome_js_parser::parse;
 use rome_js_syntax::{LanguageVariant, SourceType};
@@ -173,14 +173,10 @@ pub fn run(
         IndentStyle::Tab
     };
 
-    let context = JsFormatContext {
-        indent_style,
-        line_width: options.line_width.try_into().unwrap_or_default(),
-        options: JsFormatOptions {
-            quote_style: options.quote_style.parse().unwrap_or_default(),
-        },
-        source_type,
-    };
+    let context = JsFormatContext::new(source_type)
+        .with_indent_style(indent_style)
+        .with_line_width(options.line_width.try_into().unwrap_or_default())
+        .with_quote_style(options.quote_style.parse().unwrap_or_default());
 
     let (cst, ast) = if output_json {
         let cst_json = clean_up_json(


### PR DESCRIPTION
## Summary

Remove the `Copy` from `JsFormatContext` to allow storing non-copyable data in the context. The idea is to store the extracted comments as an `Rc<Comments>` but this isn't possible today because `Rc` (nor `Comments`) implements `Copy`.

## Test Plan

The rust compiler is so kind to point me towards all places where we now need to call `clone` (only in tests). 
