### PR TITLE
docs: fix order of sections for lint rules

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/no_async_promise_executor.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_async_promise_executor.rs
@@ -11,14 +11,6 @@ declare_rule! {
     /// 2. If a Promise executor function is using `await`, this is usually a sign that it is not actually necessary to use the `new Promise` constructor, or the scope of the `new Promise` constructor can be reduced.
     ///
     /// ## Examples
-    /// ### Valid
-    ///
-    /// ```js
-    ///   new Promise((resolve, reject) => {})
-    ///   new Promise((resolve, reject) => {}, async function unrelated() {})
-    ///   new Foo(async (resolve, reject) => {})
-    ///   new Foo((( (resolve, reject) => {} )))
-    /// ```
     ///
     /// ### Invalid
     ///
@@ -32,6 +24,15 @@ declare_rule! {
     ///
     /// ```js,expect_diagnostic
     ///   new Promise(((((async () => {})))))
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    ///   new Promise((resolve, reject) => {})
+    ///   new Promise((resolve, reject) => {}, async function unrelated() {})
+    ///   new Foo(async (resolve, reject) => {})
+    ///   new Foo((( (resolve, reject) => {} )))
     /// ```
     pub(crate) NoAsyncPromiseExecutor = "noAsyncPromiseExecutor"
 }

--- a/crates/rome_js_analyze/src/analyzers/no_empty_pattern.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_empty_pattern.rs
@@ -7,18 +7,6 @@ declare_rule! {
     /// Disallows empty destructuring patterns.
     /// ## Examples
     ///
-    /// ### Valid
-    /// The following cases are valid because they create new bindings.
-    ///
-    /// ```js
-    /// var {a = {}} = foo;
-    /// var {a, b = {}} = foo;
-    /// var {a = []} = foo;
-    /// function foo({a = {}}) {}
-    /// function foo({a = []}) {}
-    /// var [a] = foo;
-    /// ```
-    ///
     /// ### Invalid
     ///
     /// ```js,expect_diagnostic
@@ -33,6 +21,17 @@ declare_rule! {
     /// function foo({}) {}
     /// ```
     ///
+    /// ### Valid
+    /// The following cases are valid because they create new bindings.
+    ///
+    /// ```js
+    /// var {a = {}} = foo;
+    /// var {a, b = {}} = foo;
+    /// var {a = []} = foo;
+    /// function foo({a = {}}) {}
+    /// function foo({a = []}) {}
+    /// var [a] = foo;
+    /// ```
     pub(crate) NoEmptyPattern = "noEmptyPattern"
 }
 

--- a/crates/rome_js_analyze/src/analyzers/no_unsafe_negation.rs
+++ b/crates/rome_js_analyze/src/analyzers/no_unsafe_negation.rs
@@ -13,6 +13,16 @@ declare_rule! {
     ///
     /// ## Examples
     ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// !1 in [1,2];
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// /**test*/!/** test*/1 instanceof [1,2];
+    /// ```
+    ///
     /// ### Valid
     /// ```js
     /// -1 in [1,2];
@@ -21,13 +31,6 @@ declare_rule! {
     /// void 1 in [1,2];
     /// delete 1 in [1,2];
     /// +1 instanceof [1,2];
-    /// ```
-    /// ### Invalid
-    /// ```js,expect_diagnostic
-    /// !1 in [1,2];
-    /// ```
-    /// ```js,expect_diagnostic
-    /// /**test*/!/** test*/1 instanceof [1,2];
     /// ```
     pub(crate) NoUnsafeNegation = "noUnsafeNegation"
 }

--- a/crates/rome_js_analyze/src/analyzers/use_shorthand_array_type.rs
+++ b/crates/rome_js_analyze/src/analyzers/use_shorthand_array_type.rs
@@ -15,14 +15,6 @@ declare_rule! {
     ///
     /// ## Examples
     ///
-    /// ### Valid
-    ///
-    /// ```ts
-    /// let valid: Array<Foo | Bar>;
-    /// let valid: Array<keyof Bar>;
-    /// let valid: Array<foo | bar>;
-    /// ```
-    ///
     /// ### Invalid
     /// ```ts,expect_diagnostic
     /// let valid: Array<foo>;
@@ -42,6 +34,14 @@ declare_rule! {
     ///
     /// ```ts,expect_diagnostic
     /// let invalid: Array<[number, number]>;
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```ts
+    /// let valid: Array<Foo | Bar>;
+    /// let valid: Array<keyof Bar>;
+    /// let valid: Array<foo | bar>;
     /// ```
     pub(crate) UseShorthandArrayType = "useShorthandArrayType"
 }

--- a/website/src/docs/lint/rules/noAsyncPromiseExecutor.md
+++ b/website/src/docs/lint/rules/noAsyncPromiseExecutor.md
@@ -13,15 +13,6 @@ The executor function can also be an async function. However, this is usually a 
 2. If a Promise executor function is using `await`, this is usually a sign that it is not actually necessary to use the `new Promise` constructor, or the scope of the `new Promise` constructor can be reduced.
 ## Examples
 
-### Valid
-
-```jsx
-  new Promise((resolve, reject) => {})
-  new Promise((resolve, reject) => {}, async function unrelated() {})
-  new Foo(async (resolve, reject) => {})
-  new Foo((( (resolve, reject) => {} )))
-```
-
 ### Invalid
 
 ```jsx
@@ -59,4 +50,13 @@ new Promise(async function foo(resolve, reject) {})
   <span style="color: rgb(38, 148, 255);">│</span>                   <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
 
 </code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+  new Promise((resolve, reject) => {})
+  new Promise((resolve, reject) => {}, async function unrelated() {})
+  new Foo(async (resolve, reject) => {})
+  new Foo((( (resolve, reject) => {} )))
+```
 

--- a/website/src/docs/lint/rules/noEmptyPattern.md
+++ b/website/src/docs/lint/rules/noEmptyPattern.md
@@ -9,19 +9,6 @@ Disallows empty destructuring patterns.
 
 ## Examples
 
-### Valid
-
-The following cases are valid because they create new bindings.
-
-```jsx
-var {a = {}} = foo;
-var {a, b = {}} = foo;
-var {a = []} = foo;
-function foo({a = {}}) {}
-function foo({a = []}) {}
-var [a] = foo;
-```
-
 ### Invalid
 
 ```jsx
@@ -59,4 +46,17 @@ function foo({}) {}
   <span style="color: rgb(38, 148, 255);">│</span>              <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
 
 </code></pre>{% endraw %}
+
+### Valid
+
+The following cases are valid because they create new bindings.
+
+```jsx
+var {a = {}} = foo;
+var {a, b = {}} = foo;
+var {a = []} = foo;
+function foo({a = {}}) {}
+function foo({a = []}) {}
+var [a] = foo;
+```
 

--- a/website/src/docs/lint/rules/noUnsafeNegation.md
+++ b/website/src/docs/lint/rules/noUnsafeNegation.md
@@ -9,17 +9,6 @@ Disallow using unsafe negation.
 
 ## Examples
 
-### Valid
-
-```jsx
--1 in [1,2];
-~1 in [1,2];
-typeof 1 in [1,2];
-void 1 in [1,2];
-delete 1 in [1,2];
-+1 instanceof [1,2];
-```
-
 ### Invalid
 
 ```jsx
@@ -55,4 +44,15 @@ delete 1 in [1,2];
   0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">/**test*/!/** test*/(1 instanceof [1,2]);</span>
 
 </code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+-1 in [1,2];
+~1 in [1,2];
+typeof 1 in [1,2];
+void 1 in [1,2];
+delete 1 in [1,2];
++1 instanceof [1,2];
+```
 

--- a/website/src/docs/lint/rules/useShorthandArrayType.md
+++ b/website/src/docs/lint/rules/useShorthandArrayType.md
@@ -9,14 +9,6 @@ When expressing array types, this rule promotes the usage of `T[]` shorthand ins
 
 ## Examples
 
-### Valid
-
-```ts
-let valid: Array<Foo | Bar>;
-let valid: Array<keyof Bar>;
-let valid: Array<foo | bar>;
-```
-
 ### Invalid
 
 ```ts
@@ -103,4 +95,12 @@ let invalid: Array<[number, number]>;
   0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">let invalid: [number, number][];</span>
 
 </code></pre>{% endraw %}
+
+### Valid
+
+```ts
+let valid: Array<Foo | Bar>;
+let valid: Array<keyof Bar>;
+let valid: Array<foo | bar>;
+```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

There are few rules that have the order of invalid/valid section inverted. This PR fixes them.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Deployed website, and check it the result is fine.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
