### PR TITLE
feat(rome_js_analyze): noShoutyConstants

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/js.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js.rs
@@ -4,4 +4,5 @@ use rome_analyze::declare_group;
 mod no_arguments;
 mod no_catch_assign;
 mod no_label_var;
-declare_group! { pub (crate) Js { name : "js" , rules : [no_arguments :: NoArguments , no_catch_assign :: NoCatchAssign , no_label_var :: NoLabelVar ,] } }
+mod no_shouty_constants;
+declare_group! { pub (crate) Js { name : "js" , rules : [no_arguments :: NoArguments , no_catch_assign :: NoCatchAssign , no_label_var :: NoLabelVar , no_shouty_constants :: NoShoutyConstants ,] } }

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
@@ -7,9 +7,8 @@ use rome_diagnostics::Applicability;
 use rome_js_semantic::{AllReferencesExtensions, Reference};
 use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsAnyRoot, JsIdentifierBinding,
-    JsIdentifierExpression, JsLanguage, JsReferenceIdentifier, JsStringLiteralExpression,
-    JsSyntaxKind, JsVariableDeclaration, JsVariableDeclarator, JsVariableDeclaratorList,
-    JsVariableStatement,
+    JsIdentifierExpression, JsLanguage, JsStringLiteralExpression, JsVariableDeclaration,
+    JsVariableDeclarator, JsVariableDeclaratorList, JsVariableStatement,
 };
 use rome_rowan::{AstNode, AstSeparatedList, BatchMutation, BatchMutationExt, SyntaxNodeCast};
 
@@ -44,7 +43,7 @@ fn is_id_and_string_literal_inner_text_equal(
     let literal_text = literal.inner_string_text();
 
     if id_text == literal_text {
-        return Some((id.clone(), literal.clone()));
+        Some((id.clone(), literal.clone()))
     } else {
         None
     }
@@ -69,21 +68,17 @@ fn remove_declarator(
         // Find the declarator we want to remove
         // remove its trailing comma, if there is one
         let mut previous_element = None;
-        loop {
-            if let Some(element) = elements.next() {
-                if let Some(node) = element.node().ok() {
-                    if node == declarator {
-                        batch.remove_node(node.clone());
-                        if let Some(comma) = element.trailing_separator().ok().flatten() {
-                            batch.remove_token(comma.clone());
-                        }
-                        break;
+        for element in elements.by_ref() {
+            if let Ok(node) = element.node() {
+                if node == declarator {
+                    batch.remove_node(node.clone());
+                    if let Some(comma) = element.trailing_separator().ok().flatten() {
+                        batch.remove_token(comma.clone());
                     }
+                    break;
                 }
-                previous_element = Some(element);
-            } else {
-                break;
             }
+            previous_element = Some(element);
         }
 
         // if it is the last declarator of the list

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
@@ -1,0 +1,186 @@
+use crate::{semantic_services::Semantic, JsRuleAction};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
+use rome_console::markup;
+use rome_diagnostics::Applicability;
+use rome_js_semantic::{AllReferencesExtensions, Reference};
+use rome_js_syntax::{
+    JsAnyExpression, JsAnyLiteralExpression, JsAnyRoot, JsIdentifierBinding,
+    JsIdentifierExpression, JsLanguage, JsReferenceIdentifier, JsStringLiteralExpression,
+    JsSyntaxKind, JsVariableDeclaration, JsVariableDeclarator, JsVariableDeclaratorList,
+    JsVariableStatement,
+};
+use rome_rowan::{AstNode, AstSeparatedList, BatchMutation, BatchMutationExt, SyntaxNodeCast};
+
+declare_rule! {
+    /// Disallow the use of constants which its value is the upper-case version of its name.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// const FOO = "FOO";
+    /// console.log(FOO);
+    /// ```
+    pub(crate) NoShoutyConstants = "noShoutyConstants"
+}
+
+/// Check for
+/// a = "a" (true)
+/// a = "b" (false)
+fn is_id_and_string_literal_inner_text_equal(
+    declarator: &JsVariableDeclarator,
+) -> Option<(JsIdentifierBinding, JsStringLiteralExpression)> {
+    let id = declarator.id().ok()?;
+    let id = id.as_js_any_binding()?.as_js_identifier_binding()?;
+    let id_text = id.syntax().text_trimmed();
+
+    let expression = declarator.initializer()?.expression().ok()?;
+    let literal = expression
+        .as_js_any_literal_expression()?
+        .as_js_string_literal_expression()?;
+    let literal_text = literal.inner_string_text();
+
+    if id_text == literal_text {
+        return Some((id.clone(), literal.clone()));
+    } else {
+        None
+    }
+}
+
+/// Removes the declarator, and:
+/// 1 - removes the statement if the declaration only has one declarator;
+/// 2 - removes commas around the declarator to keep the declaration list valid.
+fn remove_declarator(
+    batch: &mut BatchMutation<JsLanguage, JsAnyRoot>,
+    declarator: &JsVariableDeclarator,
+) -> Option<()> {
+    let list = declarator.parent::<JsVariableDeclaratorList>()?;
+    let declaration = list.parent::<JsVariableDeclaration>()?;
+
+    if list.syntax_list().len() == 1 {
+        let statement = declaration.parent::<JsVariableStatement>()?;
+        batch.remove_node(statement);
+    } else {
+        let mut elements = list.elements();
+
+        // Find the declarator we want to remove
+        // remove its trailing comma, if there is one
+        let mut previous_element = None;
+        loop {
+            if let Some(element) = elements.next() {
+                if let Some(node) = element.node().ok() {
+                    if node == declarator {
+                        batch.remove_node(node.clone());
+                        if let Some(comma) = element.trailing_separator().ok().flatten() {
+                            batch.remove_token(comma.clone());
+                        }
+                        break;
+                    }
+                }
+                previous_element = Some(element);
+            } else {
+                break;
+            }
+        }
+
+        // if it is the last declarator of the list
+        // removes the comma before this element
+        let is_last = elements.next().is_none();
+        if is_last {
+            if let Some(element) = previous_element {
+                if let Some(comma) = element.trailing_separator().ok().flatten() {
+                    batch.remove_token(comma.clone());
+                }
+            }
+        }
+    }
+
+    Some(())
+}
+
+pub struct State {
+    literal: JsStringLiteralExpression,
+    references: Vec<Reference>,
+}
+
+impl Rule for NoShoutyConstants {
+    const CATEGORY: RuleCategory = RuleCategory::Lint;
+
+    type Query = Semantic<JsVariableDeclarator>;
+    type State = State;
+    type Signals = Option<Self::State>;
+
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        let declarator = ctx.query();
+        let declaration = declarator
+            .parent::<JsVariableDeclaratorList>()?
+            .parent::<JsVariableDeclaration>()?;
+
+        if declaration.is_const() {
+            if let Some((binding, literal)) = is_id_and_string_literal_inner_text_equal(declarator)
+            {
+                return Some(State {
+                    literal,
+                    references: binding.all_references(ctx.model()).collect(),
+                });
+            }
+        }
+
+        None
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let declarator = ctx.query();
+
+        let mut diag = RuleDiagnostic::warning(
+            declarator.syntax().text_trimmed_range(),
+            markup! {
+                "Redundant constant declaration."
+            },
+        );
+
+        for reference in state.references.iter() {
+            let node = reference.node();
+            diag = diag.secondary(node.text_trimmed_range(), "Used here.")
+        }
+
+        let diag = diag.footer_note(
+            markup! {"You should avoid declaring constants with a string that's the same
+    value as the variable name. It introduces a level of unnecessary
+    indirection when it's only two additional characters to inline."},
+        );
+
+        Some(diag)
+    }
+
+    fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
+        let root = ctx.root();
+        let literal = JsAnyLiteralExpression::JsStringLiteralExpression(state.literal.clone());
+
+        let mut batch = root.begin();
+
+        remove_declarator(&mut batch, ctx.query());
+
+        for reference in state.references.iter() {
+            let node = reference
+                .node()
+                .parent()?
+                .cast::<JsIdentifierExpression>()?;
+
+            batch.replace_node(
+                JsAnyExpression::JsIdentifierExpression(node),
+                JsAnyExpression::JsAnyLiteralExpression(literal.clone()),
+            );
+        }
+
+        Some(JsRuleAction {
+            category: ActionCategory::Refactor,
+            applicability: Applicability::Unspecified,
+            message: markup! { "Use the constant value directly" }.to_owned(),
+            root: batch.commit(),
+        })
+    }
+}

--- a/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
+++ b/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
@@ -1,0 +1,7 @@
+const FOO = "FOO";
+console.log(FOO, FOO2);
+
+// rome-ignore lint(js/useSingleVarDeclarator): ignore useSingleVarDeclarator
+const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
+
+console.log(FOO, FOO4);

--- a/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
+++ b/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
@@ -1,7 +1,6 @@
 const FOO = "FOO";
 console.log(FOO, FOO2);
 
-// rome-ignore lint(js/useSingleVarDeclarator): ignore useSingleVarDeclarator
 const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
 
 console.log(FOO, FOO4);

--- a/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js.snap
@@ -1,0 +1,103 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: noShoutyConstants.js
+---
+# Input
+```js
+const FOO = "FOO";
+console.log(FOO, FOO2);
+
+const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
+
+console.log(FOO, FOO4);
+```
+
+# Diagnostics
+```
+warning[js/noShoutyConstants]: Redundant constant declaration.
+  ┌─ noShoutyConstants.js:1:7
+  │
+1 │ const FOO = "FOO";
+  │       -----------
+2 │ console.log(FOO, FOO2);
+  │             --- Used here.
+  ·
+6 │ console.log(FOO, FOO4);
+  │             --- Used here.
+
+Suggested fix: Use the constant value directly
+    | @@ -1,6 +2,5 @@
+0   | - const FOO = "FOO";
+1   | - console.log(FOO, FOO2);
+2 0 |   
+  1 | + console.log("FOO", FOO2);
+  2 | + 
+3 3 |   const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
+4 4 |   
+5   | - console.log(FOO, FOO4);
+  5 | + console.log("FOO", FOO4);
+
+=  note: You should avoid declaring constants with a string that's the same
+    value as the variable name. It introduces a level of unnecessary
+    indirection when it's only two additional characters to inline.
+
+
+```
+
+```
+warning[js/noShoutyConstants]: Redundant constant declaration.
+  ┌─ noShoutyConstants.js:4:7
+  │
+2 │ console.log(FOO, FOO2);
+  │                  ---- Used here.
+3 │ 
+4 │ const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
+  │       -------------
+
+Suggested fix: Use the constant value directly
+    | @@ -1,6 +1,6 @@
+0 0 |   const FOO = "FOO";
+1   | - console.log(FOO, FOO2);
+  1 | + console.log(FOO, "FOO2");
+2 2 |   
+3   | - const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
+  3 | + const a = "FOO3", FOO4 = "FOO4";
+4 4 |   
+5 5 |   console.log(FOO, FOO4);
+
+=  note: You should avoid declaring constants with a string that's the same
+    value as the variable name. It introduces a level of unnecessary
+    indirection when it's only two additional characters to inline.
+
+
+```
+
+```
+warning[js/noShoutyConstants]: Redundant constant declaration.
+  ┌─ noShoutyConstants.js:4:34
+  │
+4 │ const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
+  │                                  -------------
+5 │ 
+6 │ console.log(FOO, FOO4);
+  │                  ---- Used here.
+
+Suggested fix: Use the constant value directly
+    | @@ -1,6 +1,6 @@
+0 0 |   const FOO = "FOO";
+1 1 |   console.log(FOO, FOO2);
+2 2 |   
+3   | - const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
+  3 | + const FOO2 = "FOO2", a = "FOO3";
+4 4 |   
+5   | - console.log(FOO, FOO4);
+  5 | + console.log(FOO, "FOO4");
+
+=  note: You should avoid declaring constants with a string that's the same
+    value as the variable name. It introduces a level of unnecessary
+    indirection when it's only two additional characters to inline.
+
+
+```
+
+

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -1,6 +1,4 @@
-use crate::{
-    AstNode, Language, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxNodeCast, SyntaxToken,
-};
+use crate::{AstNode, Language, SyntaxElement, SyntaxNode, SyntaxNodeCast, SyntaxToken};
 use std::{collections::BinaryHeap, iter::once};
 
 pub trait BatchMutationExt<L>: AstNode<Language = L>

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -1,4 +1,6 @@
-use crate::{AstNode, Language, NodeOrToken, SyntaxNode, SyntaxNodeCast};
+use crate::{
+    AstNode, Language, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxNodeCast, SyntaxToken,
+};
 use std::{collections::BinaryHeap, iter::once};
 
 pub trait BatchMutationExt<L>: AstNode<Language = L>
@@ -33,7 +35,7 @@ struct CommitChange<L: Language> {
     parent: Option<SyntaxNode<L>>,
     parent_range: Option<(u32, u32)>,
     new_node_slot: usize,
-    new_node: Option<SyntaxNode<L>>,
+    new_node: Option<SyntaxElement<L>>,
 }
 
 impl<L: Language> PartialEq for CommitChange<L> {
@@ -82,6 +84,46 @@ where
     L: Language,
     N: AstNode<Language = L>,
 {
+    pub fn remove_token(&mut self, prev_token: SyntaxToken<L>) {
+        let new_node_slot = prev_token.index();
+        let parent = prev_token.parent();
+        let parent_range: Option<(u32, u32)> = parent.as_ref().map(|p| {
+            let range = p.text_range();
+            (range.start().into(), range.end().into())
+        });
+        let parent_depth = parent.as_ref().map(|p| p.ancestors().count()).unwrap_or(0);
+
+        self.changes.push(CommitChange {
+            parent_depth,
+            parent,
+            parent_range,
+            new_node_slot,
+            new_node: None,
+        });
+    }
+
+    pub fn remove_node<T>(&mut self, prev_node: T)
+    where
+        T: AstNode<Language = L>,
+    {
+        let prev_node = prev_node.into_syntax();
+        let new_node_slot = prev_node.index();
+        let parent = prev_node.parent();
+        let parent_range: Option<(u32, u32)> = parent.as_ref().map(|p| {
+            let range = p.text_range();
+            (range.start().into(), range.end().into())
+        });
+        let parent_depth = parent.as_ref().map(|p| p.ancestors().count()).unwrap_or(0);
+
+        self.changes.push(CommitChange {
+            parent_depth,
+            parent,
+            parent_range,
+            new_node_slot,
+            new_node: None,
+        });
+    }
+
     pub fn replace_node<T>(&mut self, prev_node: T, next_node: T)
     where
         T: AstNode<Language = L>,
@@ -100,7 +142,7 @@ where
             parent,
             parent_range,
             new_node_slot,
-            new_node: Some(next_node.into_syntax()),
+            new_node: Some(SyntaxElement::Node(next_node.into_syntax())),
         });
     }
 
@@ -159,8 +201,7 @@ where
 
                 let mut current_parent = current_parent.detach();
 
-                for (index, node) in modifications {
-                    let replace_with = node.map(NodeOrToken::Node);
+                for (index, replace_with) in modifications {
                     current_parent = current_parent.splice_slots(index..=index, once(replace_with));
                 }
 
@@ -169,10 +210,13 @@ where
                     parent: grandparent,
                     parent_range: grandparent_range,
                     new_node_slot: currentparent_slot,
-                    new_node: Some(current_parent),
+                    new_node: Some(SyntaxElement::Node(current_parent)),
                 });
             } else {
-                return item.new_node.and_then(|x| x.cast()).unwrap();
+                return item
+                    .new_node
+                    .and_then(|x| x.into_node().unwrap().cast())
+                    .unwrap();
             }
         }
 

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -249,7 +249,7 @@ impl<L: Language> SyntaxNode<L> {
 
     /// Returns the index of this node inside of its parent
     #[inline]
-    pub fn index(&self) -> usize {
+    pub(crate) fn index(&self) -> usize {
         self.raw.index()
     }
 

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -249,7 +249,7 @@ impl<L: Language> SyntaxNode<L> {
 
     /// Returns the index of this node inside of its parent
     #[inline]
-    pub(crate) fn index(&self) -> usize {
+    pub fn index(&self) -> usize {
         self.raw.index()
     }
 

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -91,6 +91,13 @@ Disallow labels that share a name with a variable
 Disallow negation in the condition of an <code>if</code> statement if it has an <code>else</code> clause
 </div>
 <div class="rule">
+<h3 data-toc-exclude id="noShoutyConstants">
+	<a href="/docs/lint/rules/noShoutyConstants">noShoutyConstants</a>
+	<a class="header-anchor" href="#noShoutyConstants"></a>
+</h3>
+Disallow the use of constants which its value is the upper-case version of its name.
+</div>
+<div class="rule">
 <h3 data-toc-exclude id="noSparseArray">
 	<a href="/docs/lint/rules/noSparseArray">noSparseArray</a>
 	<a class="header-anchor" href="#noSparseArray"></a>

--- a/website/src/docs/lint/rules/noShoutyConstants.md
+++ b/website/src/docs/lint/rules/noShoutyConstants.md
@@ -1,0 +1,39 @@
+---
+title: Lint Rule noShoutyConstants
+layout: layouts/rule.liquid
+---
+
+# noShoutyConstants
+
+Disallow the use of constants which its value is the upper-case version of its name.
+
+## Examples
+
+### Invalid
+
+```jsx
+const FOO = "FOO";
+console.log(FOO);
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">js/noShoutyConstants</span><span style="color: Orange;">]</span><em>: </em><em>Redundant constant declaration.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> js/noShoutyConstants.js:1:7
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> const FOO = &quot;FOO&quot;;
+  <span style="color: rgb(38, 148, 255);">│</span>       <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+<span style="color: rgb(38, 148, 255);">2</span> <span style="color: rgb(38, 148, 255);">│</span> console.log(FOO);
+  <span style="color: rgb(38, 148, 255);">│</span>             <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span> <span style="color: rgb(38, 148, 255);">Used here.</span>
+
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use the constant value directly</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1,2 +1,2 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">const FOO = &quot;FOO&quot;;</span>
+1   | <span style="color: Tomato;">- </span><span style="color: Tomato;">console.log(FOO);</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"></span>
+  1 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">console.log(&quot;FOO&quot;);</span>
+
+=  note: You should avoid declaring constants with a string that's the same
+    value as the variable name. It introduces a level of unnecessary
+    indirection when it's only two additional characters to inline.
+
+</code></pre>{% endraw %}
+


### PR DESCRIPTION
## Summary

Implements https://github.com/rome/tools/issues/2836


```
warning[js/noShoutyConstants]: Redundant constant declaration.
  ┌─ noShoutyConstants.js:1:7
  │
1 │ const FOO = "FOO";
  │       -----------
2 │ console.log(FOO, FOO2);
  │             --- Used here.
  ·
6 │ console.log(FOO, FOO4);
  │             --- Used here.

Suggested fix: Use the constant value directly
    | @@ -1,6 +2,5 @@
0   | - const FOO = "FOO";
1   | - console.log(FOO, FOO2);
2 0 |   
  1 | + console.log("FOO", FOO2);
  2 | + 
3 3 |   const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
4 4 |   
5   | - console.log(FOO, FOO4);
  5 | + console.log("FOO", FOO4);

=  note: You should avoid declaring constants with a string that's the same
    value as the variable name. It introduces a level of unnecessary
    indirection when it's only two additional characters to inline.
```

## Test Plan

```
> cargo rome-cli check crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
```
