### PR TITLE
feat(rome_js_formatter): add format element label

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -47,7 +47,7 @@ pub use arguments::{Argument, Arguments};
 pub use buffer::{Buffer, BufferExtensions, BufferSnapshot, Inspect, PreambleBuffer, VecBuffer};
 pub use builders::{
     block_indent, comment, empty_line, get_lines_before, group_elements, hard_line_break,
-    if_group_breaks, if_group_fits_on_line, indent, line_suffix, soft_block_indent,
+    if_group_breaks, if_group_fits_on_line, indent, labelled, line_suffix, soft_block_indent,
     soft_line_break, soft_line_break_or_space, soft_line_indent_or_space, space_token, token,
     BestFitting,
 };

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -295,6 +295,12 @@ impl<'a> Printer<'a> {
                 }
             }
             FormatElement::Interned(content) => queue.enqueue(PrintElementCall::new(content, args)),
+            FormatElement::Label(label) => queue.extend(
+                label
+                    .content
+                    .iter()
+                    .map(|element| PrintElementCall::new(element, args)),
+            ),
         }
     }
 
@@ -832,6 +838,12 @@ fn fits_element_on_line<'a, 'rest>(
             }
         }
         FormatElement::Interned(content) => queue.enqueue(PrintElementCall::new(content, args)),
+        FormatElement::Label(label) => queue.extend(
+            label
+                .content
+                .iter()
+                .map(|element| PrintElementCall::new(element, args)),
+        ),
     }
 
     Fits::Maybe


### PR DESCRIPTION
## Summary

This PR introduces the new IR element `Label`. This IR matches Prettier's `label` command.
- https://github.com/prettier/prettier/blob/main/commands.md#label

This IR can be useful if representation depends on different representation of child content. 
E.g., to decide how to print an assignment expression, we might want to know whether its right-hand side has been printed as a method call chain, not as a plain function call. 

## Test Plan

Added a new doc showing how to use the new IR