### PR TITLE
feat(rome_js_semantic): Enrich the semantic model with read/write information

### DIFF
--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -60,7 +60,7 @@ impl SemanticModelData {
         &self,
         range: &TextRange,
     ) -> std::slice::Iter<'_, (ReferenceType, TextRange)> {
-        if let Some(v) = self.declaration_all_references.get(&range) {
+        if let Some(v) = self.declaration_all_references.get(range) {
             v.iter()
         } else {
             [].iter()
@@ -71,7 +71,7 @@ impl SemanticModelData {
         &self,
         range: &TextRange,
     ) -> std::slice::Iter<'_, (ReferenceType, TextRange)> {
-        if let Some(v) = self.declaration_all_reads.get(&range) {
+        if let Some(v) = self.declaration_all_reads.get(range) {
             v.iter()
         } else {
             [].iter()
@@ -82,7 +82,7 @@ impl SemanticModelData {
         &self,
         range: &TextRange,
     ) -> std::slice::Iter<'_, (ReferenceType, TextRange)> {
-        if let Some(v) = self.declaration_all_writes.get(&range) {
+        if let Some(v) = self.declaration_all_writes.get(range) {
             v.iter()
         } else {
             [].iter()
@@ -262,17 +262,11 @@ impl Reference {
     }
 
     pub fn is_read(&self) -> bool {
-        match self.ty {
-            ReferenceType::Read => true,
-            _ => false,
-        }
+        matches!(self.ty, ReferenceType::Read)
     }
 
     pub fn is_write(&self) -> bool {
-        match self.ty {
-            ReferenceType::Write => true,
-            _ => false,
-        }
+        matches!(self.ty, ReferenceType::Write)
     }
 }
 
@@ -291,7 +285,7 @@ impl<'a> Iterator for ReferencesIter<'a> {
         Some(Reference {
             data: self.data.clone(),
             node: node.clone(),
-            range: range.clone(),
+            range: *range,
             ty: *ty,
         })
     }


### PR DESCRIPTION
## Summary

This PR enriches the Semantic Model with information about if references are "reading" or "writing". This can really simplify rules like https://github.com/rome/tools/pull/2849#issuecomment-1181544741

One interesting point is what to do with initializers. Today I **do not** flag initializers as writes.

## Test Plan

```
> cargo test -p rome_js_semantic -- ok_semantic_model
```
