### PR TITLE
fix(rome_js_formatter): breaking logic for member chains

### DIFF
--- a/crates/rome_js_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/property_class_member.rs
@@ -1,38 +1,18 @@
 use crate::prelude::*;
-use rome_formatter::{format_args, write};
-
-use crate::utils::FormatWithSemicolon;
-
+use crate::utils::{FormatWithSemicolon, JsAnyAssignmentLike};
+use rome_formatter::write;
 use rome_js_syntax::JsPropertyClassMember;
-use rome_js_syntax::JsPropertyClassMemberFields;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsPropertyClassMember;
 
 impl FormatNodeRule<JsPropertyClassMember> for FormatJsPropertyClassMember {
     fn fmt_fields(&self, node: &JsPropertyClassMember, f: &mut JsFormatter) -> FormatResult<()> {
-        let JsPropertyClassMemberFields {
-            modifiers,
-            name,
-            property_annotation,
-            value,
-            semicolon_token,
-        } = node.as_fields();
-
+        let semicolon_token = node.semicolon_token();
+        let body = format_with(|f| write!(f, [JsAnyAssignmentLike::from(node.clone())]));
         write!(
             f,
-            [FormatWithSemicolon::new(
-                &format_args!(
-                    modifiers.format(),
-                    space_token(),
-                    name.format(),
-                    property_annotation.format(),
-                    value
-                        .format()
-                        .with_or_empty(|node, f| write![f, [space_token(), node]]),
-                ),
-                semicolon_token.as_ref()
-            )]
+            [FormatWithSemicolon::new(&body, semicolon_token.as_ref())]
         )
     }
 }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -457,16 +457,10 @@ mod test {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-const MyComponentWithLongName2: React.VoidFunctionComponent<
-  MyComponentWithLongNameProps
-> = ({
-  x,
-}) => {
-  const a = useA();
-  return (
-   f
-  );
-};
+fetchUser(id) 
+    // ffeeffefe
+  .then(fetchAccountForUser)
+  .catch(handleFetchError);
         "#;
         let syntax = SourceType::tsx();
         let tree = parse(src, 0, syntax);

--- a/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
+++ b/crates/rome_js_formatter/src/ts/classes/property_signature_class_member.rs
@@ -1,9 +1,7 @@
 use crate::prelude::*;
-use rome_formatter::{format_args, write};
-
-use crate::utils::FormatWithSemicolon;
-
-use rome_js_syntax::{TsPropertySignatureClassMember, TsPropertySignatureClassMemberFields};
+use crate::utils::{FormatWithSemicolon, JsAnyAssignmentLike};
+use rome_formatter::write;
+use rome_js_syntax::TsPropertySignatureClassMember;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatTsPropertySignatureClassMember;
@@ -14,24 +12,11 @@ impl FormatNodeRule<TsPropertySignatureClassMember> for FormatTsPropertySignatur
         node: &TsPropertySignatureClassMember,
         f: &mut JsFormatter,
     ) -> FormatResult<()> {
-        let TsPropertySignatureClassMemberFields {
-            modifiers,
-            name,
-            property_annotation,
-            semicolon_token,
-        } = node.as_fields();
-
+        let semicolon_token = node.semicolon_token();
+        let body = format_with(|f| write!(f, [JsAnyAssignmentLike::from(node.clone())]));
         write!(
             f,
-            [FormatWithSemicolon::new(
-                &format_args!(
-                    modifiers.format(),
-                    space_token(),
-                    name.format(),
-                    property_annotation.format(),
-                ),
-                semicolon_token.as_ref()
-            )]
+            [FormatWithSemicolon::new(&body, semicolon_token.as_ref())]
         )
     }
 }

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -3,11 +3,13 @@ use crate::utils::object::write_member_name;
 use crate::utils::JsAnyBinaryLikeExpression;
 use rome_formatter::{format_args, write, VecBuffer};
 use rome_js_syntax::{
-    JsAnyAssignmentPattern, JsAnyBindingPattern, JsAnyExpression, JsAnyFunctionBody,
-    JsAnyObjectAssignmentPatternMember, JsAnyObjectBindingPatternMember, JsAnyObjectMemberName,
-    JsAssignmentExpression, JsInitializerClause, JsObjectAssignmentPattern,
-    JsObjectAssignmentPatternProperty, JsObjectBindingPattern, JsPropertyObjectMember,
-    JsSyntaxKind, JsVariableDeclarator, TsAnyVariableAnnotation, TsIdentifierBinding, TsType,
+    JsAnyAssignmentPattern, JsAnyBindingPattern, JsAnyClassMemberName, JsAnyExpression,
+    JsAnyFunctionBody, JsAnyObjectAssignmentPatternMember, JsAnyObjectBindingPatternMember,
+    JsAnyObjectMemberName, JsAssignmentExpression, JsInitializerClause, JsLiteralMemberName,
+    JsObjectAssignmentPattern, JsObjectAssignmentPatternProperty, JsObjectBindingPattern,
+    JsPropertyClassMember, JsPropertyClassMemberFields, JsPropertyObjectMember, JsSyntaxKind,
+    JsVariableDeclarator, TsAnyVariableAnnotation, TsIdentifierBinding,
+    TsPropertySignatureClassMember, TsPropertySignatureClassMemberFields, TsType,
     TsTypeAliasDeclaration,
 };
 use rome_js_syntax::{JsAnyLiteralExpression, JsSyntaxNode};
@@ -19,11 +21,19 @@ declare_node_union! {
         JsAssignmentExpression |
         JsObjectAssignmentPatternProperty |
         JsVariableDeclarator |
-        TsTypeAliasDeclaration
+        TsTypeAliasDeclaration |
+        JsPropertyClassMember |
+        TsPropertySignatureClassMember
 }
 
 declare_node_union! {
-    pub(crate) LeftAssignmentLike = JsAnyAssignmentPattern | JsAnyObjectMemberName | JsAnyBindingPattern | TsIdentifierBinding
+    pub(crate) LeftAssignmentLike =
+        JsAnyAssignmentPattern |
+        JsAnyObjectMemberName |
+        JsAnyBindingPattern |
+        TsIdentifierBinding |
+        JsLiteralMemberName |
+        JsAnyClassMemberName
 }
 
 declare_node_union! {
@@ -297,11 +307,18 @@ impl JsAnyAssignmentLike {
                 Ok(assignment_pattern.pattern()?.into())
             }
             JsAnyAssignmentLike::JsVariableDeclarator(variable_declarator) => {
-                // SAFETY: Calling `unwrap` here is safe because we check `should_only_left` variant at the beginning of the `layout` function
+                // SAFETY: Calling `unwrap` here is safe because we check `has_only_left_hand_side` variant at the beginning of the `layout` function
                 Ok(variable_declarator.initializer().unwrap().into())
             }
             JsAnyAssignmentLike::TsTypeAliasDeclaration(type_alias_declaration) => {
                 Ok(type_alias_declaration.ty()?.into())
+            }
+            JsAnyAssignmentLike::JsPropertyClassMember(n) => {
+                // SAFETY: Calling `unwrap` here is safe because we check `has_only_left_hand_side` variant at the beginning of the `layout` function
+                Ok(n.value().unwrap().into())
+            }
+            JsAnyAssignmentLike::TsPropertySignatureClassMember(_) => {
+                unreachable!("TsPropertySignatureClassMember doesn't have any right side. If you're here, `has_only_left_hand_side` hasn't been called")
             }
         }
     }
@@ -321,6 +338,12 @@ impl JsAnyAssignmentLike {
             JsAnyAssignmentLike::TsTypeAliasDeclaration(type_alias_declaration) => {
                 Ok(type_alias_declaration.binding_identifier()?.into())
             }
+            JsAnyAssignmentLike::JsPropertyClassMember(property_class_member) => {
+                Ok(property_class_member.name()?.into())
+            }
+            JsAnyAssignmentLike::TsPropertySignatureClassMember(
+                property_signature_class_member,
+            ) => Ok(property_signature_class_member.name()?.into()),
         }
     }
 
@@ -340,7 +363,7 @@ impl JsAnyAssignmentLike {
     fn write_left(&self, f: &mut JsFormatter) -> FormatResult<bool> {
         match self {
             JsAnyAssignmentLike::JsPropertyObjectMember(property) => {
-                let width = write_member_name(&property.name()?, f)?;
+                let width = write_member_name(&property.name()?.into(), f)?;
                 let text_width_for_break =
                     (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
                 Ok(width < text_width_for_break)
@@ -351,7 +374,7 @@ impl JsAnyAssignmentLike {
                 Ok(false)
             }
             JsAnyAssignmentLike::JsObjectAssignmentPatternProperty(property) => {
-                let width = write_member_name(&property.member()?, f)?;
+                let width = write_member_name(&property.member()?.into(), f)?;
                 let text_width_for_break =
                     (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
                 Ok(width < text_width_for_break)
@@ -372,6 +395,40 @@ impl JsAnyAssignmentLike {
                     write!(f, [type_parameters.format(),])?;
                 }
                 Ok(false)
+            }
+            JsAnyAssignmentLike::JsPropertyClassMember(property_class_member) => {
+                let JsPropertyClassMemberFields {
+                    modifiers,
+                    name,
+                    property_annotation,
+                    value: _,
+                    semicolon_token: _,
+                } = property_class_member.as_fields();
+                write!(f, [modifiers.format(), space_token()])?;
+                let width = write_member_name(&name?.into(), f)?;
+                write!(f, [property_annotation.format()])?;
+                let text_width_for_break =
+                    (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
+                Ok(width < text_width_for_break)
+            }
+            JsAnyAssignmentLike::TsPropertySignatureClassMember(
+                property_signature_class_member,
+            ) => {
+                let TsPropertySignatureClassMemberFields {
+                    modifiers,
+                    name,
+                    property_annotation,
+                    semicolon_token: _,
+                } = property_signature_class_member.as_fields();
+
+                write!(f, [modifiers.format(), space_token(),])?;
+
+                let width = write_member_name(&name?.into(), f)?;
+
+                write!(f, [property_annotation.format()])?;
+                let text_width_for_break =
+                    (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
+                Ok(width < text_width_for_break)
             }
         }
     }
@@ -401,6 +458,15 @@ impl JsAnyAssignmentLike {
                 let eq_token = type_alias_declaration.eq_token()?;
                 write!(f, [space_token(), eq_token.format()])
             }
+            JsAnyAssignmentLike::JsPropertyClassMember(property_class_member) => {
+                if let Some(initializer) = property_class_member.value() {
+                    let eq_token = initializer.eq_token()?;
+                    write!(f, [space_token(), eq_token.format()])?
+                }
+                Ok(())
+            }
+            // this variant doesn't have any operator
+            JsAnyAssignmentLike::TsPropertySignatureClassMember(_) => Ok(()),
         }
     }
 
@@ -434,6 +500,15 @@ impl JsAnyAssignmentLike {
                 let ty = type_alias_declaration.ty()?;
                 write!(f, [space_token(), ty.format()])
             }
+            JsAnyAssignmentLike::JsPropertyClassMember(property_class_member) => {
+                if let Some(initializer) = property_class_member.value() {
+                    let expression = initializer.expression()?;
+                    write!(f, [space_token(), expression.format()])?;
+                }
+                Ok(())
+            }
+            // this variant doesn't have any right part
+            JsAnyAssignmentLike::TsPropertySignatureClassMember(_) => Ok(()),
         }
     }
 
@@ -482,8 +557,10 @@ impl JsAnyAssignmentLike {
     fn has_only_left_hand_side(&self) -> bool {
         if let JsAnyAssignmentLike::JsVariableDeclarator(declarator) = self {
             declarator.initializer().is_none()
+        } else if let JsAnyAssignmentLike::JsPropertyClassMember(class_member) = self {
+            class_member.value().is_none()
         } else {
-            false
+            matches!(self, JsAnyAssignmentLike::TsPropertySignatureClassMember(_))
         }
     }
 

--- a/crates/rome_js_formatter/src/utils/member_chain/flatten_item.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/flatten_item.rs
@@ -73,6 +73,18 @@ impl FlattenItem {
         }
     }
 
+    pub(crate) fn has_leading_comments(&self) -> SyntaxResult<bool> {
+        Ok(match self {
+            FlattenItem::StaticMember(node) => {
+                node.syntax().has_comments_direct()
+                    || node.operator_token()?.has_leading_comments()
+            }
+            FlattenItem::CallExpression(node) => node.syntax().has_leading_comments(),
+            FlattenItem::ComputedMember(node) => node.syntax().has_leading_comments(),
+            FlattenItem::Node(node) => node.has_leading_comments(),
+        })
+    }
+
     /// There are cases like Object.keys(), Observable.of(), _.values() where
     /// they are the subject of all the chained calls and therefore should
     /// be kept on the same line:

--- a/crates/rome_js_formatter/src/utils/member_chain/groups.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/groups.rs
@@ -1,8 +1,7 @@
+use crate::context::TabWidth;
 use crate::prelude::*;
 use crate::utils::member_chain::flatten_item::FlattenItem;
 use crate::utils::member_chain::simple_argument::SimpleArgument;
-
-use crate::context::TabWidth;
 use rome_js_syntax::JsCallExpression;
 use rome_rowan::{AstSeparatedList, SyntaxResult};
 use std::mem;
@@ -78,7 +77,11 @@ impl Groups {
     }
 
     /// It tells if the groups should be break on multiple lines
-    pub fn groups_should_break(&self, calls_count: usize) -> SyntaxResult<bool> {
+    pub fn groups_should_break(
+        &self,
+        calls_count: usize,
+        head_group: &HeadGroup,
+    ) -> FormatResult<bool> {
         // Do not allow the group to break if it only contains a single call expression
         if calls_count <= 1 {
             return Ok(false);
@@ -90,7 +93,50 @@ impl Groups {
         let call_expressions_are_not_simple =
             calls_count > 2 && self.call_expressions_are_not_simple()?;
 
-        Ok(call_expressions_are_not_simple)
+        // TODO: add here will_break logic
+
+        let node_has_comments = self.has_comments()? || head_group.has_comments();
+
+        let should_break = node_has_comments || call_expressions_are_not_simple;
+
+        Ok(should_break)
+    }
+
+    /// Checks if the groups contain comments.
+    pub fn has_comments(&self) -> SyntaxResult<bool> {
+        let mut has_leading_comments = false;
+
+        let flat_groups = self.groups.iter().flat_map(|item| item.iter());
+        for item in flat_groups {
+            if item.has_leading_comments()? {
+                has_leading_comments = true;
+                break;
+            }
+        }
+
+        let has_trailing_comments = self
+            .groups
+            .iter()
+            .flat_map(|item| item.iter())
+            .any(|item| item.has_trailing_comments());
+
+        let cutoff_has_leading_comments = if self.groups.len() >= self.cutoff as usize {
+            let group = self.groups.get(self.cutoff as usize);
+            if let Some(group) = group {
+                let first_item = group.first();
+                if let Some(first_item) = first_item {
+                    first_item.has_leading_comments()?
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        Ok(has_leading_comments || has_trailing_comments || cutoff_has_leading_comments)
     }
 
     /// Format groups on multiple lines
@@ -109,6 +155,10 @@ impl Groups {
     ///
     /// It's up to the printer to decide which one to use.
     pub fn write(&self, f: &mut JsFormatter) -> FormatResult<()> {
+        if self.groups.len() == 0 {
+            return Ok(());
+        }
+
         f.join()
             .entries(self.groups.iter().flat_map(|group| group.iter()))
             .finish()
@@ -218,6 +268,10 @@ impl HeadGroup {
 
     pub fn expand_group(&mut self, group: Vec<FlattenItem>) {
         self.items.extend(group)
+    }
+
+    fn has_comments(&self) -> bool {
+        self.items.iter().any(|item| item.has_trailing_comments())
     }
 }
 

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -294,7 +294,7 @@ fn write_groups(
     // TODO use Alternatives once available
     write!(f, [head_group])?;
 
-    if groups.groups_should_break(calls_count)? {
+    if groups.groups_should_break(calls_count, &head_group)? {
         write!(
             f,
             [indent(&format_args!(

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 256
 expression: call.js
 ---
 # Input
@@ -77,9 +78,8 @@ expect(
 );
 // .toThrowError(/Required parameter/);
 
-expect(
-	() => asyncRequest({ type: "foo", url: "/test-endpoint" }),
-).not.toThrowError();
+expect(() => asyncRequest({ type: "foo", url: "/test-endpoint" })).not
+	.toThrowError();
 
 expect(
 	() => asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" }),

--- a/crates/rome_js_formatter/tests/specs/prettier/js/class-comment/class-property.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/class-comment/class-property.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: class-property.js
 ---
 # Input
@@ -18,10 +19,10 @@ class X {
 ```js
 class X {
   TEMPLATE =
-  // tab index is needed so we can focus, which is needed for keyboard events
-  '<div class="ag-large-text" tabindex="0">' +
-    '<div class="ag-large-textarea"></div>' +
-    "</div>";
+    // tab index is needed so we can focus, which is needed for keyboard events
+    '<div class="ag-large-text" tabindex="0">' +
+      '<div class="ag-large-textarea"></div>' +
+      "</div>";
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/classes-private-fields/with_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/classes-private-fields/with_comments.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: with_comments.js
 ---
 # Input
@@ -18,10 +19,10 @@ class A {
 ```js
 class A {
   #foobar =
-  // comment to break
-  1 +
-    // comment to break again
-    2;
+    // comment to break
+    1 +
+      // comment to break again
+      2;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/classes/property.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/classes/property.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: property.js
 ---
 # Input
@@ -29,15 +30,15 @@ class B {
 ```js
 class A {
   foobar =
-  // comment to break
-  1 +
-    // comment to break again
-    2;
+    // comment to break
+    1 +
+      // comment to break again
+      2;
 }
 
 class B {
-  someInstanceProperty = this.props.foofoofoofoofoofoo && this.props
-    .barbarbarbar;
+  someInstanceProperty =
+    this.props.foofoofoofoofoofoo && this.props.barbarbarbar;
 
   someInstanceProperty2 = {
     foo: this.props.foofoofoofoofoofoo && this.props.barbarbarbar,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
@@ -35,26 +35,30 @@ db.collection('indexOptionDefault').createIndex({ a: 1 }, {
 # Output
 ```js
 //https://github.com/prettier/prettier/issues/3002
-beep.boop().baz("foo", {
-  some: {
-    thing: {
-      nested: true,
+beep
+  .boop()
+  .baz("foo", {
+    some: {
+      thing: {
+        nested: true,
+      },
     },
-  },
-}, { another: { thing: true } }, () => {});
+  }, { another: { thing: true } }, () => {});
 
 //https://github.com/prettier/prettier/issues/2984
-db.collection("indexOptionDefault").createIndex({ a: 1 }, {
-  indexOptionDefaults: true,
-  w: 2,
-  wtimeout: 1000,
-}, function (err) {
-  test.equal(null, err);
-  test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+db
+  .collection("indexOptionDefault")
+  .createIndex({ a: 1 }, {
+    indexOptionDefaults: true,
+    w: 2,
+    wtimeout: 1000,
+  }, function (err) {
+    test.equal(null, err);
+    test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
-  client.close();
-  done();
-});
+    client.close();
+    done();
+  });
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
@@ -65,73 +65,73 @@ angular.module('AngularAppModule')
 ```js
 function f() {
   return observableFromSubscribeFunction()
-  // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
-  // configurable.
-  .debounceTime(debounceInterval);
+    // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+    // configurable.
+    .debounceTime(debounceInterval);
 }
 
 _.a(a)
-/* very very very very very very very long such that it is longer than 80 columns */
-.a();
+  /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
 
 _.a(
   a,
-) /* very very very very very very very long such that it is longer than 80 columns */.a();
+) /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
 
 _.a(
   a,
-) /* very very very very very very very long such that it is longer than 80 columns */.a();
+) /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
 
 Something
 // $FlowFixMe(>=0.41.0)
 .getInstance(this.props.dao).getters();
 
 // Warm-up first
-measure().then(() => {
-  SomethingLong();
-});
+measure()
+  .then(() => {
+    SomethingLong();
+  });
 
-measure() // Warm-up first
-.then(() => {
-  SomethingLong();
-});
+measure()
+  // Warm-up first
+  .then(() => {
+    SomethingLong();
+  });
 
-const configModel = this.baseConfigurationService.getCache().consolidated.merge(
-  // global/default values (do NOT modify)
-  this.cachedWorkspaceConfig,
-);
+const configModel = this.baseConfigurationService
+  .getCache()
+  .consolidated // global/default values (do NOT modify)
+  .merge(this.cachedWorkspaceConfig);
 
-this.doWriteConfiguration(
-  target,
-  value,
-  options,
-) // queue up writes to prevent race conditions
-.then(
-  () => null,
-  (error) => {
-    return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(
-      error,
-      target,
-      value,
-    );
-  },
-);
+this.doWriteConfiguration(target, value, options)
+  // queue up writes to prevent race conditions
+  .then(
+    () => null,
+    (error) => {
+      return options.donotNotifyError ? TPromise.wrapError(
+        error,
+      ) : this.onError(error, target, value);
+    },
+  );
 
 ret = __DEV__ ?
 // $FlowFixMe: this type differs according to the env
 vm.runInContext(source, ctx) : a;
 
-angular.module("AngularAppModule")
-// Hello, I am comment.
-.constant("API_URL", "http://localhost:8080/api");
+angular
+  .module("AngularAppModule")
+  // Hello, I am comment.
+  .constant("API_URL", "http://localhost:8080/api");
 
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-    3:   // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
-    9: /* very very very very very very very long such that it is longer than 80 columns */
-   14: ) /* very very very very very very very long such that it is longer than 80 columns */.a();
-   18: ) /* very very very very very very very long such that it is longer than 80 columns */.a();
+    3:     // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+    9:   /* very very very very very very very long such that it is longer than 80 columns */
+   14: ) /* very very very very very very very long such that it is longer than 80 columns */
+   19: ) /* very very very very very very very long such that it is longer than 80 columns */
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
@@ -180,8 +180,11 @@ somePromise
 
 // you can still force multi-line chaining with a comment:
 const sha256_2 = (data) =>
-  crypto // breakme
-  .createHash("sha256").update(data).digest("hex");
+  crypto
+    // breakme
+    .createHash("sha256")
+    .update(data)
+    .digest("hex");
 
 // examples from https://github.com/prettier/prettier/pull/4765
 
@@ -241,10 +244,10 @@ const date = moment.utc(userInput).hour(0).minute(0).second(0);
 
 fetchUser(id).then(fetchAccountForUser).catch(handleFetchError);
 
-fetchUser(
-  id,
-) //
-.then(fetchAccountForUser).catch(handleFetchError);
+fetchUser(id)
+  //
+  .then(fetchAccountForUser)
+  .catch(handleFetchError);
 
 // examples from https://github.com/prettier/prettier/issues/3107
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/optional-chaining/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/optional-chaining/comments.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: comments.js
 ---
 # Input
@@ -56,9 +57,11 @@ foo.bar.baz
 # Output
 ```js
 function foo() {
-  return a.b().c()
-  // Comment
-  ?.d();
+  return a
+    .b()
+    .c()
+    // Comment
+    ?.d();
 }
 
 fooBar

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-2485.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-2485.ts.snap
@@ -16,15 +16,10 @@ class x {
 # Output
 ```js
 class x {
-  private readonly rawConfigFromFile$: BehaviorSubject<any> = new BehaviorSubject(
-    notRead,
-  );
+  private readonly rawConfigFromFile$: BehaviorSubject<any> =
+    new BehaviorSubject(notRead);
 }
 
 ```
 
-# Lines exceeding max width of 80 characters
-```
-    2:   private readonly rawConfigFromFile$: BehaviorSubject<any> = new BehaviorSubject(
-```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method-chain/comment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method-chain/comment.ts.snap
@@ -19,18 +19,19 @@ this.firebase.object(`/shops/${shopLocation.shop}`)
 
 # Output
 ```js
-this.firebase.object(`/shops/${shopLocation.shop}`)
-// keep distance info
-.first((
-  shop: ShopQueryResult,
-  index: number,
-  source: Observable<ShopQueryResult>,
-): any => {
-  // add distance to result
-  const s = shop;
-  s.distance = shopLocation.distance;
-  return s;
-});
+this.firebase
+  .object(`/shops/${shopLocation.shop}`)
+  // keep distance info
+  .first((
+    shop: ShopQueryResult,
+    index: number,
+    source: Observable<ShopQueryResult>,
+  ): any => {
+    // add distance to result
+    const s = shop;
+    s.distance = shopLocation.distance;
+    return s;
+  });
 
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds again a check on the breaking logic of the member chain. The check is around comments. I also fixed the previous logic, where the check for certain comments was incorrectly done.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

`cargo test` and checked that snapshots are correctly updated

PR 
**File Based Average Prettier Similarity**: 77.33%  
**Line Based Average Prettier Similarity**: 72.59%  

`main`
**File Based Average Prettier Similarity**: 77.25%  
**Line Based Average Prettier Similarity**: 72.45%  

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
