### PR TITLE
feat(rome_control_flow): introduce explicit exception control flow

### DIFF
--- a/crates/rome_js_analyze/src/control_flow/visitor.rs
+++ b/crates/rome_js_analyze/src/control_flow/visitor.rs
@@ -82,7 +82,7 @@ declare_visitor! {
     ControlFlowVisitor {
         statement: StatementVisitor,
         block: BlockVisitor,
-        try_finally: TryFinallyVisitor,
+        try_stmt: TryVisitor,
         catch: CatchVisitor,
         finally: FinallyVisitor,
         if_stmt: IfVisitor,

--- a/crates/rome_js_analyze/tests/specs/noDeadCode/JsTryFinallyStatement.js
+++ b/crates/rome_js_analyze/tests/specs/noDeadCode/JsTryFinallyStatement.js
@@ -1,12 +1,60 @@
 function JsTryFinallyStatement1() {
     try {
-        test();
+        tryBlock();
     } catch (err) {
-        test();
+        catchClause();
     } finally {
-        test();
+        finallyClause();
         return;
     }
 
     afterFinallyReturn();
+}
+
+function JsTryFinallyStatement2() {
+    return;
+
+    try {
+        tryBlock();
+    } catch (err) {
+        catchClause();
+    } finally {
+        finallyClause();
+    }
+}
+
+function JsTryFinallyStatement3() {
+    try {
+        try {
+            tryBlock1();
+        } catch {
+        } finally {
+            return;
+        }
+
+        afterTryStatement1();
+    } catch (err) {
+        catchClause2();
+    }
+
+    afterTryStatement2();
+}
+
+function JsTryFinallyStatement4() {
+    try {
+        tryBlock1();
+        return;
+    } catch {
+        return;
+    } finally {
+        if (value) {
+            statement1();
+        } else {
+            statement2();
+        }
+
+        finallyClause();
+    }
+
+    afterTryStatement();
 }

--- a/crates/rome_js_analyze/tests/specs/noDeadCode/JsTryFinallyStatement.js.snap
+++ b/crates/rome_js_analyze/tests/specs/noDeadCode/JsTryFinallyStatement.js.snap
@@ -6,15 +6,63 @@ expression: JsTryFinallyStatement.js
 ```js
 function JsTryFinallyStatement1() {
     try {
-        test();
+        tryBlock();
     } catch (err) {
-        test();
+        catchClause();
     } finally {
-        test();
+        finallyClause();
         return;
     }
 
     afterFinallyReturn();
+}
+
+function JsTryFinallyStatement2() {
+    return;
+
+    try {
+        tryBlock();
+    } catch (err) {
+        catchClause();
+    } finally {
+        finallyClause();
+    }
+}
+
+function JsTryFinallyStatement3() {
+    try {
+        try {
+            tryBlock1();
+        } catch {
+        } finally {
+            return;
+        }
+
+        afterTryStatement1();
+    } catch (err) {
+        catchClause2();
+    }
+
+    afterTryStatement2();
+}
+
+function JsTryFinallyStatement4() {
+    try {
+        tryBlock1();
+        return;
+    } catch {
+        return;
+    } finally {
+        if (value) {
+            statement1();
+        } else {
+            statement2();
+        }
+
+        finallyClause();
+    }
+
+    afterTryStatement();
 }
 
 ```
@@ -29,6 +77,97 @@ warning[noDeadCode]: This code is unreachable
    ·
 11 │     afterFinallyReturn();
    │     --------------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryFinallyStatement.js:18:9
+   │
+15 │     return;
+   │     ------- This statement will return from the function ...
+   ·
+18 │         tryBlock();
+   │         ----------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryFinallyStatement.js:20:9
+   │
+15 │     return;
+   │     ------- This statement will return from the function ...
+   ·
+20 │         catchClause();
+   │         -------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryFinallyStatement.js:22:9
+   │
+15 │     return;
+   │     ------- This statement will return from the function ...
+   ·
+22 │         finallyClause();
+   │         ---------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryFinallyStatement.js:35:9
+   │
+32 │             return;
+   │             ------- This statement will return from the function ...
+   ·
+35 │         afterTryStatement1();
+   │         --------------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryFinallyStatement.js:37:9
+   │
+32 │             return;
+   │             ------- This statement will return from the function ...
+   ·
+37 │         catchClause2();
+   │         --------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryFinallyStatement.js:40:5
+   │
+32 │             return;
+   │             ------- This statement will return from the function ...
+   ·
+40 │     afterTryStatement2();
+   │     --------------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryFinallyStatement.js:59:5
+   │
+46 │         return;
+   │         ------- This statement will return from the function ...
+   ·
+59 │     afterTryStatement();
+   │     -------------------- ... before it can reach this code
 
 
 ```

--- a/crates/rome_js_analyze/tests/specs/noDeadCode/JsTryStatement.js
+++ b/crates/rome_js_analyze/tests/specs/noDeadCode/JsTryStatement.js
@@ -1,11 +1,39 @@
 function JsTryStatement1() {
     try {
-        test();
+        tryBlock();
         return;
     } catch (err) {
-        test();
+        catchClause();
         return;
     }
 
     afterTryCatchReturn();
+}
+
+function JsTryStatement2() {
+    try {
+        tryBlock();
+        return;
+    } catch (err) {
+        catchClause();
+    }
+
+    afterTryCatchReturn();
+}
+
+function JsTryStatement3() {
+    return;
+
+    try {
+        tryBlock();
+    } catch (err) {
+        catchClause();
+    }
+}
+
+function JsTryStatement4() {
+    try {
+    } catch (err) {
+        catchClause();
+    }
 }

--- a/crates/rome_js_analyze/tests/specs/noDeadCode/JsTryStatement.js.snap
+++ b/crates/rome_js_analyze/tests/specs/noDeadCode/JsTryStatement.js.snap
@@ -6,14 +6,42 @@ expression: JsTryStatement.js
 ```js
 function JsTryStatement1() {
     try {
-        test();
+        tryBlock();
         return;
     } catch (err) {
-        test();
+        catchClause();
         return;
     }
 
     afterTryCatchReturn();
+}
+
+function JsTryStatement2() {
+    try {
+        tryBlock();
+        return;
+    } catch (err) {
+        catchClause();
+    }
+
+    afterTryCatchReturn();
+}
+
+function JsTryStatement3() {
+    return;
+
+    try {
+        tryBlock();
+    } catch (err) {
+        catchClause();
+    }
+}
+
+function JsTryStatement4() {
+    try {
+    } catch (err) {
+        catchClause();
+    }
 }
 
 ```
@@ -31,6 +59,42 @@ warning[noDeadCode]: This code is unreachable
    ·
 10 │     afterTryCatchReturn();
    │     ---------------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryStatement.js:28:9
+   │
+25 │     return;
+   │     ------- This statement will return from the function ...
+   ·
+28 │         tryBlock();
+   │         ----------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryStatement.js:30:9
+   │
+25 │     return;
+   │     ------- This statement will return from the function ...
+   ·
+30 │         catchClause();
+   │         -------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsTryStatement.js:37:9
+   │
+37 │         catchClause();
+   │         --------------
 
 
 ```

--- a/crates/rome_rowan/src/macros.rs
+++ b/crates/rome_rowan/src/macros.rs
@@ -70,7 +70,7 @@ macro_rules! declare_node_union {
 
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                std::fmt::Display::fmt(self.syntax(), f)
+                std::fmt::Display::fmt($crate::AstNode::syntax(self), f)
             }
         }
 
@@ -80,17 +80,17 @@ macro_rules! declare_node_union {
             }
         } )*
 
-        impl From<$name> for $crate::SyntaxNode<<$name as AstNode>::Language> {
-            fn from(n: $name) -> $crate::SyntaxNode<<$name as AstNode>::Language> {
+        impl From<$name> for $crate::SyntaxNode<<$name as $crate::AstNode>::Language> {
+            fn from(n: $name) -> $crate::SyntaxNode<<$name as $crate::AstNode>::Language> {
                 match n {
                     $( $name::$variant(it) => it.into(), )*
                 }
             }
         }
 
-        impl From<$name> for $crate::SyntaxElement<<$name as AstNode>::Language> {
-            fn from(n: $name) -> $crate::SyntaxElement<<$name as AstNode>::Language> {
-                $crate::SyntaxNode::<<$name as AstNode>::Language>::from(n).into()
+        impl From<$name> for $crate::SyntaxElement<<$name as $crate::AstNode>::Language> {
+            fn from(n: $name) -> $crate::SyntaxElement<<$name as $crate::AstNode>::Language> {
+                $crate::SyntaxNode::<<$name as $crate::AstNode>::Language>::from(n).into()
             }
         }
     };


### PR DESCRIPTION
## Summary

This PR replaces the (temporary) initial implementation of try-catch-finally statements in the control flow analysis (based on the concept of multiple entry points) with a more complete modelling solution for the exception control flow. The `BasicBlock` struct that make up the control flow graph now also contain a list of "exception handlers" and "cleanup handlers": these handlers point to a set of blocks to be executed in order when an exception is thrown (either with an explicit throw instruction or as a possible side-effect of a statement) or when the function returns respectively.

For JavaScript, the exceptions handlers of a block are all the `finally` clauses found going upward in the syntax tree until a `catch` clause is found (the block corresponding to this clause is the last handler in the list), while the cleanup handlers are made of all the `finally` clauses going up to the root level of the function (and ignoring all catch clauses)

The last change I've made is introducing a new `finally_fallthrough` flag on `Jump` instructions. This flag is used specifically to mark the implicit jump instruction inserted by the control flow generator at the end of a `finally` block towards the next statement: when the finally clause gets executed as an exception or cleanup handler instead of going through the normal control flow the target block of this jump gets modified to the next handler in the chain if it exists, or as a return instruction otherwise.

## Test Plan

I've added additional test cases for `JsTryStatement` and `JsTryFinallyStatement` under the snapshots for the `noDeadCode` rule
