### PR TITLE
feat: replace the system allocator with mimalloc on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ca136052550448f55df7898c6dbe651c6b574fe38a0d9ea687a9f8088a2e2c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +931,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f64ad83c969af2e732e907564deb0d0ed393cec4af80776f77dd77a1a427698"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1336,6 +1354,7 @@ dependencies = [
  "crossbeam",
  "hdrhistogram",
  "lazy_static",
+ "mimalloc",
  "parking_lot",
  "pico-args",
  "rayon",
@@ -1549,6 +1568,7 @@ dependencies = [
  "anyhow",
  "futures",
  "indexmap",
+ "mimalloc",
  "parking_lot",
  "rome_analyze",
  "rome_console",
@@ -2485,6 +2505,7 @@ dependencies = [
  "dhat",
  "humansize",
  "itertools",
+ "mimalloc",
  "pico-args",
  "regex",
  "rome_analyze",

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -23,3 +23,6 @@ hdrhistogram = { version = "7.5.0", default-features = false }
 crossbeam = "0.8.1"
 thiserror = "1.0.30"
 rayon = "1.5.1"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+mimalloc = "0.1.29"

--- a/crates/rome_cli/src/bin/rome.rs
+++ b/crates/rome_cli/src/bin/rome.rs
@@ -1,5 +1,9 @@
 use rome_cli::{run_cli, setup_panic_handler, CliSession, Termination};
 
+#[cfg(target_os = "windows")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 ///
 /// To run this example, run:
 ///

--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -29,5 +29,8 @@ tracing-subscriber = "0.3.5"
 parking_lot = "0.12.0"
 futures = "0.3"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+mimalloc = "0.1.29"
+
 [dev-dependencies]
 tower = { version = "0.4.12", features = ["timeout"] }

--- a/crates/rome_lsp/src/main.rs
+++ b/crates/rome_lsp/src/main.rs
@@ -4,6 +4,10 @@ use tracing_tree::HierarchicalLayer;
 
 use rome_lsp::server::run_server;
 
+#[cfg(target_os = "windows")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     let stdin = tokio::io::stdin();

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -23,6 +23,9 @@ url = "2.2.2"
 itertools = "0.10.3"
 ansi_rgb = "0.2.0"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+mimalloc = "0.1.29"
+
 # dhat-on
 dhat = { version = "0.2.4", optional = true }
 humansize = {version = "1.1.1", optional = true }

--- a/xtask/bench/src/main.rs
+++ b/xtask/bench/src/main.rs
@@ -9,6 +9,10 @@ use dhat::DhatAlloc;
 #[global_allocator]
 static ALLOCATOR: DhatAlloc = DhatAlloc;
 
+#[cfg(all(target_os = "windows", not(feature = "dhat-on")))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> Result<(), pico_args::Error> {
     #[cfg(feature = "dhat-on")]
     let _dhat = dhat::Dhat::start_heap_profiling();


### PR DESCRIPTION
## Summary

This change adds the `mimalloc` crate as a dependency of `rome_cli`, `rome_lsp` and `xtask_bench`, and uses the provided `MiMalloc` allocator in the resulting binaries instead of the default (system) allocator on Windows

Since the benchmark actions are being run on Linux, here is the improvements I measured when running all the benchmark suites on my machine:
```
group                                    mimalloc                               sysalloc
-----                                    --------                               --------
analyzer/css.js                          1.00      2.2±0.13ms     5.3 MB/sec    2.41      5.3±1.75ms     2.2 MB/sec
analyzer/index.js                        1.00      4.5±0.34ms     7.2 MB/sec    2.42     10.9±2.81ms     3.0 MB/sec
analyzer/lint.ts                         1.00      3.2±0.18ms    12.9 MB/sec    1.64      5.3±0.59ms     7.8 MB/sec
analyzer/parser.ts                       1.00      7.1±0.40ms     6.8 MB/sec    1.89     13.3±2.31ms     3.6 MB/sec
analyzer/router.ts                       1.00      4.8±0.30ms    12.8 MB/sec    2.13     10.2±3.03ms     6.0 MB/sec
analyzer/statement.ts                    1.00      6.1±0.35ms     5.8 MB/sec    1.91     11.6±2.20ms     3.0 MB/sec
analyzer/typescript.ts                   1.00      9.0±0.46ms     6.1 MB/sec    2.04     18.3±5.51ms     3.0 MB/sec

formatter/checker.ts                     1.00   320.2±25.53ms     8.1 MB/sec    1.46   466.7±31.38ms     5.6 MB/sec
formatter/compiler.js                    1.00   204.9±18.59ms     5.1 MB/sec    1.57   321.9±28.05ms     3.3 MB/sec
formatter/d3.min.js                      1.00   167.0±12.69ms  1607.1 KB/sec    1.57   262.3±27.08ms  1023.1 KB/sec
formatter/dojo.js                        1.00     12.3±1.36ms     5.6 MB/sec    1.52     18.7±3.06ms     3.7 MB/sec
formatter/ios.d.ts                       1.00   232.8±41.46ms     8.0 MB/sec    1.41   328.7±25.71ms     5.7 MB/sec
formatter/jquery.min.js                  1.00    64.8±20.42ms  1305.7 KB/sec    2.01   130.5±19.46ms   648.6 KB/sec
formatter/math.js                        1.00   346.7±37.09ms  1912.6 KB/sec    1.50   520.3±38.18ms  1274.4 KB/sec
formatter/parser.ts                      1.00      7.8±0.73ms     6.2 MB/sec    1.45     11.3±0.78ms     4.3 MB/sec
formatter/pixi.min.js                    1.00   192.5±21.07ms     2.3 MB/sec    1.53   293.9±28.54ms  1529.3 KB/sec
formatter/react-dom.production.min.js    1.00    83.2±21.17ms  1415.7 KB/sec    1.07    89.0±65.80ms  1323.5 KB/sec
formatter/react.production.min.js        1.00      4.6±0.63ms  1355.2 KB/sec    1.78      8.3±1.68ms   763.4 KB/sec
formatter/router.ts                      1.00      7.1±1.86ms     8.6 MB/sec    1.22      8.6±0.57ms     7.1 MB/sec
formatter/tex-chtml-full.js              1.00   443.7±47.14ms     2.1 MB/sec    1.56   694.0±51.20ms  1344.5 KB/sec
formatter/three.min.js                   1.00   214.0±15.02ms     2.7 MB/sec    1.59   339.6±32.35ms  1770.5 KB/sec
formatter/typescript.js                  1.00  1297.5±80.09ms     7.3 MB/sec    1.27  1651.0±188.23ms     5.8 MB/sec
formatter/vue.global.prod.js             1.00   125.7±10.00ms   981.7 KB/sec    1.58   198.7±35.41ms   620.8 KB/sec

parser/checker.ts                        1.00   200.1±21.68ms    13.0 MB/sec    1.37   273.5±29.17ms     9.5 MB/sec
parser/compiler.js                       1.00   119.4±14.05ms     8.8 MB/sec    1.09   130.0±45.31ms     8.1 MB/sec
parser/d3.min.js                         1.00     78.0±7.40ms     3.4 MB/sec    1.07    83.4±14.63ms     3.1 MB/sec
parser/dojo.js                           1.00      7.1±1.03ms     9.7 MB/sec    1.10      7.8±2.79ms     8.8 MB/sec
parser/ios.d.ts                          1.00   174.9±16.95ms    10.7 MB/sec    1.33   231.8±32.61ms     8.0 MB/sec
parser/jquery.min.js                     1.00     21.5±7.30ms     3.9 MB/sec    1.31     28.0±6.12ms     2.9 MB/sec
parser/math.js                           1.00   136.2±18.57ms     4.8 MB/sec    1.13   154.2±51.88ms     4.2 MB/sec
parser/parser.ts                         1.00      4.5±0.53ms    10.7 MB/sec    1.53      6.9±2.46ms     7.0 MB/sec
parser/pixi.min.js                       1.08     95.9±9.92ms     4.6 MB/sec    1.00    88.5±37.16ms     5.0 MB/sec
parser/react-dom.production.min.js       1.17     32.9±4.86ms     3.5 MB/sec    1.00     28.1±8.53ms     4.1 MB/sec
parser/react.production.min.js           1.35      2.1±0.77ms     2.9 MB/sec    1.00  1579.7±369.79µs     3.9 MB/sec
parser/router.ts                         1.00      3.7±0.61ms    16.7 MB/sec    1.45      5.3±0.86ms    11.5 MB/sec
parser/tex-chtml-full.js                 1.00   195.6±19.67ms     4.7 MB/sec    1.02   198.8±60.05ms     4.6 MB/sec
parser/three.min.js                      1.00    97.8±12.48ms     6.0 MB/sec    1.13   110.1±40.18ms     5.3 MB/sec
parser/typescript.js                     1.00   790.8±73.79ms    12.0 MB/sec    1.45  1144.7±97.97ms     8.3 MB/sec
parser/vue.global.prod.js                1.12     43.1±4.82ms     2.8 MB/sec    1.00    38.6±10.96ms     3.1 MB/sec
```

## Test Plan

Not sure if this is applicable ? to give more context, the allocator is such a fundamental part of the language it would probably be easy to detect it if it were broken, but on the other hand we don't run any test on Windows
