### PR TITLE
ci: run the CLI on the VSCode extension and website codebase in the Rust PR workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -98,7 +98,6 @@ jobs:
         with:
           command: documentation
 
-
   codegen:
     name: Codegen
     runs-on: ubuntu-latest
@@ -130,3 +129,21 @@ jobs:
             git status
             exit 1
           fi
+
+  test-cli:
+    name: Test CLI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install toolchain
+        run: rustup show
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Run CLI on JavaScript code
+        uses: actions-rs/cargo@v1
+        continue-on-error: true
+        with:
+          command: rome-cli
+          args: ci editors website

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: editors/vscode
         run: |
           echo "prerelease=true" >> $GITHUB_ENV
-          echo "version=$(node ./scripts/updateVersionForPrerelease.js)" >> $GITHUB_ENV
+          echo "version=$(node ./scripts/updateVersionForPrerelease.mjs)" >> $GITHUB_ENV
 
       - name: Check version status
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

This adds an additional job to the `pull_request` workflow that builds the CLI and tries to run it in CI mode over the `editors` (VSCode extension) and `website` directories. This step is "information only" and is marked as `continue-on-error` to avoid causing the workflow to fail since those parts of the codebase are also tested using the latest release of the CLI in their corresponding workflow, and unreleased changes in the linter or formatter may lead to differences between the two set of warnings and errors being emitted.

I also included a small fix in the LSP release workflow, the path to the version update script was out of sync with the actual file in the repo

## Test Plan

Run the workflow and check that it works as expected
