### PR TITLE
perf(rome_analyze): optimize code actions diff generation

### DIFF
--- a/crates/rome_rowan/src/cursor/node.rs
+++ b/crates/rome_rowan/src/cursor/node.rs
@@ -7,6 +7,7 @@ use crate::{
 use std::hash::{Hash, Hasher};
 use std::iter::FusedIterator;
 use std::ops;
+use std::ptr::NonNull;
 use std::rc::Rc;
 use std::{fmt, iter};
 use text_size::{TextRange, TextSize};
@@ -149,6 +150,11 @@ impl SyntaxNode {
     #[inline]
     pub fn text_trimmed(&self) -> SyntaxNodeText {
         SyntaxNodeText::with_range(self.clone(), self.text_trimmed_range())
+    }
+
+    #[inline]
+    pub(crate) fn key(&self) -> (NonNull<()>, TextSize) {
+        self.data().key()
     }
 
     #[inline]

--- a/crates/rome_rowan/src/cursor/token.rs
+++ b/crates/rome_rowan/src/cursor/token.rs
@@ -4,6 +4,7 @@ use crate::{
     green, Direction, GreenToken, GreenTokenData, RawSyntaxKind, SyntaxTokenText, WalkEvent,
 };
 use std::hash::{Hash, Hasher};
+use std::ptr::NonNull;
 use std::rc::Rc;
 use std::{fmt, iter};
 use text_size::{TextRange, TextSize};
@@ -57,6 +58,10 @@ impl SyntaxToken {
                 );
             }
         }
+    }
+
+    pub(crate) fn key(&self) -> (NonNull<()>, TextSize) {
+        self.data().key()
     }
 
     #[inline]

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -39,8 +39,8 @@ pub use crate::{
     green::RawSyntaxKind,
     syntax::{
         Language, SendNode, SyntaxElement, SyntaxElementChildren, SyntaxKind, SyntaxList,
-        SyntaxNode, SyntaxNodeChildren, SyntaxToken, SyntaxTriviaPiece, SyntaxTriviaPieceComments,
-        TriviaPiece, TriviaPieceKind,
+        SyntaxNode, SyntaxNodeChildren, SyntaxSlot, SyntaxToken, SyntaxTriviaPiece,
+        SyntaxTriviaPieceComments, TriviaPiece, TriviaPieceKind,
     },
     syntax_factory::*,
     syntax_node_text::SyntaxNodeText,

--- a/crates/rome_rowan/src/syntax.rs
+++ b/crates/rome_rowan/src/syntax.rs
@@ -12,10 +12,11 @@ pub use trivia::{
 };
 
 pub use element::SyntaxElement;
+pub(crate) use node::SyntaxSlots;
 pub use node::{
     Preorder, PreorderWithTokens, SendNode, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren,
+    SyntaxSlot,
 };
-pub(crate) use node::{SyntaxSlot, SyntaxSlots};
 
 pub use token::SyntaxToken;
 

--- a/crates/rome_rowan/src/syntax/element.rs
+++ b/crates/rome_rowan/src/syntax/element.rs
@@ -1,11 +1,19 @@
 use crate::syntax::SyntaxTrivia;
 use crate::{cursor, Language, NodeOrToken, SyntaxNode, SyntaxToken};
 use std::iter;
-use text_size::TextRange;
+use std::ptr::NonNull;
+use text_size::{TextRange, TextSize};
 
 pub type SyntaxElement<L> = NodeOrToken<SyntaxNode<L>, SyntaxToken<L>>;
 
 impl<L: Language> SyntaxElement<L> {
+    pub fn key(&self) -> (NonNull<()>, TextSize) {
+        match self {
+            NodeOrToken::Node(it) => it.key(),
+            NodeOrToken::Token(it) => it.key(),
+        }
+    }
+
     pub fn text_range(&self) -> TextRange {
         match self {
             NodeOrToken::Node(it) => it.text_range(),

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -11,6 +11,7 @@ use std::any::TypeId;
 use std::fmt::{Debug, Formatter};
 use std::iter::{self, FusedIterator};
 use std::marker::PhantomData;
+use std::ptr::NonNull;
 use std::{fmt, ops};
 use text_size::{TextRange, TextSize};
 
@@ -48,6 +49,10 @@ impl<L: Language> SyntaxNode<L> {
 
     fn green_node(&self) -> GreenNode {
         self.raw.green().to_owned()
+    }
+
+    pub fn key(&self) -> (NonNull<()>, TextSize) {
+        self.raw.key()
     }
 
     /// Returns the element stored in the slot with the given index. Returns [None] if the slot is empty.
@@ -710,6 +715,14 @@ impl<L: Language> SyntaxSlot<L> {
     pub fn into_token(self) -> Option<SyntaxToken<L>> {
         match self {
             SyntaxSlot::Token(token) => Some(token),
+            _ => None,
+        }
+    }
+
+    pub fn into_syntax_element(self) -> Option<SyntaxElement<L>> {
+        match self {
+            SyntaxSlot::Node(node) => Some(SyntaxElement::Node(node)),
+            SyntaxSlot::Token(token) => Some(SyntaxElement::Token(token)),
             _ => None,
         }
     }

--- a/crates/rome_rowan/src/syntax/token.rs
+++ b/crates/rome_rowan/src/syntax/token.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use std::fmt;
 use std::marker::PhantomData;
+use std::ptr::NonNull;
 use text_size::{TextRange, TextSize};
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -47,6 +48,10 @@ impl<L: Language> SyntaxToken<L> {
 
     pub(super) fn green_token(&self) -> GreenToken {
         self.raw.green().to_owned()
+    }
+
+    pub fn key(&self) -> (NonNull<()>, TextSize) {
+        self.raw.key()
     }
 
     pub fn kind(&self) -> L::Kind {


### PR DESCRIPTION
## Summary

The generation of code action diffs shows up a lot when profiling the analyzer, so I've optimized it a bit by making it skip over irrelevant subtrees. For `find_diff_range` this implies comparing the green nodes between the old and new version of the tree, so I've made the `key` method public on `SyntaxNode` / `SyntaxToken` / `SyntaxElement`

## Test Plan

The snapshot tests for the analyzer still pass, as well as the unit tests for `find_diff_range` although I had to change the expected values since the function now compares the green nodes instead of the text content
