### PR TITLE
fix(rome_js_formatter): regression of call arguments

### DIFF
--- a/crates/rome_formatter/src/buffer.rs
+++ b/crates/rome_formatter/src/buffer.rs
@@ -748,8 +748,7 @@ impl<'buffer, Context> NullBuffer<'buffer, Context> {
 impl<Context> Buffer for NullBuffer<'_, Context> {
     type Context = Context;
 
-    fn write_element(&mut self, element: FormatElement) -> FormatResult<()> {
-        drop(element);
+    fn write_element(&mut self, _element: FormatElement) -> FormatResult<()> {
         Ok(())
     }
 
@@ -765,7 +764,5 @@ impl<Context> Buffer for NullBuffer<'_, Context> {
         BufferSnapshot::Position(0)
     }
 
-    fn restore_snapshot(&mut self, snapshot: BufferSnapshot) {
-        drop(snapshot);
-    }
+    fn restore_snapshot(&mut self, _snapshot: BufferSnapshot) {}
 }

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -179,6 +179,33 @@ impl FormatNodeRule<JsCallArguments> for FormatJsCallArguments {
                 )
             });
 
+            let mut null_buffer = f.inspect_null();
+            let mut arguments_break = separated.iter().map(|element| {
+                let mut will_break_buffer = null_buffer.inspect_will_break();
+                write!(will_break_buffer, [element]).ok();
+                will_break_buffer.will_break()
+            });
+            let any_breaks = arguments_break.any(|will_break| will_break);
+            let an_argument_breaks = arguments_break.enumerate().any(|(index, will_break)| {
+                return if should_group_first_argument && index > 0
+                    || (should_group_last_argument && index < args.len() - 1)
+                {
+                    will_break
+                } else if index > 0 && index < args.len() - 1 {
+                    will_break
+                } else {
+                    false
+                };
+            });
+
+            if an_argument_breaks {
+                return write!(f, [all_arguments_expanded]);
+            }
+
+            if any_breaks {
+                write!(f, [expand_parent()])?;
+            }
+
             write!(
                 f,
                 [best_fitting![

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -457,8 +457,9 @@ mod test {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-"hol\a"
-'hol\c'
+test.expect(t => {
+	t.true(a);
+}, false);
         "#;
         let syntax = SourceType::tsx();
         let tree = parse(src, 0, syntax);

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 257
+assertion_line: 259
 expression: arrow_nested.js
 ---
 # Input
@@ -62,12 +62,13 @@ const promiseFromCallback = (fn) =>
 			}),
 	);
 
-runtimeAgent.getProperties(objectId, false, false, false, (
-	// ownProperties // accessorPropertiesOnly // generatePreview
-	error,
-	properties,
-	internalProperties,
-) => {
-	return 1;
-});
+runtimeAgent.getProperties(
+	objectId,
+	false, // ownProperties
+	false, // accessorPropertiesOnly
+	false, // generatePreview
+	(error, properties, internalProperties) => {
+		return 1;
+	},
+);
 

--- a/crates/rome_js_formatter/tests/specs/js/module/call_expression.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/call_expression.js
@@ -43,4 +43,6 @@ test.expect(t => {
 
 test.expect(t => {
     t.true(a)
-}, false, /* something */)
+}, false,
+    // comment
+    )

--- a/crates/rome_js_formatter/tests/specs/js/module/call_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/call_expression.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 256
+assertion_line: 259
 expression: call_expression.js
 ---
 # Input
@@ -49,7 +49,9 @@ test.expect(t => {
 
 test.expect(t => {
     t.true(a)
-}, false, /* something */)
+}, false,
+    // comment
+    )
 =============================
 # Outputs
 ## Output 1
@@ -99,5 +101,7 @@ test.expect((t) => {
 
 test.expect((t) => {
 	t.true(a);
-}, false /* something */);
+}, false
+// comment
+);
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/parent.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/break-calls/parent.js.snap
@@ -19,14 +19,15 @@ runtimeAgent.getProperties(
 
 # Output
 ```js
-runtimeAgent.getProperties(objectId, false, false, false, (
-  // ownProperties // accessorPropertiesOnly // generatePreview
-  error,
-  properties,
-  internalProperties,
-) => {
-  return 1;
-});
+runtimeAgent.getProperties(
+  objectId,
+  false, // ownProperties
+  false, // accessorPropertiesOnly
+  false, // generatePreview
+  (error, properties, internalProperties) => {
+    return 1;
+  },
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
@@ -48,17 +48,21 @@ beep
 //https://github.com/prettier/prettier/issues/2984
 db
   .collection("indexOptionDefault")
-  .createIndex({ a: 1 }, {
-    indexOptionDefaults: true,
-    w: 2,
-    wtimeout: 1000,
-  }, function (err) {
-    test.equal(null, err);
-    test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+  .createIndex(
+    { a: 1 },
+    {
+      indexOptionDefaults: true,
+      w: 2,
+      wtimeout: 1000,
+    },
+    function (err) {
+      test.equal(null, err);
+      test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
-    client.close();
-    done();
-  });
+      client.close();
+      done();
+    },
+  );
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/preserve-line/argument-list.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/preserve-line/argument-list.js.snap
@@ -311,11 +311,14 @@ stuff.doThing(someStuff, -1, {
   accept: (node) => doSomething(node),
 });
 
-doThing(someOtherStuff,
-// This is important
-true, {
-  decline: (creditCard) => takeMoney(creditCard),
-});
+doThing(
+  someOtherStuff,
+  // This is important
+  true,
+  {
+    decline: (creditCard) => takeMoney(creditCard),
+  },
+);
 
 func(() => {
   thing();


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixed #2720 

The new logic checks if any arguments breaks and if so, it does a custom printing.

Doing so, it triggered a regression of the new code that we didn't see before:

This snippet:

```js
test.expect(t => {
	t.true(a);
}, false /* inline comment */ );
```

Would be formatted

```js
test.expect ((t) => {
	t.true(a);
}, false /* inline comment */ );
```

Note the space added before the first `(`. This regression is caused by a bug inside the function `write_space_between_comment_and_token`, which triggers a false positive condition and it adds a space before the token.

I will have to look into it later. In order to avoid to commit wrong code, I changed the snippet that was causing the false positive.

I will open an issue to track this bug


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

`cargo test` and checked that the regression is not fixed

PR 

**File Based Average Prettier Similarity**: 77.40%  
**Line Based Average Prettier Similarity**: 72.66%  

`main`
**File Based Average Prettier Similarity**: 77.33%  
**Line Based Average Prettier Similarity**: 72.61% 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
