### PR TITLE
fix(rome_js_formatter): indentation before arrow fn is JSX

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,22 +1,22 @@
 {
 	"name": "rome",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rome",
-			"version": "0.8.0",
+			"version": "0.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"vscode-languageclient": "^8.0.0-next.13"
+				"vscode-languageclient": "^8.0.1"
 			},
 			"devDependencies": {
-				"@types/node": "^16.11.9",
-				"@types/vscode": "^1.52.0",
-				"esbuild": "^0.14.27",
+				"@types/node": "^18.0.0",
+				"@types/vscode": "^1.68.1",
+				"esbuild": "^0.14.47",
 				"typescript": "^4.5.2",
-				"vsce": "^2.7.0"
+				"vsce": "^2.9.2"
 			},
 			"engines": {
 				"npm": "^8",
@@ -24,15 +24,15 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "16.11.19",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
-			"integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng==",
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+			"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.63.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.1.tgz",
-			"integrity": "sha512-Z+ZqjRcnGfHP86dvx/BtSwWyZPKQ/LBdmAVImY82TphyjOw2KgTKcp7Nx92oNwCTsHzlshwexAG/WiY2JuUm3g==",
+			"version": "1.68.1",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.1.tgz",
+			"integrity": "sha512-fXlaq13NT5yHh6yZ3c+UxXloTSk34mIvsNFYyQCeO5Po2BLFAwz7EZT4kQ43B64/aPcnAenyWy3QasrTofBOnQ==",
 			"dev": true
 		},
 		"node_modules/ansi-regex": {
@@ -447,9 +447,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.31.tgz",
-			"integrity": "sha512-QA0fUM13+JZzcvg1bdrhi7wo8Lr5IRHA9ypNn2znqxGqb66dSK6pAh01TjyBOhzZGazPQJZ1K26VrCAQJ715qA==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.47.tgz",
+			"integrity": "sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -459,32 +459,32 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"esbuild-android-64": "0.14.31",
-				"esbuild-android-arm64": "0.14.31",
-				"esbuild-darwin-64": "0.14.31",
-				"esbuild-darwin-arm64": "0.14.31",
-				"esbuild-freebsd-64": "0.14.31",
-				"esbuild-freebsd-arm64": "0.14.31",
-				"esbuild-linux-32": "0.14.31",
-				"esbuild-linux-64": "0.14.31",
-				"esbuild-linux-arm": "0.14.31",
-				"esbuild-linux-arm64": "0.14.31",
-				"esbuild-linux-mips64le": "0.14.31",
-				"esbuild-linux-ppc64le": "0.14.31",
-				"esbuild-linux-riscv64": "0.14.31",
-				"esbuild-linux-s390x": "0.14.31",
-				"esbuild-netbsd-64": "0.14.31",
-				"esbuild-openbsd-64": "0.14.31",
-				"esbuild-sunos-64": "0.14.31",
-				"esbuild-windows-32": "0.14.31",
-				"esbuild-windows-64": "0.14.31",
-				"esbuild-windows-arm64": "0.14.31"
+				"esbuild-android-64": "0.14.47",
+				"esbuild-android-arm64": "0.14.47",
+				"esbuild-darwin-64": "0.14.47",
+				"esbuild-darwin-arm64": "0.14.47",
+				"esbuild-freebsd-64": "0.14.47",
+				"esbuild-freebsd-arm64": "0.14.47",
+				"esbuild-linux-32": "0.14.47",
+				"esbuild-linux-64": "0.14.47",
+				"esbuild-linux-arm": "0.14.47",
+				"esbuild-linux-arm64": "0.14.47",
+				"esbuild-linux-mips64le": "0.14.47",
+				"esbuild-linux-ppc64le": "0.14.47",
+				"esbuild-linux-riscv64": "0.14.47",
+				"esbuild-linux-s390x": "0.14.47",
+				"esbuild-netbsd-64": "0.14.47",
+				"esbuild-openbsd-64": "0.14.47",
+				"esbuild-sunos-64": "0.14.47",
+				"esbuild-windows-32": "0.14.47",
+				"esbuild-windows-64": "0.14.47",
+				"esbuild-windows-arm64": "0.14.47"
 			}
 		},
 		"node_modules/esbuild-android-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.31.tgz",
-			"integrity": "sha512-MYkuJ91w07nGmr4EouejOZK2j/f5TCnsKxY8vRr2+wpKKfHD1LTJK28VbZa+y1+AL7v1V9G98ezTUwsV3CmXNw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz",
+			"integrity": "sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==",
 			"cpu": [
 				"x64"
 			],
@@ -498,9 +498,9 @@
 			}
 		},
 		"node_modules/esbuild-android-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.31.tgz",
-			"integrity": "sha512-0rkH/35s7ZVcsw6nS0IAkR0dekSbjZGWdlOAf3jV0lGoPqqw0x6/TmaV9w7DQgUERTH1ApmPlpAMU4kVkCq9Jg==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz",
+			"integrity": "sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -514,9 +514,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.31.tgz",
-			"integrity": "sha512-kP6xPZHxtJa36Hb0jC05L3VzQSZBW2f3bpnQS20czXTRGEmM2GDiYpGdI5g2QYaw6vC4PYXjnigq8usd9g9jnQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz",
+			"integrity": "sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==",
 			"cpu": [
 				"x64"
 			],
@@ -530,9 +530,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.31.tgz",
-			"integrity": "sha512-1ZMog4hkNsdBGtDDtsftUqX6S9N52gEx4vX5aVehsSptgoBFIar1XrPiBTQty7YNH+bJasTpSVaZQgElCVvPKQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz",
+			"integrity": "sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==",
 			"cpu": [
 				"arm64"
 			],
@@ -546,9 +546,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.31.tgz",
-			"integrity": "sha512-Zo0BYj7QpVFWoUpkv6Ng0RO2eJ4zk/WDaHMO88+jr5HuYmxsOre0imgwaZVPquTuJnCvL1G48BFucJ3tFflSeQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz",
+			"integrity": "sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==",
 			"cpu": [
 				"x64"
 			],
@@ -562,9 +562,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.31.tgz",
-			"integrity": "sha512-t85bS6jbRpmdjr4pdr/FY/fpx8lo1vv9S7BAs2EsXKJQhRDMIiC3QW+k2acYJoRuqirlvJcJVFQGCq/PfyC1kA==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz",
+			"integrity": "sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -578,9 +578,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-32": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.31.tgz",
-			"integrity": "sha512-XYtOk/GodSkv+UOYVwryGpGPuFnszsMvRMKq6cIUfFfdssHuKDsU9IZveyCG44J106J39ABenQ5EetbYtVJHUw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz",
+			"integrity": "sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==",
 			"cpu": [
 				"ia32"
 			],
@@ -594,9 +594,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.31.tgz",
-			"integrity": "sha512-Zf9CZxAxaXWHLqCg/QZ/hs0RU0XV3IBxV+ENQzy00S4QOTnZAvSLgPciILHHrVJ0lPIlb4XzAqlLM5y6iI2LIw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz",
+			"integrity": "sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==",
 			"cpu": [
 				"x64"
 			],
@@ -610,9 +610,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.31.tgz",
-			"integrity": "sha512-RpiaeHPRlgCCDskxoyIsI49BhcDtZ4cl8+SLffizDm0yMNWP538SUg0ezQ2TTOPj3/svaGIbkRDwYtAon0Sjkg==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz",
+			"integrity": "sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==",
 			"cpu": [
 				"arm"
 			],
@@ -626,9 +626,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.31.tgz",
-			"integrity": "sha512-V/H0tv+xpQ9IOHM+o85oCKNNidIEc5CcnDWl0V+hPd2F03dqdbFkWPBGphx8rD4JSQn6UefUQ1iH7y1qIzO8Fw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz",
+			"integrity": "sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==",
 			"cpu": [
 				"arm64"
 			],
@@ -642,9 +642,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.31.tgz",
-			"integrity": "sha512-9/oBfAckInRuUg6AEgdCLLn6KJ6UOJDOLmUinTsReVSg6AfV6wxYQJq9iQM2idRogP7GUpomJ+bvCdWXpotQRQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz",
+			"integrity": "sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==",
 			"cpu": [
 				"mips64el"
 			],
@@ -658,9 +658,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.31.tgz",
-			"integrity": "sha512-NMcb14Pg+8q8raGkzor9/R3vQwKzgxE3694BtO2SDLBwJuL2C1dQ1ZtM1t7ZvArQBgT8RiZVxb0/3fD+qGNk7g==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz",
+			"integrity": "sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -674,9 +674,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.31.tgz",
-			"integrity": "sha512-l13yvmsVfawAnoYfcpuvml+nTlrOmtdceXYufSkXl2DOb0JKcuR6ARlAzuQCDcpo49SOJy1cCxpwlOIsUQBfzA==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz",
+			"integrity": "sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==",
 			"cpu": [
 				"riscv64"
 			],
@@ -690,9 +690,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-s390x": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.31.tgz",
-			"integrity": "sha512-GIwV9mY3koYja9MCSkKLk1P7rj+MkPV0UsGsZ575hEcIBrXeKN9jBi6X/bxDDPEN/SUAH35cJhBNrZU4x9lEfg==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz",
+			"integrity": "sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==",
 			"cpu": [
 				"s390x"
 			],
@@ -706,9 +706,9 @@
 			}
 		},
 		"node_modules/esbuild-netbsd-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.31.tgz",
-			"integrity": "sha512-bJ+pyLvKQm+Obp5k7/Wk8e9Gdkls56F1aiI3uptoIfOIUqsZImH7pDyTrSufwqsFp62kO9LRuwXnjDwQtPyhFQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz",
+			"integrity": "sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==",
 			"cpu": [
 				"x64"
 			],
@@ -722,9 +722,9 @@
 			}
 		},
 		"node_modules/esbuild-openbsd-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.31.tgz",
-			"integrity": "sha512-NRAAPPca05H9j9Xab0kVXK0V6/pyZGGy8d2Y8KS0BMwWEydlD4KCJDmH8/7bWCKYLRGOOCE9/GPBJyPWHFW3sg==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz",
+			"integrity": "sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==",
 			"cpu": [
 				"x64"
 			],
@@ -738,9 +738,9 @@
 			}
 		},
 		"node_modules/esbuild-sunos-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.31.tgz",
-			"integrity": "sha512-9uA+V8w9Eehu4ldb95lPWdgCMcMO5HH6pXmfkk5usn3JsSZxKdLKsXB4hYgP80wscZvVYXJl2G+KNxsUTfPhZw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz",
+			"integrity": "sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==",
 			"cpu": [
 				"x64"
 			],
@@ -754,9 +754,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-32": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.31.tgz",
-			"integrity": "sha512-VGdncQTqoxD9q3v/dk0Yugbmx2FzOkcs0OemBYc1X9KXOLQYH0uQbLJIckZdZOC3J+JKSExbYFrzYCOwWPuNyA==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz",
+			"integrity": "sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -770,9 +770,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.31.tgz",
-			"integrity": "sha512-v/2ye5zBqpmCzi3bLCagStbNQlnOsY7WtMrD2Q0xZxeSIXONxji15KYtVee5o7nw4lXWbQSS1BL8G6BBMvtq4A==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz",
+			"integrity": "sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==",
 			"cpu": [
 				"x64"
 			],
@@ -786,9 +786,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.31.tgz",
-			"integrity": "sha512-RXeU42FJoG1sriNHg73h4S+5B7L/gw+8T7U9u8IWqSSEbY6fZvBh4uofugiU1szUDqqP00GHwZ09WgYe3lGZiw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz",
+			"integrity": "sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1687,9 +1687,9 @@
 			"dev": true
 		},
 		"node_modules/vsce": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.7.0.tgz",
-			"integrity": "sha512-CKU34wrQlbKDeJCRBkd1a8iwF9EvNxcYMg9hAUH6AxFGR6Wo2IKWwt3cJIcusHxx6XdjDHWlfAS/fJN30uvVnA==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.9.2.tgz",
+			"integrity": "sha512-xyLqL4U82BilUX1t6Ym2opQEa2tLGWYjbgB7+ETeNVXlIJz5sWBJjQJSYJVFOKJSpiOtQclolu88cj7oY6vvPQ==",
 			"dev": true,
 			"dependencies": {
 				"azure-devops-node-api": "^11.0.1",
@@ -1721,24 +1721,24 @@
 			}
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "8.0.0-next.7",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.7.tgz",
-			"integrity": "sha512-JX/F31LEsims0dAlOTKFE4E+AJMiJvdRSRViifFJSqSN7EzeYyWlfuDchF7g91oRNPZOIWfibTkDf3/UMsQGzQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
+			"integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "8.0.0-next.13",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.0-next.13.tgz",
-			"integrity": "sha512-X4GL8ZhQgTxeLSkGYZKyOjJ80TYauDVH1UmtR++xK4lIIDfWjUFN7oZBuUIlGj0EIY28qDgB180bAaOzKCDJFA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
+			"integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
 			"dependencies": {
 				"minimatch": "^3.0.4",
 				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.0-next.15"
+				"vscode-languageserver-protocol": "3.17.1"
 			},
 			"engines": {
-				"vscode": "^1.63.0"
+				"vscode": "^1.67.0"
 			}
 		},
 		"node_modules/vscode-languageclient/node_modules/semver": {
@@ -1756,18 +1756,18 @@
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.0-next.15",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.15.tgz",
-			"integrity": "sha512-73LffxyP/0TRyk3J7bCYt0BuFBzk4Qvo5TqZndOsP+uBDbRV4IT7ebu4M/XoPDSCyZ+jDIxW7if/JbhBznmwBg==",
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
+			"integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
 			"dependencies": {
-				"vscode-jsonrpc": "8.0.0-next.7",
-				"vscode-languageserver-types": "3.17.0-next.8"
+				"vscode-jsonrpc": "8.0.1",
+				"vscode-languageserver-types": "3.17.1"
 			}
 		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.0-next.8",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.8.tgz",
-			"integrity": "sha512-Mwj+FemiEk4QUUms1GGvXwDC+laJGVFuA4glbMVJTxfXdfOFZaEuyVlLobjccBo+NzD+5oEzzejTX7nWGNajjQ=="
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
+			"integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
 		},
 		"node_modules/wide-align": {
 			"version": "1.1.5",
@@ -1833,15 +1833,15 @@
 	},
 	"dependencies": {
 		"@types/node": {
-			"version": "16.11.19",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
-			"integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng==",
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+			"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.63.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.1.tgz",
-			"integrity": "sha512-Z+ZqjRcnGfHP86dvx/BtSwWyZPKQ/LBdmAVImY82TphyjOw2KgTKcp7Nx92oNwCTsHzlshwexAG/WiY2JuUm3g==",
+			"version": "1.68.1",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.1.tgz",
+			"integrity": "sha512-fXlaq13NT5yHh6yZ3c+UxXloTSk34mIvsNFYyQCeO5Po2BLFAwz7EZT4kQ43B64/aPcnAenyWy3QasrTofBOnQ==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -2155,170 +2155,170 @@
 			"dev": true
 		},
 		"esbuild": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.31.tgz",
-			"integrity": "sha512-QA0fUM13+JZzcvg1bdrhi7wo8Lr5IRHA9ypNn2znqxGqb66dSK6pAh01TjyBOhzZGazPQJZ1K26VrCAQJ715qA==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.47.tgz",
+			"integrity": "sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==",
 			"dev": true,
 			"requires": {
-				"esbuild-android-64": "0.14.31",
-				"esbuild-android-arm64": "0.14.31",
-				"esbuild-darwin-64": "0.14.31",
-				"esbuild-darwin-arm64": "0.14.31",
-				"esbuild-freebsd-64": "0.14.31",
-				"esbuild-freebsd-arm64": "0.14.31",
-				"esbuild-linux-32": "0.14.31",
-				"esbuild-linux-64": "0.14.31",
-				"esbuild-linux-arm": "0.14.31",
-				"esbuild-linux-arm64": "0.14.31",
-				"esbuild-linux-mips64le": "0.14.31",
-				"esbuild-linux-ppc64le": "0.14.31",
-				"esbuild-linux-riscv64": "0.14.31",
-				"esbuild-linux-s390x": "0.14.31",
-				"esbuild-netbsd-64": "0.14.31",
-				"esbuild-openbsd-64": "0.14.31",
-				"esbuild-sunos-64": "0.14.31",
-				"esbuild-windows-32": "0.14.31",
-				"esbuild-windows-64": "0.14.31",
-				"esbuild-windows-arm64": "0.14.31"
+				"esbuild-android-64": "0.14.47",
+				"esbuild-android-arm64": "0.14.47",
+				"esbuild-darwin-64": "0.14.47",
+				"esbuild-darwin-arm64": "0.14.47",
+				"esbuild-freebsd-64": "0.14.47",
+				"esbuild-freebsd-arm64": "0.14.47",
+				"esbuild-linux-32": "0.14.47",
+				"esbuild-linux-64": "0.14.47",
+				"esbuild-linux-arm": "0.14.47",
+				"esbuild-linux-arm64": "0.14.47",
+				"esbuild-linux-mips64le": "0.14.47",
+				"esbuild-linux-ppc64le": "0.14.47",
+				"esbuild-linux-riscv64": "0.14.47",
+				"esbuild-linux-s390x": "0.14.47",
+				"esbuild-netbsd-64": "0.14.47",
+				"esbuild-openbsd-64": "0.14.47",
+				"esbuild-sunos-64": "0.14.47",
+				"esbuild-windows-32": "0.14.47",
+				"esbuild-windows-64": "0.14.47",
+				"esbuild-windows-arm64": "0.14.47"
 			}
 		},
 		"esbuild-android-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.31.tgz",
-			"integrity": "sha512-MYkuJ91w07nGmr4EouejOZK2j/f5TCnsKxY8vRr2+wpKKfHD1LTJK28VbZa+y1+AL7v1V9G98ezTUwsV3CmXNw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz",
+			"integrity": "sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-android-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.31.tgz",
-			"integrity": "sha512-0rkH/35s7ZVcsw6nS0IAkR0dekSbjZGWdlOAf3jV0lGoPqqw0x6/TmaV9w7DQgUERTH1ApmPlpAMU4kVkCq9Jg==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz",
+			"integrity": "sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.31.tgz",
-			"integrity": "sha512-kP6xPZHxtJa36Hb0jC05L3VzQSZBW2f3bpnQS20czXTRGEmM2GDiYpGdI5g2QYaw6vC4PYXjnigq8usd9g9jnQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz",
+			"integrity": "sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.31.tgz",
-			"integrity": "sha512-1ZMog4hkNsdBGtDDtsftUqX6S9N52gEx4vX5aVehsSptgoBFIar1XrPiBTQty7YNH+bJasTpSVaZQgElCVvPKQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz",
+			"integrity": "sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.31.tgz",
-			"integrity": "sha512-Zo0BYj7QpVFWoUpkv6Ng0RO2eJ4zk/WDaHMO88+jr5HuYmxsOre0imgwaZVPquTuJnCvL1G48BFucJ3tFflSeQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz",
+			"integrity": "sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.31.tgz",
-			"integrity": "sha512-t85bS6jbRpmdjr4pdr/FY/fpx8lo1vv9S7BAs2EsXKJQhRDMIiC3QW+k2acYJoRuqirlvJcJVFQGCq/PfyC1kA==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz",
+			"integrity": "sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-32": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.31.tgz",
-			"integrity": "sha512-XYtOk/GodSkv+UOYVwryGpGPuFnszsMvRMKq6cIUfFfdssHuKDsU9IZveyCG44J106J39ABenQ5EetbYtVJHUw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz",
+			"integrity": "sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.31.tgz",
-			"integrity": "sha512-Zf9CZxAxaXWHLqCg/QZ/hs0RU0XV3IBxV+ENQzy00S4QOTnZAvSLgPciILHHrVJ0lPIlb4XzAqlLM5y6iI2LIw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz",
+			"integrity": "sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.31.tgz",
-			"integrity": "sha512-RpiaeHPRlgCCDskxoyIsI49BhcDtZ4cl8+SLffizDm0yMNWP538SUg0ezQ2TTOPj3/svaGIbkRDwYtAon0Sjkg==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz",
+			"integrity": "sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.31.tgz",
-			"integrity": "sha512-V/H0tv+xpQ9IOHM+o85oCKNNidIEc5CcnDWl0V+hPd2F03dqdbFkWPBGphx8rD4JSQn6UefUQ1iH7y1qIzO8Fw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz",
+			"integrity": "sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-mips64le": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.31.tgz",
-			"integrity": "sha512-9/oBfAckInRuUg6AEgdCLLn6KJ6UOJDOLmUinTsReVSg6AfV6wxYQJq9iQM2idRogP7GUpomJ+bvCdWXpotQRQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz",
+			"integrity": "sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-ppc64le": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.31.tgz",
-			"integrity": "sha512-NMcb14Pg+8q8raGkzor9/R3vQwKzgxE3694BtO2SDLBwJuL2C1dQ1ZtM1t7ZvArQBgT8RiZVxb0/3fD+qGNk7g==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz",
+			"integrity": "sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-riscv64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.31.tgz",
-			"integrity": "sha512-l13yvmsVfawAnoYfcpuvml+nTlrOmtdceXYufSkXl2DOb0JKcuR6ARlAzuQCDcpo49SOJy1cCxpwlOIsUQBfzA==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz",
+			"integrity": "sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-s390x": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.31.tgz",
-			"integrity": "sha512-GIwV9mY3koYja9MCSkKLk1P7rj+MkPV0UsGsZ575hEcIBrXeKN9jBi6X/bxDDPEN/SUAH35cJhBNrZU4x9lEfg==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz",
+			"integrity": "sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-netbsd-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.31.tgz",
-			"integrity": "sha512-bJ+pyLvKQm+Obp5k7/Wk8e9Gdkls56F1aiI3uptoIfOIUqsZImH7pDyTrSufwqsFp62kO9LRuwXnjDwQtPyhFQ==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz",
+			"integrity": "sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-openbsd-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.31.tgz",
-			"integrity": "sha512-NRAAPPca05H9j9Xab0kVXK0V6/pyZGGy8d2Y8KS0BMwWEydlD4KCJDmH8/7bWCKYLRGOOCE9/GPBJyPWHFW3sg==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz",
+			"integrity": "sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-sunos-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.31.tgz",
-			"integrity": "sha512-9uA+V8w9Eehu4ldb95lPWdgCMcMO5HH6pXmfkk5usn3JsSZxKdLKsXB4hYgP80wscZvVYXJl2G+KNxsUTfPhZw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz",
+			"integrity": "sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-32": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.31.tgz",
-			"integrity": "sha512-VGdncQTqoxD9q3v/dk0Yugbmx2FzOkcs0OemBYc1X9KXOLQYH0uQbLJIckZdZOC3J+JKSExbYFrzYCOwWPuNyA==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz",
+			"integrity": "sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.31.tgz",
-			"integrity": "sha512-v/2ye5zBqpmCzi3bLCagStbNQlnOsY7WtMrD2Q0xZxeSIXONxji15KYtVee5o7nw4lXWbQSS1BL8G6BBMvtq4A==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz",
+			"integrity": "sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-arm64": {
-			"version": "0.14.31",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.31.tgz",
-			"integrity": "sha512-RXeU42FJoG1sriNHg73h4S+5B7L/gw+8T7U9u8IWqSSEbY6fZvBh4uofugiU1szUDqqP00GHwZ09WgYe3lGZiw==",
+			"version": "0.14.47",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz",
+			"integrity": "sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -3016,9 +3016,9 @@
 			"dev": true
 		},
 		"vsce": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.7.0.tgz",
-			"integrity": "sha512-CKU34wrQlbKDeJCRBkd1a8iwF9EvNxcYMg9hAUH6AxFGR6Wo2IKWwt3cJIcusHxx6XdjDHWlfAS/fJN30uvVnA==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.9.2.tgz",
+			"integrity": "sha512-xyLqL4U82BilUX1t6Ym2opQEa2tLGWYjbgB7+ETeNVXlIJz5sWBJjQJSYJVFOKJSpiOtQclolu88cj7oY6vvPQ==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^11.0.1",
@@ -3044,18 +3044,18 @@
 			}
 		},
 		"vscode-jsonrpc": {
-			"version": "8.0.0-next.7",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.7.tgz",
-			"integrity": "sha512-JX/F31LEsims0dAlOTKFE4E+AJMiJvdRSRViifFJSqSN7EzeYyWlfuDchF7g91oRNPZOIWfibTkDf3/UMsQGzQ=="
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
+			"integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
 		},
 		"vscode-languageclient": {
-			"version": "8.0.0-next.13",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.0-next.13.tgz",
-			"integrity": "sha512-X4GL8ZhQgTxeLSkGYZKyOjJ80TYauDVH1UmtR++xK4lIIDfWjUFN7oZBuUIlGj0EIY28qDgB180bAaOzKCDJFA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
+			"integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
 			"requires": {
 				"minimatch": "^3.0.4",
 				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.0-next.15"
+				"vscode-languageserver-protocol": "3.17.1"
 			},
 			"dependencies": {
 				"semver": {
@@ -3069,18 +3069,18 @@
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.17.0-next.15",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.15.tgz",
-			"integrity": "sha512-73LffxyP/0TRyk3J7bCYt0BuFBzk4Qvo5TqZndOsP+uBDbRV4IT7ebu4M/XoPDSCyZ+jDIxW7if/JbhBznmwBg==",
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
+			"integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
 			"requires": {
-				"vscode-jsonrpc": "8.0.0-next.7",
-				"vscode-languageserver-types": "3.17.0-next.8"
+				"vscode-jsonrpc": "8.0.1",
+				"vscode-languageserver-types": "3.17.1"
 			}
 		},
 		"vscode-languageserver-types": {
-			"version": "3.17.0-next.8",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.8.tgz",
-			"integrity": "sha512-Mwj+FemiEk4QUUms1GGvXwDC+laJGVFuA4glbMVJTxfXdfOFZaEuyVlLobjccBo+NzD+5oEzzejTX7nWGNajjQ=="
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
+			"integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
 		},
 		"wide-align": {
 			"version": "1.1.5",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,11 +3,13 @@
 	"publisher": "rome",
 	"displayName": "Rome",
 	"description": "Rome LSP VS Code Extension",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"icon": "icon.png",
 	"activationEvents": [
 		"onLanguage:javascript",
+		"onLanguage:javascriptreact",
 		"onLanguage:typescript",
+		"onLanguage:typescriptreact",
 		"onCommand:rome.syntaxTree"
 	],
 	"main": "./out/main.js",
@@ -19,7 +21,7 @@
 		"url": "https://github.com/rome/tools/issues"
 	},
 	"engines": {
-		"vscode": "^1.63.0",
+		"vscode": "^1.68.1",
 		"npm": "^8"
 	},
 	"contributes": {
@@ -144,16 +146,17 @@
 		"package": "vsce package -o rome_lsp.vsix",
 		"build": "npm run compile -- --minify && npm run package",
 		"install-extension": "code --install-extension rome_lsp.vsix",
-		"format": "cargo run --bin rome format ./src/ ./scripts"
+		"format": "cargo run --bin rome format ./src/ ./scripts",
+		"tsc": "tsc"
 	},
 	"dependencies": {
-		"vscode-languageclient": "^8.0.0-next.13"
+		"vscode-languageclient": "^8.0.1"
 	},
 	"devDependencies": {
-		"@types/node": "^16.11.9",
-		"@types/vscode": "^1.52.0",
+		"@types/node": "^18.0.0",
+		"@types/vscode": "^1.68.1",
 		"typescript": "^4.5.2",
-		"vsce": "^2.7.0",
-		"esbuild": "^0.14.27"
+		"vsce": "^2.9.2",
+		"esbuild": "^0.14.47"
 	}
 }

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -44,6 +44,8 @@ export async function activate(context: ExtensionContext) {
 		documentSelector: [
 			{ scheme: "file", language: "javascript" },
 			{ scheme: "file", language: "typescript" },
+			{ scheme: "file", language: "javascriptreact" },
+			{ scheme: "file", language: "typescriptreact" },
 		],
 	};
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR enables formatting of `jsx` and `tsx` files inside the VS Code extension.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tried locally by installing it on my VS Code. The user has to manually enable Rome as default formatter for these files

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
