### PR TITLE
feat(rome_js_semantic): get declaration for JsIdentifierAssignment

### DIFF
--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -447,7 +447,7 @@ mod test {
     use rome_rowan::SyntaxNodeCast;
 
     #[test]
-    pub fn ok_semantic_model_events_sink() {
+    pub fn ok_semantic_model() {
         let r = rome_js_parser::parse(
             "function f(){let a = arguments[0]; let b = a + 1; b = 2;}",
             0,

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -378,7 +378,7 @@ impl SemanticModelBuilder {
             }
             Read {
                 range,
-                declated_at: declaration_at,
+                declared_at: declaration_at,
             } => {
                 self.declarations_by_range.insert(range, declaration_at);
             }
@@ -388,7 +388,19 @@ impl SemanticModelBuilder {
             } => {
                 self.declarations_by_range.insert(range, declaration_at);
             }
-            _ => {}
+            Write {
+                range,
+                declared_at: declaration_at,
+            } => {
+                self.declarations_by_range.insert(range, declaration_at);
+            }
+            HoistedWrite {
+                range,
+                declared_at: declaration_at,
+            } => {
+                self.declarations_by_range.insert(range, declaration_at);
+            }
+            UnresolvedReference { .. } => {}
         }
     }
 
@@ -437,7 +449,7 @@ mod test {
     #[test]
     pub fn ok_semantic_model_events_sink() {
         let r = rome_js_parser::parse(
-            "function f(){let a = arguments[0]; let b = a + 1;}",
+            "function f(){let a = arguments[0]; let b = a + 1; b = 2;}",
             0,
             SourceType::js_module(),
         );
@@ -448,6 +460,13 @@ mod test {
             .descendants()
             .filter_map(|x| x.cast::<JsReferenceIdentifier>())
             .find(|x| x.text() == "arguments")
+            .unwrap();
+
+        let b_from_b_equals_2 = r
+            .syntax()
+            .descendants()
+            .filter_map(|x| x.cast::<JsIdentifierAssignment>())
+            .find(|x| x.text() == "b")
             .unwrap();
 
         // Scope hierarchy  navigation
@@ -501,19 +520,24 @@ mod test {
         let binding = block_scope.get_binding("a").unwrap();
         assert_eq!("a", binding.syntax().text_trimmed());
 
-        // Declarations
+        // Declaration (from Read reference)
 
         let arguments_declaration = arguments_reference.declaration(&model);
         assert!(arguments_declaration.is_none());
 
-        let a_reference = r
+        let a_from_a_plus_1 = r
             .syntax()
             .descendants()
             .filter_map(|x| x.cast::<JsReferenceIdentifier>())
             .find(|x| x.text() == "a")
             .unwrap();
 
-        let a_declaration = a_reference.declaration(&model).unwrap();
+        let a_declaration = a_from_a_plus_1.declaration(&model).unwrap();
         assert_eq!("a", a_declaration.syntax().text_trimmed());
+
+        // Declarations (from Write reference)
+
+        let b_declaration = b_from_b_equals_2.declaration(&model).unwrap();
+        assert_eq!("b", b_declaration.syntax().text_trimmed());
     }
 }

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -1,5 +1,7 @@
 use crate::assert_semantics;
 
+// Reads
+
 assert_semantics! {
     ok_reference_read_global, "let a/*#A*/ = 1; let b = a/*READ A*/ + 1;",
 
@@ -17,9 +19,10 @@ assert_semantics! {
 f(1);"#,
 }
 
-// hoisting
+// Read Hoisting
+
 assert_semantics! {
-    ok_hoisting_inside_function, "function f() {
+    ok_hoisting_read_inside_function, "function f() {
     a = 2;
     let b = a/*READ A*/ + 1;
     console.log(a, b);
@@ -27,7 +30,7 @@ assert_semantics! {
     var a/*#A*/;
 }
 f();",
-    ok_hoisting_var_inside_if, r#"function f() {
+    ok_hoisting_read_var_inside_if, r#"function f() {
     a = 1;
     let b = a/*READ A*/ + 1;
     console.log(a, b);
@@ -36,21 +39,21 @@ f();",
     }
 }
 f();"#,
-    ok_hoisting_redeclaration_before_use, r#"var a/*#A1*/ = 1;
+    ok_hoisting_read_redeclaration_before_use, r#"var a/*#A1*/ = 1;
 function f() {
     var a/*#A2*/ = 10;
     console.log(a/*READ A2*/);
 }
 f();"#,
 
-ok_hoisting_redeclaration_after_use, r#"var a/*#A1*/ = 1;
+ok_hoisting_read_redeclaration_after_use, r#"var a/*#A1*/ = 1;
 function f() {
     console.log(a/*READ A2*/);
     var a/*#A2*/ = 10;
 }
 f();"#,
 
-        ok_hoisting_for_of, r#"function f() {
+        ok_hoisting_read_for_of, r#"function f() {
     for (var a/*#A*/ of [1,2,3]) {
         console.log(a/*READ A*/)
     }
@@ -58,7 +61,7 @@ f();"#,
 }
 f()"#,
 
-    ok_hoisting_for_in, r#"function f() {
+    ok_hoisting_read_for_in, r#"function f() {
     for (var a/*#A*/ in [1,2,3]) {
         console.log(a/*READ A*/)
     }
@@ -66,14 +69,14 @@ f()"#,
 }
 f()"#,
 
-    ok_hoisting_let_after_reference_same_scope, r#"var a = 1;
+    ok_hoisting_read_let_after_reference_same_scope, r#"var a = 1;
 function f() {
     console.log(a/*READ A*/);
     let a/*#A*/ = 2;
 }
 f()"#,
 
-ok_hoisting_let_after_reference_different_scope, r#"var a/*#A*/ = 1;
+ok_hoisting_read_let_after_reference_different_scope, r#"var a/*#A*/ = 1;
 function f() {
     console.log(a/*READ A*/);
     if (true) {
@@ -81,6 +84,35 @@ function f() {
     }
 }
 f()"#,
+}
+
+// Write
+
+assert_semantics! {
+    ok_reference_write_global, "let a/*#A*/; a/*WRITE A*/ = 1;",
+    ok_reference_write_inner_scope, r#"function f(a/*#A1*/) {
+    a/*WRITE A1*/ = 1;
+    console.log(a);
+    if (true) {
+        let a/*#A2*/;
+        a/*WRITE A2*/ = 2;
+        console.log(a);
+    }
+    a/*WRITE A1*/ = 3;
+    console.log(3);
+}
+f(1);"#,
+}
+
+// Write Hoisting
+
+assert_semantics! {
+    ok_hoisting_write_inside_function, "function f() {
+    a/*WRITE A*/ = 2;
+    console.log(a);
+    var a/*#A*/;
+}
+f();",
 }
 
 assert_semantics! {


### PR DESCRIPTION
## Summary

This PR extract ```JsIdentifierAssignment``` as ```Write``` and ```HoistedWrite``` events and integrate these events in the ```SemanticModel```. 

This means that now we can get declarations on statements like:

```
a = 1;
a++;
```

## Test Plan

```
> cargo -p rome_js_semantic -- ok_reference_write
> cargo -p rome_js_semantic -- ok_hoisting_write
> cargo test -p rome_js_semantic -- ok_semantic_model
```

