### PR TITLE
refactor(rome_analyze): merge analyzer phases

### DIFF
--- a/crates/rome_analyze/src/context.rs
+++ b/crates/rome_analyze/src/context.rs
@@ -1,10 +1,10 @@
-use crate::{registry::RuleRoot, services::ServiceBag, Queryable, Rule};
+use crate::{
+    registry::RuleRoot, CannotCreateServicesError, FromServices, Queryable, Rule, ServiceBag,
+};
 use std::ops::Deref;
 
 type RuleQueryResult<R> = <<R as Rule>::Query as Queryable>::Output;
 type RuleServiceBag<R> = <<R as Rule>::Query as Queryable>::Services;
-type RuleContextCreationError<R> =
-    <<<R as Rule>::Query as Queryable>::Services as TryFrom<ServiceBag>>::Error;
 
 pub struct RuleContext<'a, R>
 where
@@ -22,12 +22,12 @@ where
     pub fn new(
         query_result: &'a RuleQueryResult<R>,
         root: &'a RuleRoot<R>,
-        services: ServiceBag,
-    ) -> Result<Self, RuleContextCreationError<R>> {
+        services: &ServiceBag,
+    ) -> Result<Self, CannotCreateServicesError> {
         Ok(Self {
             query_result,
             root,
-            services: services.try_into()?,
+            services: FromServices::from_services(services)?,
         })
     }
 

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -287,10 +287,9 @@ mod tests {
             &mut emit_signal,
         );
 
-        analyzer.add_visitor(SyntaxVisitor::default());
+        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
 
         let ctx: AnalyzerContext<RawLanguage> = AnalyzerContext {
-            phase: Phases::Syntax,
             file_id: 0,
             root,
             range: None,

--- a/crates/rome_analyze/src/query.rs
+++ b/crates/rome_analyze/src/query.rs
@@ -3,19 +3,14 @@ use rome_rowan::{AstNode, Language, SyntaxKindSet, SyntaxNode, TextRange};
 
 use crate::{
     registry::{NodeLanguage, Phase},
-    services::ServiceBag,
+    services::FromServices,
 };
-
-pub enum CannotCreateServicesError {
-    /// List the missing services necessary to create the service bag
-    MissingServices(&'static [&'static str]),
-}
 
 /// Trait implemented for all types, for example lint rules can query them to emit diagnostics or code actions.
 pub trait Queryable: Sized {
     type Output;
     type Language: Language;
-    type Services: TryFrom<ServiceBag> + Phase;
+    type Services: FromServices + Phase;
 
     /// Statically declares which [QueryMatch] variant is matched by this
     /// [Queryable] type. For instance the [Ast] queryable matches on

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -241,7 +241,7 @@ impl<L: Language> RegistryRule<L> {
             // SAFETY: The rule should never get executed in the first place
             // if the query doesn't match
             let query_result = <R::Query as Queryable>::unwrap_match(&params.query);
-            let ctx = match RuleContext::new(&query_result, params.root, params.services.clone()) {
+            let ctx = match RuleContext::new(&query_result, params.root, params.services) {
                 Ok(ctx) => ctx,
                 Err(_) => return,
             };
@@ -252,10 +252,10 @@ impl<L: Language> RegistryRule<L> {
 
                 let signal = Box::new(RuleSignal::<G, R>::new(
                     params.file_id,
-                    params.root.clone(),
+                    params.root,
                     query_result.clone(),
                     result,
-                    params.services.clone(),
+                    params.services,
                 ));
 
                 params.signal_queue.push(SignalEntry {

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// Defines all the phases that the [RuleRegistry] supports.
 #[repr(usize)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Phases {
     Syntax = 0,
     Semantic = 1,

--- a/crates/rome_analyze/src/services.rs
+++ b/crates/rome_analyze/src/services.rs
@@ -1,18 +1,23 @@
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    ops::Deref,
-    sync::Arc,
 };
 
-use crate::CannotCreateServicesError;
+pub enum CannotCreateServicesError {
+    /// List the missing services necessary to create the service bag
+    MissingServices(&'static [&'static str]),
+}
+
+pub trait FromServices: Sized {
+    fn from_services(services: &ServiceBag) -> Result<Self, CannotCreateServicesError>;
+}
 
 #[derive(Default)]
-pub struct ServiceBagData {
+pub struct ServiceBag {
     services: HashMap<TypeId, Box<dyn Any>>,
 }
 
-impl ServiceBagData {
+impl ServiceBag {
     pub fn insert_service<T: 'static + Clone>(&mut self, service: T) {
         let id = TypeId::of::<T>();
         self.services.insert(id, Box::new(service));
@@ -25,38 +30,8 @@ impl ServiceBagData {
     }
 }
 
-#[derive(Clone)]
-pub struct ServiceBag(Arc<ServiceBagData>);
-
-impl Default for ServiceBag {
-    fn default() -> Self {
-        let services = ServiceBagData::default();
-        ServiceBag::new(services)
-    }
-}
-
-impl ServiceBag {
-    pub fn new(services: ServiceBagData) -> Self {
-        Self(Arc::new(services))
-    }
-
-    pub fn get_mut(&mut self) -> Option<&mut ServiceBagData> {
-        let ServiceBag(data) = self;
-        Arc::get_mut(data)
-    }
-}
-
-impl Deref for ServiceBag {
-    type Target = ServiceBagData;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
-    }
-}
-
-impl TryFrom<ServiceBag> for () {
-    type Error = CannotCreateServicesError;
-    fn try_from(_: ServiceBag) -> Result<Self, Self::Error> {
+impl FromServices for () {
+    fn from_services(_: &ServiceBag) -> Result<Self, CannotCreateServicesError> {
         Ok(())
     }
 }

--- a/crates/rome_analyze/src/services.rs
+++ b/crates/rome_analyze/src/services.rs
@@ -39,6 +39,11 @@ impl ServiceBag {
     pub fn new(services: ServiceBagData) -> Self {
         Self(Arc::new(services))
     }
+
+    pub fn get_mut(&mut self) -> Option<&mut ServiceBagData> {
+        let ServiceBag(data) = self;
+        Arc::get_mut(data)
+    }
 }
 
 impl Deref for ServiceBag {

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -114,10 +114,9 @@ mod tests {
 
         let mut analyzer = Analyzer::new(&mut matcher, |_| unreachable!(), &mut emit_signal);
 
-        analyzer.add_visitor(SyntaxVisitor::default());
+        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
 
         let ctx: AnalyzerContext<RawLanguage> = AnalyzerContext {
-            phase: Phases::Syntax,
             file_id: 0,
             root,
             range: None,

--- a/crates/rome_analyze/src/visitor.rs
+++ b/crates/rome_analyze/src/visitor.rs
@@ -51,7 +51,7 @@ pub trait Visitor {
         ctx: VisitorContext<Self::Language>,
     );
 
-    fn finish(&mut self, ctx: VisitorFinishContext<Self::Language>) {
+    fn finish(self: Box<Self>, ctx: VisitorFinishContext<Self::Language>) {
         let _ = ctx;
     }
 }

--- a/crates/rome_analyze/src/visitor.rs
+++ b/crates/rome_analyze/src/visitor.rs
@@ -6,7 +6,7 @@ use rome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
 use crate::{
     matcher::MatchQueryParams,
     registry::{NodeLanguage, Phases},
-    LanguageRoot, QueryMatch, QueryMatcher, ServiceBag, SignalEntry,
+    AnalyzerContext, LanguageRoot, QueryMatch, QueryMatcher, ServiceBag, SignalEntry,
 };
 
 /// Mutable context objects shared by all visitors
@@ -44,6 +44,10 @@ pub trait Visitor {
         event: &WalkEvent<SyntaxNode<Self::Language>>,
         ctx: VisitorContext<Self::Language>,
     );
+
+    fn finish(&mut self, ctx: &mut AnalyzerContext<Self::Language>) {
+        let _ = ctx;
+    }
 }
 
 /// A node visitor is a special kind of visitor that does not have a persistent

--- a/crates/rome_analyze/src/visitor.rs
+++ b/crates/rome_analyze/src/visitor.rs
@@ -6,21 +6,21 @@ use rome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
 use crate::{
     matcher::MatchQueryParams,
     registry::{NodeLanguage, Phases},
-    AnalyzerContext, LanguageRoot, QueryMatch, QueryMatcher, ServiceBag, SignalEntry,
+    LanguageRoot, QueryMatch, QueryMatcher, ServiceBag, SignalEntry,
 };
 
 /// Mutable context objects shared by all visitors
-pub struct VisitorContext<'a, L: Language> {
+pub struct VisitorContext<'phase, 'query, L: Language> {
     pub phase: Phases,
     pub file_id: FileId,
-    pub root: &'a LanguageRoot<L>,
-    pub services: &'a ServiceBag,
+    pub root: &'phase LanguageRoot<L>,
+    pub services: &'phase ServiceBag,
     pub range: Option<TextRange>,
-    pub(crate) query_matcher: &'a mut dyn QueryMatcher<L>,
-    pub(crate) signal_queue: &'a mut BinaryHeap<SignalEntry<L>>,
+    pub(crate) query_matcher: &'query mut dyn QueryMatcher<L>,
+    pub(crate) signal_queue: &'query mut BinaryHeap<SignalEntry<'phase, L>>,
 }
 
-impl<'a, L: Language> VisitorContext<'a, L> {
+impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
     pub fn match_query(&mut self, query: QueryMatch<L>) {
         self.query_matcher.match_query(MatchQueryParams {
             phase: self.phase,
@@ -31,6 +31,12 @@ impl<'a, L: Language> VisitorContext<'a, L> {
             signal_queue: self.signal_queue,
         })
     }
+}
+
+/// Mutable context objects provided to the finish hook of visitors
+pub struct VisitorFinishContext<'a, L: Language> {
+    pub root: &'a LanguageRoot<L>,
+    pub services: &'a mut ServiceBag,
 }
 
 /// Visitors are the main building blocks of the analyzer: they receive syntax
@@ -45,7 +51,7 @@ pub trait Visitor {
         ctx: VisitorContext<Self::Language>,
     );
 
-    fn finish(&mut self, ctx: &mut AnalyzerContext<Self::Language>) {
+    fn finish(&mut self, ctx: VisitorFinishContext<Self::Language>) {
         let _ = ctx;
     }
 }

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -16,7 +16,7 @@ mod registry;
 mod semantic_analyzers;
 mod semantic_services;
 
-use crate::{registry::build_registry, semantic_services::SemanticVisitor};
+use crate::{registry::build_registry, semantic_services::SemanticModelBuilderVisitor};
 
 pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
 
@@ -60,7 +60,7 @@ where
 
     analyzer.add_visitor(Phases::Syntax, make_visitor());
     analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
-    analyzer.add_visitor(Phases::Syntax, SemanticVisitor::new(root));
+    analyzer.add_visitor(Phases::Syntax, SemanticModelBuilderVisitor::new(root));
 
     analyzer.add_visitor(Phases::Semantic, SyntaxVisitor::default());
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_arguments.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_arguments.rs
@@ -37,8 +37,9 @@ impl Rule for NoArguments {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let reference = ctx.query();
+        let value_token = reference.value_token().ok()?;
 
-        let name = reference.syntax().text_trimmed();
+        let name = value_token.text_trimmed();
         if name == "arguments" {
             let model = ctx.model();
             let declaration = model.declaration(reference);

--- a/crates/rome_js_analyze/src/semantic_services.rs
+++ b/crates/rome_js_analyze/src/semantic_services.rs
@@ -1,5 +1,3 @@
-use std::mem::swap;
-
 use rome_analyze::{
     CannotCreateServicesError, FromServices, Phase, Phases, QueryKey, QueryMatch, Queryable,
     ServiceBag, Visitor, VisitorContext, VisitorFinishContext,
@@ -59,12 +57,12 @@ where
     }
 }
 
-pub(crate) struct SemanticVisitor {
+pub(crate) struct SemanticModelBuilderVisitor {
     extractor: SemanticEventExtractor,
     builder: SemanticModelBuilder,
 }
 
-impl SemanticVisitor {
+impl SemanticModelBuilderVisitor {
     pub(crate) fn new(root: &JsAnyRoot) -> Self {
         Self {
             extractor: SemanticEventExtractor::default(),
@@ -73,7 +71,7 @@ impl SemanticVisitor {
     }
 }
 
-impl Visitor for SemanticVisitor {
+impl Visitor for SemanticModelBuilderVisitor {
     type Language = JsLanguage;
 
     fn visit(
@@ -96,11 +94,8 @@ impl Visitor for SemanticVisitor {
         }
     }
 
-    fn finish(&mut self, ctx: VisitorFinishContext<JsLanguage>) {
-        let mut builder = SemanticModelBuilder::new(ctx.root.clone());
-        swap(&mut builder, &mut self.builder);
-
-        let model = builder.build();
+    fn finish(self: Box<Self>, ctx: VisitorFinishContext<JsLanguage>) {
+        let model = self.builder.build();
         ctx.services.insert_service(model);
     }
 }

--- a/crates/rome_js_analyze/src/semantic_services.rs
+++ b/crates/rome_js_analyze/src/semantic_services.rs
@@ -1,9 +1,12 @@
+use std::mem::swap;
+
 use rome_analyze::{
-    CannotCreateServicesError, Phase, Phases, QueryKey, QueryMatch, Queryable, ServiceBag,
+    AnalyzerContext, CannotCreateServicesError, Phase, Phases, QueryKey, QueryMatch, Queryable,
+    ServiceBag, Visitor, VisitorContext,
 };
-use rome_js_semantic::SemanticModel;
-use rome_js_syntax::JsLanguage;
-use rome_rowan::AstNode;
+use rome_js_semantic::{SemanticEventExtractor, SemanticModel, SemanticModelBuilder};
+use rome_js_syntax::{JsAnyRoot, JsLanguage, WalkEvent};
+use rome_rowan::{AstNode, SyntaxNode};
 
 pub struct SemanticServices {
     model: SemanticModel,
@@ -55,5 +58,56 @@ where
             QueryMatch::Syntax(node) => N::unwrap_cast(node.clone()),
             _ => panic!("tried to unwrap unsupported QueryMatch kind, expected Syntax"),
         }
+    }
+}
+
+pub(crate) struct SemanticVisitor {
+    extractor: SemanticEventExtractor,
+    builder: SemanticModelBuilder,
+}
+
+impl SemanticVisitor {
+    pub(crate) fn new(root: &JsAnyRoot) -> Self {
+        Self {
+            extractor: SemanticEventExtractor::default(),
+            builder: SemanticModelBuilder::new(root.clone()),
+        }
+    }
+}
+
+impl Visitor for SemanticVisitor {
+    type Language = JsLanguage;
+
+    fn visit(
+        &mut self,
+        event: &WalkEvent<SyntaxNode<JsLanguage>>,
+        _ctx: VisitorContext<JsLanguage>,
+    ) {
+        match event {
+            WalkEvent::Enter(node) => {
+                self.builder.push_node(node);
+                self.extractor.enter(node);
+            }
+            WalkEvent::Leave(node) => {
+                self.extractor.leave(node);
+            }
+        }
+
+        while let Some(e) = self.extractor.pop() {
+            self.builder.push_event(e);
+        }
+    }
+
+    fn finish(&mut self, ctx: &mut AnalyzerContext<JsLanguage>) {
+        let mut builder = SemanticModelBuilder::new(ctx.root.clone());
+        swap(&mut builder, &mut self.builder);
+
+        let services = ctx
+            .services
+            .get_mut()
+            .expect("service bag has outstanding references");
+
+        let model = builder.build();
+        services.insert_service(model);
     }
 }

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -189,6 +189,7 @@ impl SemanticEventExtractor {
 
     /// See [SemanticEvent] for a more detailed description
     /// of which ```SyntaxNode``` generates which events.
+    #[inline]
     pub fn enter(&mut self, node: &JsSyntaxNode) {
         use rome_js_syntax::JsSyntaxKind::*;
 
@@ -304,6 +305,7 @@ impl SemanticEventExtractor {
 
     /// See [SemanticEvent] for a more detailed description
     /// of which ```SyntaxNode``` generates which events.
+    #[inline]
     pub fn leave(&mut self, node: &JsSyntaxNode) {
         use rome_js_syntax::JsSyntaxKind::*;
 
@@ -327,6 +329,7 @@ impl SemanticEventExtractor {
     }
 
     /// Return any previous extracted [SemanticEvent].
+    #[inline]
     pub fn pop(&mut self) -> Option<SemanticEvent> {
         self.stash.pop_front()
     }

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -573,10 +573,12 @@ impl SemanticModelBuilder {
         }
     }
 
+    #[inline]
     pub fn push_node(&mut self, node: &JsSyntaxNode) {
         self.node_by_range.insert(node.text_range(), node.clone());
     }
 
+    #[inline]
     pub fn push_event(&mut self, e: SemanticEvent) {
         use SemanticEvent::*;
         match e {
@@ -678,6 +680,7 @@ impl SemanticModelBuilder {
         }
     }
 
+    #[inline]
     pub fn build(self) -> SemanticModel {
         let data = SemanticModelData {
             root: self.root,


### PR DESCRIPTION
## Summary

This change merges the execution of the multiple phases of the analyzer into the `Analyzer` struct itself. This allows some derived data like the line suppression cache to be reused between phases, generally improving the performances of the analysis.

In order to support this I've modified the way the way the semantic model is generate to use a `Visitor`, and added a new `finish` hook to visitors called once the entire file has been visited to give them an opportunity to mutate the service bag and inject additional services for subsequent phases.

In turn, in order to provide the visitors with a mutable access to the service bag I changed the way ownership of the bag is managed from using reference counting to using normal Rust references tied to an explicit `'phase` lifetime: the service bag is immutably borrowed by the visitors, rules and signals for the duration of the phase, then mutably borrowed by the visitors once the phase completes.

I've also included a few other optimizations that were found while profiling, namely marking some methods in `rome_js_semantic` as inlinable, and changing the `NoArguments` rule to read the text of the token directly instead of the binding node

## Test Plan

This is an infrastructure change, it should not have any noticeable side-effects and all the tests for the analyzer should continue to pass
