### PR TITLE
feat(rome_js_formatter): class property members as assignment like

### DIFF
--- a/crates/rome_js_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/property_class_member.rs
@@ -1,38 +1,18 @@
 use crate::prelude::*;
-use rome_formatter::{format_args, write};
-
-use crate::utils::FormatWithSemicolon;
-
+use crate::utils::{FormatWithSemicolon, JsAnyAssignmentLike};
+use rome_formatter::write;
 use rome_js_syntax::JsPropertyClassMember;
-use rome_js_syntax::JsPropertyClassMemberFields;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsPropertyClassMember;
 
 impl FormatNodeRule<JsPropertyClassMember> for FormatJsPropertyClassMember {
     fn fmt_fields(&self, node: &JsPropertyClassMember, f: &mut JsFormatter) -> FormatResult<()> {
-        let JsPropertyClassMemberFields {
-            modifiers,
-            name,
-            property_annotation,
-            value,
-            semicolon_token,
-        } = node.as_fields();
-
+        let semicolon_token = node.semicolon_token();
+        let body = format_with(|f| write!(f, [JsAnyAssignmentLike::from(node.clone())]));
         write!(
             f,
-            [FormatWithSemicolon::new(
-                &format_args!(
-                    modifiers.format(),
-                    space_token(),
-                    name.format(),
-                    property_annotation.format(),
-                    value
-                        .format()
-                        .with_or_empty(|node, f| write![f, [space_token(), node]]),
-                ),
-                semicolon_token.as_ref()
-            )]
+            [FormatWithSemicolon::new(&body, semicolon_token.as_ref())]
         )
     }
 }

--- a/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
@@ -1,9 +1,7 @@
 use crate::prelude::*;
-use rome_formatter::{format_args, write};
-
-use crate::utils::FormatWithSemicolon;
-
-use rome_js_syntax::{TsPropertySignatureClassMember, TsPropertySignatureClassMemberFields};
+use crate::utils::{FormatWithSemicolon, JsAnyAssignmentLike};
+use rome_formatter::write;
+use rome_js_syntax::TsPropertySignatureClassMember;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsPropertySignatureClassMember;
@@ -14,24 +12,11 @@ impl FormatNodeRule<TsPropertySignatureClassMember> for FormatTsPropertySignatur
         node: &TsPropertySignatureClassMember,
         f: &mut JsFormatter,
     ) -> FormatResult<()> {
-        let TsPropertySignatureClassMemberFields {
-            modifiers,
-            name,
-            property_annotation,
-            semicolon_token,
-        } = node.as_fields();
-
+        let semicolon_token = node.semicolon_token();
+        let body = format_with(|f| write!(f, [JsAnyAssignmentLike::from(node.clone())]));
         write!(
             f,
-            [FormatWithSemicolon::new(
-                &format_args!(
-                    modifiers.format(),
-                    space_token(),
-                    name.format(),
-                    property_annotation.format(),
-                ),
-                semicolon_token.as_ref()
-            )]
+            [FormatWithSemicolon::new(&body, semicolon_token.as_ref())]
         )
     }
 }

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -559,10 +559,8 @@ impl JsAnyAssignmentLike {
             declarator.initializer().is_none()
         } else if let JsAnyAssignmentLike::JsPropertyClassMember(class_member) = self {
             class_member.value().is_none()
-        } else if let JsAnyAssignmentLike::TsPropertySignatureClassMember(_) = self {
-            true
         } else {
-            false
+            matches!(self, JsAnyAssignmentLike::TsPropertySignatureClassMember(_))
         }
     }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/class-comment/class-property.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/class-comment/class-property.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: class-property.js
 ---
 # Input
@@ -18,10 +19,10 @@ class X {
 ```js
 class X {
   TEMPLATE =
-  // tab index is needed so we can focus, which is needed for keyboard events
-  '<div class="ag-large-text" tabindex="0">' +
-    '<div class="ag-large-textarea"></div>' +
-    "</div>";
+    // tab index is needed so we can focus, which is needed for keyboard events
+    '<div class="ag-large-text" tabindex="0">' +
+      '<div class="ag-large-textarea"></div>' +
+      "</div>";
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/classes-private-fields/with_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/classes-private-fields/with_comments.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: with_comments.js
 ---
 # Input
@@ -18,10 +19,10 @@ class A {
 ```js
 class A {
   #foobar =
-  // comment to break
-  1 +
-    // comment to break again
-    2;
+    // comment to break
+    1 +
+      // comment to break again
+      2;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/classes/property.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/classes/property.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: property.js
 ---
 # Input
@@ -29,15 +30,15 @@ class B {
 ```js
 class A {
   foobar =
-  // comment to break
-  1 +
-    // comment to break again
-    2;
+    // comment to break
+    1 +
+      // comment to break again
+      2;
 }
 
 class B {
-  someInstanceProperty = this.props.foofoofoofoofoofoo && this.props
-    .barbarbarbar;
+  someInstanceProperty =
+    this.props.foofoofoofoofoofoo && this.props.barbarbarbar;
 
   someInstanceProperty2 = {
     foo: this.props.foofoofoofoofoofoo && this.props.barbarbarbar,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-2485.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-2485.ts.snap
@@ -16,15 +16,10 @@ class x {
 # Output
 ```js
 class x {
-  private readonly rawConfigFromFile$: BehaviorSubject<any> = new BehaviorSubject(
-    notRead,
-  );
+  private readonly rawConfigFromFile$: BehaviorSubject<any> =
+    new BehaviorSubject(notRead);
 }
 
 ```
 
-# Lines exceeding max width of 80 characters
-```
-    2:   private readonly rawConfigFromFile$: BehaviorSubject<any> = new BehaviorSubject(
-```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This adds `TsPropertySignatureClassMember` and `JsPropertyClassMember` to be formatted as "assignment like"

This PR implements https://github.com/rome/tools/issues/2424

The next fix on the table would be to finish up certain conditions to trigger the correct layout, but with this PR, we completed the number of nodes that require this type of formatting.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Made sure that the updated snapshots are correct

PR 
**File Based Average Prettier Similarity**: 77.22%  
**Line Based Average Prettier Similarity**: 72.43%  

`main`
**File Based Average Prettier Similarity**: 77.16%  
**Line Based Average Prettier Similarity**: 72.41%  

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
