### PR TITLE
 fix(rome_js_formatter): breaking logic for member chains

### DIFF
--- a/crates/rome_js_formatter/src/utils/member_chain/flatten_item.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/flatten_item.rs
@@ -73,6 +73,17 @@ impl FlattenItem {
         }
     }
 
+    pub(crate) fn has_leading_comments(&self) -> SyntaxResult<bool> {
+        Ok(match self {
+            FlattenItem::StaticMember(node) => {
+                node.syntax().has_comments_direct() || node.operator_token()?.has_leading_comments()
+            }
+            FlattenItem::CallExpression(node) => node.syntax().has_leading_comments(),
+            FlattenItem::ComputedMember(node) => node.syntax().has_leading_comments(),
+            FlattenItem::Node(node) => node.has_leading_comments(),
+        })
+    }
+
     /// There are cases like Object.keys(), Observable.of(), _.values() where
     /// they are the subject of all the chained calls and therefore should
     /// be kept on the same line:

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -294,7 +294,7 @@ fn write_groups(
     // TODO use Alternatives once available
     write!(f, [head_group])?;
 
-    if groups.groups_should_break(calls_count)? {
+    if groups.groups_should_break(calls_count, &head_group)? {
         write!(
             f,
             [indent(&format_args!(

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 256
 expression: call.js
 ---
 # Input
@@ -77,9 +78,8 @@ expect(
 );
 // .toThrowError(/Required parameter/);
 
-expect(
-	() => asyncRequest({ type: "foo", url: "/test-endpoint" }),
-).not.toThrowError();
+expect(() => asyncRequest({ type: "foo", url: "/test-endpoint" })).not
+	.toThrowError();
 
 expect(
 	() => asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" }),

--- a/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
@@ -35,26 +35,30 @@ db.collection('indexOptionDefault').createIndex({ a: 1 }, {
 # Output
 ```js
 //https://github.com/prettier/prettier/issues/3002
-beep.boop().baz("foo", {
-  some: {
-    thing: {
-      nested: true,
+beep
+  .boop()
+  .baz("foo", {
+    some: {
+      thing: {
+        nested: true,
+      },
     },
-  },
-}, { another: { thing: true } }, () => {});
+  }, { another: { thing: true } }, () => {});
 
 //https://github.com/prettier/prettier/issues/2984
-db.collection("indexOptionDefault").createIndex({ a: 1 }, {
-  indexOptionDefaults: true,
-  w: 2,
-  wtimeout: 1000,
-}, function (err) {
-  test.equal(null, err);
-  test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+db
+  .collection("indexOptionDefault")
+  .createIndex({ a: 1 }, {
+    indexOptionDefaults: true,
+    w: 2,
+    wtimeout: 1000,
+  }, function (err) {
+    test.equal(null, err);
+    test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
-  client.close();
-  done();
-});
+    client.close();
+    done();
+  });
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
@@ -65,73 +65,73 @@ angular.module('AngularAppModule')
 ```js
 function f() {
   return observableFromSubscribeFunction()
-  // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
-  // configurable.
-  .debounceTime(debounceInterval);
+    // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+    // configurable.
+    .debounceTime(debounceInterval);
 }
 
 _.a(a)
-/* very very very very very very very long such that it is longer than 80 columns */
-.a();
+  /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
 
 _.a(
   a,
-) /* very very very very very very very long such that it is longer than 80 columns */.a();
+) /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
 
 _.a(
   a,
-) /* very very very very very very very long such that it is longer than 80 columns */.a();
+) /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
 
 Something
 // $FlowFixMe(>=0.41.0)
 .getInstance(this.props.dao).getters();
 
 // Warm-up first
-measure().then(() => {
-  SomethingLong();
-});
+measure()
+  .then(() => {
+    SomethingLong();
+  });
 
-measure() // Warm-up first
-.then(() => {
-  SomethingLong();
-});
+measure()
+  // Warm-up first
+  .then(() => {
+    SomethingLong();
+  });
 
-const configModel = this.baseConfigurationService.getCache().consolidated.merge(
-  // global/default values (do NOT modify)
-  this.cachedWorkspaceConfig,
-);
+const configModel = this.baseConfigurationService
+  .getCache()
+  .consolidated // global/default values (do NOT modify)
+  .merge(this.cachedWorkspaceConfig);
 
-this.doWriteConfiguration(
-  target,
-  value,
-  options,
-) // queue up writes to prevent race conditions
-.then(
-  () => null,
-  (error) => {
-    return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(
-      error,
-      target,
-      value,
-    );
-  },
-);
+this.doWriteConfiguration(target, value, options)
+  // queue up writes to prevent race conditions
+  .then(
+    () => null,
+    (error) => {
+      return options.donotNotifyError ? TPromise.wrapError(
+        error,
+      ) : this.onError(error, target, value);
+    },
+  );
 
 ret = __DEV__ ?
 // $FlowFixMe: this type differs according to the env
 vm.runInContext(source, ctx) : a;
 
-angular.module("AngularAppModule")
-// Hello, I am comment.
-.constant("API_URL", "http://localhost:8080/api");
+angular
+  .module("AngularAppModule")
+  // Hello, I am comment.
+  .constant("API_URL", "http://localhost:8080/api");
 
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-    3:   // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
-    9: /* very very very very very very very long such that it is longer than 80 columns */
-   14: ) /* very very very very very very very long such that it is longer than 80 columns */.a();
-   18: ) /* very very very very very very very long such that it is longer than 80 columns */.a();
+    3:     // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+    9:   /* very very very very very very very long such that it is longer than 80 columns */
+   14: ) /* very very very very very very very long such that it is longer than 80 columns */
+   19: ) /* very very very very very very very long such that it is longer than 80 columns */
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
@@ -180,8 +180,11 @@ somePromise
 
 // you can still force multi-line chaining with a comment:
 const sha256_2 = (data) =>
-  crypto // breakme
-  .createHash("sha256").update(data).digest("hex");
+  crypto
+    // breakme
+    .createHash("sha256")
+    .update(data)
+    .digest("hex");
 
 // examples from https://github.com/prettier/prettier/pull/4765
 
@@ -241,10 +244,10 @@ const date = moment.utc(userInput).hour(0).minute(0).second(0);
 
 fetchUser(id).then(fetchAccountForUser).catch(handleFetchError);
 
-fetchUser(
-  id,
-) //
-.then(fetchAccountForUser).catch(handleFetchError);
+fetchUser(id)
+  //
+  .then(fetchAccountForUser)
+  .catch(handleFetchError);
 
 // examples from https://github.com/prettier/prettier/issues/3107
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/optional-chaining/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/optional-chaining/comments.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 182
 expression: comments.js
 ---
 # Input
@@ -56,9 +57,11 @@ foo.bar.baz
 # Output
 ```js
 function foo() {
-  return a.b().c()
-  // Comment
-  ?.d();
+  return a
+    .b()
+    .c()
+    // Comment
+    ?.d();
 }
 
 fooBar

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method-chain/comment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method-chain/comment.ts.snap
@@ -19,18 +19,19 @@ this.firebase.object(`/shops/${shopLocation.shop}`)
 
 # Output
 ```js
-this.firebase.object(`/shops/${shopLocation.shop}`)
-// keep distance info
-.first((
-  shop: ShopQueryResult,
-  index: number,
-  source: Observable<ShopQueryResult>,
-): any => {
-  // add distance to result
-  const s = shop;
-  s.distance = shopLocation.distance;
-  return s;
-});
+this.firebase
+  .object(`/shops/${shopLocation.shop}`)
+  // keep distance info
+  .first((
+    shop: ShopQueryResult,
+    index: number,
+    source: Observable<ShopQueryResult>,
+  ): any => {
+    // add distance to result
+    const s = shop;
+    s.distance = shopLocation.distance;
+    return s;
+  });
 
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds again a check on the breaking logic of the member chain. The check is around comments. I also fixed the previous logic, where the check for certain comments was incorrectly done.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

`cargo test` and checked that snapshots are correctly updated

PR 
**File Based Average Prettier Similarity**: 77.33%  
**Line Based Average Prettier Similarity**: 72.59%  

`main`
**File Based Average Prettier Similarity**: 77.25%  
**Line Based Average Prettier Similarity**: 72.45%  

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
