### PR TITLE
fix(rome_js_analyze/useTemplate):  comments in trivia when merge `Vec<JsAnyExpression>` into a `JsTemplate`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/js/use_template.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_template.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsBinaryExpression, JsBinaryOperator, JsSyntaxKind,
     JsSyntaxToken, JsTemplate, JsTemplateElementList, T,
 };
-use rome_rowan::{AstNode, AstNodeExt, AstNodeList, SyntaxToken};
+use rome_rowan::{AstNode, AstNodeExt, AstNodeList, SyntaxToken, TriviaPiece};
 
 use crate::{utils::escape_string, JsRuleAction};
 
@@ -145,22 +145,51 @@ fn convert_expressions_to_js_template(exprs: &Vec<JsAnyExpression>) -> Option<Js
                 reduced_exprs.extend(flatten_template_element_list(template.elements())?);
             }
             _ => {
-                // drop the trivia of original expression make the generated `JsTemplate` a little nicer, if we don't do this
+                // drop the leading and trailing whitespace of original expression make the generated `JsTemplate` a little nicer, if we don't do this
                 // the `1 * (2 + "foo") + "bar"` will become
                 // ```js
                 // `${1 * (2 + "foo") }bar`
                 // ```
                 let expr_next = expr.clone();
                 let first_token = expr_next.syntax().first_token()?;
-                let expr_next = expr_next.replace_token_discard_trivia(
-                    first_token.clone(),
-                    first_token.with_leading_trivia(std::iter::empty()),
-                )?;
+                // drop the leading whitespace of leading trivia of first token
+                let next_first_token = JsSyntaxToken::new_detached(
+                    first_token.kind(),
+                    first_token.text().trim_start(),
+                    first_token
+                        .leading_trivia()
+                        .pieces()
+                        .skip_while(|item| item.is_newline() || item.is_whitespace())
+                        .map(|item| TriviaPiece::new(item.kind(), item.text_len()))
+                        .collect::<Vec<_>>(),
+                    first_token
+                        .trailing_trivia()
+                        .pieces()
+                        .map(|item| TriviaPiece::new(item.kind(), item.text_len())),
+                );
+                let expr_next = expr_next
+                    .replace_token_discard_trivia(first_token.clone(), next_first_token)?;
+                // Drop the trailing whitespace of trailing trivia of last token
                 let last_token = expr_next.syntax().last_token()?;
-                let expr_next = expr_next.replace_token_discard_trivia(
-                    last_token.clone(),
-                    last_token.with_trailing_trivia(std::iter::empty()),
-                )?;
+                let mut next_last_token_trailing = last_token
+                    .trailing_trivia()
+                    .pieces()
+                    .rev()
+                    .skip_while(|item| item.is_newline() || item.is_whitespace())
+                    .map(|item| TriviaPiece::new(item.kind(), item.text_len()))
+                    .collect::<Vec<_>>();
+                next_last_token_trailing.reverse();
+                let next_last_token = JsSyntaxToken::new_detached(
+                    last_token.kind(),
+                    last_token.text().trim_end(),
+                    last_token
+                        .leading_trivia()
+                        .pieces()
+                        .map(|item| TriviaPiece::new(item.kind(), item.text_len())),
+                    next_last_token_trailing,
+                );
+                let expr_next =
+                    expr_next.replace_token_discard_trivia(last_token.clone(), next_last_token)?;
                 let template_element =
                     JsAnyTemplateElement::JsTemplateElement(make::js_template_element(
                         SyntaxToken::new_detached(JsSyntaxKind::DOLLAR_CURLY, "${", [], []),
@@ -224,11 +253,7 @@ fn is_unnecessary_string_concat_expression(node: &JsBinaryExpression) -> Option<
         rome_js_syntax::JsAnyExpression::JsAnyLiteralExpression(
             rome_js_syntax::JsAnyLiteralExpression::JsStringLiteralExpression(string_literal),
         ) => {
-            if escape_string(string_literal.value_token().ok()?.text_trimmed())
-                .ok()?
-                .find(|ch| matches!(ch, '\n' | '`'))
-                .is_none()
-            {
+            if has_new_line_or_tick(string_literal).is_none() {
                 return Some(true);
             }
         }
@@ -244,17 +269,22 @@ fn is_unnecessary_string_concat_expression(node: &JsBinaryExpression) -> Option<
         rome_js_syntax::JsAnyExpression::JsAnyLiteralExpression(
             rome_js_syntax::JsAnyLiteralExpression::JsStringLiteralExpression(string_literal),
         ) => {
-            if escape_string(string_literal.value_token().ok()?.text_trimmed())
-                .ok()?
-                .find(|ch| matches!(ch, '\n' | '`'))
-                .is_none()
-            {
+            if has_new_line_or_tick(string_literal).is_none() {
                 return Some(true);
             }
         }
         _ => (),
     }
     None
+}
+
+/// Check if the string literal has new line or tick
+fn has_new_line_or_tick(
+    string_literal: rome_js_syntax::JsStringLiteralExpression,
+) -> Option<usize> {
+    escape_string(string_literal.value_token().ok()?.text_trimmed())
+        .ok()?
+        .find(|ch| matches!(ch, '\n' | '`'))
 }
 
 /// Convert [JsBinaryExpression] recursively only if the `operator` is `+` into Vec<[JsAnyExpression]>

--- a/crates/rome_js_analyze/src/analyzers/js/use_template.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_template.rs
@@ -155,7 +155,7 @@ fn convert_expressions_to_js_template(exprs: &Vec<JsAnyExpression>) -> Option<Js
                 // drop the leading whitespace of leading trivia of first token
                 // ## Example
                 // `1 *    (2 + "foo") /**trailing */             + "bar"`
-                //     ^^^ drop                          ^^^^^^^^^^^^^ drop             
+                //     ^^^ drop                          ^^^^^^^^^^^^^ drop
                 let next_first_token = JsSyntaxToken::new_detached(
                     first_token.kind(),
                     first_token.text().trim_start(),

--- a/crates/rome_js_analyze/src/analyzers/js/use_template.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_template.rs
@@ -153,6 +153,9 @@ fn convert_expressions_to_js_template(exprs: &Vec<JsAnyExpression>) -> Option<Js
                 let expr_next = expr.clone();
                 let first_token = expr_next.syntax().first_token()?;
                 // drop the leading whitespace of leading trivia of first token
+                // ## Example
+                // `1 *    (2 + "foo") /**trailing */             + "bar"`
+                //     ^^^ drop                          ^^^^^^^^^^^^^ drop             
                 let next_first_token = JsSyntaxToken::new_detached(
                     first_token.kind(),
                     first_token.text().trim_start(),

--- a/crates/rome_js_analyze/src/analyzers/js/use_template.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_template.rs
@@ -155,7 +155,7 @@ fn convert_expressions_to_js_template(exprs: &Vec<JsAnyExpression>) -> Option<Js
                 // drop the leading whitespace of leading trivia of first token
                 // ## Example
                 // `1 *    (2 + "foo") /**trailing */             + "bar"`
-                //     ^^^ drop                          ^^^^^^^^^^^^^ drop
+                //     ^^^^ drop                     ^^^^^^^^^^^^^ drop
                 let next_first_token = JsSyntaxToken::new_detached(
                     first_token.kind(),
                     first_token.text().trim_start(),

--- a/crates/rome_js_analyze/tests/specs/js/useTemplate.js
+++ b/crates/rome_js_analyze/tests/specs/js/useTemplate.js
@@ -13,3 +13,5 @@ console.log("foo" + `bar${`baz${"bat" + "bam"}`}` + "boo");
 console.log("foo" + 1 + 2);
 1 + "2" - 3;
 foo() + " bar";
+
+1 * /**leading*/"foo"    /**trailing */                   + "bar"

--- a/crates/rome_js_analyze/tests/specs/js/useTemplate.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/useTemplate.js.snap
@@ -21,6 +21,8 @@ console.log("foo" + 1 + 2);
 1 + "2" - 3;
 foo() + " bar";
 
+1 * /**leading*/"foo"    /**trailing */                   + "bar"
+
 ```
 
 # Diagnostics
@@ -200,7 +202,7 @@ warning[js/useTemplate]: Template literals are preferred over string concatenati
    │             -------------
 
 Suggested fix: Use a TemplateLiteral.
-      | @@ -10,6 +10,6 @@
+      | @@ -10,7 +10,7 @@
  9  9 |   console.log(1 * (2 + "foo") + "bar");
 10 10 |   console.log("foo" + 1);
 11 11 |   console.log("foo" + `bar${`baz${"bat" + "bam"}`}` + "boo");
@@ -208,6 +210,7 @@ Suggested fix: Use a TemplateLiteral.
    12 | + console.log(`foo${1}${2}`);
 13 13 |   1 + "2" - 3;
 14 14 |   foo() + " bar";
+15 15 |   
 
 
 ```
@@ -220,13 +223,15 @@ warning[js/useTemplate]: Template literals are preferred over string concatenati
    │ -------
 
 Suggested fix: Use a TemplateLiteral.
-      | @@ -11,5 +11,5 @@
+      | @@ -11,7 +11,7 @@
 10 10 |   console.log("foo" + 1);
 11 11 |   console.log("foo" + `bar${`baz${"bat" + "bam"}`}` + "boo");
 12 12 |   console.log("foo" + 1 + 2);
 13    | - 1 + "2" - 3;
    13 | + `${1}2` - 3;
 14 14 |   foo() + " bar";
+15 15 |   
+16 16 |   1 * /**leading*/"foo"    /**trailing */                   + "bar"
 
 
 ```
@@ -239,12 +244,32 @@ warning[js/useTemplate]: Template literals are preferred over string concatenati
    │ --------------
 
 Suggested fix: Use a TemplateLiteral.
-      | @@ -12,4 +12,4 @@
+      | @@ -12,6 +12,6 @@
 11 11 |   console.log("foo" + `bar${`baz${"bat" + "bam"}`}` + "boo");
 12 12 |   console.log("foo" + 1 + 2);
 13 13 |   1 + "2" - 3;
 14    | - foo() + " bar";
    14 | + `${foo()} bar`;
+15 15 |   
+16 16 |   1 * /**leading*/"foo"    /**trailing */                   + "bar"
+
+
+```
+
+```
+warning[js/useTemplate]: Template literals are preferred over string concatenation.
+   ┌─ useTemplate.js:17:1
+   │
+17 │ 1 * /**leading*/"foo"    /**trailing */                   + "bar"
+   │ -----------------------------------------------------------------
+
+Suggested fix: Use a TemplateLiteral.
+      | @@ -14,4 +14,4 @@
+13 13 |   1 + "2" - 3;
+14 14 |   foo() + " bar";
+15 15 |   
+16    | - 1 * /**leading*/"foo"    /**trailing */                   + "bar"
+   16 | + `${1 * /**leading*/"foo"    /**trailing */}bar`
 
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
1. Handle case comments in trivia when merging `Vec<JsAnyExpression>` into a `JsTemplate`
2. For more details, you could see https://github.com/rome/tools/pull/2803#discussion_r920826576
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. cargo test
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
