### PR TITLE
 feature(rome_js_formatter): Track suppression handling 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,9 +1459,11 @@ dependencies = [
 name = "rome_js_formatter"
 version = "0.0.0"
 dependencies = [
+ "cfg-if",
  "countme",
  "ctor",
  "iai",
+ "indexmap",
  "insta",
  "parking_lot",
  "quickcheck",

--- a/crates/rome_formatter/src/buffer.rs
+++ b/crates/rome_formatter/src/buffer.rs
@@ -276,7 +276,7 @@ Make sure that you take and restore the snapshot in order and that this snapshot
 ///
 /// drop(with_preamble);
 ///
-/// let formatted = Formatted::new(buffer.into_element(), PrinterOptions::default());
+/// let formatted = Formatted::new(buffer.into_element(), SimpleFormatContext::default());
 /// assert_eq!("# heading\nthis text will be on a new line", formatted.print().as_code());
 /// ```
 ///
@@ -300,7 +300,7 @@ Make sure that you take and restore the snapshot in order and that this snapshot
 /// let mut with_preamble = PreambleBuffer::new(&mut buffer, Preamble);
 /// drop(with_preamble);
 ///
-/// let formatted = Formatted::new(buffer.into_element(), PrinterOptions::default());
+/// let formatted = Formatted::new(buffer.into_element(), SimpleFormatContext::default());
 /// assert_eq!("", formatted.print().as_code());
 /// ```
 pub struct PreambleBuffer<'buf, Preamble, Context> {

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -194,6 +194,9 @@ impl From<LineWidth> for u16 {
 /// Defines the common formatting options. Implementations can define additional options that
 /// are specific to formatting a specific object.
 pub trait FormatContext {
+    /// The type storing a snapshot of the context's (mutable) state.
+    type Snapshot;
+
     /// The indent style.
     fn indent_style(&self) -> IndentStyle;
 
@@ -202,15 +205,23 @@ pub trait FormatContext {
 
     /// Derives the print options from the these format options
     fn as_print_options(&self) -> PrinterOptions;
+
+    /// Snapshots the state of the context that can be restored with `restore_snapshot`.
+    fn snapshot(&self) -> Self::Snapshot;
+
+    /// Restores the contexts state to the state when the snapshot was taken.
+    fn restore_snapshot(&mut self, snapshot: Self::Snapshot);
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct SimpleFormatContext {
     pub indent_style: IndentStyle,
     pub line_width: LineWidth,
 }
 
 impl FormatContext for SimpleFormatContext {
+    type Snapshot = ();
+
     fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -224,6 +235,10 @@ impl FormatContext for SimpleFormatContext {
             .with_indent(self.indent_style)
             .with_print_width(self.line_width)
     }
+
+    fn snapshot(&self) -> Self::Snapshot {}
+
+    fn restore_snapshot(&mut self, _: Self::Snapshot) {}
 }
 
 /// Lightweight sourcemap marker between source and output tokens
@@ -236,26 +251,35 @@ pub struct SourceMarker {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Formatted {
+pub struct Formatted<Context> {
     root: FormatElement,
-    options: PrinterOptions,
+    context: Context,
 }
 
-impl Formatted {
-    pub fn new(root: FormatElement, options: PrinterOptions) -> Self {
-        Self { root, options }
+impl<Context> Formatted<Context> {
+    pub fn new(root: FormatElement, context: Context) -> Self {
+        Self { root, context }
     }
 
-    pub fn print(&self) -> Printed {
-        Printer::new(self.options.clone()).print(&self.root)
-    }
-
-    pub fn print_with_indent(&self, indent: u16) -> Printed {
-        Printer::new(self.options.clone()).print_with_indent(&self.root, indent)
+    pub fn context(&self) -> &Context {
+        &self.context
     }
 
     pub fn into_format_element(self) -> FormatElement {
         self.root
+    }
+}
+
+impl<Context> Formatted<Context>
+where
+    Context: FormatContext,
+{
+    pub fn print(&self) -> Printed {
+        Printer::new(self.context.as_print_options()).print(&self.root)
+    }
+
+    pub fn print_with_indent(&self, indent: u16) -> Printed {
+        Printer::new(self.context.as_print_options()).print_with_indent(&self.root, indent)
     }
 }
 
@@ -492,7 +516,7 @@ pub trait FormatRuleWithOptions<T>: FormatRule<T> {
 /// use rome_formatter::prelude::*;
 /// use rome_formatter::{format, Formatted, FormatWithRule};
 /// use rome_rowan::{Language, SyntaxNode};
-/// fn format_node<L: Language, F: FormatWithRule<SimpleFormatContext, Item=SyntaxNode<L>>>(node: F) -> FormatResult<Formatted> {
+/// fn format_node<L: Language, F: FormatWithRule<SimpleFormatContext, Item=SyntaxNode<L>>>(node: F) -> FormatResult<Formatted<SimpleFormatContext>> {
 ///     let formatted = format!(SimpleFormatContext::default(), [node]);
 ///     let syntax = node.item();
 ///     // Do something with syntax
@@ -630,7 +654,7 @@ where
 ///
 /// write!(&mut buffer, [format_args!(token("Hello World"))]).unwrap();
 ///
-/// let formatted = Formatted::new(buffer.into_element(), PrinterOptions::default());
+/// let formatted = Formatted::new(buffer.into_element(), SimpleFormatContext::default());
 ///
 /// assert_eq!("Hello World", formatted.print().as_code())
 /// ```
@@ -646,7 +670,7 @@ where
 ///
 /// write!(&mut buffer, [token("Hello World")]).unwrap();
 ///
-/// let formatted = Formatted::new(buffer.into_element(), PrinterOptions::default());
+/// let formatted = Formatted::new(buffer.into_element(), SimpleFormatContext::default());
 ///
 /// assert_eq!("Hello World", formatted.print().as_code())
 /// ```
@@ -685,11 +709,13 @@ pub fn write<Context>(
 /// let formatted = format!(SimpleFormatContext::default(), [token("test")]).unwrap();
 /// assert_eq!("test", formatted.print().as_code());
 /// ```
-pub fn format<Context>(context: Context, arguments: Arguments<Context>) -> FormatResult<Formatted>
+pub fn format<Context>(
+    context: Context,
+    arguments: Arguments<Context>,
+) -> FormatResult<Formatted<Context>>
 where
     Context: FormatContext,
 {
-    let print_options = context.as_print_options();
     let mut state = FormatState::new(context);
     let mut buffer = VecBuffer::with_capacity(arguments.items().len(), &mut state);
 
@@ -697,7 +723,7 @@ where
 
     Ok(Formatted {
         root: buffer.into_element(),
-        options: print_options,
+        context: state.into_context(),
     })
 }
 
@@ -711,9 +737,8 @@ pub fn format_node<
 >(
     context: Context,
     root: &N,
-) -> FormatResult<Formatted> {
+) -> FormatResult<Formatted<Context>> {
     tracing::trace_span!("format_node").in_scope(move || {
-        let print_options = context.as_print_options();
         let mut state = FormatState::new(context);
         let mut buffer = VecBuffer::new(&mut state);
 
@@ -723,7 +748,7 @@ pub fn format_node<
 
         state.assert_formatted_all_tokens(root.item());
 
-        Ok(Formatted::new(document, print_options))
+        Ok(Formatted::new(document, state.into_context()))
     })
 }
 
@@ -1160,6 +1185,10 @@ impl<Context> FormatState<Context> {
         }
     }
 
+    pub fn into_context(self) -> Context {
+        self.context
+    }
+
     /// Returns `true` if the last written content is an inline comment with no trailing whitespace.
     ///
     /// The formatting of the next content may need to insert a whitespace to separate the
@@ -1238,28 +1267,6 @@ impl<Context> FormatState<Context> {
         &mut self.context
     }
 
-    pub fn snapshot(&self) -> FormatStateSnapshot {
-        FormatStateSnapshot {
-            last_content_inline_comment: self.last_content_inline_comment,
-            last_token_kind: self.last_token_kind,
-            manual_handled_comments_len: self.manually_formatted_comments.len(),
-            #[cfg(debug_assertions)]
-            printed_tokens: self.printed_tokens.clone(),
-        }
-    }
-
-    pub fn restore_snapshot(&mut self, snapshot: FormatStateSnapshot) {
-        self.last_content_inline_comment = snapshot.last_content_inline_comment;
-        self.last_token_kind = snapshot.last_token_kind;
-        self.manually_formatted_comments
-            .truncate(snapshot.manual_handled_comments_len);
-        cfg_if::cfg_if! {
-            if #[cfg(debug_assertions)] {
-                self.printed_tokens = snapshot.printed_tokens;
-            }
-        }
-    }
-
     /// Creates a new group id that is unique to this document. The passed debug name is used in the
     /// [std::fmt::Debug] of the document if this is a debug build.
     /// The name is unused for production builds and has no meaning on the equality of two group ids.
@@ -1291,6 +1298,35 @@ impl<Context> FormatState<Context> {
     }
 }
 
+impl<Context> FormatState<Context>
+where
+    Context: FormatContext,
+{
+    pub fn snapshot(&self) -> FormatStateSnapshot<Context::Snapshot> {
+        FormatStateSnapshot {
+            context: self.context.snapshot(),
+            last_content_inline_comment: self.last_content_inline_comment,
+            last_token_kind: self.last_token_kind,
+            manual_handled_comments_len: self.manually_formatted_comments.len(),
+            #[cfg(debug_assertions)]
+            printed_tokens: self.printed_tokens.clone(),
+        }
+    }
+
+    pub fn restore_snapshot(&mut self, snapshot: FormatStateSnapshot<Context::Snapshot>) {
+        self.context.restore_snapshot(snapshot.context);
+        self.last_content_inline_comment = snapshot.last_content_inline_comment;
+        self.last_token_kind = snapshot.last_token_kind;
+        self.manually_formatted_comments
+            .truncate(snapshot.manual_handled_comments_len);
+        cfg_if::cfg_if! {
+            if #[cfg(debug_assertions)] {
+                self.printed_tokens = snapshot.printed_tokens;
+            }
+        }
+    }
+}
+
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub struct LastTokenKind {
     kind_type: TypeId,
@@ -1307,7 +1343,8 @@ impl LastTokenKind {
     }
 }
 
-pub struct FormatStateSnapshot {
+pub struct FormatStateSnapshot<Context> {
+    context: Context,
     last_content_inline_comment: bool,
     last_token_kind: Option<LastTokenKind>,
     manual_handled_comments_len: usize,

--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -205,7 +205,7 @@ macro_rules! format {
 /// // Takes the first variant if everything fits on a single line
 /// assert_eq!(
 ///     "aVeryLongIdentifier([1, 2, 3])",
-///     Formatted::new(elements.clone(), PrinterOptions::default())
+///     Formatted::new(elements.clone(), SimpleFormatContext::default())
 ///         .print()
 ///         .as_code()
 /// );
@@ -214,7 +214,7 @@ macro_rules! format {
 /// // has some additional line breaks to make sure inner groups don't break
 /// assert_eq!(
 ///     "aVeryLongIdentifier([\n\t1, 2, 3\n])",
-///     Formatted::new(elements.clone(), PrinterOptions::default().with_print_width(21.try_into().unwrap()))
+///     Formatted::new(elements.clone(), SimpleFormatContext { line_width: 21.try_into().unwrap(), ..SimpleFormatContext::default() })
 ///         .print()
 ///         .as_code()
 /// );
@@ -222,7 +222,7 @@ macro_rules! format {
 /// // Prints the last option as last resort
 /// assert_eq!(
 ///     "aVeryLongIdentifier(\n\t[\n\t\t1,\n\t\t2,\n\t\t3\n\t]\n)",
-///     Formatted::new(elements.clone(), PrinterOptions::default().with_print_width(20.try_into().unwrap()))
+///     Formatted::new(elements.clone(), SimpleFormatContext { line_width: 20.try_into().unwrap(), ..SimpleFormatContext::default() })
 ///         .print()
 ///         .as_code()
 /// );
@@ -401,7 +401,10 @@ mod tests {
 
         let best_fitting_code = Formatted::new(
             formatted_best_fitting.into_format_element(),
-            PrinterOptions::default().with_print_width(30.try_into().unwrap()),
+            SimpleFormatContext {
+                line_width: 30.try_into().unwrap(),
+                ..SimpleFormatContext::default()
+            },
         )
         .print()
         .as_code()
@@ -409,7 +412,10 @@ mod tests {
 
         let normal_list_code = Formatted::new(
             formatted_normal_list.into_format_element(),
-            PrinterOptions::default().with_print_width(30.try_into().unwrap()),
+            SimpleFormatContext {
+                line_width: 30.try_into().unwrap(),
+                ..SimpleFormatContext::default()
+            },
         )
         .print()
         .as_code()

--- a/crates/rome_js_formatter/Cargo.toml
+++ b/crates/rome_js_formatter/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cfg-if = "1.0.0"
+indexmap = "1.8.2"
 rome_js_syntax = { path = "../rome_js_syntax" }
 rome_formatter = { path = "../rome_formatter" }
 rome_rowan = { path = "../rome_rowan" }

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -1,8 +1,11 @@
+#[cfg(debug_assertions)]
+use indexmap::IndexSet;
 use rome_formatter::printer::PrinterOptions;
 use rome_formatter::{
     CommentContext, CommentKind, CommentStyle, FormatContext, IndentStyle, LineWidth,
 };
-use rome_js_syntax::{JsLanguage, JsSyntaxKind, SourceType};
+use rome_js_syntax::suppression::{has_suppressions_category, SuppressionCategory};
+use rome_js_syntax::{JsLanguage, JsSyntaxKind, JsSyntaxNode, SourceType};
 use rome_rowan::SyntaxTriviaPieceComments;
 use std::fmt;
 use std::fmt::Debug;
@@ -21,6 +24,9 @@ pub struct JsFormatContext {
 
     /// Information relative to the current file
     source_type: SourceType,
+
+    #[cfg(debug_assertions)]
+    checked_node_suppressions: IndexSet<JsSyntaxNode>,
 }
 
 impl JsFormatContext {
@@ -62,6 +68,53 @@ impl JsFormatContext {
     pub fn source_type(&self) -> SourceType {
         self.source_type
     }
+
+    /// Returns `true` if the passed node has a suppression comment and
+    /// tracks in debug builds that the suppression comments of this node have been checked.
+    #[inline]
+    pub(crate) fn is_suppressed(&mut self, node: &JsSyntaxNode) -> bool {
+        self.checked_suppressed(node);
+        has_suppressions_category(SuppressionCategory::Format, node)
+    }
+
+    /// Tracks that the formatting manually checked if the passed in node has a suppression comment
+    /// in debug builds.
+    pub(crate) fn checked_suppressed(&mut self, #[allow(unused_variables)] node: &JsSyntaxNode) {
+        cfg_if::cfg_if! {
+            if #[cfg(debug_assertions)] {
+                self.checked_node_suppressions.insert(node.clone());
+            }
+        }
+    }
+
+    /// Asserts that the suppression comments of all nodes have been handled in debug builds.
+    ///
+    /// # Panics
+    /// If the suppression comments of a node have not been checked.
+    #[inline]
+    pub(crate) fn assert_checked_all_suppressions(
+        &self,
+        #[allow(unused_variables)] root: &JsSyntaxNode,
+    ) {
+        cfg_if::cfg_if! {
+            if #[cfg(debug_assertions)] {
+                for node in root.descendants() {
+                    if !self.checked_node_suppressions.contains(&node) {
+                        // No need to explicitly check nodes where the node is the first element of its parent
+                        // (in which case the suppression would suppress the parent node), or when
+                        // the node is a list for which Rome doesn't support suppression comments
+                        if node.prev_sibling_or_token().is_none() || node.kind().is_list() {
+                            continue;
+                        }
+
+                        panic!(r#"The node {node:#?} has been formatted without checking if it has suppression comments.
+Ensure that the formatter calls into the node's formatting rule by using `node.format()` or
+manually test if the node has a suppression comment using `f.context_mut().is_suppressed(node.syntax())` if using the node's format rule isn't an option"#)
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
@@ -89,6 +142,8 @@ impl JsFormatContext {
 }
 
 impl FormatContext for JsFormatContext {
+    type Snapshot = JsFormatContextSnapshot;
+
     fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -102,6 +157,26 @@ impl FormatContext for JsFormatContext {
             .with_indent(self.indent_style)
             .with_print_width(self.line_width)
     }
+
+    fn snapshot(&self) -> Self::Snapshot {
+        JsFormatContextSnapshot {
+            #[cfg(debug_assertions)]
+            node_suppressions_len: self.checked_node_suppressions.len(),
+        }
+    }
+
+    fn restore_snapshot(&mut self, #[allow(unused)] snapshot: Self::Snapshot) {
+        cfg_if::cfg_if! {
+            if #[cfg(debug_assertions)] {
+                self.checked_node_suppressions.truncate(snapshot.node_suppressions_len);
+            }
+        }
+    }
+}
+
+pub struct JsFormatContextSnapshot {
+    #[cfg(debug_assertions)]
+    node_suppressions_len: usize,
 }
 
 impl fmt::Display for JsFormatContext {

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -71,8 +71,27 @@ impl JsFormatContext {
 
     /// Returns `true` if the passed node has a suppression comment and
     /// tracks in debug builds that the suppression comments of this node have been checked.
+    ///
+    /// # Examples
+    /// ```
+    /// use rome_js_formatter::context::JsFormatContext;
+    /// use rome_js_formatter::prelude::*;
+    /// use rome_js_parser::parse_expression;
+    /// use rome_js_syntax::SourceType;
+    ///
+    /// let root = parse_expression(r#"
+    /// // rome-ignore format: Suppressed for testing purposes
+    /// console.log('abcd');
+    /// "#, 0).tree();
+    ///
+    /// let call_expression = root.expression().unwrap();
+    /// let mut context = JsFormatContext::new(SourceType::js_module());
+    ///
+    /// assert!(context.is_suppressed(call_expression.syntax()));
+    /// ```
+    ///
     #[inline]
-    pub(crate) fn is_suppressed(&mut self, node: &JsSyntaxNode) -> bool {
+    pub fn is_suppressed(&mut self, node: &JsSyntaxNode) -> bool {
         self.checked_suppressed(node);
         has_suppressions_category(SuppressionCategory::Format, node)
     }

--- a/crates/rome_js_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/property_class_member.rs
@@ -9,10 +9,12 @@ pub struct FormatJsPropertyClassMember;
 impl FormatNodeRule<JsPropertyClassMember> for FormatJsPropertyClassMember {
     fn fmt_fields(&self, node: &JsPropertyClassMember, f: &mut JsFormatter) -> FormatResult<()> {
         let semicolon_token = node.semicolon_token();
-        let body = format_with(|f| write!(f, [JsAnyAssignmentLike::from(node.clone())]));
         write!(
             f,
-            [FormatWithSemicolon::new(&body, semicolon_token.as_ref())]
+            [FormatWithSemicolon::new(
+                &JsAnyAssignmentLike::from(node.clone()),
+                semicolon_token.as_ref()
+            )]
         )
     }
 }

--- a/crates/rome_js_formatter/src/js/module/import_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_named_clause.rs
@@ -52,7 +52,8 @@ impl FormatNodeRule<JsImportNamedClause> for FormatJsImportNamedClause {
         } else {
             match named_import {
                 JsAnyNamedImport::JsNamedImportSpecifiers(ref specifiers)
-                    if specifiers.specifiers().len() == 1 =>
+                    if specifiers.specifiers().len() == 1
+                        && !f.context_mut().is_suppressed(specifiers.syntax()) =>
                 {
                     // SAFETY: we know that the `specifiers.specifiers().len() == 1`, so unwrap `iter().next()` is safe.
                     let first_specifier = specifiers.specifiers().elements().next().unwrap();

--- a/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
@@ -25,22 +25,25 @@ impl FormatNodeRule<JsxExpressionChild> for FormatJsxExpressionChild {
             JsAnyLiteralExpression::JsStringLiteralExpression(string_literal),
         )) = &expression
         {
-            if !string_literal.syntax().has_comments_direct()
+            let str_token = string_literal.value_token()?;
+            let trimmed_text = str_token.text_trimmed();
+
+            let has_space_text = trimmed_text == "' '" || trimmed_text == "\" \"";
+            let no_trivia = !str_token.has_leading_non_whitespace_trivia()
+                && !str_token.has_trailing_comments()
                 && !l_curly_token.has_trailing_comments()
-                && !r_curly_token.has_leading_comments()
-            {
-                if let Ok(str_token) = string_literal.value_token() {
-                    if str_token.text().contains("' '") || str_token.text().contains("\" \"") {
-                        return write![
-                            f,
-                            [
-                                format_removed(&l_curly_token),
-                                format_replaced(&str_token, &JsxSpace::default()),
-                                format_removed(&r_curly_token)
-                            ]
-                        ];
-                    }
-                }
+                && !r_curly_token.has_leading_non_whitespace_trivia();
+            let is_suppressed = f.context_mut().is_suppressed(string_literal.syntax());
+
+            if has_space_text && no_trivia && !is_suppressed {
+                return write![
+                    f,
+                    [
+                        format_removed(&l_curly_token),
+                        format_replaced(&str_token, &JsxSpace::default()),
+                        format_removed(&r_curly_token)
+                    ]
+                ];
             }
         }
 

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -3,7 +3,7 @@
 mod cst;
 mod js;
 mod jsx;
-pub(crate) mod prelude;
+pub mod prelude;
 mod ts;
 pub mod utils;
 

--- a/crates/rome_js_formatter/src/utils/format_conditional.rs
+++ b/crates/rome_js_formatter/src/utils/format_conditional.rs
@@ -31,19 +31,29 @@ impl Conditional {
     fn format_head(&self, f: &mut JsFormatter) -> FormatResult<()> {
         match self {
             Conditional::Expression(expr) => {
-                write![f, [expr.test()?.format(), space_token(),]]
+                if f.context_mut().is_suppressed(expr.syntax()) {
+                    write!(f, [format_verbatim_node(expr.syntax())])
+                } else {
+                    write![f, [expr.test()?.format(), space_token(),]]
+                }
             }
-            Conditional::Type(t) => write![
-                f,
-                [
-                    t.check_type()?.format(),
-                    space_token(),
-                    t.extends_token()?.format(),
-                    space_token(),
-                    t.extends_type()?.format(),
-                    space_token(),
-                ]
-            ],
+            Conditional::Type(t) => {
+                if f.context_mut().is_suppressed(t.syntax()) {
+                    write!(f, [format_verbatim_node(t.syntax())])
+                } else {
+                    write![
+                        f,
+                        [
+                            t.check_type()?.format(),
+                            space_token(),
+                            t.extends_token()?.format(),
+                            space_token(),
+                            t.extends_type()?.format(),
+                            space_token(),
+                        ]
+                    ]
+                }
+            }
         }
     }
     fn consequent_to_conditional(&self) -> FormatResult<Option<Self>> {

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -23,7 +23,6 @@ pub(crate) use member_chain::format_call_expression;
 pub(crate) use object_like::JsObjectLike;
 pub(crate) use object_pattern_like::JsObjectPatternLike;
 use rome_formatter::{format_args, normalize_newlines, write, Buffer, VecBuffer};
-use rome_js_syntax::suppression::{has_suppressions_category, SuppressionCategory};
 use rome_js_syntax::{
     JsAnyExpression, JsAnyFunction, JsAnyStatement, JsInitializerClause, JsLanguage,
     JsTemplateElement, Modifiers, TsTemplateElement, TsType,
@@ -179,10 +178,6 @@ impl Format<JsFormatContext> for FormatBodyStatement<'_> {
             }
         }
     }
-}
-
-pub(crate) fn has_formatter_suppressions(node: &JsSyntaxNode) -> bool {
-    has_suppressions_category(SuppressionCategory::Format, node)
 }
 
 /// This function consumes a list of modifiers and applies a predictable sorting.

--- a/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js
@@ -256,3 +256,10 @@ var looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 let loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2 = this(
 	//comment
 	-12312312321321312).ewqeqewqweqweqweqweqweqweqw;
+
+
+const a
+	// rome-ignore format: Ignore the initializer
+				=
+
+			[A,    B,   C].push( aaa )

--- a/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
@@ -262,6 +262,13 @@ let looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 	//comment
 	-12312312321321312).ewqeqewqweqweqweqweqweqweqw;
 
+
+const a
+	// rome-ignore format: Ignore the initializer
+				=
+
+			[A,    B,   C].push( aaa )
+
 =============================
 # Outputs
 ## Output 1
@@ -720,6 +727,12 @@ let looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 		//comment
 		-12312312321321312,
 	).ewqeqewqweqweqweqweqweqweqw;
+
+const a
+	// rome-ignore format: Ignore the initializer
+				=
+
+			[A,    B,   C].push( aaa );
 
 
 ## Lines exceeding width of 80 characters

--- a/crates/rome_rowan/src/syntax/token.rs
+++ b/crates/rome_rowan/src/syntax/token.rs
@@ -92,7 +92,7 @@ impl<L: Language> SyntaxToken<L> {
     }
 
     /// Returns the text of a token, including all trivia as an owned value.
-    ///  
+    ///
     /// ```
     /// use rome_rowan::raw_language::{RawLanguage, RawLanguageKind, RawSyntaxTreeBuilder};
     /// use rome_rowan::*;
@@ -295,7 +295,6 @@ impl<L: Language> SyntaxToken<L> {
     pub fn has_trailing_comments(&self) -> bool {
         self.trailing_trivia()
             .pieces()
-            .into_iter()
             .any(|piece| piece.is_comments())
     }
 
@@ -303,8 +302,14 @@ impl<L: Language> SyntaxToken<L> {
     pub fn has_leading_comments(&self) -> bool {
         self.leading_trivia()
             .pieces()
-            .into_iter()
             .any(|piece| piece.is_comments())
+    }
+
+    /// Checks if the token has any leading trivia that isn't a whitespace nor a line break
+    pub fn has_leading_non_whitespace_trivia(&self) -> bool {
+        self.leading_trivia()
+            .pieces()
+            .any(|piece| piece.is_whitespace() || piece.is_newline())
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds a debug-only tracking that verifies if the formatter checked the suppression comments for every node. Doing so is useful in cases where our implementation bypasses the node's `FormatNodeRule` implementation that otherwise handles suppressions automatically.


## Test Plan

Fixed the existing tests that started failing because of missing suppression checks. 
