### PR TITLE
refactor(rome_formatter): Use `memoized.inspect` over `buffer.inspect`

### DIFF
--- a/crates/rome_formatter/src/buffer.rs
+++ b/crates/rome_formatter/src/buffer.rs
@@ -492,10 +492,10 @@ pub trait BufferExtensions: Buffer + Sized {
         WillBreakBuffer::new(self)
     }
 
-    /// It emits a custom buffer called [IsLabelledBuffer], which tracks
+    /// Wraps the current buffer in a [HasLabelBuffer], which tracks
     /// labelled elements written in the main buffer, it does so by
-    /// checking if [element](FormatElement) is [label](FormatElement::Label)
-    /// with expected [label_id](LabelId).
+    /// checking if [element](FormatElement) is a [label](FormatElement::Label)
+    /// with the expected [label_id](LabelId).
     ///
     /// This functionality can be used only on one element and only after the element
     /// is written in the buffer.

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -373,7 +373,7 @@ pub struct LabelId {
 }
 
 impl LabelId {
-    pub(crate) fn of<T: ?Sized + 'static>() -> Self {
+    pub fn of<T: ?Sized + 'static>() -> Self {
         Self {
             id: TypeId::of::<T>(),
             #[cfg(debug_assertions)]
@@ -580,6 +580,15 @@ impl FormatElement {
             FormatElement::LineSuffixBoundary => false,
             FormatElement::ExpandParent => true,
             FormatElement::Interned(inner) => inner.0.will_break(),
+        }
+    }
+
+    /// Returns true if the element has the given label.
+    pub fn has_label(&self, label_id: LabelId) -> bool {
+        match self {
+            FormatElement::Label(label) => label.label_id == label_id,
+            FormatElement::Interned(interned) => interned.deref().has_label(label_id),
+            _ => false,
         }
     }
 

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -46,10 +46,7 @@ use std::any::TypeId;
 use crate::printed_tokens::PrintedTokens;
 use crate::printer::{Printer, PrinterOptions};
 pub use arguments::{Argument, Arguments};
-pub use buffer::{
-    Buffer, BufferExtensions, BufferSnapshot, Inspect, IsLabelledBuffer, NullBuffer,
-    PreambleBuffer, VecBuffer, WillBreakBuffer,
-};
+pub use buffer::{Buffer, BufferExtensions, BufferSnapshot, Inspect, PreambleBuffer, VecBuffer};
 pub use builders::{
     block_indent, comment, empty_line, get_lines_before, group_elements, hard_line_break,
     if_group_breaks, if_group_fits_on_line, indent, labelled, line_suffix, soft_block_indent,
@@ -65,8 +62,6 @@ use rome_rowan::{
     SyntaxToken, SyntaxTriviaPieceComments, TextRange, TextSize, TokenAtOffset,
 };
 use std::error::Error;
-use std::fmt;
-use std::fmt::Display;
 use std::num::ParseIntError;
 use std::str::FromStr;
 
@@ -173,8 +168,8 @@ impl TryFrom<u16> for LineWidth {
     }
 }
 
-impl Display for LineWidthFromIntError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for LineWidthFromIntError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
             "The line width exceeds the maximum value ({})",
@@ -344,7 +339,7 @@ pub enum FormatError {
     SyntaxError,
 }
 
-impl fmt::Display for FormatError {
+impl std::fmt::Display for FormatError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FormatError::SyntaxError => fmt.write_str("syntax error"),
@@ -1130,11 +1125,11 @@ pub struct FormatState<Context> {
     pub printed_tokens: PrintedTokens,
 }
 
-impl<Context> fmt::Debug for FormatState<Context>
+impl<Context> std::fmt::Debug for FormatState<Context>
 where
-    Context: fmt::Debug,
+    Context: std::fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("FormatState")
             .field("context", &self.context)
             .field(

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -46,7 +46,10 @@ use std::any::TypeId;
 use crate::printed_tokens::PrintedTokens;
 use crate::printer::{Printer, PrinterOptions};
 pub use arguments::{Argument, Arguments};
-pub use buffer::{Buffer, BufferExtensions, BufferSnapshot, Inspect, PreambleBuffer, VecBuffer};
+pub use buffer::{
+    Buffer, BufferExtensions, BufferSnapshot, HasLabelBuffer, Inspect, PreambleBuffer, VecBuffer,
+    WillBreakBuffer,
+};
 pub use builders::{
     block_indent, comment, empty_line, get_lines_before, group_elements, hard_line_break,
     if_group_breaks, if_group_fits_on_line, indent, labelled, line_suffix, soft_block_indent,

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -222,7 +222,7 @@ impl IntoFormat<JsFormatContext> for JsSyntaxToken {
 /// Formats a range within a file, supported by Rome
 ///
 /// This runs a simple heuristic to determine the initial indentation
-/// level of the node based on the provided [FormatContext], which
+/// level of the node based on the provided [JsFormatContext], which
 /// must match currently the current initial of the file. Additionally,
 /// because the reformatting happens only locally the resulting code
 /// will be indented with the same level as the original selection,
@@ -269,7 +269,7 @@ pub fn format_node(context: JsFormatContext, root: &JsSyntaxNode) -> FormatResul
 /// Formats a single node within a file, supported by Rome.
 ///
 /// This runs a simple heuristic to determine the initial indentation
-/// level of the node based on the provided [FormatContext], which
+/// level of the node based on the provided [JsFormatContext], which
 /// must match currently the current initial of the file. Additionally,
 /// because the reformatting happens only locally the resulting code
 /// will be indented with the same level as the original selection,

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -1,5 +1,5 @@
 //! This module provides important and useful traits to help to format tokens and nodes
-//! when implementing the [crate::FormatNode] trait.
+//! when implementing the [crate::FormatNodeRule] trait.
 
 pub(crate) use crate::{
     AsFormat as _, FormatNodeRule, FormattedIterExt, JsFormatContext, JsFormatter,

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -154,10 +154,7 @@ pub(crate) fn node_has_leading_newline(node: &JsSyntaxNode) -> bool {
 }
 
 /// Format an element with a single line head and a body that might
-/// be either a block or a single statement
-///
-/// This will place the head element inside a [hard_group_elements], but
-/// the body will broken out of flat printing if its a single statement
+/// be either a block or a single statement.
 pub struct FormatBodyStatement<'a> {
     body: &'a JsAnyStatement,
 }


### PR DESCRIPTION
Use `memoized.inspect` to make formatting decision on only later written content instead of the buffer inspection methods `labelled` and `will_break.

The buffer methods are preferred when inspecting content that gets written before needing to know if the content will break or is labelled.

## Test Plan

`cargo test`
