### PR TITLE
refactor(rome_formatter): Format leading/trailing node comments with most outer node

### DIFF
--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -1,14 +1,12 @@
 use crate::prelude::*;
 use crate::{
-    format_element, write, Argument, Arguments, BufferSnapshot, FormatState, GroupId,
-    PreambleBuffer, TextRange, TextSize,
+    format_element, write, Argument, Arguments, GroupId, PreambleBuffer, TextRange, TextSize,
 };
 use crate::{Buffer, VecBuffer};
 use rome_rowan::{Language, SyntaxNode, SyntaxToken, SyntaxTokenText, TextLen};
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::marker::PhantomData;
-use std::ops::Deref;
 
 /// A line break that only gets printed if the enclosing `Group` doesn't fit on a single line.
 /// It's omitted if the enclosing `Group` fits on a single line.
@@ -456,73 +454,6 @@ impl<Context> Format<Context> for LineSuffixBoundary {
     }
 }
 
-/// Marks some content as a comment trivia.
-///
-/// This does not directly influence how this content will be printed, but some
-/// parts of the formatter may chose to handle this element in a specific way
-///
-/// ## Examples
-///
-/// ```
-/// use rome_formatter::{format, write, format_args};
-/// use rome_formatter::prelude::*;
-///
-/// let elements = format!(
-///     SimpleFormatContext::default(),
-///     [
-///         group_elements(&format_args![
-///             comment(&format_args![token("// test"), hard_line_break()]),
-///             format_with(|f| {
-///                 write!(f, [
-///                     comment(&format_args![token("/* inline */"), hard_line_break()]).memoized(),
-///                     token("a"),
-///                     soft_line_break_or_space(),
-///                 ])
-///             }).memoized(),
-///             token("b"),
-///             soft_line_break_or_space(),
-///             token("c")
-///         ])
-///     ]
-/// ).unwrap();
-///
-/// assert_eq!(
-///     "// test\n/* inline */\na b c",
-///     elements.print().as_code()
-/// );
-/// ```
-#[inline]
-pub fn comment<Content, Context>(content: &Content) -> FormatComment<Context>
-where
-    Content: Format<Context>,
-{
-    FormatComment {
-        content: Argument::new(content),
-    }
-}
-
-#[derive(Copy, Clone)]
-pub struct FormatComment<'a, Context> {
-    content: Argument<'a, Context>,
-}
-
-impl<Context> Format<Context> for FormatComment<'_, Context> {
-    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        let mut buffer = VecBuffer::new(f.state_mut());
-
-        buffer.write_fmt(Arguments::from(&self.content))?;
-        let content = buffer.into_vec();
-
-        f.write_element(FormatElement::Comment(content.into_boxed_slice()))
-    }
-}
-
-impl<Context> std::fmt::Debug for FormatComment<'_, Context> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Comment").field(&"{{content}}").finish()
-    }
-}
-
 /// Inserts a single space. Allows to separate different tokens.
 ///
 /// # Examples
@@ -935,7 +866,7 @@ impl<Context> GroupElements<'_, Context> {
 
 impl<Context> Format<Context> for GroupElements<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        let mut buffer = GroupElementsBuffer::new(f);
+        let mut buffer = VecBuffer::new(f.state_mut());
         buffer.write_fmt(Arguments::from(&self.content))?;
         let content = buffer.into_vec();
 
@@ -958,150 +889,6 @@ impl<Context> std::fmt::Debug for GroupElements<'_, Context> {
             .field("content", &"{{content}}")
             .finish()
     }
-}
-
-/// Custom buffer implementation for `GroupElements` that moves the leading comments out of the group
-/// to prevent that a leading line comment expands the token's enclosing group.
-///
-/// # Examples
-///
-/// ```javascript
-/// /* a comment */
-/// [1]
-/// ```
-///
-/// The `/* a comment */` belongs to the `[` group token that is part of a group wrapping the whole
-/// `[1]` expression. It's important that the comment `/* a comment */` gets moved out of the group element
-/// to avoid that the `[1]` group expands because of the line break inserted by the comment.
-struct GroupElementsBuffer<'inner, Context> {
-    inner: &'inner mut dyn Buffer<Context = Context>,
-
-    /// The group inner content
-    content: Vec<FormatElement>,
-}
-
-impl<'inner, Context> GroupElementsBuffer<'inner, Context> {
-    fn new(inner: &'inner mut dyn Buffer<Context = Context>) -> Self {
-        Self {
-            inner,
-            content: Vec::new(),
-        }
-    }
-
-    fn into_vec(self) -> Vec<FormatElement> {
-        self.content
-    }
-
-    fn write_interned(&mut self, interned: Interned) -> FormatResult<()> {
-        debug_assert!(self.content.is_empty());
-
-        match interned.deref() {
-            FormatElement::Comment(_) => {
-                self.inner.write_element(FormatElement::Interned(interned))
-            }
-            FormatElement::List(list) => {
-                let mut content_start = 0;
-
-                for element in list.iter() {
-                    match element {
-                        element @ FormatElement::Comment(_) => {
-                            content_start += 1;
-                            // Cloning comments should be alright as they are rarely nested
-                            // and the case where all elements of an interned data structure are comments
-                            // are rare
-                            self.inner.write_element(element.clone())?;
-                        }
-                        FormatElement::Interned(interned) => {
-                            self.write_interned(interned.clone())?;
-                            content_start += 1;
-
-                            if !self.content.is_empty() {
-                                // Interned struct contained non-comment
-                                break;
-                            }
-                        }
-                        _ => {
-                            // Found the first non-comment / nested interned element
-                            break;
-                        }
-                    }
-                }
-
-                // No leading comments, this group has no comments
-                if content_start == 0 {
-                    self.content.push(FormatElement::Interned(interned));
-                    return Ok(());
-                }
-
-                let content = &list[content_start..];
-
-                // It is necessary to mutate the interned elements, write cloned elements
-                self.write_elements(content.iter().cloned())
-            }
-            FormatElement::Interned(interned) => self.write_interned(interned.clone()),
-            _ => {
-                self.content.push(FormatElement::Interned(interned));
-                Ok(())
-            }
-        }
-    }
-}
-
-impl<Context> Buffer for GroupElementsBuffer<'_, Context> {
-    type Context = Context;
-
-    fn write_element(&mut self, element: FormatElement) -> FormatResult<()> {
-        if self.content.is_empty() {
-            match element {
-                FormatElement::List(list) => {
-                    self.write_elements(list.into_vec())?;
-                }
-                FormatElement::Interned(interned) => match Interned::try_unwrap(interned) {
-                    Ok(owned) => self.write_element(owned)?,
-                    Err(interned) => self.write_interned(interned)?,
-                },
-                comment @ FormatElement::Comment { .. } => {
-                    self.inner.write_element(comment)?;
-                }
-                element => self.content.push(element),
-            }
-        } else {
-            match element {
-                FormatElement::List(list) => {
-                    self.content.extend(list.into_vec());
-                }
-                element => self.content.push(element),
-            }
-        }
-
-        Ok(())
-    }
-
-    fn state(&self) -> &FormatState<Self::Context> {
-        self.inner.state()
-    }
-
-    fn state_mut(&mut self) -> &mut FormatState<Self::Context> {
-        self.inner.state_mut()
-    }
-
-    fn snapshot(&self) -> BufferSnapshot {
-        BufferSnapshot::Any(Box::new(GroupElementsBufferSnapshot {
-            inner: self.inner.snapshot(),
-            content_len: self.content.len(),
-        }))
-    }
-
-    fn restore_snapshot(&mut self, snapshot: BufferSnapshot) {
-        let snapshot = snapshot.unwrap_any::<GroupElementsBufferSnapshot>();
-        self.inner.restore_snapshot(snapshot.inner);
-        self.content.truncate(snapshot.content_len);
-    }
-}
-
-struct GroupElementsBufferSnapshot {
-    inner: BufferSnapshot,
-    content_len: usize,
 }
 
 /// IR element that forces the parent group to print in expanded mode.

--- a/crates/rome_formatter/src/comments.rs
+++ b/crates/rome_formatter/src/comments.rs
@@ -1,3 +1,4 @@
+use crate::CommentStyle;
 use rome_rowan::{Language, SyntaxTriviaPieceComments};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -105,4 +106,11 @@ impl CommentKind {
     pub const fn is_inline(&self) -> bool {
         matches!(self, CommentKind::InlineBlock | CommentKind::Block)
     }
+}
+
+/// Stores comments specific context information.
+pub trait CommentContext<L: Language> {
+    type Style: CommentStyle<L>;
+
+    fn comment_style(&self) -> Self::Style;
 }

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -142,7 +142,7 @@ impl Debug for FormatElement {
                 best_fitting.fmt(fmt)
             }
             FormatElement::ExpandParent => write!(fmt, "ExpandParent"),
-            FormatElement::Interned(inner) => inner.fmt(fmt),
+            FormatElement::Interned(inner) => fmt.debug_tuple("Interned").field(&inner).finish(),
         }
     }
 }

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -54,12 +54,6 @@ pub enum FormatElement {
     /// line suffixes, potentially by inserting a hard line break.
     LineSuffixBoundary,
 
-    /// Special semantic element letting the printer and formatter know this is
-    /// a comment content, and it should only have a limited influence on the
-    /// formatting (for instance line breaks contained within will not cause
-    /// the parent group to break if this element is at the start of it).
-    Comment(Box<[FormatElement]>),
-
     /// A token that tracks tokens/nodes that are printed using [`format_verbatim`](crate::Formatter::format_verbatim) API
     Verbatim(Verbatim),
 
@@ -139,7 +133,6 @@ impl Debug for FormatElement {
                 fmt.debug_tuple("LineSuffix").field(content).finish()
             }
             FormatElement::LineSuffixBoundary => write!(fmt, "LineSuffixBoundary"),
-            FormatElement::Comment(content) => fmt.debug_tuple("Comment").field(content).finish(),
             FormatElement::Verbatim(verbatim) => fmt
                 .debug_tuple("Verbatim")
                 .field(&verbatim.element)
@@ -332,12 +325,6 @@ impl Debug for BestFitting {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Interned(Rc<FormatElement>);
 
-impl Interned {
-    pub(crate) fn try_unwrap(this: Interned) -> Result<FormatElement, Interned> {
-        Rc::try_unwrap(this.0).map_err(Interned)
-    }
-}
-
 impl Debug for Interned {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
@@ -509,7 +496,7 @@ impl FormatElement {
             FormatElement::Space => false,
             FormatElement::Line(line_mode) => matches!(line_mode, LineMode::Hard | LineMode::Empty),
             FormatElement::Indent(content) => content.will_break(),
-            FormatElement::Group(Group { content, .. }) | FormatElement::Comment(content) => {
+            FormatElement::Group(Group { content, .. }) => {
                 content.iter().any(FormatElement::will_break)
             }
             FormatElement::ConditionalGroupContent(group) => group.content.will_break(),
@@ -538,7 +525,7 @@ impl FormatElement {
             FormatElement::List(list) => {
                 list.iter().rev().find_map(|element| element.last_element())
             }
-            FormatElement::Line(_) | FormatElement::Comment(_) => None,
+            FormatElement::Line(_) => None,
 
             FormatElement::Indent(indent) => indent.last_element(),
             FormatElement::Group(group) => group

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -1156,7 +1156,7 @@ impl<Context> FormatState<Context> {
     }
 
     /// Sets whether the last written content is an inline comment that has no trailing whitespace.
-    pub fn set_last_content_is_inline_comment(&mut self, has_comment: bool) {
+    pub fn set_last_content_inline_comment(&mut self, has_comment: bool) {
         self.last_content_inline_comment = has_comment;
     }
 
@@ -1167,13 +1167,14 @@ impl<Context> FormatState<Context> {
 
     /// Sets the kind of the last formatted token and sets `last_content_inline_comment` to `false`.
     pub fn set_last_token_kind<Kind: SyntaxKind + 'static>(&mut self, kind: Kind) {
-        // Reset the last comment kind before token because we've now seen a token.
-        self.last_content_inline_comment = false;
-
-        self.last_token_kind = Some(LastTokenKind {
+        self.set_last_token_kind_raw(Some(LastTokenKind {
             kind_type: TypeId::of::<Kind>(),
             kind: kind.to_raw(),
-        });
+        }));
+    }
+
+    pub fn set_last_token_kind_raw(&mut self, kind: Option<LastTokenKind>) {
+        self.last_token_kind = kind;
     }
 
     /// Mark the passed comment as formatted. This is necessary if a comment from a token is formatted

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -53,7 +53,7 @@ pub use builders::{
     soft_line_break, soft_line_break_or_space, soft_line_indent_or_space, space_token, token,
     BestFitting,
 };
-pub use comments::{CommentKind, SourceComment};
+pub use comments::{CommentContext, CommentKind, SourceComment};
 pub use format_element::{normalize_newlines, FormatElement, Token, Verbatim, LINE_TERMINATORS};
 pub use group_id::GroupId;
 use indexmap::IndexSet;
@@ -1303,7 +1303,7 @@ pub struct FormatStateSnapshot {
 }
 
 /// Defines how to format comments for a specific [Language].
-pub trait CommentStyle<L: Language> {
+pub trait CommentStyle<L: Language>: Copy {
     /// Returns the kind of the comment
     fn get_comment_kind(&self, comment: &SyntaxTriviaPieceComments<L>) -> CommentKind;
 

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -1303,20 +1303,18 @@ pub struct FormatStateSnapshot {
 }
 
 /// Defines how to format comments for a specific [Language].
-pub trait CommentStyle: Copy {
-    type Language: Language;
-
+pub trait CommentStyle<L: Language> {
     /// Returns the kind of the comment
-    fn get_comment_kind(&self, comment: &SyntaxTriviaPieceComments<Self::Language>) -> CommentKind;
+    fn get_comment_kind(&self, comment: &SyntaxTriviaPieceComments<L>) -> CommentKind;
 
     /// Returns `true` if a token with the passed `kind` marks the start of a group. Common group tokens are:
     /// * left parentheses: `(`, `[`, `{`
-    fn is_group_start_token(&self, kind: <Self::Language as Language>::Kind) -> bool;
+    fn is_group_start_token(&self, kind: L::Kind) -> bool;
 
     /// Returns `true` if a token with the passed `kind` marks the end of a group. Common group end tokens are:
     /// * right parentheses: `)`, `]`, `}`
     /// * end of statement token: `;`
     /// * element separator: `,` or `.`.
     /// * end of file token: `EOF`
-    fn is_group_end_token(&self, kind: <Self::Language as Language>::Kind) -> bool;
+    fn is_group_end_token(&self, kind: L::Kind) -> bool;
 }

--- a/crates/rome_formatter/src/prelude.rs
+++ b/crates/rome_formatter/src/prelude.rs
@@ -3,7 +3,10 @@ pub use crate::format_element::*;
 pub use crate::format_extensions::{FormatOptional as _, MemoizeFormat};
 pub use crate::formatter::Formatter;
 pub use crate::printer::PrinterOptions;
-pub use crate::token::format_trimmed_token;
+pub use crate::token::{
+    format_leading_trivia, format_only_if_breaks, format_removed, format_replaced,
+    format_trailing_trivia, format_trimmed_token,
+};
 
 pub use crate::{
     best_fitting, dbg_write, format, format_args, write, Buffer as _, BufferExtensions, Format,

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -307,7 +307,7 @@ impl<'a> Printer<'a> {
         // If the indentation level has changed since these line suffixes were queued,
         // insert a line break before to push the comments into the new indent block
         // SAFETY: Indexing into line_suffixes is guarded by the above call to is_empty
-        let has_line_break = false; // self.state.line_suffixes[0].args.indent < args.indent;
+        let has_line_break = self.state.line_suffixes[0].args.indent < args.indent;
 
         // Print this line break element again once all the line suffixes have been flushed
         let call_self = PrintElementCall::new(line_break, args);

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -233,10 +233,6 @@ impl<'a> Printer<'a> {
                 self.queue_line_suffixes(HARD_BREAK, args, queue);
             }
 
-            FormatElement::Comment(content) => {
-                queue.extend(content.iter().map(|e| PrintElementCall::new(e, args)))
-            }
-
             FormatElement::Verbatim(verbatim) => {
                 if let VerbatimKind::Verbatim { length } = &verbatim.kind {
                     self.state.verbatim_markers.push(TextRange::at(
@@ -311,7 +307,7 @@ impl<'a> Printer<'a> {
         // If the indentation level has changed since these line suffixes were queued,
         // insert a line break before to push the comments into the new indent block
         // SAFETY: Indexing into line_suffixes is guarded by the above call to is_empty
-        let has_line_break = self.state.line_suffixes[0].args.indent < args.indent;
+        let has_line_break = false; // self.state.line_suffixes[0].args.indent < args.indent;
 
         // Print this line break element again once all the line suffixes have been flushed
         let call_self = PrintElementCall::new(line_break, args);
@@ -811,13 +807,10 @@ fn fits_element_on_line<'a, 'rest>(
             }
         }
 
-        FormatElement::Comment(content) => {
-            queue.extend(content.iter().map(|e| PrintElementCall::new(e, args)))
-        }
-
         FormatElement::Verbatim(verbatim) => {
             queue.enqueue(PrintElementCall::new(&verbatim.element, args))
         }
+
         FormatElement::BestFitting(best_fitting) => {
             let content = match args.mode {
                 PrintMode::Flat => best_fitting.most_flat(),
@@ -1192,11 +1185,11 @@ two lines`,
                 token("]")
             ]),
             token(";"),
-            comment(&line_suffix(&format_args![
+            &line_suffix(&format_args![
                 space_token(),
                 token("// trailing"),
                 space_token()
-            ]),)
+            ])
         ]);
 
         assert_eq!(printed.as_code(), "[1, 2, 3]; // trailing")

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -1,10 +1,6 @@
 use crate::prelude::*;
-use crate::{AsFormat, JsCommentStyle};
-use rome_formatter::token::{
-    format_token_trailing_trivia, FormatInserted, FormatInsertedCloseParen,
-    FormatInsertedOpenParen, FormatLeadingTrivia, FormatOnlyIfBreaks, FormatRemoved,
-    FormatReplaced,
-};
+use crate::AsFormat;
+use rome_formatter::token::{FormatInserted, FormatInsertedCloseParen, FormatInsertedOpenParen};
 use rome_formatter::{format_args, write, Argument, Arguments, GroupId, PreambleBuffer, VecBuffer};
 use rome_js_syntax::{JsLanguage, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, Direction, Language, SyntaxTriviaPiece};
@@ -45,24 +41,22 @@ where
     }
 }
 
-pub fn format_inserted(kind: JsSyntaxKind) -> FormatInserted<JsCommentStyle> {
+pub fn format_inserted(kind: JsSyntaxKind) -> FormatInserted<JsLanguage> {
     FormatInserted::new(
         kind,
         kind.to_string().expect("Expected a punctuation token"),
-        JsCommentStyle,
     )
 }
 
 pub fn format_inserted_open_paren(
     before_token: Option<JsSyntaxToken>,
     kind: JsSyntaxKind,
-) -> FormatInsertedOpenParen<JsCommentStyle> {
+) -> FormatInsertedOpenParen<JsLanguage> {
     FormatInsertedOpenParen::new(
         before_token,
         kind,
         kind.to_string()
             .expect("Expected a punctuation token as the open paren token."),
-        JsCommentStyle,
     )
 }
 
@@ -70,13 +64,12 @@ pub fn format_inserted_close_paren(
     after_token: &Option<JsSyntaxToken>,
     kind: JsSyntaxKind,
     f: &mut JsFormatter,
-) -> FormatInsertedCloseParen<JsCommentStyle> {
+) -> FormatInsertedCloseParen<JsLanguage> {
     FormatInsertedCloseParen::after_token(
         after_token,
         kind,
         kind.to_string()
             .expect("Expected a punctuation token as the close paren token."),
-        JsCommentStyle,
         f,
     )
 }
@@ -159,46 +152,6 @@ impl Format<JsFormatContext> for FormatParenthesize<'_> {
             )
         }
     }
-}
-
-/// Formats the leading and trailing trivia of a removed token.
-///
-/// Formats all leading and trailing comments up to the first line break or skipped token trivia as a trailing
-/// comment of the previous token. The remaining trivia is then printed as leading trivia of the next token.
-pub const fn format_removed(token: &JsSyntaxToken) -> FormatRemoved<JsCommentStyle> {
-    FormatRemoved::new(token, JsCommentStyle)
-}
-
-/// Print out a `token` from the original source with a different `content`.
-///
-/// This will print the trivia that belong to `token` to `content`;
-/// `token` is then marked as consumed by the formatter.
-pub fn format_replaced<'a, 'content>(
-    token: &'a JsSyntaxToken,
-    content: &'content impl Format<JsFormatContext>,
-) -> FormatReplaced<'a, 'content, JsCommentStyle, JsFormatContext> {
-    FormatReplaced::new(token, content, JsCommentStyle)
-}
-
-/// Formats the given token only if the group does break and otherwise retains the tokens trivia.
-pub fn format_only_if_breaks<'a, 'content, Content>(
-    token: &'a JsSyntaxToken,
-    content: &'content Content,
-) -> FormatOnlyIfBreaks<'a, 'content, JsCommentStyle, JsFormatContext>
-where
-    Content: Format<JsFormatContext>,
-{
-    FormatOnlyIfBreaks::new(token, content, JsCommentStyle)
-}
-
-/// Formats the leading trivia (comments, skipped token trivia) of a token
-pub fn format_leading_trivia(token: &JsSyntaxToken) -> FormatLeadingTrivia<JsCommentStyle> {
-    FormatLeadingTrivia::new(token, JsCommentStyle)
-}
-
-/// Formats the trailing trivia (comments) of a token
-pub fn format_trailing_trivia(token: &JsSyntaxToken) -> impl Format<JsFormatContext> {
-    format_token_trailing_trivia(token, JsCommentStyle)
 }
 
 /// "Formats" a node according to its original formatting in the source text. Being able to format
@@ -546,7 +499,7 @@ impl<'t> OpenDelimiter<'t> {
     pub(crate) fn format_token(&self) -> impl Format<JsFormatContext> + 't {
         format_with(|f| {
             f.state_mut().track_token(self.open_token);
-            write!(f, [format_trimmed_token(self.open_token, JsCommentStyle)])
+            write!(f, [format_trimmed_token(self.open_token)])
         })
     }
 }
@@ -578,7 +531,7 @@ impl<'t> CloseDelimiter<'t> {
     pub(crate) fn format_token(&self) -> impl Format<JsFormatContext> + 't {
         format_with(|f| {
             f.state_mut().track_token(self.close_token);
-            write!(f, [format_trimmed_token(self.close_token, JsCommentStyle)])
+            write!(f, [format_trimmed_token(self.close_token)])
         })
     }
 }

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -466,7 +466,7 @@ impl Format<JsFormatContext> for FormatDelimited<'_, '_> {
             close_delimiter.format_token().fmt(f)
         });
 
-        let _grouped = match mode {
+        match mode {
             // Group is useless, the block indent would expand it right anyway
             DelimitedMode::BlockIndent => write!(f, [delimited])?,
             DelimitedMode::SoftBlockIndent(group_id) | DelimitedMode::SoftBlockSpaces(group_id) => {
@@ -546,7 +546,7 @@ impl<'t> OpenDelimiter<'t> {
     pub(crate) fn format_token(&self) -> impl Format<JsFormatContext> + 't {
         format_with(|f| {
             f.state_mut().track_token(self.open_token);
-            write!(f, [format_trimmed_token(self.open_token)])
+            write!(f, [format_trimmed_token(self.open_token, JsCommentStyle)])
         })
     }
 }
@@ -578,7 +578,7 @@ impl<'t> CloseDelimiter<'t> {
     pub(crate) fn format_token(&self) -> impl Format<JsFormatContext> + 't {
         format_with(|f| {
             f.state_mut().track_token(self.close_token);
-            write!(f, [format_trimmed_token(self.close_token)])
+            write!(f, [format_trimmed_token(self.close_token, JsCommentStyle)])
         })
     }
 }

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -1,7 +1,9 @@
 use crate::prelude::*;
 use crate::AsFormat;
-use rome_formatter::token::{FormatInserted, FormatInsertedCloseParen, FormatInsertedOpenParen};
-use rome_formatter::{format_args, write, Argument, Arguments, GroupId, PreambleBuffer, VecBuffer};
+use rome_formatter::token::FormatInserted;
+use rome_formatter::{
+    format_args, write, Argument, Arguments, GroupId, PreambleBuffer, TriviaKind, VecBuffer,
+};
 use rome_js_syntax::{JsLanguage, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, Direction, Language, SyntaxTriviaPiece};
 

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -1,6 +1,7 @@
 use rome_formatter::printer::PrinterOptions;
-use rome_formatter::{FormatContext, IndentStyle, LineWidth};
-use rome_js_syntax::SourceType;
+use rome_formatter::{CommentKind, CommentStyle, FormatContext, IndentStyle, LineWidth};
+use rome_js_syntax::{JsLanguage, JsSyntaxKind, SourceType};
+use rome_rowan::SyntaxTriviaPieceComments;
 use std::fmt;
 use std::fmt::Debug;
 use std::str::FromStr;
@@ -81,6 +82,40 @@ impl fmt::Display for JsFormatContext {
         writeln!(f, "Line width: {}", self.line_width.value())?;
         write!(f, "{}", self.options)?;
         Ok(())
+    }
+}
+
+impl CommentStyle<JsLanguage> for JsFormatContext {
+    fn get_comment_kind(&self, comment: &SyntaxTriviaPieceComments<JsLanguage>) -> CommentKind {
+        if comment.text().starts_with("/*") {
+            if comment.has_newline() {
+                CommentKind::Block
+            } else {
+                CommentKind::InlineBlock
+            }
+        } else {
+            CommentKind::Line
+        }
+    }
+
+    fn is_group_start_token(&self, kind: JsSyntaxKind) -> bool {
+        matches!(
+            kind,
+            JsSyntaxKind::L_PAREN | JsSyntaxKind::L_BRACK | JsSyntaxKind::L_CURLY
+        )
+    }
+
+    fn is_group_end_token(&self, kind: JsSyntaxKind) -> bool {
+        matches!(
+            kind,
+            JsSyntaxKind::R_BRACK
+                | JsSyntaxKind::R_CURLY
+                | JsSyntaxKind::R_PAREN
+                | JsSyntaxKind::COMMA
+                | JsSyntaxKind::SEMICOLON
+                | JsSyntaxKind::DOT
+                | JsSyntaxKind::EOF
+        )
     }
 }
 

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -1,5 +1,7 @@
 use rome_formatter::printer::PrinterOptions;
-use rome_formatter::{CommentKind, CommentStyle, FormatContext, IndentStyle, LineWidth};
+use rome_formatter::{
+    CommentContext, CommentKind, CommentStyle, FormatContext, IndentStyle, LineWidth,
+};
 use rome_js_syntax::{JsLanguage, JsSyntaxKind, SourceType};
 use rome_rowan::SyntaxTriviaPieceComments;
 use std::fmt;
@@ -85,7 +87,18 @@ impl fmt::Display for JsFormatContext {
     }
 }
 
-impl CommentStyle<JsLanguage> for JsFormatContext {
+impl CommentContext<JsLanguage> for JsFormatContext {
+    type Style = JsCommentStyle;
+
+    fn comment_style(&self) -> Self::Style {
+        JsCommentStyle
+    }
+}
+
+#[derive(Eq, PartialEq, Copy, Clone, Debug, Default)]
+pub struct JsCommentStyle;
+
+impl CommentStyle<JsLanguage> for JsCommentStyle {
     fn get_comment_kind(&self, comment: &SyntaxTriviaPieceComments<JsLanguage>) -> CommentKind {
         if comment.text().starts_with("/*") {
             if comment.has_newline() {

--- a/crates/rome_js_formatter/src/generated.rs
+++ b/crates/rome_js_formatter/src/generated.rs
@@ -9140,6 +9140,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxSpreadChild {
         )
     }
 }
+impl FormatRule < rome_js_syntax :: JsArrayAssignmentPatternElementList > for crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList { type Context = JsFormatContext ; fn fmt (& self , node : & rome_js_syntax :: JsArrayAssignmentPatternElementList , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsArrayAssignmentPatternElementList > :: fmt (self , node , f) } }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsArrayAssignmentPatternElementList {
     type Format = FormatRefWithRule < 'a , rome_js_syntax :: JsArrayAssignmentPatternElementList , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList > ;
     fn format(&'a self) -> Self::Format {
@@ -9152,6 +9153,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayAssignmentPat
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList :: default ())
     }
 }
+impl FormatRule<rome_js_syntax::JsArrayBindingPatternElementList>
+    for crate::js::lists::array_binding_pattern_element_list::FormatJsArrayBindingPatternElementList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsArrayBindingPatternElementList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsArrayBindingPatternElementList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsArrayBindingPatternElementList {
     type Format = FormatRefWithRule < 'a , rome_js_syntax :: JsArrayBindingPatternElementList , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList > ;
     fn format(&'a self) -> Self::Format {
@@ -9162,6 +9175,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayBindingPatter
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsArrayBindingPatternElementList , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList :: default ())
+    }
+}
+impl FormatRule<rome_js_syntax::JsArrayElementList>
+    for crate::js::lists::array_element_list::FormatJsArrayElementList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsArrayElementList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsArrayElementList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsArrayElementList {
@@ -9189,6 +9214,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayElementList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsCallArgumentList>
+    for crate::js::lists::call_argument_list::FormatJsCallArgumentList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsCallArgumentList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsCallArgumentList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsCallArgumentList {
     type Format = FormatRefWithRule<
         'a,
@@ -9212,6 +9249,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsCallArgumentList {
             self,
             crate::js::lists::call_argument_list::FormatJsCallArgumentList::default(),
         )
+    }
+}
+impl FormatRule<rome_js_syntax::JsClassMemberList>
+    for crate::js::lists::class_member_list::FormatJsClassMemberList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsClassMemberList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsClassMemberList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsClassMemberList {
@@ -9239,6 +9288,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsClassMemberList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsConstructorModifierList>
+    for crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsConstructorModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsConstructorModifierList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsConstructorModifierList {
     type Format = FormatRefWithRule<
         'a,
@@ -9262,6 +9323,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConstructorModifie
             self,
             crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList::default(),
         )
+    }
+}
+impl FormatRule<rome_js_syntax::JsConstructorParameterList>
+    for crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsConstructorParameterList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsConstructorParameterList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsConstructorParameterList {
@@ -9291,6 +9364,14 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConstructorParamet
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsDirectiveList>
+    for crate::js::lists::directive_list::FormatJsDirectiveList
+{
+    type Context = JsFormatContext;
+    fn fmt(&self, node: &rome_js_syntax::JsDirectiveList, f: &mut JsFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsDirectiveList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsDirectiveList {
     type Format = FormatRefWithRule<
         'a,
@@ -9316,6 +9397,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsDirectiveList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsExportNamedFromSpecifierList>
+    for crate::js::lists::export_named_from_specifier_list::FormatJsExportNamedFromSpecifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsExportNamedFromSpecifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsExportNamedFromSpecifierList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsExportNamedFromSpecifierList {
     type Format = FormatRefWithRule<
         'a,
@@ -9333,6 +9426,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedFromSpe
     >;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: export_named_from_specifier_list :: FormatJsExportNamedFromSpecifierList :: default ())
+    }
+}
+impl FormatRule<rome_js_syntax::JsExportNamedSpecifierList>
+    for crate::js::lists::export_named_specifier_list::FormatJsExportNamedSpecifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsExportNamedSpecifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsExportNamedSpecifierList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsExportNamedSpecifierList {
@@ -9354,6 +9459,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedSpecifi
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: export_named_specifier_list :: FormatJsExportNamedSpecifierList :: default ())
     }
 }
+impl FormatRule<rome_js_syntax::JsImportAssertionEntryList>
+    for crate::js::lists::import_assertion_entry_list::FormatJsImportAssertionEntryList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsImportAssertionEntryList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsImportAssertionEntryList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsImportAssertionEntryList {
     type Format = FormatRefWithRule<
         'a,
@@ -9371,6 +9488,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportAssertionEnt
     >;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: import_assertion_entry_list :: FormatJsImportAssertionEntryList :: default ())
+    }
+}
+impl FormatRule<rome_js_syntax::JsMethodModifierList>
+    for crate::js::lists::method_modifier_list::FormatJsMethodModifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsMethodModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsMethodModifierList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsMethodModifierList {
@@ -9398,6 +9527,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsMethodModifierList
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsModuleItemList>
+    for crate::js::lists::module_item_list::FormatJsModuleItemList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsModuleItemList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsModuleItemList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsModuleItemList {
     type Format = FormatRefWithRule<
         'a,
@@ -9423,6 +9564,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsModuleItemList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsNamedImportSpecifierList>
+    for crate::js::lists::named_import_specifier_list::FormatJsNamedImportSpecifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsNamedImportSpecifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsNamedImportSpecifierList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsNamedImportSpecifierList {
     type Format = FormatRefWithRule<
         'a,
@@ -9442,6 +9595,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsNamedImportSpecifi
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: named_import_specifier_list :: FormatJsNamedImportSpecifierList :: default ())
     }
 }
+impl FormatRule < rome_js_syntax :: JsObjectAssignmentPatternPropertyList > for crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList { type Context = JsFormatContext ; fn fmt (& self , node : & rome_js_syntax :: JsObjectAssignmentPatternPropertyList , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsObjectAssignmentPatternPropertyList > :: fmt (self , node , f) } }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsObjectAssignmentPatternPropertyList {
     type Format = FormatRefWithRule < 'a , rome_js_syntax :: JsObjectAssignmentPatternPropertyList , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList > ;
     fn format(&'a self) -> Self::Format {
@@ -9454,6 +9608,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectAssignmentPa
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList :: default ())
     }
 }
+impl FormatRule < rome_js_syntax :: JsObjectBindingPatternPropertyList > for crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList { type Context = JsFormatContext ; fn fmt (& self , node : & rome_js_syntax :: JsObjectBindingPatternPropertyList , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsObjectBindingPatternPropertyList > :: fmt (self , node , f) } }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsObjectBindingPatternPropertyList {
     type Format = FormatRefWithRule < 'a , rome_js_syntax :: JsObjectBindingPatternPropertyList , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList > ;
     fn format(&'a self) -> Self::Format {
@@ -9464,6 +9619,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectBindingPatte
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsObjectBindingPatternPropertyList , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList :: default ())
+    }
+}
+impl FormatRule<rome_js_syntax::JsObjectMemberList>
+    for crate::js::lists::object_member_list::FormatJsObjectMemberList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsObjectMemberList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsObjectMemberList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsObjectMemberList {
@@ -9491,6 +9658,14 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectMemberList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsParameterList>
+    for crate::js::lists::parameter_list::FormatJsParameterList
+{
+    type Context = JsFormatContext;
+    fn fmt(&self, node: &rome_js_syntax::JsParameterList, f: &mut JsFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsParameterList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsParameterList {
     type Format = FormatRefWithRule<
         'a,
@@ -9514,6 +9689,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsParameterList {
             self,
             crate::js::lists::parameter_list::FormatJsParameterList::default(),
         )
+    }
+}
+impl FormatRule<rome_js_syntax::JsPropertyModifierList>
+    for crate::js::lists::property_modifier_list::FormatJsPropertyModifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsPropertyModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsPropertyModifierList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsPropertyModifierList {
@@ -9541,6 +9728,14 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsPropertyModifierLi
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsStatementList>
+    for crate::js::lists::statement_list::FormatJsStatementList
+{
+    type Context = JsFormatContext;
+    fn fmt(&self, node: &rome_js_syntax::JsStatementList, f: &mut JsFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsStatementList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsStatementList {
     type Format = FormatRefWithRule<
         'a,
@@ -9564,6 +9759,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsStatementList {
             self,
             crate::js::lists::statement_list::FormatJsStatementList::default(),
         )
+    }
+}
+impl FormatRule<rome_js_syntax::JsSwitchCaseList>
+    for crate::js::lists::switch_case_list::FormatJsSwitchCaseList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsSwitchCaseList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsSwitchCaseList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsSwitchCaseList {
@@ -9591,6 +9798,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSwitchCaseList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsTemplateElementList>
+    for crate::js::lists::template_element_list::FormatJsTemplateElementList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsTemplateElementList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsTemplateElementList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsTemplateElementList {
     type Format = FormatRefWithRule<
         'a,
@@ -9614,6 +9833,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsTemplateElementLis
             self,
             crate::js::lists::template_element_list::FormatJsTemplateElementList::default(),
         )
+    }
+}
+impl FormatRule<rome_js_syntax::JsVariableDeclaratorList>
+    for crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsVariableDeclaratorList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsVariableDeclaratorList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsVariableDeclaratorList {
@@ -9641,6 +9872,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsVariableDeclarator
         )
     }
 }
+impl FormatRule<rome_js_syntax::JsxAttributeList>
+    for crate::jsx::lists::attribute_list::FormatJsxAttributeList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::JsxAttributeList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsxAttributeList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::JsxAttributeList {
     type Format = FormatRefWithRule<
         'a,
@@ -9664,6 +9907,14 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAttributeList {
             self,
             crate::jsx::lists::attribute_list::FormatJsxAttributeList::default(),
         )
+    }
+}
+impl FormatRule<rome_js_syntax::JsxChildList>
+    for crate::jsx::lists::child_list::FormatJsxChildList
+{
+    type Context = JsFormatContext;
+    fn fmt(&self, node: &rome_js_syntax::JsxChildList, f: &mut JsFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::JsxChildList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::JsxChildList {
@@ -9691,6 +9942,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxChildList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::TsEnumMemberList>
+    for crate::ts::lists::enum_member_list::FormatTsEnumMemberList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsEnumMemberList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsEnumMemberList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::TsEnumMemberList {
     type Format = FormatRefWithRule<
         'a,
@@ -9716,6 +9979,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsEnumMemberList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::TsIndexSignatureModifierList>
+    for crate::ts::lists::index_signature_modifier_list::FormatTsIndexSignatureModifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsIndexSignatureModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsIndexSignatureModifierList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::TsIndexSignatureModifierList {
     type Format = FormatRefWithRule<
         'a,
@@ -9733,6 +10008,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIndexSignatureModi
     >;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: index_signature_modifier_list :: FormatTsIndexSignatureModifierList :: default ())
+    }
+}
+impl FormatRule<rome_js_syntax::TsIntersectionTypeElementList>
+    for crate::ts::lists::intersection_type_element_list::FormatTsIntersectionTypeElementList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsIntersectionTypeElementList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsIntersectionTypeElementList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::TsIntersectionTypeElementList {
@@ -9754,6 +10041,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIntersectionTypeEl
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: intersection_type_element_list :: FormatTsIntersectionTypeElementList :: default ())
     }
 }
+impl FormatRule<rome_js_syntax::TsMethodSignatureModifierList>
+    for crate::ts::lists::method_signature_modifier_list::FormatTsMethodSignatureModifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsMethodSignatureModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsMethodSignatureModifierList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::TsMethodSignatureModifierList {
     type Format = FormatRefWithRule<
         'a,
@@ -9771,6 +10070,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMethodSignatureMod
     >;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: method_signature_modifier_list :: FormatTsMethodSignatureModifierList :: default ())
+    }
+}
+impl FormatRule<rome_js_syntax::TsPropertyParameterModifierList>
+    for crate::ts::lists::property_parameter_modifier_list::FormatTsPropertyParameterModifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsPropertyParameterModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsPropertyParameterModifierList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::TsPropertyParameterModifierList {
@@ -9792,6 +10103,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPropertyParameterM
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_parameter_modifier_list :: FormatTsPropertyParameterModifierList :: default ())
     }
 }
+impl FormatRule<rome_js_syntax::TsPropertySignatureModifierList>
+    for crate::ts::lists::property_signature_modifier_list::FormatTsPropertySignatureModifierList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsPropertySignatureModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsPropertySignatureModifierList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::TsPropertySignatureModifierList {
     type Format = FormatRefWithRule<
         'a,
@@ -9809,6 +10132,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPropertySignatureM
     >;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_signature_modifier_list :: FormatTsPropertySignatureModifierList :: default ())
+    }
+}
+impl FormatRule<rome_js_syntax::TsTemplateElementList>
+    for crate::ts::lists::template_element_list::FormatTsTemplateElementList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsTemplateElementList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsTemplateElementList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::TsTemplateElementList {
@@ -9836,6 +10171,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTemplateElementLis
         )
     }
 }
+impl FormatRule<rome_js_syntax::TsTupleTypeElementList>
+    for crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsTupleTypeElementList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsTupleTypeElementList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::TsTupleTypeElementList {
     type Format = FormatRefWithRule<
         'a,
@@ -9859,6 +10206,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTupleTypeElementLi
             self,
             crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList::default(),
         )
+    }
+}
+impl FormatRule<rome_js_syntax::TsTypeArgumentList>
+    for crate::ts::lists::type_argument_list::FormatTsTypeArgumentList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsTypeArgumentList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsTypeArgumentList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::TsTypeArgumentList {
@@ -9886,6 +10245,12 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeArgumentList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::TsTypeList> for crate::ts::lists::type_list::FormatTsTypeList {
+    type Context = JsFormatContext;
+    fn fmt(&self, node: &rome_js_syntax::TsTypeList, f: &mut JsFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsTypeList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::TsTypeList {
     type Format = FormatRefWithRule<
         'a,
@@ -9909,6 +10274,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeList {
             self,
             crate::ts::lists::type_list::FormatTsTypeList::default(),
         )
+    }
+}
+impl FormatRule<rome_js_syntax::TsTypeMemberList>
+    for crate::ts::lists::type_member_list::FormatTsTypeMemberList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsTypeMemberList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsTypeMemberList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::TsTypeMemberList {
@@ -9936,6 +10313,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeMemberList {
         )
     }
 }
+impl FormatRule<rome_js_syntax::TsTypeParameterList>
+    for crate::ts::lists::type_parameter_list::FormatTsTypeParameterList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsTypeParameterList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsTypeParameterList>::fmt(self, node, f)
+    }
+}
 impl<'a> AsFormat<'a> for rome_js_syntax::TsTypeParameterList {
     type Format = FormatRefWithRule<
         'a,
@@ -9959,6 +10348,18 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeParameterList 
             self,
             crate::ts::lists::type_parameter_list::FormatTsTypeParameterList::default(),
         )
+    }
+}
+impl FormatRule<rome_js_syntax::TsUnionTypeVariantList>
+    for crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList
+{
+    type Context = JsFormatContext;
+    fn fmt(
+        &self,
+        node: &rome_js_syntax::TsUnionTypeVariantList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<rome_js_syntax::TsUnionTypeVariantList>::fmt(self, node, f)
     }
 }
 impl<'a> AsFormat<'a> for rome_js_syntax::TsUnionTypeVariantList {

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -37,11 +37,10 @@ impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
         match node.parameters()? {
             JsAnyArrowFunctionParameters::JsAnyBinding(binding) => write!(
                 f,
-                [format_parenthesize(
-                    binding.syntax().first_token(),
-                    &format_args![binding.format(), if_group_breaks(&token(",")),],
-                    binding.syntax().last_token(),
-                )
+                [format_parenthesize(&format_args![
+                    binding.format(),
+                    if_group_breaks(&token(",")),
+                ],)
                 .grouped_with_soft_block_indent()]
             )?,
             JsAnyArrowFunctionParameters::JsParameters(params) => write![f, [params.format()]]?,

--- a/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
@@ -38,7 +38,10 @@ impl FormatNodeRule<JsCaseClause> for FormatJsCaseClause {
             // block to push them into
             return write!(f, [hard_line_break()]);
         } else if is_first_child_block_stmt {
-            write![f, [space_token(), consequent.format()]]
+            write![
+                f,
+                [space_token(), line_suffix_boundary(), consequent.format()]
+            ]
         } else {
             // no line break needed after because it is added by the indent in the switch statement
             write!(

--- a/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
@@ -28,7 +28,10 @@ impl FormatNodeRule<JsDefaultClause> for FormatJsDefaultClause {
         if consequent.is_empty() {
             write!(f, [hard_line_break()])
         } else if first_child_is_block_stmt {
-            write!(f, [space_token(), consequent.format()])
+            write!(
+                f,
+                [space_token(), line_suffix_boundary(), consequent.format()]
+            )
         } else {
             // no line break needed after because it is added by the indent in the switch statement
             write!(

--- a/crates/rome_js_formatter/src/js/classes/extends_clause.rs
+++ b/crates/rome_js_formatter/src/js/classes/extends_clause.rs
@@ -34,14 +34,7 @@ impl FormatNodeRule<JsExtendsClause> for FormatJsExtendsClause {
                 .map_or(false, |p| p.kind() == JS_ASSIGNMENT_EXPRESSION)
             {
                 if super_class.syntax().has_leading_comments() || has_trailing_comments {
-                    write!(
-                        f,
-                        [format_parenthesize(
-                            super_class.syntax().first_token(),
-                            &content,
-                            super_class.syntax().last_token()
-                        )]
-                    )
+                    write!(f, [format_parenthesize(&content)])
                 } else {
                     let content = content.memoized();
                     write!(

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -82,10 +82,8 @@ impl FormatNodeRule<JsCallArguments> for FormatJsCallArguments {
             // We also disallow the trailing separator, we are interested in doing it manually.
             let separated: Vec<_> = args
                 .format_separated(JsSyntaxKind::COMMA)
-                .with_options(
-                    FormatSeparatedOptions::default()
-                        .with_trailing_separator(TrailingSeparator::Omit),
-                )
+                .with_trailing_separator(TrailingSeparator::Omit)
+                .group_nodes(false)
                 .map(|e| e.memoized())
                 .collect();
 
@@ -153,7 +151,6 @@ impl FormatNodeRule<JsCallArguments> for FormatJsCallArguments {
                                             write_arguments_multi_line(separated.iter(), f)
                                         }),
                                         &r_leading_trivia,
-                                        soft_line_break()
                                     ]),
                                     &r_paren
                                 ]
@@ -191,11 +188,9 @@ impl FormatNodeRule<JsCallArguments> for FormatJsCallArguments {
                         l_paren,
                         l_trailing_trivia,
                         &soft_block_indent(&format_with(|f| {
-                            let separated =
-                                args.format_separated(JsSyntaxKind::COMMA).with_options(
-                                    FormatSeparatedOptions::default()
-                                        .with_trailing_separator(TrailingSeparator::Omit),
-                                );
+                            let separated = args
+                                .format_separated(JsSyntaxKind::COMMA)
+                                .with_trailing_separator(TrailingSeparator::Omit);
                             write_arguments_multi_line(separated, f)
                         }),),
                         r_leading_trivia,

--- a/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
@@ -18,14 +18,7 @@ impl FormatNodeRule<JsNumberLiteralExpression> for FormatJsNumberLiteralExpressi
 
         if let Some(static_member_expression) = node.parent::<JsStaticMemberExpression>() {
             if static_member_expression.object()?.syntax() == node.syntax() {
-                return write!(
-                    f,
-                    [format_parenthesize(
-                        Some(value_token.clone()),
-                        &value_token.format(),
-                        Some(value_token.clone())
-                    )]
-                );
+                return write!(f, [format_parenthesize(&value_token.format(),)]);
             }
         }
 

--- a/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -30,12 +30,7 @@ impl FormatNodeRule<JsStringLiteralExpression> for FormatJsStringLiteralExpressi
             .is_some();
 
         if needs_parenthesis {
-            format_parenthesize(
-                Some(value_token.clone()),
-                &formatted,
-                Some(value_token.clone()),
-            )
-            .fmt(f)
+            format_parenthesize(&formatted).fmt(f)
         } else {
             formatted.fmt(f)
         }

--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -58,11 +58,9 @@ impl FormatNodeRule<JsUnaryExpression> for FormatJsUnaryExpression {
         if is_ambiguous_expression {
             operator_token.format().fmt(f)?;
 
-            let first_token = argument.syntax().first_token();
-            let last_token = argument.syntax().last_token();
             let format_argument = argument.format();
 
-            let parenthesize = format_parenthesize(first_token, &format_argument, last_token);
+            let parenthesize = format_parenthesize(&format_argument);
 
             if is_simple_expression(&argument)? {
                 parenthesize.fmt(f)

--- a/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
@@ -5,10 +5,10 @@ use rome_js_syntax::JsArrayAssignmentPatternElementList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsArrayAssignmentPatternElementList;
 
-impl FormatRule<JsArrayAssignmentPatternElementList> for FormatJsArrayAssignmentPatternElementList {
-    type Context = JsFormatContext;
-
-    fn fmt(
+impl FormatNodeRule<JsArrayAssignmentPatternElementList>
+    for FormatJsArrayAssignmentPatternElementList
+{
+    fn fmt_fields(
         &self,
         node: &JsArrayAssignmentPatternElementList,
         formatter: &mut JsFormatter,

--- a/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
@@ -5,10 +5,8 @@ use rome_js_syntax::JsArrayBindingPatternElementList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsArrayBindingPatternElementList;
 
-impl FormatRule<JsArrayBindingPatternElementList> for FormatJsArrayBindingPatternElementList {
-    type Context = JsFormatContext;
-
-    fn fmt(
+impl FormatNodeRule<JsArrayBindingPatternElementList> for FormatJsArrayBindingPatternElementList {
+    fn fmt_fields(
         &self,
         node: &JsArrayBindingPatternElementList,
         formatter: &mut JsFormatter,

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -22,10 +22,8 @@ impl FormatRuleWithOptions<JsArrayElementList> for FormatJsArrayElementList {
     }
 }
 
-impl FormatRule<JsArrayElementList> for FormatJsArrayElementList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsArrayElementList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsArrayElementList> for FormatJsArrayElementList {
+    fn fmt_fields(&self, node: &JsArrayElementList, f: &mut JsFormatter) -> FormatResult<()> {
         if !has_formatter_trivia(node.syntax()) && can_print_fill(node) {
             // Using format_separated is valid in this case as can_print_fill does not allow holes
             return f

--- a/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
@@ -15,10 +15,10 @@ impl FormatNodeRule<JsCallArgumentList> for FormatJsCallArgumentList {
         write!(
             f,
             [&group_elements(&soft_block_indent(&format_with(|f| {
-                let separated = node.format_separated(JsSyntaxKind::COMMA).with_options(
-                    FormatSeparatedOptions::default()
-                        .with_trailing_separator(TrailingSeparator::Omit),
-                );
+                let separated = node
+                    .format_separated(JsSyntaxKind::COMMA)
+                    .group_nodes(false)
+                    .with_trailing_separator(TrailingSeparator::Omit);
                 write_arguments_multi_line(separated, f)
             })))]
         )

--- a/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
@@ -6,10 +6,8 @@ use rome_js_syntax::{JsCallArgumentList, JsSyntaxKind};
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsCallArgumentList;
 
-impl FormatRule<JsCallArgumentList> for FormatJsCallArgumentList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsCallArgumentList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsCallArgumentList> for FormatJsCallArgumentList {
+    fn fmt_fields(&self, node: &JsCallArgumentList, f: &mut JsFormatter) -> FormatResult<()> {
         if node.len() == 0 {
             return Ok(());
         }

--- a/crates/rome_js_formatter/src/js/lists/class_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/class_member_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::JsClassMemberList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsClassMemberList;
 
-impl FormatRule<JsClassMemberList> for FormatJsClassMemberList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsClassMemberList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsClassMemberList> for FormatJsClassMemberList {
+    fn fmt_fields(&self, node: &JsClassMemberList, f: &mut JsFormatter) -> FormatResult<()> {
         let mut join = f.join_nodes_with_hardline();
 
         for member in node {

--- a/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
@@ -5,10 +5,12 @@ use rome_rowan::AstNodeList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsConstructorModifierList;
 
-impl FormatRule<JsConstructorModifierList> for FormatJsConstructorModifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsConstructorModifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsConstructorModifierList> for FormatJsConstructorModifierList {
+    fn fmt_fields(
+        &self,
+        node: &JsConstructorModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         f.join_with(&space_token())
             .entries(node.iter().formatted())
             .finish()

--- a/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
@@ -4,10 +4,12 @@ use rome_js_syntax::{JsAnyConstructorParameter, JsConstructorParameterList, JsSy
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsConstructorParameterList;
 
-impl FormatRule<JsConstructorParameterList> for FormatJsConstructorParameterList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsConstructorParameterList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsConstructorParameterList> for FormatJsConstructorParameterList {
+    fn fmt_fields(
+        &self,
+        node: &JsConstructorParameterList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         // The trailing separator is disallowed if the last element in the list is a rest parameter
         let has_trailing_rest = match node.into_iter().last() {
             Some(elem) => matches!(elem?, JsAnyConstructorParameter::JsRestParameter(_)),

--- a/crates/rome_js_formatter/src/js/lists/directive_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/directive_list.rs
@@ -6,10 +6,8 @@ use rome_rowan::{AstNode, AstNodeList};
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsDirectiveList;
 
-impl FormatRule<JsDirectiveList> for FormatJsDirectiveList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsDirectiveList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsDirectiveList> for FormatJsDirectiveList {
+    fn fmt_fields(&self, node: &JsDirectiveList, f: &mut JsFormatter) -> FormatResult<()> {
         if node.is_empty() {
             return Ok(());
         }

--- a/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
@@ -4,10 +4,12 @@ use rome_js_syntax::{JsExportNamedFromSpecifierList, JsSyntaxKind};
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsExportNamedFromSpecifierList;
 
-impl FormatRule<JsExportNamedFromSpecifierList> for FormatJsExportNamedFromSpecifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsExportNamedFromSpecifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsExportNamedFromSpecifierList> for FormatJsExportNamedFromSpecifierList {
+    fn fmt_fields(
+        &self,
+        node: &JsExportNamedFromSpecifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         f.join_with(&soft_line_break_or_space())
             .entries(node.format_separated(JsSyntaxKind::COMMA))
             .finish()

--- a/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
@@ -4,10 +4,12 @@ use rome_js_syntax::{JsExportNamedSpecifierList, JsSyntaxKind};
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsExportNamedSpecifierList;
 
-impl FormatRule<JsExportNamedSpecifierList> for FormatJsExportNamedSpecifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsExportNamedSpecifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsExportNamedSpecifierList> for FormatJsExportNamedSpecifierList {
+    fn fmt_fields(
+        &self,
+        node: &JsExportNamedSpecifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         f.join_with(&soft_line_break_or_space())
             .entries(node.format_separated(JsSyntaxKind::COMMA))
             .finish()

--- a/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
@@ -4,10 +4,12 @@ use rome_js_syntax::{JsImportAssertionEntryList, JsSyntaxKind};
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsImportAssertionEntryList;
 
-impl FormatRule<JsImportAssertionEntryList> for FormatJsImportAssertionEntryList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsImportAssertionEntryList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsImportAssertionEntryList> for FormatJsImportAssertionEntryList {
+    fn fmt_fields(
+        &self,
+        node: &JsImportAssertionEntryList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         f.join_with(&soft_line_break_or_space())
             .entries(node.format_separated(JsSyntaxKind::COMMA))
             .finish()

--- a/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
@@ -5,10 +5,8 @@ use rome_js_syntax::JsMethodModifierList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsMethodModifierList;
 
-impl FormatRule<JsMethodModifierList> for FormatJsMethodModifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsMethodModifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsMethodModifierList> for FormatJsMethodModifierList {
+    fn fmt_fields(&self, node: &JsMethodModifierList, f: &mut JsFormatter) -> FormatResult<()> {
         f.join_with(&space_token())
             .entries(sort_modifiers_by_precedence(node).into_iter().formatted())
             .finish()

--- a/crates/rome_js_formatter/src/js/lists/module_item_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/module_item_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::JsModuleItemList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsModuleItemList;
 
-impl FormatRule<JsModuleItemList> for FormatJsModuleItemList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsModuleItemList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsModuleItemList> for FormatJsModuleItemList {
+    fn fmt_fields(&self, node: &JsModuleItemList, f: &mut JsFormatter) -> FormatResult<()> {
         let mut join = f.join_nodes_with_hardline();
 
         for module_item in node {

--- a/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
@@ -4,10 +4,12 @@ use rome_js_syntax::{JsNamedImportSpecifierList, JsSyntaxKind};
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsNamedImportSpecifierList;
 
-impl FormatRule<JsNamedImportSpecifierList> for FormatJsNamedImportSpecifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsNamedImportSpecifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsNamedImportSpecifierList> for FormatJsNamedImportSpecifierList {
+    fn fmt_fields(
+        &self,
+        node: &JsNamedImportSpecifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         f.join_with(&soft_line_break_or_space())
             .entries(node.format_separated(JsSyntaxKind::COMMA))
             .finish()

--- a/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
@@ -6,12 +6,10 @@ use rome_js_syntax::{
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsObjectAssignmentPatternPropertyList;
 
-impl FormatRule<JsObjectAssignmentPatternPropertyList>
+impl FormatNodeRule<JsObjectAssignmentPatternPropertyList>
     for FormatJsObjectAssignmentPatternPropertyList
 {
-    type Context = JsFormatContext;
-
-    fn fmt(
+    fn fmt_fields(
         &self,
         node: &JsObjectAssignmentPatternPropertyList,
         f: &mut JsFormatter,

--- a/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
@@ -6,10 +6,10 @@ use rome_js_syntax::{
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsObjectBindingPatternPropertyList;
 
-impl FormatRule<JsObjectBindingPatternPropertyList> for FormatJsObjectBindingPatternPropertyList {
-    type Context = JsFormatContext;
-
-    fn fmt(
+impl FormatNodeRule<JsObjectBindingPatternPropertyList>
+    for FormatJsObjectBindingPatternPropertyList
+{
+    fn fmt_fields(
         &self,
         node: &JsObjectBindingPatternPropertyList,
         f: &mut JsFormatter,

--- a/crates/rome_js_formatter/src/js/lists/object_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_member_list.rs
@@ -5,10 +5,8 @@ use rome_rowan::{AstNode, AstSeparatedList};
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsObjectMemberList;
 
-impl FormatRule<JsObjectMemberList> for FormatJsObjectMemberList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsObjectMemberList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsObjectMemberList> for FormatJsObjectMemberList {
+    fn fmt_fields(&self, node: &JsObjectMemberList, f: &mut JsFormatter) -> FormatResult<()> {
         let mut join = f.join_nodes_with_soft_line();
 
         for (element, formatted) in node

--- a/crates/rome_js_formatter/src/js/lists/parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/parameter_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::{JsAnyParameter, JsParameterList, JsSyntaxKind};
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsParameterList;
 
-impl FormatRule<JsParameterList> for FormatJsParameterList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsParameterList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsParameterList> for FormatJsParameterList {
+    fn fmt_fields(&self, node: &JsParameterList, f: &mut JsFormatter) -> FormatResult<()> {
         // The trailing separator is disallowed if the last element in the list is a rest parameter
         let has_trailing_rest = match node.into_iter().last() {
             Some(elem) => matches!(elem?, JsAnyParameter::JsRestParameter(_)),

--- a/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
@@ -5,10 +5,8 @@ use rome_js_syntax::JsPropertyModifierList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsPropertyModifierList;
 
-impl FormatRule<JsPropertyModifierList> for FormatJsPropertyModifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsPropertyModifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsPropertyModifierList> for FormatJsPropertyModifierList {
+    fn fmt_fields(&self, node: &JsPropertyModifierList, f: &mut JsFormatter) -> FormatResult<()> {
         f.join_with(&space_token())
             .entries(sort_modifiers_by_precedence(node).into_iter().formatted())
             .finish()

--- a/crates/rome_js_formatter/src/js/lists/statement_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/statement_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::JsStatementList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsStatementList;
 
-impl FormatRule<JsStatementList> for FormatJsStatementList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsStatementList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsStatementList> for FormatJsStatementList {
+    fn fmt_fields(&self, node: &JsStatementList, f: &mut JsFormatter) -> FormatResult<()> {
         let mut join = f.join_nodes_with_hardline();
 
         for statement in node.iter() {

--- a/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::JsSwitchCaseList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsSwitchCaseList;
 
-impl FormatRule<JsSwitchCaseList> for FormatJsSwitchCaseList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsSwitchCaseList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsSwitchCaseList> for FormatJsSwitchCaseList {
+    fn fmt_fields(&self, node: &JsSwitchCaseList, f: &mut JsFormatter) -> FormatResult<()> {
         let mut join = f.join_nodes_with_hardline();
 
         for case in node {

--- a/crates/rome_js_formatter/src/js/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/template_element_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::JsTemplateElementList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsTemplateElementList;
 
-impl FormatRule<JsTemplateElementList> for FormatJsTemplateElementList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsTemplateElementList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsTemplateElementList> for FormatJsTemplateElementList {
+    fn fmt_fields(&self, node: &JsTemplateElementList, f: &mut JsFormatter) -> FormatResult<()> {
         let mut join = f.join();
 
         for element in node {

--- a/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
@@ -8,10 +8,8 @@ use rome_rowan::AstSeparatedList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsVariableDeclaratorList;
 
-impl FormatRule<JsVariableDeclaratorList> for FormatJsVariableDeclaratorList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsVariableDeclaratorList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsVariableDeclaratorList> for FormatJsVariableDeclaratorList {
+    fn fmt_fields(&self, node: &JsVariableDeclaratorList, f: &mut JsFormatter) -> FormatResult<()> {
         let last_index = node.len().saturating_sub(1);
 
         let mut declarators = node.elements().enumerate().map(|(index, element)| {

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -25,13 +25,9 @@ impl FormatNodeRule<JsReturnStatement> for FormatJsReturnStatement {
                         write!(f, [space_token()])?;
 
                         if let JsAnyExpression::JsSequenceExpression(_expression) = argument {
-                            format_parenthesize(
-                                argument.syntax().first_token(),
-                                &argument.format(),
-                                argument.syntax().last_token(),
-                            )
-                            .grouped_with_soft_block_indent()
-                            .fmt(f)?;
+                            format_parenthesize(&argument.format())
+                                .grouped_with_soft_block_indent()
+                                .fmt(f)?;
                         } else {
                             write![f, [argument.format()]]?;
                         }

--- a/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/attribute_list.rs
@@ -5,10 +5,8 @@ use rome_js_syntax::JsxAttributeList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsxAttributeList;
 
-impl FormatRule<JsxAttributeList> for FormatJsxAttributeList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsxAttributeList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsxAttributeList> for FormatJsxAttributeList {
+    fn fmt_fields(&self, node: &JsxAttributeList, f: &mut JsFormatter) -> FormatResult<()> {
         let attributes = format_with(|f| {
             f.join_with(&soft_line_break_or_space())
                 .entries(node.iter().formatted())

--- a/crates/rome_js_formatter/src/jsx/lists/child_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/child_list.rs
@@ -6,10 +6,8 @@ use rome_js_syntax::JsxChildList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsxChildList;
 
-impl FormatRule<JsxChildList> for FormatJsxChildList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &JsxChildList, formatter: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<JsxChildList> for FormatJsxChildList {
+    fn fmt_fields(&self, node: &JsxChildList, formatter: &mut JsFormatter) -> FormatResult<()> {
         if contains_meaningful_jsx_text(node) {
             formatter
                 .fill(soft_line_break())

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -9,16 +9,16 @@ pub mod utils;
 
 use crate::utils::has_formatter_suppressions;
 use rome_formatter::prelude::*;
-use rome_formatter::{write, CommentKind, CommentStyle};
+use rome_formatter::write;
 use rome_formatter::{Buffer, FormatOwnedWithRule, FormatRefWithRule, Formatted, Printed};
 use rome_js_syntax::{
     JsAnyDeclaration, JsAnyStatement, JsLanguage, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
 };
+use rome_rowan::AstNode;
 use rome_rowan::SyntaxResult;
 use rome_rowan::TextRange;
-use rome_rowan::{AstNode, SyntaxTriviaPieceComments};
 
-use crate::builders::{format_leading_trivia, format_suppressed_node, format_trailing_trivia};
+use crate::builders::format_suppressed_node;
 use crate::context::JsFormatContext;
 use crate::cst::FormatJsSyntaxNode;
 use std::iter::FusedIterator;
@@ -196,7 +196,7 @@ impl FormatRule<JsSyntaxToken> for FormatJsSyntaxToken {
             f,
             [
                 format_leading_trivia(token),
-                format_trimmed_token(token, JsCommentStyle),
+                format_trimmed_token(token),
                 format_trailing_trivia(token),
             ]
         )
@@ -278,45 +278,6 @@ pub fn format_node(context: JsFormatContext, root: &JsSyntaxNode) -> FormatResul
 /// It returns a [Formatted] result
 pub fn format_sub_tree(context: JsFormatContext, root: &JsSyntaxNode) -> FormatResult<Printed> {
     rome_formatter::format_sub_tree(context, &root.format())
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct JsCommentStyle;
-
-impl CommentStyle for JsCommentStyle {
-    type Language = JsLanguage;
-
-    fn get_comment_kind(&self, comment: &SyntaxTriviaPieceComments<Self::Language>) -> CommentKind {
-        if comment.text().starts_with("/*") {
-            if comment.has_newline() {
-                CommentKind::Block
-            } else {
-                CommentKind::InlineBlock
-            }
-        } else {
-            CommentKind::Line
-        }
-    }
-
-    fn is_group_start_token(&self, kind: JsSyntaxKind) -> bool {
-        matches!(
-            kind,
-            JsSyntaxKind::L_PAREN | JsSyntaxKind::L_BRACK | JsSyntaxKind::L_CURLY
-        )
-    }
-
-    fn is_group_end_token(&self, kind: JsSyntaxKind) -> bool {
-        matches!(
-            kind,
-            JsSyntaxKind::R_BRACK
-                | JsSyntaxKind::R_CURLY
-                | JsSyntaxKind::R_PAREN
-                | JsSyntaxKind::COMMA
-                | JsSyntaxKind::SEMICOLON
-                | JsSyntaxKind::DOT
-                | JsSyntaxKind::EOF
-        )
-    }
 }
 
 #[cfg(test)]

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -196,7 +196,7 @@ impl FormatRule<JsSyntaxToken> for FormatJsSyntaxToken {
             f,
             [
                 format_leading_trivia(token),
-                format_trimmed_token(token),
+                format_trimmed_token(token, JsCommentStyle),
                 format_trailing_trivia(token),
             ]
         )

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -9,9 +9,8 @@ pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
 
 pub use crate::builders::{
     format_delimited, format_inserted, format_inserted_close_paren, format_inserted_open_paren,
-    format_leading_trivia, format_only_if_breaks, format_or_verbatim, format_parenthesize,
-    format_removed, format_replaced, format_suppressed_node, format_trailing_trivia,
-    format_unknown_node, format_verbatim_node,
+    format_or_verbatim, format_parenthesize, format_suppressed_node, format_unknown_node,
+    format_verbatim_node,
 };
 
 pub use crate::separated::{

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -8,9 +8,8 @@ pub use rome_formatter::prelude::*;
 pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
 
 pub use crate::builders::{
-    format_delimited, format_inserted, format_inserted_close_paren, format_inserted_open_paren,
-    format_or_verbatim, format_parenthesize, format_suppressed_node, format_unknown_node,
-    format_verbatim_node,
+    format_delimited, format_inserted, format_or_verbatim, format_parenthesize,
+    format_suppressed_node, format_unknown_node, format_verbatim_node,
 };
 
 pub use crate::separated::{

--- a/crates/rome_js_formatter/src/ts/classes/extends_clause.rs
+++ b/crates/rome_js_formatter/src/ts/classes/extends_clause.rs
@@ -13,19 +13,16 @@ impl FormatNodeRule<TsExtendsClause> for FormatTsExtendsClause {
             types,
         } = node.as_fields();
 
-        let extends_token = extends_token.format().memoized();
-        let types = types.format().memoized();
-
         write!(
             f,
-            [group_elements(&format_args!(
-                if_group_breaks(&block_indent(&format_args![
-                    &extends_token,
-                    space_token(),
-                    soft_block_indent(&types)
-                ])),
-                if_group_fits_on_line(&format_args![&extends_token, space_token(), &types]),
-            ))]
+            [
+                extends_token.format(),
+                space_token(),
+                group_elements(&indent(&format_args![
+                    soft_line_break_or_space(),
+                    &types.format()
+                ]))
+            ]
         )
     }
 }

--- a/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/interface_declaration.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-use rome_formatter::write;
+use rome_formatter::{format_args, write};
 use rome_js_syntax::{TsInterfaceDeclaration, TsInterfaceDeclarationFields};
 
 #[derive(Debug, Clone, Default)]
@@ -18,26 +18,61 @@ impl FormatNodeRule<TsInterfaceDeclaration> for FormatTsInterfaceDeclaration {
             r_curly_token,
         } = node.as_fields();
 
-        write![
-            f,
-            [
-                interface_token.format(),
-                space_token(),
-                id.format(),
-                type_parameters.format(),
-                space_token(),
-            ]
-        ]?;
+        let l_curly_token = l_curly_token?;
+        let r_curly_token = r_curly_token?;
+        let id = id?;
 
-        if let Some(extends_clause) = extends_clause {
-            write!(f, [extends_clause.format(), space_token()])?;
+        let format_id = format_with(|f| write!(f, [id.format(), type_parameters.format()]));
+
+        let format_extends = format_with(|f| {
+            if let Some(extends_clause) = &extends_clause {
+                write!(
+                    f,
+                    [
+                        soft_line_break_or_space(),
+                        extends_clause.format(),
+                        space_token()
+                    ]
+                )?;
+            }
+
+            Ok(())
+        });
+
+        write![f, [interface_token.format(), space_token()]]?;
+
+        let should_indent_extends_only = type_parameters
+            .as_ref()
+            .map_or(true, |params| !params.syntax().has_trailing_comments());
+
+        let id_has_trailing_comments = id.syntax().has_trailing_comments();
+        if id_has_trailing_comments || extends_clause.is_some() {
+            if should_indent_extends_only {
+                write!(
+                    f,
+                    [group_elements(&format_args!(
+                        format_id,
+                        indent(&format_extends)
+                    ))]
+                )?;
+            } else {
+                write!(
+                    f,
+                    [group_elements(&indent(&format_args!(
+                        format_id,
+                        format_extends
+                    )))]
+                )?;
+            }
+        } else {
+            write!(f, [format_id, format_extends])?;
         }
 
         write!(
             f,
             [
-                format_delimited(&l_curly_token?, &members.format(), &r_curly_token?,)
-                    .block_indent()
+                space_token(),
+                format_delimited(&l_curly_token, &members.format(), &r_curly_token).block_indent()
             ]
         )
     }

--- a/crates/rome_js_formatter/src/ts/declarations/type_alias_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/type_alias_declaration.rs
@@ -18,21 +18,46 @@ impl FormatNodeRule<TsTypeAliasDeclaration> for FormatTsTypeAliasDeclaration {
             semicolon_token,
         } = node.as_fields();
 
-        write!(
-            f,
-            [FormatWithSemicolon::new(
-                &format_args!(
-                    type_token.format(),
-                    space_token(),
-                    binding_identifier.format(),
-                    type_parameters.format(),
+        let eq_token = eq_token?;
+
+        let content = format_with(|f| {
+            write!(
+                f,
+                [
+                    group_elements(&format_args![
+                        type_token.format(),
+                        space_token(),
+                        binding_identifier.format(),
+                        type_parameters.format(),
+                    ]),
                     space_token(),
                     eq_token.format(),
-                    space_token(),
-                    ty.format(),
-                ),
-                semicolon_token.as_ref()
-            )]
+                ]
+            )?;
+
+            if eq_token.has_trailing_comments() {
+                let ty = ty.format().memoized();
+                let group_id = f.group_id("assignment");
+
+                write!(
+                    f,
+                    [
+                        group_elements(&indent(&soft_line_break_or_space()))
+                            .with_group_id(Some(group_id)),
+                        line_suffix_boundary(),
+                        if_group_breaks(&indent(&ty)).with_group_id(Some(group_id)),
+                        if_group_fits_on_line(&format_args![space_token(), ty])
+                            .with_group_id(Some(group_id))
+                    ]
+                )
+            } else {
+                write!(f, [space_token(), ty.format()])
+            }
+        });
+
+        write!(
+            f,
+            [FormatWithSemicolon::new(&content, semicolon_token.as_ref())]
         )
     }
 }

--- a/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
@@ -5,10 +5,8 @@ use rome_js_syntax::{JsSyntaxKind, TsEnumMemberList};
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsEnumMemberList;
 
-impl FormatRule<TsEnumMemberList> for FormatTsEnumMemberList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsEnumMemberList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsEnumMemberList> for FormatTsEnumMemberList {
+    fn fmt_fields(&self, node: &TsEnumMemberList, f: &mut JsFormatter) -> FormatResult<()> {
         let has_newline = node_has_leading_newline(node.syntax());
 
         f.join_with(&if has_newline {

--- a/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/index_signature_modifier_list.rs
@@ -6,10 +6,12 @@ use rome_js_syntax::TsIndexSignatureModifierList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsIndexSignatureModifierList;
 
-impl FormatRule<TsIndexSignatureModifierList> for FormatTsIndexSignatureModifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsIndexSignatureModifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsIndexSignatureModifierList> for FormatTsIndexSignatureModifierList {
+    fn fmt_fields(
+        &self,
+        node: &TsIndexSignatureModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         f.join_with(&space_token())
             .entries(sort_modifiers_by_precedence(node).into_iter().formatted())
             .finish()

--- a/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/intersection_type_element_list.rs
@@ -6,10 +6,12 @@ use rome_rowan::AstSeparatedList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsIntersectionTypeElementList;
 
-impl FormatRule<TsIntersectionTypeElementList> for FormatTsIntersectionTypeElementList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsIntersectionTypeElementList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsIntersectionTypeElementList> for FormatTsIntersectionTypeElementList {
+    fn fmt_fields(
+        &self,
+        node: &TsIntersectionTypeElementList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         let last_index = node.len().saturating_sub(1);
 
         f.join()

--- a/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/method_signature_modifier_list.rs
@@ -5,10 +5,12 @@ use rome_js_syntax::TsMethodSignatureModifierList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsMethodSignatureModifierList;
 
-impl FormatRule<TsMethodSignatureModifierList> for FormatTsMethodSignatureModifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsMethodSignatureModifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsMethodSignatureModifierList> for FormatTsMethodSignatureModifierList {
+    fn fmt_fields(
+        &self,
+        node: &TsMethodSignatureModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         f.join_with(&space_token())
             .entries(sort_modifiers_by_precedence(node).into_iter().formatted())
             .finish()

--- a/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_parameter_modifier_list.rs
@@ -5,10 +5,12 @@ use rome_js_syntax::TsPropertyParameterModifierList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsPropertyParameterModifierList;
 
-impl FormatRule<TsPropertyParameterModifierList> for FormatTsPropertyParameterModifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsPropertyParameterModifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsPropertyParameterModifierList> for FormatTsPropertyParameterModifierList {
+    fn fmt_fields(
+        &self,
+        node: &TsPropertyParameterModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         f.join_with(&space_token())
             .entries(sort_modifiers_by_precedence(node).into_iter().formatted())
             .finish()

--- a/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/property_signature_modifier_list.rs
@@ -5,10 +5,12 @@ use rome_js_syntax::TsPropertySignatureModifierList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsPropertySignatureModifierList;
 
-impl FormatRule<TsPropertySignatureModifierList> for FormatTsPropertySignatureModifierList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsPropertySignatureModifierList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsPropertySignatureModifierList> for FormatTsPropertySignatureModifierList {
+    fn fmt_fields(
+        &self,
+        node: &TsPropertySignatureModifierList,
+        f: &mut JsFormatter,
+    ) -> FormatResult<()> {
         f.join_with(&space_token())
             .entries(sort_modifiers_by_precedence(node).into_iter().formatted())
             .finish()

--- a/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/template_element_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::TsTemplateElementList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsTemplateElementList;
 
-impl FormatRule<TsTemplateElementList> for FormatTsTemplateElementList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsTemplateElementList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsTemplateElementList> for FormatTsTemplateElementList {
+    fn fmt_fields(&self, node: &TsTemplateElementList, f: &mut JsFormatter) -> FormatResult<()> {
         let mut join = f.join();
 
         for item in node {

--- a/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::{JsSyntaxKind, TsTupleTypeElementList};
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsTupleTypeElementList;
 
-impl FormatRule<TsTupleTypeElementList> for FormatTsTupleTypeElementList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsTupleTypeElementList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsTupleTypeElementList> for FormatTsTupleTypeElementList {
+    fn fmt_fields(&self, node: &TsTupleTypeElementList, f: &mut JsFormatter) -> FormatResult<()> {
         f.join_with(&soft_line_break_or_space())
             .entries(node.format_separated(JsSyntaxKind::COMMA))
             .finish()

--- a/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_argument_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::{JsSyntaxKind, TsTypeArgumentList};
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsTypeArgumentList;
 
-impl FormatRule<TsTypeArgumentList> for FormatTsTypeArgumentList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsTypeArgumentList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsTypeArgumentList> for FormatTsTypeArgumentList {
+    fn fmt_fields(&self, node: &TsTypeArgumentList, f: &mut JsFormatter) -> FormatResult<()> {
         f.join_with(&soft_line_break_or_space())
             .entries(
                 node.format_separated(JsSyntaxKind::COMMA)

--- a/crates/rome_js_formatter/src/ts/lists/type_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_list.rs
@@ -4,10 +4,8 @@ use rome_js_syntax::{JsSyntaxKind, TsTypeList};
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsTypeList;
 
-impl FormatRule<TsTypeList> for FormatTsTypeList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsTypeList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsTypeList> for FormatTsTypeList {
+    fn fmt_fields(&self, node: &TsTypeList, f: &mut JsFormatter) -> FormatResult<()> {
         // the grouping will be applied by the parent
         f.join_with(&soft_line_break_or_space())
             .entries(

--- a/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
@@ -7,10 +7,8 @@ use rome_rowan::AstNodeList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsTypeMemberList;
 
-impl FormatRule<TsTypeMemberList> for FormatTsTypeMemberList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsTypeMemberList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsTypeMemberList> for FormatTsTypeMemberList {
+    fn fmt_fields(&self, node: &TsTypeMemberList, f: &mut JsFormatter) -> FormatResult<()> {
         let items = node.iter();
         let last_index = items.len().saturating_sub(1);
 

--- a/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
@@ -5,10 +5,8 @@ use rome_rowan::AstSeparatedList;
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsTypeParameterList;
 
-impl FormatRule<TsTypeParameterList> for FormatTsTypeParameterList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsTypeParameterList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsTypeParameterList> for FormatTsTypeParameterList {
+    fn fmt_fields(&self, node: &TsTypeParameterList, f: &mut JsFormatter) -> FormatResult<()> {
         // nodes and formatter are not aware of the source type (TSX vs TS), which means we can't
         // exactly pin point the exact case.
         //

--- a/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/union_type_variant_list.rs
@@ -6,10 +6,8 @@ use rome_rowan::{AstSeparatedElement, AstSeparatedList};
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsUnionTypeVariantList;
 
-impl FormatRule<TsUnionTypeVariantList> for FormatTsUnionTypeVariantList {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, node: &TsUnionTypeVariantList, f: &mut JsFormatter) -> FormatResult<()> {
+impl FormatNodeRule<TsUnionTypeVariantList> for FormatTsUnionTypeVariantList {
+    fn fmt_fields(&self, node: &TsUnionTypeVariantList, f: &mut JsFormatter) -> FormatResult<()> {
         let last_index = node.len().saturating_sub(1);
 
         f.join()

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -177,7 +177,7 @@ impl Format<JsFormatContext> for RightAssignmentLike {
 /// - Assignment
 /// - Object property member
 /// - Variable declaration
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum AssignmentLikeLayout {
     /// This is a special layout usually used for variable declarations.
     /// This layout is hit, usually, when a [variable declarator](JsVariableDeclarator) doesn't have initializer:
@@ -241,7 +241,7 @@ pub(crate) enum AssignmentLikeLayout {
     Chain,
 
     /// This is a special layout usually used for long variable declarations or assignment expressions
-    /// This layout is hit, usually, when we are in the end of a chain:
+    /// This layout is hit, usually, when we are at the end of a chain:
     /// ```js
     /// var a = loreum = ipsum = "foo";
     /// ```
@@ -611,7 +611,7 @@ pub(crate) fn should_break_after_operator(right: &JsAnyExpression) -> SyntaxResu
 
     Ok(false)
 }
-/// If checks if among leading trivias, we there's a sequence of [Newline, Comment]
+/// If checks if among leading trivia, we there's a sequence of [Newline, Comment]
 pub(crate) fn has_new_line_before_comment(node: &JsSyntaxNode) -> bool {
     if let Some(leading_trivia) = node.first_leading_trivia() {
         let mut seen_newline = false;

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -220,13 +220,9 @@ fn format_sub_expression<'a>(
 ) -> impl Format<JsFormatContext> + 'a {
     format_with(move |f| {
         if needs_parens(parent_operator, sub_expression)? {
-            format_parenthesize(
-                sub_expression.syntax().first_token(),
-                &sub_expression,
-                sub_expression.syntax().last_token(),
-            )
-            .grouped_with_soft_block_indent()
-            .fmt(f)
+            format_parenthesize(&sub_expression)
+                .grouped_with_soft_block_indent()
+                .fmt(f)
         } else {
             write!(f, [sub_expression])
         }
@@ -573,10 +569,7 @@ impl FlattenedBinaryExpressionPart {
                 });
 
                 if *parenthesized {
-                    let first_token = current.syntax().first_token();
-                    let last_token = current.syntax().last_token();
-
-                    format_parenthesize(first_token, &content, last_token)
+                    format_parenthesize(&content)
                         .grouped_with_soft_block_indent()
                         .fmt(f)
                 } else {

--- a/crates/rome_js_formatter/src/utils/object.rs
+++ b/crates/rome_js_formatter/src/utils/object.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::utils::FormatLiteralStringToken;
 use crate::utils::StringLiteralParentKind;
-use rome_formatter::{write, VecBuffer};
+use rome_formatter::write;
 use rome_js_syntax::JsAnyObjectMemberName;
 use rome_js_syntax::JsSyntaxKind::JS_STRING_LITERAL;
 use rome_rowan::AstNode;
@@ -10,7 +10,7 @@ use unicode_width::UnicodeWidthStr;
 
 pub(crate) fn write_member_name(
     name: &JsAnyObjectMemberName,
-    buffer: &mut VecBuffer<JsFormatContext>,
+    f: &mut Formatter<JsFormatContext>,
 ) -> FormatResult<usize> {
     match name {
         name @ JsAnyObjectMemberName::JsLiteralMemberName(literal) => {
@@ -18,19 +18,19 @@ pub(crate) fn write_member_name(
 
             if value.kind() == JS_STRING_LITERAL {
                 let format = FormatLiteralStringToken::new(&value, StringLiteralParentKind::Member);
-                let cleaned = format.clean_text(buffer.context());
+                let cleaned = format.clean_text(f.context());
 
-                write!(buffer, [cleaned])?;
+                write!(f, [cleaned])?;
 
                 Ok(cleaned.width())
             } else {
-                write!(buffer, [name.format()])?;
+                write!(f, [name.format()])?;
 
                 Ok(value.text_trimmed().width())
             }
         }
         name => {
-            write!(buffer, [&name.format()])?;
+            write!(f, [&name.format()])?;
             Ok(name.text().width())
         }
     }

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 257
 expression: arrow_nested.js
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 257
 expression: assignment.js
 ---
 # Input
@@ -340,7 +339,7 @@ a =
 
 a = {
 	// rome-ignore format: test
-        a: { t: c = b },
+	a: { t: c = b },
 	loreum,
 	ipsurm,
 } = {};

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/call.js.snap
@@ -21,8 +21,7 @@ if (true) {
     if (true) {
       if (true) {
         if (true) {
-          longVariableName1 =
-            // @ts-ignore
+          longVariableName1 = // @ts-ignore
             (variable01 + veryLongVariableNameNumber2).method();
         }
       }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/call.js.snap
@@ -21,7 +21,8 @@ if (true) {
     if (true) {
       if (true) {
         if (true) {
-          longVariableName1 = // @ts-ignore
+          longVariableName1 =
+            // @ts-ignore
             (variable01 + veryLongVariableNameNumber2).method();
         }
       }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
@@ -84,7 +84,8 @@ f3 = (
   a = b, //comment
 ) => {};
 
-f4 = // Comment
+f4 =
+  // Comment
   () => {};
 
 f5 =

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
@@ -84,8 +84,7 @@ f3 = (
   a = b, //comment
 ) => {};
 
-f4 =
-  // Comment
+f4 = // Comment
   () => {};
 
 f5 =

--- a/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/export-default-from.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/export-default-from.js.snap
@@ -15,7 +15,6 @@ export v from 'mod';
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from
 
-
 export
 v;
 from;

--- a/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/parent.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/parent.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: parent.js
 ---
 # Input
@@ -19,14 +18,15 @@ runtimeAgent.getProperties(
 
 # Output
 ```js
-runtimeAgent.getProperties(objectId, false, false, false, (
-  // ownProperties // accessorPropertiesOnly // generatePreview
-  error,
-  properties,
-  internalProperties,
-) => {
-  return 1;
-});
+runtimeAgent.getProperties(
+  objectId,
+  false, // ownProperties
+  false, // accessorPropertiesOnly
+  false, // generatePreview
+  (error, properties, internalProperties) => {
+    return 1;
+  },
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/parent.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/parent.js.snap
@@ -18,15 +18,14 @@ runtimeAgent.getProperties(
 
 # Output
 ```js
-runtimeAgent.getProperties(
-  objectId,
-  false, // ownProperties
-  false, // accessorPropertiesOnly
-  false, // generatePreview
-  (error, properties, internalProperties) => {
-    return 1;
-  },
-);
+runtimeAgent.getProperties(objectId, false, false, false, (
+  // ownProperties // accessorPropertiesOnly // generatePreview
+  error,
+  properties,
+  internalProperties,
+) => {
+  return 1;
+});
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/class-comment/misc.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/class-comment/misc.js.snap
@@ -16,8 +16,8 @@ class x {
 # Output
 ```js
 class x {
-  focus() // comment 1
-  {
+  focus() {
+    // comment 1
     // comment 2
   }
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/class-comment/misc.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/class-comment/misc.js.snap
@@ -16,8 +16,8 @@ class x {
 # Output
 ```js
 class x {
-  focus() {
-    // comment 1
+  focus() // comment 1
+  {
     // comment 2
   }
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/last-arg.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/last-arg.js.snap
@@ -61,7 +61,7 @@ class Foo {
     lol /*string*/,
     lol2 /*string*/,
     lol3 /*string*/,
-    lol4 /*string*/,
+    lol4, /*string*/
   ) /*string*/ {}
 
   // prettier-ignore

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/switch.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/switch.js.snap
@@ -66,7 +66,8 @@ switch (foo) {
 }
 
 switch (foo) {
-  case "bar": //comment
+  case "bar":
+    //comment
     doThing(); //comment
 
   case "baz":

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/switch.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/switch.js.snap
@@ -66,8 +66,7 @@ switch (foo) {
 }
 
 switch (foo) {
-  case "bar":
-    //comment
+  case "bar": //comment
     doThing(); //comment
 
   case "baz":

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorator-comments/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorator-comments/comments.js.snap
@@ -16,8 +16,8 @@ class Something {
 ```js
 class Something {
   @Annotateme()
-    // comment
-    static property: Array<string>;
+  // comment
+  static property: Array<string>;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/destructuring-ignore/ignore.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/destructuring-ignore/ignore.js.snap
@@ -88,7 +88,7 @@ const {
 const {
   baz: {
     // prettier-ignore
-  foo2 = [1, 2,    3],
+    foo2 = [1, 2,    3],
   },
   // prettier-ignore
   bar7 =            1,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/if/expr_and_same_line_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/if/expr_and_same_line_comments.js.snap
@@ -33,40 +33,40 @@ if (a === 0) {
 } else if (a === 1) {
   doSomethingElse(); // comment B1
 } else if (a === 2) {
-  doSomethingElse(); // comment C1
-}
+  doSomethingElse();
+} // comment C1
 
 if (a === 0) {
   doSomething(); /* comment A2 */
 } else if (a === 1) {
   doSomethingElse(); /* comment B2 */
 } else if (a === 2) {
-  doSomethingElse(); /* comment C2 */
-}
+  doSomethingElse();
+} /* comment C2 */
 
 if (a === 0) {
   expr; // comment A3
 } else if (a === 1) {
   expr; // comment B3
 } else if (a === 2) {
-  expr; // comment C3
-}
+  expr;
+} // comment C3
 
 if (a === 0) {
   expr; /* comment A4 */
 } else if (a === 1) {
   expr; /* comment B4 */
 } else if (a === 2) {
-  expr; /* comment C4 */
-}
+  expr;
+} /* comment C4 */
 
 if (a === 0) {
   looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong; // comment A5
 } else if (a === 1) {
   looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong; // comment B5
 } else if (a === 2) {
-  looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong; // comment C5
-}
+  looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong;
+} // comment C5
 
 ```
 
@@ -74,6 +74,5 @@ if (a === 0) {
 ```
    34:   looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong; // comment A5
    36:   looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong; // comment B5
-   38:   looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong; // comment C5
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ignore/semi/directive.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ignore/semi/directive.js.snap
@@ -24,7 +24,7 @@ function foo() {
 
 function foo() {
   // prettier-ignore
-'use strict';
+  'use strict';
   [].forEach();
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/import/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/import/comments.js.snap
@@ -88,7 +88,7 @@ import {
   FN1, // comment 2
   /* comment 3 */ FN2,
   // FN3,
-  FN4 /* comment 4 */,
+  FN4, /* comment 4 */
   // FN4,
   // FN5
 } from "./module";

--- a/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/arrow.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/arrow.js.snap
@@ -31,8 +31,7 @@ export default function searchUsers(action$) {
     .filter((q) => !!q)
     .switchMap(
       (q) =>
-        Observable.timer(800)
-          // debounce
+        Observable.timer(800) // debounce
           .takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS))
           .mergeMap(
             () =>

--- a/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/arrow.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/arrow.js.snap
@@ -31,7 +31,8 @@ export default function searchUsers(action$) {
     .filter((q) => !!q)
     .switchMap(
       (q) =>
-        Observable.timer(800) // debounce
+        Observable.timer(800)
+          // debounce
           .takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS))
           .mergeMap(
             () =>

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: comment.js
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
@@ -274,7 +274,8 @@ action$
   .filter((q) => !!q)
   .switchMap(
     (q) =>
-      Observable.timer(800) // debounce
+      Observable.timer(800)
+        // debounce
         .takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS))
         .mergeMap(
           () =>

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: issue-4125.js
 ---
 # Input
@@ -275,8 +274,7 @@ action$
   .filter((q) => !!q)
   .switchMap(
     (q) =>
-      Observable.timer(800)
-        // debounce
+      Observable.timer(800) // debounce
         .takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS))
         .mergeMap(
           () =>

--- a/crates/rome_js_formatter/tests/specs/prettier/js/module-blocks/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/module-blocks/comments.js.snap
@@ -19,7 +19,7 @@ const m2 = module/* B1 */{
 
 # Output
 ```js
-const m = /*A1*/ module /*A2*/;
+const m = /*A1*/ module; /*A2*/
 {
   /*A3*/
   /*A4*/
@@ -29,7 +29,7 @@ const m = /*A1*/ module /*A2*/;
 } /*A7*/
 /*A8*/
 
-const m2 = module /* B1 */;
+const m2 = module; /* B1 */
 {
   /* B2 */
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/object-property-ignore/ignore.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/object-property-ignore/ignore.js.snap
@@ -96,7 +96,7 @@ foo = {
 foo = {
   baz: {
     // prettier-ignore
-  foo: [1, 2,    3],
+    foo: [1, 2,    3],
   },
   // prettier-ignore
   bar:            1,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/switch/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/switch/comments.js.snap
@@ -92,14 +92,13 @@ switch (x) {
 }
 
 switch (x) {
-  default:
-    // comment
+  default: // comment
     break;
 }
 
 switch (x) {
-  default: {
-    // comment
+  default: // comment
+  {
     break;
   }
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/switch/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/switch/comments.js.snap
@@ -92,7 +92,8 @@ switch (x) {
 }
 
 switch (x) {
-  default: // comment
+  default:
+    // comment
     break;
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/unary-expression/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/unary-expression/comments.js.snap
@@ -541,8 +541,7 @@ async function bar2() {
   /* foo */
 );
 !(
-  () =>
-    3 // foo
+  () => 3 // foo
 );
 
 function* bar() {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/class-comment/declare.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/class-comment/declare.ts.snap
@@ -22,9 +22,7 @@ extends B<T> // 3
 ```js
 declare class a // 1
   // extends b   // 2
-  implements
-    z,
-    x // 3
+  implements z, x // 3
 {
   doo: boolean;
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/after_jsx_generic.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/after_jsx_generic.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: after_jsx_generic.ts
 ---
 # Input
@@ -48,9 +47,8 @@ let comp = (
   // comment6
   ></Component>
   <Component<number>
-    // comment7
-    foo
-  ></Component>
+  // comment7
+  foo></Component>
   <Component<number>
     foo
     // comment8

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/location.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/location.ts.snap
@@ -57,7 +57,7 @@ export interface ApplicationEventData {
   registerBroadcastReceiver(
     onReceiveCallback: (
       context: any /* android.content.Context */,
-      intent: any /* android.content.Intent */,
+      intent: any, /* android.content.Intent */
     ) => void,
   ): void;
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/method_types.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/method_types.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 182
 expression: method_types.ts
 ---
 # Input
@@ -52,7 +51,7 @@ abstract class Test {
 interface foo1 {
   bar3 /* foo */ (/* baz */); // bat
   bar /* foo */ ? /* bar */ (/* baz */) /* bat */;
-  bar2 /* foo */ (/* baz */) /* bat */;
+  bar2 /* foo */ (/* baz */); /* bat */
 }
 
 interface foo2 {
@@ -86,7 +85,7 @@ let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
 abstract class Test {
   abstract foo12 /* foo */ (a: /* bar */ string): /* baz */ void;
 
-  abstract foo13 /* foo */ (/* bar */) /* baz */;
+  abstract foo13 /* foo */ (/* bar */); /* baz */
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/type_literals.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/type_literals.ts.snap
@@ -22,10 +22,10 @@ type Props3 = {
 
 # Output
 ```js
-type Props1 = {
-  // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
-  isPlaying: boolean;
-};
+type Props1 = // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+  {
+    isPlaying: boolean;
+  };
 
 type Props2 = {
   // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorators-comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorators-comments.ts.snap
@@ -83,14 +83,14 @@ class Something {
 
 class Something2 {
   @foo()
-    // comment
-    abstract property: Array<string>
+  // comment
+  abstract property: Array<string>
 }
 
 class Something3 {
   @foo()
-    // comment
-    abstract method(): Array<string>
+  // comment
+  abstract method(): Array<string>
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/export/comment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/export/comment.ts.snap
@@ -11,7 +11,7 @@ a
 
 # Output
 ```js
-export function match(): string /* the matching pattern */;
+export function match(): string; /* the matching pattern */
 a;
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/comments-generic.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/comments-generic.ts.snap
@@ -40,38 +40,34 @@ interface Foo<
 # Output
 ```js
 interface ReallyReallyLongName<
-  TypeArgumentNumberOne,
-  TypeArgumentNumberTwo,
-  TypeArgumentNumberThree,
-> extends BaseInterface {} // 1
+    TypeArgumentNumberOne,
+    TypeArgumentNumberTwo,
+    TypeArgumentNumberThree,
+  > // 1
+  extends BaseInterface {}
 
 interface ReallyReallyLongName2<
-  TypeArgumentNumberOne,
-  TypeArgumentNumberTwo,
-  TypeArgumentNumberThree,
->
-  // 1
+    TypeArgumentNumberOne,
+    TypeArgumentNumberTwo,
+    TypeArgumentNumberThree,
+  > // 1
   // 2
-  extends
-    BaseInterface
-{}
+  extends BaseInterface {}
 
 interface ReallyReallyLongName3<
-  TypeArgumentNumberOne,
-  TypeArgumentNumberTwo,
-  TypeArgumentNumberThree,
->
-  // 1
+    TypeArgumentNumberOne,
+    TypeArgumentNumberTwo,
+    TypeArgumentNumberThree,
+  > // 1
   // 2
-  extends
-    BaseInterface // 3
-{}
+  extends BaseInterface {} // 3
 
 interface Foo<
-  FOOOOOOOOOOOOOOOOOOOOOOOOOO,
-  FOOOOOOOOOOOOOOOOOOOOOOOOOO,
-  FOOOOOOOOOOOOOOOOOOOOOOOOOO,
-> extends Foo {} // comments
+    FOOOOOOOOOOOOOOOOOOOOOOOOOO,
+    FOOOOOOOOOOOOOOOOOOOOOOOOOO,
+    FOOOOOOOOOOOOOOOOOOOOOOOOOO,
+  > // comments
+  extends Foo {}
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/generic.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/generic.ts.snap
@@ -18,15 +18,14 @@ interface Foo<
 # Output
 ```js
 interface Foo<FOOOOOOOOOOOOOOOOOOOOOOOOOO, FOOOOOOOOOOOOOOOOOOOOOOO>
-  extends
-    Foo
-{}
+  extends Foo {}
 
 interface Foo<
   FOOOOOOOOOOOOOOOOOOOOOOOOOO,
   FOOOOOOOOOOOOOOOOOOOOOOOOOO,
   FOOOOOOOOOOOOOOOOOOOOOOOOOO,
-> extends Foo {}
+>
+  extends Foo {}
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/long-extends.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/long-extends.ts.snap
@@ -33,25 +33,19 @@ export interface I extends A, B, C {
 }
 
 export interface ThirdVeryLongAndBoringInterfaceName
-  extends
-    ALongAndBoringInterfaceName
-{
+  extends ALongAndBoringInterfaceName {
   c: string;
 }
 
 export interface ThirdVeryLongAndBoringInterfaceName
-  extends
-    ALongAndBoringInterfaceName,
-    AnotherLongAndBoringInterfaceName
-{
+  extends ALongAndBoringInterfaceName, AnotherLongAndBoringInterfaceName {
   c: string;
 }
 
 export interface ThirdVeryLongAndBoringInterfaceName
   extends
     AVeryLongAndBoringInterfaceName,
-    AnotherVeryLongAndBoringInterfaceName
-{
+    AnotherVeryLongAndBoringInterfaceName {
   c: string;
 }
 
@@ -59,8 +53,7 @@ export interface ThirdVeryLongAndBoringInterfaceName
   extends
     A_AVeryLongAndBoringInterfaceName,
     B_AVeryLongAndBoringInterfaceName,
-    C_AVeryLongAndBoringInterfaceName
-{
+    C_AVeryLongAndBoringInterfaceName {
   c: string;
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/break.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/break.ts.snap
@@ -100,9 +100,7 @@ declare interface ExtendsOne extends ASingleInterface {
 }
 
 declare interface ExtendsLarge
-  extends
-    ASingleInterfaceWithAReallyReallyReallyReallyLongName
-{
+  extends ASingleInterfaceWithAReallyReallyReallyReallyLongName {
   x: string;
 }
 
@@ -114,8 +112,7 @@ declare interface ExtendsMany
     Interface4,
     Interface5,
     Interface6,
-    Interface7
-{
+    Interface7 {
   x: string;
 }
 
@@ -125,9 +122,7 @@ interface ExtendsOne extends ASingleInterface {
 }
 
 interface ExtendsLarge
-  extends
-    ASingleInterfaceWithAReallyReallyReallyReallyLongName
-{
+  extends ASingleInterfaceWithAReallyReallyReallyReallyLongName {
   x: string;
 }
 
@@ -139,8 +134,7 @@ interface ExtendsMany
     Interface4,
     Interface5,
     Interface6,
-    Interface7
-{
+    Interface7 {
   s: string;
 }
 
@@ -150,9 +144,7 @@ interface ExtendsOne extends ASingleInterface<string> {
 }
 
 interface ExtendsLarge
-  extends
-    ASingleInterfaceWithAReallyReallyReallyReallyLongName<string>
-{
+  extends ASingleInterfaceWithAReallyReallyReallyReallyLongName<string> {
   x: string;
 }
 
@@ -166,8 +158,7 @@ interface ExtendsMany
       Interface5,
       Interface6,
       Interface7
-    >
-{
+    > {
   x: string;
 }
 
@@ -184,8 +175,7 @@ interface ExtendsManyWithGenerics
       Interface6,
       Interface7
     >,
-    InterfaceThree
-{
+    InterfaceThree {
   x: string;
 }
 
@@ -194,8 +184,7 @@ export interface ExtendsLongOneWithGenerics
     Bar<
       SomeLongTypeSomeLongTypeSomeLongTypeSomeLongType,
       ToBreakLineToBreakLineToBreakLine
-    >
-{}
+    > {}
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/comments-declare.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/comments-declare.ts.snap
@@ -12,8 +12,7 @@ declare interface a // 1
 
 # Output
 ```js
-declare interface a
-  // 1
+declare interface a // 1
   extends
     b // 2
 {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/comments.ts.snap
@@ -37,47 +37,40 @@ foo(): bar;}
 
 # Output
 ```js
-interface A1 {
-  // comment
+interface A1 // comment
+{
   foo(): bar;
 }
 
-interface A2 extends Base {
-  // comment
+interface A2 // comment
+  extends Base {
   foo(): bar;
 }
 
-interface A3
-  // comment1
+interface A3 // comment1
   extends
     Base // comment2
 {
   foo(): bar;
 }
 
-interface A4
-  // comment1
-  extends
-    Base // comment2
+interface A4 // comment1
+  extends Base // comment2
 // comment3
 {
   foo(): bar;
 }
 
-interface A5
-  // comment1
-  extends
-    Base // comment2
+interface A5 // comment1
+  extends Base // comment2
 // comment3
 {
   // comment4
   foo(): bar;
 }
 
-interface A6
-  // comment1
-  extends
-    Base // comment2
+interface A6 // comment1
+  extends Base // comment2
 // comment3
 {
   // comment4

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/tuple/tuple.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/tuple/tuple.ts.snap
@@ -24,7 +24,7 @@ export type SCMRawResource = [
   modes.Command /*command*/,
   string[] /*icons: light, dark*/,
   boolean /*strike through*/,
-  boolean /*faded*/,
+  boolean, /*faded*/
 ];
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/union/prettier-ignore.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/union/prettier-ignore.ts.snap
@@ -35,7 +35,7 @@ export type a =
 # Output
 ```js
 export type a =
-  // foo
+// foo
   | foo1 & foo2
   // bar
   | bar1 & bar2
@@ -43,7 +43,7 @@ export type a =
   | qux1 & qux2;
 
 export type a =
-  // foo
+// foo
   | foo1 & foo2
   // bar
   | bar1 & bar2

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 242
 expression: interface.ts
 ---
 # Input
@@ -48,7 +47,8 @@ interface C<
 	But,
 	Maybe,
 	Not,
-> extends B {
+>
+	extends B {
 	something: string;
 }
 
@@ -58,8 +58,7 @@ interface D
 		B<string, symbol>,
 		F<string, symbol>,
 		G<string, number, symbol>,
-		H<string, number, symbol>
-{
+		H<string, number, symbol> {
 	something1: string;
 	something2: string;
 	something3: string;

--- a/crates/rome_js_formatter/tests/specs/ts/suppressions.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/suppressions.ts
@@ -1,7 +1,7 @@
 
 interface Suppressions {
     // rome-ignore format: test
-    a: void
+    a:     void
 
     b: void
 }

--- a/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -6,10 +6,11 @@ expression: suppressions.ts
 
 interface Suppressions {
     // rome-ignore format: test
-    a: void
+    a:     void
 
     b: void
 }
+
 =============================
 # Outputs
 ## Output 1
@@ -20,7 +21,7 @@ Quote style: Double Quotes
 -----
 interface Suppressions {
 	// rome-ignore format: test
-    a: void
+	a:     void
 	b: void;
 }
 

--- a/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
@@ -56,10 +56,10 @@ type LongUnion =
 	| Z;
 
 type Comments =
-	// leading separator
+// leading separator
 	|
 	// leading type
 	A
-	| B /*
-trailing type */;
+	| B; /*
+trailing type */
 

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -315,9 +315,7 @@ pub fn generate_formatter() {
                 #[derive(Debug, Clone, Default)]
                 pub struct #format_id;
 
-                impl FormatRule<#node_id> for #format_id {
-                    type Context = JsFormatContext;
-
+                impl FormatNodeRule<#node_id> for #format_id {
                     fn fmt(&self, node: &#node_id, f: &mut JsFormatter) -> FormatResult<()> {
                         f.join().entries(node.iter().formatted()).finish()
                     }
@@ -330,9 +328,7 @@ pub fn generate_formatter() {
                 #[derive(Debug, Clone, Default)]
                 pub struct #format_id;
 
-                impl FormatRule<#node_id> for #format_id {
-                    type Context = JsFormatContext;
-
+                impl FormatNodeRule<#node_id> for #format_id {
                     fn fmt(&self, node: &#node_id, f: &mut JsFormatter) -> FormatResult<()> {
                         format_verbatim_node(node.syntax()).fmt(f)
                     }
@@ -436,7 +432,7 @@ impl BoilerplateImpls {
 
     fn push(&mut self, kind: &NodeKind, node_id: &Ident, format_id: &TokenStream) {
         let format_rule_impl = match kind {
-            NodeKind::List { .. } | NodeKind::Union { .. } => quote!(),
+            NodeKind::Union { .. } => quote!(),
             _ => quote! {
                 impl FormatRule<rome_js_syntax::#node_id> for #format_id {
                    type Context = JsFormatContext;


### PR DESCRIPTION

## Summary

This PR isn't ready yet. It considerably regresses performance and there are still a few instabilities when it comes to formatting comments. But it tries to address the first issue described in #2768 by formatting leading/trailing comments at the start/end of a node with the most outer node rather than the token. 

I mainly want to put this up in case you hit any more instability issues while I'm on PTO and need an urgent fix. This should then be a good starting point. 

CC: @leops @yassere @ematipico 

## Test Plan
