### PR TITLE
fix(rome_js_analyze): add missing control flow root nodes

### DIFF
--- a/crates/rome_js_analyze/src/control_flow/visitor.rs
+++ b/crates/rome_js_analyze/src/control_flow/visitor.rs
@@ -1,7 +1,11 @@
 use std::{any::TypeId, ops::ControlFlow};
 
 use rome_analyze::{merge_node_visitors, QueryMatch, Visitor, VisitorContext};
-use rome_js_syntax::{JsAnyFunction, JsLanguage, JsModule, JsScript};
+use rome_js_syntax::{
+    JsAnyFunction, JsConstructorClassMember, JsGetterClassMember, JsGetterObjectMember, JsLanguage,
+    JsMethodClassMember, JsMethodObjectMember, JsModule, JsScript, JsSetterClassMember,
+    JsSetterObjectMember,
+};
 use rome_rowan::{declare_node_union, AstNode, SyntaxError, SyntaxResult};
 
 use super::{nodes::*, FunctionBuilder};
@@ -131,7 +135,16 @@ pub(super) struct FunctionVisitor {
 }
 
 declare_node_union! {
-    JsAnyControlFlowRoot = JsModule | JsScript | JsAnyFunction
+    JsAnyControlFlowRoot = JsModule
+        | JsScript
+        | JsAnyFunction
+        | JsGetterObjectMember
+        | JsSetterObjectMember
+        | JsMethodObjectMember
+        | JsConstructorClassMember
+        | JsMethodClassMember
+        | JsGetterClassMember
+        | JsSetterClassMember
 }
 
 impl<B> rome_analyze::NodeVisitor<ControlFlowVisitor<B>, B> for FunctionVisitor {

--- a/crates/rome_js_analyze/tests/specs/noDeadCode/NestedFunctions.js
+++ b/crates/rome_js_analyze/tests/specs/noDeadCode/NestedFunctions.js
@@ -1,0 +1,50 @@
+const JsFunctionExpression = function () {
+    return;
+}
+
+function JsFunctionDeclaration() {
+    return;
+}
+
+const JsArrowFunctionExpression = function () {
+    return;
+}
+
+export default function JsFunctionExportDefaultDeclaration() {
+    return;
+}
+
+const object = {
+    get JsGetterObjectMember() {
+        return;
+    },
+
+    set JsSetterObjectMember(value) {
+        return;
+    },
+
+    JsMethodObjectMember() {
+        return;
+    },
+};
+
+class Class {
+    // JsConstructorClassMember
+    constructor() {
+        return;
+    }
+
+    JsMethodClassMember() {
+        return;
+    }
+
+    get JsGetterClassMember() {
+        return;
+    }
+
+    set JsSetterClassMember(value) {
+        return;
+    }
+}
+
+statement();

--- a/crates/rome_js_analyze/tests/specs/noDeadCode/NestedFunctions.js.snap
+++ b/crates/rome_js_analyze/tests/specs/noDeadCode/NestedFunctions.js.snap
@@ -1,0 +1,60 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: NestedFunctions.js
+---
+# Input
+```js
+const JsFunctionExpression = function () {
+    return;
+}
+
+function JsFunctionDeclaration() {
+    return;
+}
+
+const JsArrowFunctionExpression = function () {
+    return;
+}
+
+export default function JsFunctionExportDefaultDeclaration() {
+    return;
+}
+
+const object = {
+    get JsGetterObjectMember() {
+        return;
+    },
+
+    set JsSetterObjectMember(value) {
+        return;
+    },
+
+    JsMethodObjectMember() {
+        return;
+    },
+};
+
+class Class {
+    // JsConstructorClassMember
+    constructor() {
+        return;
+    }
+
+    JsMethodClassMember() {
+        return;
+    }
+
+    get JsGetterClassMember() {
+        return;
+    }
+
+    set JsSetterClassMember(value) {
+        return;
+    }
+}
+
+statement();
+
+```
+
+


### PR DESCRIPTION
## Summary

The `JsAnyControlFlowRoot` union in the control flow analysis for JS was missing the object member and class member nodes, causing the control flow for these functions to "leak" into the parent context, causing an erroneous CFG and potentially false positive diagnostics to be emitted

## Test Plan

I've added an additional snapshot test for the `noDeadCode` rule checking a single expression statement at the root level does not get marked as unreachable because of previous return instructions in nested function types
