### PR TITLE
feat(rome_control_flow): add the control flow crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "rome_console",
+ "rome_control_flow",
  "rome_diagnostics",
  "rome_js_factory",
  "rome_js_syntax",
@@ -1344,6 +1345,13 @@ dependencies = [
  "text-size",
  "trybuild",
  "unicode-width",
+]
+
+[[package]]
+name = "rome_control_flow"
+version = "0.1.0"
+dependencies = [
+ "rome_rowan",
 ]
 
 [[package]]

--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 rome_rowan = { path = "../rome_rowan" }
+rome_control_flow = { path = "../rome_control_flow" }
 rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 bitflags = "1.3.2"

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -15,6 +15,7 @@ pub struct RuleRegistry<'a, L: Language, B> {
     /// Holds a collection of rules for each [SyntaxKind] node type that has
     /// lint rules associated with it
     ast_rules: Vec<SyntaxKindRules<L, B>>,
+    control_flow: Vec<RegistryRule<L, B>>,
     emit_signal: Box<dyn FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<B> + 'a>,
 }
 
@@ -22,6 +23,7 @@ impl<'a, L: Language, B> RuleRegistry<'a, L, B> {
     pub fn new(emit_signal: impl FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<B> + 'a) -> Self {
         Self {
             ast_rules: Vec::new(),
+            control_flow: Vec::new(),
             emit_signal: Box::new(emit_signal),
         }
     }
@@ -52,6 +54,9 @@ impl<'a, L: Language, B> RuleRegistry<'a, L, B> {
                     let node = &mut self.ast_rules[index];
                     node.rules.push(RegistryRule::of::<R>());
                 }
+            }
+            QueryKey::ControlFlowGraph => {
+                self.control_flow.push(RegistryRule::of::<R>());
             }
         }
     }
@@ -110,6 +115,7 @@ where
                     None => return ControlFlow::Continue(()),
                 }
             }
+            QueryMatch::ControlFlowGraph(_) => &self.control_flow,
         };
 
         // Run all the rules registered to this QueryMatch

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -119,6 +119,7 @@ mod tests {
                     nodes.push(node.kind());
                     ControlFlow::Continue(())
                 }
+                _ => panic!("unexpected QueryMatch variant"),
             }),
         };
 

--- a/crates/rome_control_flow/Cargo.toml
+++ b/crates/rome_control_flow/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rome_control_flow"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rome_rowan = { path = "../rome_rowan" }

--- a/crates/rome_control_flow/src/builder.rs
+++ b/crates/rome_control_flow/src/builder.rs
@@ -1,0 +1,75 @@
+use rome_rowan::Language;
+
+use crate::{BasicBlock, ControlFlowGraph, Instruction};
+
+/// Identifier for a block in a [ControlFlowGraph]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BlockId {
+    index: u32,
+}
+
+impl BlockId {
+    /// Returns the index of the block in the function
+    pub fn index(self) -> u32 {
+        self.index
+    }
+}
+
+/// Helper struct for building an instance of [ControlFlowGraph], the builder
+/// keeps track of an "insertion cursor" within the graph where [Instruction]
+/// should be added
+pub struct FunctionBuilder<L: Language> {
+    result: ControlFlowGraph<L>,
+    block_cursor: BlockId,
+}
+
+impl<L: Language> Default for FunctionBuilder<L> {
+    fn default() -> Self {
+        Self {
+            result: ControlFlowGraph::new(),
+            block_cursor: BlockId { index: 0 },
+        }
+    }
+}
+
+impl<L: Language> FunctionBuilder<L> {
+    /// Finishes building the function
+    pub fn finish(self) -> ControlFlowGraph<L> {
+        self.result
+    }
+
+    /// Allocate a new empty block, returning its [BlockId]
+    pub fn append_block(&mut self) -> BlockId {
+        let index = self
+            .result
+            .blocks
+            .len()
+            .try_into()
+            .expect("BlockId overflow");
+
+        self.result.blocks.push(BasicBlock::new());
+        BlockId { index }
+    }
+
+    /// Get the [BlockId] at the current position of the cursor
+    pub fn cursor(&self) -> BlockId {
+        self.block_cursor
+    }
+
+    /// Move the cursor to the end of `block`
+    pub fn set_cursor(&mut self, block: BlockId) {
+        debug_assert!(block.index < self.result.blocks.len() as u32);
+        self.block_cursor = block;
+    }
+
+    /// Insert an instruction at the current position of the cursor
+    pub fn append_instruction(&mut self, inst: Instruction<L>) {
+        let index = self.block_cursor.index as usize;
+        self.result.blocks[index].instructions.push(inst);
+    }
+
+    /// Add a block to the list of entry points for the function
+    pub fn add_entry_block(&mut self, block: BlockId) {
+        self.result.entry_blocks.push(block.index());
+    }
+}

--- a/crates/rome_control_flow/src/lib.rs
+++ b/crates/rome_control_flow/src/lib.rs
@@ -9,7 +9,7 @@ pub mod builder;
 
 use crate::builder::BlockId;
 
-/// The ControlFlowGraph is an auxiliary data structure to the syntax tree,
+/// The [ControlFlowGraph] is an auxiliary data structure to the syntax tree,
 /// representing the execution order of statements and expressions in a given
 /// function as a graph of [BasicBlock]
 #[derive(Debug, Clone)]
@@ -35,12 +35,12 @@ impl<L: Language> ControlFlowGraph<L> {
 }
 
 /// A basic block represents an atomic unit of control flow, a flat list of
-/// instruction that will be executed linearly when the function is run
+/// instructions that will be executed linearly when a function is run.
 ///
-/// Note however that while the instructions that comprise a basic block are
+/// Note, however, that while the instructions that comprise a basic block are
 /// guaranteed to be executed in order from the start towards the end, the
 /// block may not be executed entirely if a jump or return instruction is
-/// encountered
+/// encountered.
 #[derive(Debug, Clone)]
 pub struct BasicBlock<L: Language> {
     pub instructions: Vec<Instruction<L>>,
@@ -54,14 +54,14 @@ impl<L: Language> BasicBlock<L> {
     }
 }
 
-/// Instructions are used to represent statements or expression being executed
-/// for side effects, as well as potential divergence points for the control flow
+/// Instructions are used to represent statements or expressions being executed
+/// as side effects, as well as potential divergence points for the control flow.
 ///
 /// Each node has an associated kind, as well as an optional syntax node: the
 /// node is useful to emit diagnostics but does not have a semantic value, and
-/// is optional as the code generating the control flow graph may emit
-/// instructions that do not correspond to any node in the syntax tree to model
-/// the control flow of the program accurately
+/// is optional. The code generating the control flow graph may emit
+/// instructions that do not correspond to any node in the syntax tree, to model
+/// the control flow of the program accurately.
 #[derive(Debug, Clone)]
 pub struct Instruction<L: Language> {
     pub kind: InstructionKind,
@@ -75,15 +75,15 @@ pub enum InstructionKind {
     /// evaluated at this point in the program
     Statement,
     /// This instruction may cause the control flow to diverge towards `block`,
-    /// either unconditionally if `conditional` is set to false, or after
+    /// either unconditionally if `conditional` is set to `false`, or after
     /// evaluating the associated syntax node otherwise
     Jump { conditional: bool, block: BlockId },
     /// This instruction causes the control flow to unconditionally abort the
-    /// execution of the function, either due to a `return` or `throw` statement
+    /// execution of the function, for example is JavaScript this can be triggered by a `return` or `throw` statement
     Return,
 }
 
-/// The Display implementation for ControlFlowGraph prints a flowchart in
+/// The Display implementation for [ControlFlowGraph] prints a flowchart in
 /// mermaid.js syntax
 ///
 /// By default the graph is printed in "simple" mode where each basic block is

--- a/crates/rome_control_flow/src/lib.rs
+++ b/crates/rome_control_flow/src/lib.rs
@@ -1,0 +1,250 @@
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+};
+
+use rome_rowan::{Language, SyntaxNode};
+
+pub mod builder;
+
+use crate::builder::BlockId;
+
+/// The ControlFlowGraph is an auxiliary data structure to the syntax tree,
+/// representing the execution order of statements and expressions in a given
+/// function as a graph of [BasicBlock]
+#[derive(Debug, Clone)]
+pub struct ControlFlowGraph<L: Language> {
+    /// List of blocks that make up this function
+    pub blocks: Vec<BasicBlock<L>>,
+    /// Indices of the block that act as "entry point" for the function,
+    /// defined as points that the control flow may arbitrarily jump into
+    ///
+    /// Currently this is used for the first block in the function, as well as
+    /// `catch` and `finally` clauses to model the exception control flow
+    /// possibly diverging into these
+    pub entry_blocks: Vec<u32>,
+}
+
+impl<L: Language> ControlFlowGraph<L> {
+    fn new() -> Self {
+        ControlFlowGraph {
+            blocks: vec![BasicBlock::new()],
+            entry_blocks: vec![0],
+        }
+    }
+}
+
+/// A basic block represents an atomic unit of control flow, a flat list of
+/// instruction that will be executed linearly when the function is run
+///
+/// Note however that while the instructions that comprise a basic block are
+/// guaranteed to be executed in order from the start towards the end, the
+/// block may not be executed entirely if a jump or return instruction is
+/// encountered
+#[derive(Debug, Clone)]
+pub struct BasicBlock<L: Language> {
+    pub instructions: Vec<Instruction<L>>,
+}
+
+impl<L: Language> BasicBlock<L> {
+    fn new() -> Self {
+        Self {
+            instructions: Vec::new(),
+        }
+    }
+}
+
+/// Instructions are used to represent statements or expression being executed
+/// for side effects, as well as potential divergence points for the control flow
+///
+/// Each node has an associated kind, as well as an optional syntax node: the
+/// node is useful to emit diagnostics but does not have a semantic value, and
+/// is optional as the code generating the control flow graph may emit
+/// instructions that do not correspond to any node in the syntax tree to model
+/// the control flow of the program accurately
+#[derive(Debug, Clone)]
+pub struct Instruction<L: Language> {
+    pub kind: InstructionKind,
+    pub node: Option<SyntaxNode<L>>,
+}
+
+/// The different types of supported [Instruction]
+#[derive(Copy, Clone, Debug)]
+pub enum InstructionKind {
+    /// Indicates the [SyntaxNode] associated with this instruction is to be
+    /// evaluated at this point in the program
+    Statement,
+    /// This instruction may cause the control flow to diverge towards `block`,
+    /// either unconditionally if `conditional` is set to false, or after
+    /// evaluating the associated syntax node otherwise
+    Jump { conditional: bool, block: BlockId },
+    /// This instruction causes the control flow to unconditionally abort the
+    /// execution of the function, either due to a `return` or `throw` statement
+    Return,
+}
+
+/// The Display implementation for ControlFlowGraph prints a flowchart in
+/// mermaid.js syntax
+///
+/// By default the graph is printed in "simple" mode where each basic block is
+/// represented as a node in the graph:
+///
+/// ```mermaid
+/// flowchart TB
+///     block_0["<b>block_0</b><br/>Statement(JS_VARIABLE_DECLARATION 38..47)<br/>Jump { block: 1 }"]
+///     block_1["<b>block_1</b><br/>Jump { condition: JS_BINARY_EXPRESSION 49..58, block: 2 }<br/>Jump { block: 3 }"]
+///     block_2["<b>block_2</b><br/>Statement(JS_POST_UPDATE_EXPRESSION 60..63)"]
+///     block_3["<b>block_3</b><br/>Statement(JS_EXPRESSION_STATEMENT 260..277)"]
+///     
+///     block_0 --> block_1
+///     block_1 -- "JS_BINARY_EXPRESSION 49..58" --> block_2
+///     block_1 --> block_3
+/// ```
+///
+/// However the graph can also be printed in "detailed" mode by formatting it
+/// in alternate mode using `{:#}`, this will print each basic block as a
+/// subgraph instead:
+///
+/// ```mermaid
+/// flowchart TB
+///     subgraph block_0
+///         direction TB
+///         block_0_inst_0["Statement(JS_VARIABLE_DECLARATION 38..47)"]
+///         block_0_inst_0 --> block_0_inst_1["Jump { block: 1 }"]
+///     end
+///     subgraph block_1
+///         direction TB
+///         block_1_inst_0["Jump { condition: JS_BINARY_EXPRESSION 49..58, block: 2 }"]
+///         block_1_inst_0 --> block_1_inst_1["Jump { block: 3 }"]
+///     end
+///     subgraph block_2
+///         direction TB
+///         block_2_inst_0["Statement(JS_POST_UPDATE_EXPRESSION 60..63)"]
+///     end
+///     subgraph block_3
+///         direction TB
+///         block_3_inst_0["Statement(JS_EXPRESSION_STATEMENT 260..277)"]
+///     end
+///
+///     block_0_inst_1 --> block_1
+///     block_1_inst_0 -- "JS_BINARY_EXPRESSION 49..58" --> block_2
+///     block_1_inst_1 --> block_3
+/// ```
+impl<L: Language> Display for ControlFlowGraph<L> {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        writeln!(fmt, "flowchart TB")?;
+
+        let mut links = HashMap::new();
+        for (id, block) in self.blocks.iter().enumerate() {
+            if fmt.alternate() {
+                writeln!(fmt, "    subgraph block_{id}")?;
+                writeln!(fmt, "        direction TB")?;
+            } else {
+                write!(fmt, "    block_{id}[\"<b>block_{id}</b><br/>")?;
+            }
+
+            for (index, inst) in block.instructions.iter().enumerate() {
+                if fmt.alternate() {
+                    write!(fmt, "        ")?;
+
+                    if let Some(index) = index.checked_sub(1) {
+                        write!(fmt, "block_{id}_inst_{index} --> ")?;
+                    }
+
+                    writeln!(fmt, "block_{id}_inst_{index}[\"{inst}\"]")?;
+                } else {
+                    if index > 0 {
+                        write!(fmt, "<br/>")?;
+                    }
+
+                    write!(fmt, "{inst}")?;
+                }
+
+                if let InstructionKind::Jump { conditional, block } = inst.kind {
+                    links.insert(
+                        (id, index, block.index()),
+                        inst.node
+                            .as_ref()
+                            .filter(|_| conditional)
+                            .map(|node| (node.kind(), node.text_trimmed_range())),
+                    );
+                }
+            }
+
+            if fmt.alternate() {
+                writeln!(fmt, "    end")?;
+            } else {
+                writeln!(fmt, "\"]")?;
+            }
+        }
+
+        writeln!(fmt)?;
+
+        for ((id, index, to), condition) in links {
+            write!(fmt, "    block_{id}")?;
+
+            if fmt.alternate() {
+                write!(fmt, "_inst_{index}")?;
+            }
+
+            if let Some((cond, range)) = condition {
+                write!(fmt, " -- \"{cond:?} {range:?}\"")?;
+            }
+
+            writeln!(fmt, " --> block_{to}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<L: Language> Display for Instruction<L> {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        match self.kind {
+            InstructionKind::Statement => {
+                if let Some(node) = &self.node {
+                    write!(
+                        fmt,
+                        "Statement({:?} {:?})",
+                        node.kind(),
+                        node.text_trimmed_range()
+                    )
+                } else {
+                    write!(fmt, "Statement")
+                }
+            }
+
+            InstructionKind::Jump {
+                conditional: true,
+                block,
+            } if self.node.is_some() => {
+                // SAFETY: Checked by the above call to `is_some`
+                let node = self.node.as_ref().unwrap();
+                write!(
+                    fmt,
+                    "Jump {{ condition: {:?} {:?}, block: {} }}",
+                    node.kind(),
+                    node.text_trimmed_range(),
+                    block.index()
+                )
+            }
+
+            InstructionKind::Jump { block, .. } => {
+                write!(fmt, "Jump {{ block: {} }}", block.index())
+            }
+
+            InstructionKind::Return => {
+                if let Some(node) = &self.node {
+                    write!(
+                        fmt,
+                        "Return({:?} {:?})",
+                        node.kind(),
+                        node.text_trimmed_range()
+                    )
+                } else {
+                    write!(fmt, "Return")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a new `rome_control_flow` containing the data structures needed to represent a control flow graph, as well as associated helpers for building such a graph.

The control flow graph is an auxiliary data structure to the syntax tree representing the execution order of statements and expressions in the function as a graph of "basic blocks" comprised of a flattened list of instruction. There are currently 3 kind of instructions: `Statement` denotes the execution of a certain syntax node that may have some side effects but does not explicitly impact the control flow, `Jump` signals an edge from the current block to another block in the function (the edge may be conditional in which case it will generally be associated with an expression), and finally `Return` represents an exit point for the function (these includes return statements but also throw statements).

As an example, considering the following JavaScript function:

```js
function exampleLoop(count) {
    for(let i = 0; i < count; i++) {
        if(count - i === 2) {
            continue;
        }

        if(i % 3 === 0) {
            callExpression(i + 1);
        } else {
            callExpression(i);
        }
    }

    callExpression();
}
```

The following control flow graph would be generated:

```mermaid
flowchart TB
    block_0["<b>block_0</b><br/>Statement(JS_VARIABLE_DECLARATION 38..47)<br/>Jump { block: 1 }"]
    block_1["<b>block_1</b><br/>Jump { condition: JS_BINARY_EXPRESSION 49..58, block: 4 }<br/>Jump { block: 3 }"]
    block_2["<b>block_2</b><br/>Statement(JS_POST_UPDATE_EXPRESSION 60..63)<br/>Jump { block: 1 }"]
    block_3["<b>block_3</b><br/>Statement(JS_EXPRESSION_STATEMENT 260..277)"]
    block_4["<b>block_4</b><br/>Jump { condition: JS_BINARY_EXPRESSION 78..93, block: 5 }<br/>Jump { block: 6 }"]
    block_5["<b>block_5</b><br/>Jump { block: 2 }<br/>Jump { block: 6 }"]
    block_6["<b>block_6</b><br/>Jump { condition: JS_BINARY_EXPRESSION 141..152, block: 7 }<br/>Jump { block: 8 }"]
    block_7["<b>block_7</b><br/>Statement(JS_EXPRESSION_STATEMENT 168..190)<br/>Jump { block: 9 }"]
    block_8["<b>block_8</b><br/>Statement(JS_EXPRESSION_STATEMENT 220..238)<br/>Jump { block: 9 }"]
    block_9["<b>block_9</b><br/>Jump { block: 2 }"]

    block_4 --> block_6
    block_1 --> block_3
    block_1 -- "JS_BINARY_EXPRESSION 49..58" --> block_4
    block_6 -- "JS_BINARY_EXPRESSION 141..152" --> block_7
    block_5 --> block_2
    block_2 --> block_1
    block_8 --> block_9
    block_0 --> block_1
    block_6 --> block_8
    block_7 --> block_9
    block_9 --> block_2
    block_4 -- "JS_BINARY_EXPRESSION 78..93" --> block_5
    block_5 --> block_6
```

(Note that the generated graph contains extraneous jumps and edges, these could be avoided in the generation pass but ultimately it does not influence the end result as everything following an unconditional jump is treated as unreachable)

## Test Plan

The crate doesn't really have any tests at the moment since it's mostly comprised of definitions for plain data structures, while the code generating these is intended to live in the language-specific analyzer implementations. I could however try to add a few tests for the `FunctionBuilder` helper using the `RawLanguage` from `rome_rowan`
