### PR TITLE
feat(rome_rowan): batch mutation for syntax nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ version = "0.0.0"
 dependencies = [
  "countme",
  "hashbrown",
+ "iai",
  "memoffset",
  "quickcheck",
  "quickcheck_macros",

--- a/crates/rome_rowan/Cargo.toml
+++ b/crates/rome_rowan/Cargo.toml
@@ -21,6 +21,11 @@ serde_crate = { package = "serde", version = "1.0.133", optional = true, default
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
 serde_json = "1.0.79"
+iai = "*"
 
 [features]
 serde = ["serde_crate", "text-size/serde"]
+
+[[bench]]
+name = "mutation"
+harness = false

--- a/crates/rome_rowan/benches/mutation.rs
+++ b/crates/rome_rowan/benches/mutation.rs
@@ -1,4 +1,3 @@
-use iai::{black_box, main};
 use rome_rowan::{
     raw_language::{LiteralExpression, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
     AstNode, AstNodeExt, BatchMutationExt, SyntaxNodeCast,

--- a/crates/rome_rowan/benches/mutation.rs
+++ b/crates/rome_rowan/benches/mutation.rs
@@ -1,0 +1,70 @@
+use iai::{black_box, main};
+use rome_rowan::{
+    raw_language::{LiteralExpression, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
+    AstNode, AstNodeExt, BatchMutationExt, SyntaxNodeCast,
+};
+
+/// ```
+/// 0: ROOT@0..1
+///     0: LITERAL_EXPRESSION@0..1
+///         0: STRING_TOKEN@0..1 "a" [] []
+/// ```
+fn tree_one(a: &str) -> (RawLanguageRoot, String) {
+    let mut builder = RawSyntaxTreeBuilder::new();
+    builder
+        .start_node(RawLanguageKind::ROOT)
+        .start_node(RawLanguageKind::LITERAL_EXPRESSION)
+        .token(RawLanguageKind::STRING_TOKEN, a)
+        .finish_node()
+        .finish_node();
+    let root = builder.finish().cast::<RawLanguageRoot>().unwrap();
+    let s = format!("{:#?}", root.syntax());
+    (root, s)
+}
+
+fn find(root: &RawLanguageRoot, name: &str) -> LiteralExpression {
+    root.syntax()
+        .descendants()
+        .find(|x| x.kind() == RawLanguageKind::LITERAL_EXPRESSION && x.text_trimmed() == name)
+        .unwrap()
+        .cast::<LiteralExpression>()
+        .unwrap()
+}
+
+fn clone_detach(root: &RawLanguageRoot, name: &str) -> LiteralExpression {
+    root.syntax()
+        .descendants()
+        .find(|x| x.kind() == RawLanguageKind::LITERAL_EXPRESSION && x.text_trimmed() == name)
+        .unwrap()
+        .detach()
+        .cast::<LiteralExpression>()
+        .unwrap()
+}
+
+fn mutation_replace_node() -> usize {
+    let (before, _) = tree_one("a");
+    let (expected, _) = tree_one("b");
+
+    let a = find(&before, "a");
+    let b = clone_detach(&expected, "b");
+
+    let root = before.replace_node(a, b).unwrap();
+
+    root.syntax().descendants().count()
+}
+
+fn mutation_batch() -> usize {
+    let (before, _) = tree_one("a");
+    let (expected, _) = tree_one("b");
+
+    let a = find(&before, "a");
+    let b = clone_detach(&expected, "b");
+
+    let mut batch = before.begin();
+    batch.replace_node(a, b);
+    let root = batch.commit();
+
+    root.syntax().descendants().count()
+}
+
+iai::main!(mutation_replace_node, mutation_batch);

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -5,6 +5,7 @@ pub trait BatchMutationExt<L>: AstNode<Language = L>
 where
     L: Language,
 {
+    #[must_use = "This method consumes the node and return the BatchMutation api that returns the new SynytaxNode on commit"]
     fn begin(self) -> BatchMutation<L, Self>;
 }
 
@@ -13,6 +14,7 @@ where
     L: Language,
     T: AstNode<Language = L>,
 {
+    #[must_use = "This method consumes the node and return the BatchMutation api that returns the new SynytaxNode on commit"]
     fn begin(self) -> BatchMutation<L, Self> {
         BatchMutation {
             root: self,
@@ -41,6 +43,13 @@ impl<L: Language> PartialEq for CommitChange<L> {
 }
 impl<L: Language> Eq for CommitChange<L> {}
 
+/// We order first by depth. Then by the range of the node.
+///
+/// The first is important to guarantee that all nodes that will be changed
+/// in the future are still valid with using SyntaxNode that we have.
+///
+/// The second is important to guarante that the ".peek()" we do below is sufficient
+/// to see the same node in case of two or more nodes having the same depth.
 impl<L: Language> PartialOrd for CommitChange<L> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         let self_range = self.parent_range.unwrap_or((0u32, 0u32));

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -1,0 +1,299 @@
+use crate::{AstNode, Language, NodeOrToken, SyntaxNode, SyntaxNodeCast};
+use std::{collections::BinaryHeap, iter::once};
+
+pub trait BatchMutationExt<L>: AstNode<Language = L>
+where
+    L: Language,
+{
+    fn begin(self) -> BatchMutation<L, Self>;
+}
+
+impl<L, T> BatchMutationExt<L> for T
+where
+    L: Language,
+    T: AstNode<Language = L>,
+{
+    fn begin(self) -> BatchMutation<L, Self> {
+        BatchMutation {
+            root: self,
+            changes: vec![],
+        }
+    }
+}
+
+/// Stores the changed requested using [BatchMutation].
+pub struct Change<L>
+where
+    L: Language,
+{
+    parent: SyntaxNode<L>,
+    index: usize,
+    next_node: Option<SyntaxNode<L>>,
+}
+
+/// Stores the changes internally used by the [BatchMutation::commit] algorithm.
+/// It needs to be sorted by depth, then by range start and range end.
+///
+/// This is necesasry so we can aggregate all changes to the same node using "peek".
+#[derive(Debug)]
+struct CommitChange<L: Language> {
+    parent: Option<SyntaxNode<L>>,
+    parent_range: Option<(u32, u32)>,
+    index: usize,
+    new_node: Option<SyntaxNode<L>>,
+    depth: usize,
+}
+
+impl<L: Language> PartialEq for CommitChange<L> {
+    fn eq(&self, other: &Self) -> bool {
+        self.parent == other.parent
+    }
+}
+impl<L: Language> Eq for CommitChange<L> {}
+
+impl<L: Language> PartialOrd for CommitChange<L> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let self_range = self.parent_range.unwrap_or((0u32, 0u32));
+        let other_range = other.parent_range.unwrap_or((0u32, 0u32));
+
+        (self.depth, self_range.0, self_range.1).partial_cmp(&(
+            other.depth,
+            other_range.0,
+            other_range.1,
+        ))
+    }
+}
+impl<L: Language> Ord for CommitChange<L> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.depth.cmp(&other.depth)
+    }
+}
+
+pub struct BatchMutation<L, N>
+where
+    L: Language,
+    N: AstNode<Language = L>,
+{
+    root: N,
+    changes: Vec<Change<L>>,
+}
+
+impl<L, N> BatchMutation<L, N>
+where
+    L: Language,
+    N: AstNode<Language = L>,
+{
+    pub fn replace_node<T>(&mut self, prev_node: T, next_node: T)
+    where
+        T: AstNode<Language = L>,
+    {
+        let prev_node = prev_node.into_syntax();
+        let index = prev_node.index();
+        let parent = prev_node.parent().unwrap();
+
+        self.changes.push(Change {
+            parent,
+            index,
+            next_node: Some(next_node.into_syntax()),
+        });
+    }
+
+    /// The core of the batch mutation algorithm can be summarized as:
+    /// 1 - Iterate all requested changes;
+    /// 2 - Insert them into a heap (priority queue) by depth. Deeper changes are done first;
+    /// 3 - Loop popping requested changes from the heap, taking the deepest change we have for the moment;
+    /// 4 - Each requested change has a "parent", an "index" and the "new node" (or None);
+    /// 5 - Clone the current parent's "parent", the "greatparent";
+    /// 6 - Detach the current "parent" from the tree;
+    /// 7 - Replace the old node at "index" at the current "parent" with the current "new node";
+    /// 8 - Insert into the heap the greatparent as the parent and the current "parent" as the "new node";
+    ///
+    /// This is the simple case. The algorithm also has a more complex case when to changes have a common ancestor,
+    /// which can actually be one of the changed nodes.
+    ///
+    /// To address this case at step 3, when we pop a new change to apply it, we actually aggregate all changes to the current
+    /// parent together. This is done by the heap because we also sort by node and it's range.
+    ///
+    pub fn commit(self) -> N {
+        // Fill the heap with the requested changes
+
+        let mut changes: BinaryHeap<CommitChange<L>> = BinaryHeap::new();
+
+        for change in self.changes {
+            let depth = change.parent.ancestors().count();
+            let range = change.parent.text_range();
+            changes.push(CommitChange {
+                parent: Some(change.parent),
+                parent_range: Some((range.start().into(), range.end().into())),
+                index: change.index,
+                new_node: change.next_node,
+                depth,
+            });
+        }
+
+        while let Some(item) = changes.pop() {
+            // If parent is None, we reached the root
+            if let Some(current_parent) = item.parent {
+                // This must be done before the detachment below
+                // because we need nodes valid in the old tree
+
+                let grandparent = current_parent.parent();
+                let grandparent_range = grandparent.as_ref().map(|g| {
+                    let range = g.text_range();
+                    (range.start().into(), range.end().into())
+                });
+                let grandparent_index = current_parent.index();
+
+                // Aggregate all modifications to the current parent
+                // This works because of the Ord we defined in the [CommitChange] struct
+
+                let mut modifications = vec![(item.index, item.new_node)];
+                loop {
+                    if let Some(next_change_parent) = changes.peek().and_then(|i| i.parent.as_ref())
+                    {
+                        if *next_change_parent == current_parent {
+                            let next_change = changes.pop().unwrap();
+                            modifications.push((next_change.index, next_change.new_node));
+                            continue;
+                        }
+                    }
+                    break;
+                }
+
+                // Now we detach the current parent, make all the modifications
+                // and push a pending change to its parent.
+
+                let mut current_parent = current_parent.detach();
+
+                for (index, node) in modifications {
+                    let replace_with = node.map(NodeOrToken::Node);
+                    current_parent = current_parent.splice_slots(index..=index, once(replace_with));
+                }
+
+                changes.push(CommitChange {
+                    parent: grandparent,
+                    parent_range: grandparent_range,
+                    index: grandparent_index,
+                    new_node: Some(current_parent),
+                    depth: item.depth - 1,
+                });
+            } else {
+                return item.new_node.and_then(|x| x.cast()).unwrap();
+            }
+        }
+
+        self.root
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        raw_language::{LiteralExpression, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
+        AstNode, BatchMutationExt, SyntaxNodeCast,
+    };
+
+    /// ```
+    /// 0: ROOT@0..1
+    ///     0: LITERAL_EXPRESSION@0..1
+    ///         0: STRING_TOKEN@0..1 "a" [] []
+    /// ```
+    fn tree_one(a: &str) -> (RawLanguageRoot, String) {
+        let mut builder = RawSyntaxTreeBuilder::new();
+        builder
+            .start_node(RawLanguageKind::ROOT)
+            .start_node(RawLanguageKind::LITERAL_EXPRESSION)
+            .token(RawLanguageKind::STRING_TOKEN, a)
+            .finish_node()
+            .finish_node();
+        let root = builder.finish().cast::<RawLanguageRoot>().unwrap();
+        let s = format!("{:#?}", root.syntax());
+        (root, s)
+    }
+
+    /// ```
+    /// 0: ROOT@0..1
+    ///     0: LITERAL_EXPRESSION@0..1
+    ///         0: STRING_TOKEN@0..1 "a" [] []
+    ///     1: LITERAL_EXPRESSION@0..1
+    ///         0: STRING_TOKEN@0..1 "b" [] []
+    /// ```
+    fn tree_two(a: &str, b: &str) -> (RawLanguageRoot, String) {
+        let mut builder = RawSyntaxTreeBuilder::new();
+        builder
+            .start_node(RawLanguageKind::ROOT)
+            .start_node(RawLanguageKind::LITERAL_EXPRESSION)
+            .token(RawLanguageKind::STRING_TOKEN, a)
+            .finish_node()
+            .start_node(RawLanguageKind::LITERAL_EXPRESSION)
+            .token(RawLanguageKind::STRING_TOKEN, b)
+            .finish_node()
+            .finish_node();
+        let root = builder.finish().cast::<RawLanguageRoot>().unwrap();
+        let s = format!("{:#?}", root.syntax());
+        (root, s)
+    }
+
+    fn find(root: &RawLanguageRoot, name: &str) -> LiteralExpression {
+        root.syntax()
+            .descendants()
+            .find(|x| x.kind() == RawLanguageKind::LITERAL_EXPRESSION && x.text_trimmed() == name)
+            .unwrap()
+            .cast::<LiteralExpression>()
+            .unwrap()
+    }
+
+    fn clone_detach(root: &RawLanguageRoot, name: &str) -> LiteralExpression {
+        root.syntax()
+            .descendants()
+            .find(|x| x.kind() == RawLanguageKind::LITERAL_EXPRESSION && x.text_trimmed() == name)
+            .unwrap()
+            .clone()
+            .detach()
+            .cast::<LiteralExpression>()
+            .unwrap()
+    }
+
+    #[test]
+    pub fn ok_batch_mutation_no_changes() {
+        let (before, before_debug) = tree_one("a");
+
+        let batch = before.begin();
+        let after = batch.commit();
+
+        assert_eq!(before_debug, format!("{:#?}", after.syntax()));
+    }
+
+    #[test]
+    pub fn ok_batch_mutation_one_change() {
+        let (before, _) = tree_one("a");
+        let (expected, expected_debug) = tree_one("b");
+
+        let a = find(&before, "a");
+        let b = clone_detach(&expected, "b");
+
+        let mut batch = before.begin();
+        batch.replace_node(a, b);
+        let root = batch.commit();
+
+        assert_eq!(expected_debug, format!("{:#?}", root.syntax()));
+    }
+
+    #[test]
+    pub fn ok_batch_mutation_multiple_changes_different_branches() {
+        let (before, _) = tree_two("a", "b");
+        let (expected, expected_debug) = tree_two("c", "d");
+
+        let a = find(&before, "a");
+        let b = find(&before, "b");
+        let c = clone_detach(&expected, "c");
+        let d = clone_detach(&expected, "d");
+
+        let mut batch = before.begin();
+        batch.replace_node(a, c);
+        batch.replace_node(b, d);
+        let after = batch.commit();
+
+        assert_eq!(expected_debug, format!("{:#?}", after.syntax()));
+    }
+}

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -248,7 +248,6 @@ mod tests {
             .descendants()
             .find(|x| x.kind() == RawLanguageKind::LITERAL_EXPRESSION && x.text_trimmed() == name)
             .unwrap()
-            .clone()
             .detach()
             .cast::<LiteralExpression>()
             .unwrap()

--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -12,10 +12,12 @@ use std::iter::FusedIterator;
 use std::marker::PhantomData;
 use text_size::TextRange;
 
+mod batch;
 mod mutation;
 
 use crate::syntax::{SyntaxSlot, SyntaxSlots};
 use crate::{Language, RawSyntaxKind, SyntaxKind, SyntaxList, SyntaxNode, SyntaxToken};
+pub use batch::*;
 pub use mutation::{AstNodeExt, AstNodeListExt, AstSeparatedListExt};
 
 /// Represents a set of [SyntaxKind] as a bitfield, with each bit representing

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -244,7 +244,7 @@ impl<L: Language> SyntaxNode<L> {
 
     /// Returns the index of this node inside of its parent
     #[inline]
-    fn index(&self) -> usize {
+    pub(crate) fn index(&self) -> usize {
         self.raw.index()
     }
 

--- a/crates/rome_rowan/src/syntax_node_text.rs
+++ b/crates/rome_rowan/src/syntax_node_text.rs
@@ -286,7 +286,7 @@ mod tests {
         let mut builder = RawSyntaxTreeBuilder::new();
         builder.start_node(RawLanguageKind::ROOT);
         for &chunk in chunks.iter() {
-            builder.token(RawLanguageKind::STRING_TOKEN, chunk)
+            builder.token(RawLanguageKind::STRING_TOKEN, chunk);
         }
         builder.finish_node();
         builder.finish()

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -66,9 +66,10 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
 
     /// Adds new token to the current branch.
     #[inline]
-    pub fn token(&mut self, kind: L::Kind, text: &str) {
+    pub fn token(&mut self, kind: L::Kind, text: &str) -> &mut Self {
         let (hash, token) = self.cache.token(kind.to_raw(), text);
         self.children.push((hash, token.into()));
+        self
     }
 
     /// Adds new token to the current branch.
@@ -88,15 +89,16 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
 
     /// Start new node and make it current.
     #[inline]
-    pub fn start_node(&mut self, kind: L::Kind) {
+    pub fn start_node(&mut self, kind: L::Kind) -> &mut Self {
         let len = self.children.len();
         self.parents.push((kind, len));
+        self
     }
 
     /// Finish current branch and restore previous
     /// branch as current.
     #[inline]
-    pub fn finish_node(&mut self) {
+    pub fn finish_node(&mut self) -> &mut Self {
         let (kind, first_child) = self.parents.pop().unwrap();
         let raw_kind = kind.to_raw();
 
@@ -124,6 +126,7 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
         };
 
         self.children.push((hash, node.into()));
+        self
     }
 
     /// Prepare for maybe wrapping the next node.


### PR DESCRIPTION
## Summary

This PR allows batch mutation for ```SyntaxNode```. It solves the problem that when you have a list of nodes to mutate,  after the first mutation, the rest of ```SyntaxNode``` is not valid anymore.

The API follows a transaction style, which I think blends better with Rust (instead of closures)

```rust
let mut batch = root.begin();
batch.replace_node(a, c);
batch.replace_node(b, d);
let root = batch.commit();
```

## Test Plan

All tests can be run with:

```
> cargo test -p rome_rowan -- ok_batch_mutation
```

See https://github.com/rome/tools/pull/2852#discussion_r920062297 for a more detailed discussion of the algorithm.