### PR TITLE
chore(xtask): bench analyzer on better files

### DIFF
--- a/xtask/bench/src/analyzer-libs-js.txt
+++ b/xtask/bench/src/analyzer-libs-js.txt
@@ -1,0 +1,3 @@
+https://github.com/prettier/prettier/blob/main/src/language-js/utils/index.js
+https://raw.githubusercontent.com/jquery/jquery/main/src/css.js
+https://raw.githubusercontent.com/fastify/fastify/main/lib/configValidator.js

--- a/xtask/bench/src/analyzer-libs-ts.txt
+++ b/xtask/bench/src/analyzer-libs-ts.txt
@@ -1,0 +1,6 @@
+https://raw.githubusercontent.com/microsoft/TypeScript/2a7eb58589c62529c9045c50cae31ddcca23a6ae/src/compiler/checker.ts
+https://raw.githubusercontent.com/angular/angular/master/packages/compiler/src/expression_parser/parser.ts
+https://raw.githubusercontent.com/angular/angular/master/packages/router/src/router.ts
+https://raw.githubusercontent.com/rome/tools/archived-js/internal/js-parser/parser/statement.ts
+https://raw.githubusercontent.com/rome/tools/archived-js/internal/diagnostics/descriptions/lint.ts
+https://raw.githubusercontent.com/rome/tools/archived-js/internal/js-parser/parser/typescript.ts

--- a/xtask/bench/src/lib.rs
+++ b/xtask/bench/src/lib.rs
@@ -19,6 +19,7 @@ use crate::features::parser::{run_parse, ParseMeasurement};
 pub use utils::get_code;
 
 /// What feature to benchmark
+#[derive(Eq, PartialEq)]
 pub enum FeatureToBenchmark {
     /// benchmark of the parser
     Parser,
@@ -95,8 +96,13 @@ pub fn run(args: RunArgs) {
     let regex = regex::Regex::new(args.filter.as_str()).unwrap();
 
     let mut all_suites = HashMap::new();
-    all_suites.insert("js", include_str!("libs-js.txt"));
-    all_suites.insert("ts", include_str!("libs-ts.txt"));
+    if args.feature == FeatureToBenchmark::Analyzer {
+        all_suites.insert("js", include_str!("analyzer-libs-js.txt"));
+        all_suites.insert("ts", include_str!("analyzer-libs-ts.txt"));
+    } else {
+        all_suites.insert("js", include_str!("libs-js.txt"));
+        all_suites.insert("ts", include_str!("libs-ts.txt"));
+    }
 
     let mut libs = vec![];
     let suites_to_run = args.suites.split(',');


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

The analyzer at the moment works on files that are minified. While this might be useful for performance, this creates a lot of false positives and it stresses the reporting in terms of diagnostics. 

Minified files generate code that usually goes against the lint rules. This PR creates two new files where we list non-minified files to analyze. This is a better real world example.

I couldn't find big files to lint, if you have more, please post them here

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Run the bench command and it should work

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
