### PR TITLE
fix(rome_js_analyze): only emit control flow side-effects for variable declarators with an initializer

### DIFF
--- a/crates/rome_js_analyze/src/control_flow/nodes.rs
+++ b/crates/rome_js_analyze/src/control_flow/nodes.rs
@@ -11,6 +11,7 @@ mod statement;
 mod switch_stmt;
 mod throw_stmt;
 mod try_catch;
+mod variable;
 mod while_stmt;
 
 pub(super) use block::*;
@@ -26,4 +27,5 @@ pub(super) use statement::*;
 pub(super) use switch_stmt::*;
 pub(super) use throw_stmt::*;
 pub(super) use try_catch::*;
+pub(super) use variable::*;
 pub(super) use while_stmt::*;

--- a/crates/rome_js_analyze/src/control_flow/nodes/statement.rs
+++ b/crates/rome_js_analyze/src/control_flow/nodes/statement.rs
@@ -1,6 +1,4 @@
-use rome_js_syntax::{
-    JsDebuggerStatement, JsEmptyStatement, JsExpressionStatement, JsVariableStatement,
-};
+use rome_js_syntax::{JsDebuggerStatement, JsEmptyStatement, JsExpressionStatement};
 use rome_rowan::{declare_node_union, AstNode, SyntaxResult};
 
 use crate::control_flow::{
@@ -9,7 +7,7 @@ use crate::control_flow::{
 };
 
 declare_node_union! {
-    pub(in crate::control_flow) JsSimpleStatement = JsDebuggerStatement | JsEmptyStatement | JsExpressionStatement | JsVariableStatement
+    pub(in crate::control_flow) JsSimpleStatement = JsDebuggerStatement | JsEmptyStatement | JsExpressionStatement
 }
 
 pub(in crate::control_flow) struct StatementVisitor;

--- a/crates/rome_js_analyze/src/control_flow/nodes/variable.rs
+++ b/crates/rome_js_analyze/src/control_flow/nodes/variable.rs
@@ -1,0 +1,29 @@
+use rome_js_syntax::JsVariableStatement;
+use rome_rowan::{AstNode, SyntaxResult};
+
+use crate::control_flow::{
+    visitor::{NodeVisitor, StatementStack},
+    FunctionBuilder,
+};
+
+pub(in crate::control_flow) struct VariableVisitor;
+
+impl<B> NodeVisitor<B> for VariableVisitor {
+    type Node = JsVariableStatement;
+
+    fn enter(
+        node: Self::Node,
+        builder: &mut FunctionBuilder,
+        _: StatementStack,
+    ) -> SyntaxResult<Self> {
+        let declaration = node.declaration()?;
+        for declarator in declaration.declarators() {
+            if let Some(initializer) = declarator?.initializer() {
+                let expr = initializer.expression()?;
+                builder.append_statement().with_node(expr.into_syntax());
+            }
+        }
+
+        Ok(Self)
+    }
+}

--- a/crates/rome_js_analyze/src/control_flow/visitor.rs
+++ b/crates/rome_js_analyze/src/control_flow/visitor.rs
@@ -102,6 +102,7 @@ declare_visitor! {
         continue_stmt: ContinueVisitor,
         return_stmt: ReturnVisitor,
         throw: ThrowVisitor,
+        variable: VariableVisitor,
     }
 }
 

--- a/crates/rome_js_analyze/tests/specs/noDeadCode/JsVariableStatement.js
+++ b/crates/rome_js_analyze/tests/specs/noDeadCode/JsVariableStatement.js
@@ -1,0 +1,30 @@
+function JsVariableStatement1() {
+    return;
+    var variable;
+}
+
+function JsVariableStatement2() {
+    return;
+    var variable = initializer();
+}
+
+function JsVariableStatement3() {
+    return;
+    let variable;
+}
+
+function JsVariableStatement4() {
+    return;
+    let variable = initializer();
+}
+
+function JsVariableStatement5() {
+    return;
+    const variable = initializer();
+}
+
+function JsVariableStatement6() {
+    return;
+    var variable1 = initializer(),
+        variable2 = initializer();
+}

--- a/crates/rome_js_analyze/tests/specs/noDeadCode/JsVariableStatement.js.snap
+++ b/crates/rome_js_analyze/tests/specs/noDeadCode/JsVariableStatement.js.snap
@@ -1,0 +1,103 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 98
+expression: JsVariableStatement.js
+---
+# Input
+```js
+function JsVariableStatement1() {
+    return;
+    var variable;
+}
+
+function JsVariableStatement2() {
+    return;
+    var variable = initializer();
+}
+
+function JsVariableStatement3() {
+    return;
+    let variable;
+}
+
+function JsVariableStatement4() {
+    return;
+    let variable = initializer();
+}
+
+function JsVariableStatement5() {
+    return;
+    const variable = initializer();
+}
+
+function JsVariableStatement6() {
+    return;
+    var variable1 = initializer(),
+        variable2 = initializer();
+}
+
+```
+
+# Diagnostics
+```
+warning[noDeadCode]: This code is unreachable
+  ┌─ JsVariableStatement.js:8:20
+  │
+7 │     return;
+  │     ------- This statement will return from the function ...
+8 │     var variable = initializer();
+  │                    ------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsVariableStatement.js:18:20
+   │
+17 │     return;
+   │     ------- This statement will return from the function ...
+18 │     let variable = initializer();
+   │                    ------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsVariableStatement.js:23:22
+   │
+22 │     return;
+   │     ------- This statement will return from the function ...
+23 │     const variable = initializer();
+   │                      ------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsVariableStatement.js:28:21
+   │
+27 │     return;
+   │     ------- This statement will return from the function ...
+28 │     var variable1 = initializer(),
+   │                     ------------- ... before it can reach this code
+
+
+```
+
+```
+warning[noDeadCode]: This code is unreachable
+   ┌─ JsVariableStatement.js:29:21
+   │
+27 │     return;
+   │     ------- This statement will return from the function ...
+28 │     var variable1 = initializer(),
+29 │         variable2 = initializer();
+   │                     ------------- ... before it can reach this code
+
+
+```
+
+


### PR DESCRIPTION
## Summary

This PR modifies how control flow instructions are emitted for variable statements: instead of considering the entire statement as a side effect, each initializer expression now creates it own instruction. This means variable declarations without an initializer are not considered to have any side effects in terms of control flow, checking whether the variable itself it unused will be part of the semantic analysis

Fixes #2869

## Test Plan

I've added additional test cases in `JsVariableStatement.js` to check the correct warnings are being emitted
