### PR TITLE
feat(ci): enable nightly builds

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -1,8 +1,8 @@
 name: Release CLI
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: '0 0 * * 2-6'
+  schedule:
+    - cron: '0 0 * * 2-6'
   push:
     branches:
       - main

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -1,8 +1,8 @@
 name: Release LSP
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: '0 0 * * 2-6'
+  schedule:
+    - cron: '0 0 * * 2-6'
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

This PR simply uncomments the `schedule` event for the CLI and LSP release workflows. The release schedule is the same one that was used for Rome JS, it should trigger a release build at 00:00 UTC on every workday. The publishing step still requires a manual validation from a member of the staff team in order to actually get pushed to npm or the VS Marketplace

## Test Plan

The scheduled workflow should start running automatically once the branch is merged to main
