### PR TITLE
refactor(rome_formatter): Pre-compute suppressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,7 +1463,6 @@ dependencies = [
  "countme",
  "ctor",
  "iai",
- "indexmap",
  "insta",
  "parking_lot",
  "quickcheck",

--- a/crates/rome_css_syntax/src/lib.rs
+++ b/crates/rome_css_syntax/src/lib.rs
@@ -69,6 +69,15 @@ impl rome_rowan::SyntaxKind for CssSyntaxKind {
     fn from_raw(raw: RawSyntaxKind) -> Self {
         Self::from(raw.0)
     }
+
+    fn is_root(&self) -> bool {
+        matches!(self, CSS_ROOT)
+    }
+
+    #[inline]
+    fn is_list(&self) -> bool {
+        CssSyntaxKind::is_list(*self)
+    }
 }
 
 impl TryFrom<CssSyntaxKind> for TriviaPieceKind {

--- a/crates/rome_formatter/src/comments.rs
+++ b/crates/rome_formatter/src/comments.rs
@@ -197,7 +197,9 @@ impl<L: Language> Comments<L> {
                         }
                     }
                 }
-                WalkEvent::Leave(SyntaxElement::Token(_)) => {}
+                WalkEvent::Leave(SyntaxElement::Token(_)) => {
+                    // Token already handled as part of the enter event.
+                }
             }
         }
 

--- a/crates/rome_formatter/src/comments.rs
+++ b/crates/rome_formatter/src/comments.rs
@@ -1,5 +1,12 @@
-use crate::CommentStyle;
-use rome_rowan::{Language, SyntaxTriviaPieceComments};
+use crate::FormatContext;
+use rome_rowan::{
+    Direction, Language, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxTriviaPieceComments,
+    WalkEvent,
+};
+#[cfg(debug_assertions)]
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum CommentKind {
@@ -109,8 +116,177 @@ impl CommentKind {
 }
 
 /// Stores comments specific context information.
-pub trait CommentContext<L: Language> {
+pub trait CommentContext<L: Language>: FormatContext {
     type Style: CommentStyle<L>;
 
     fn comment_style(&self) -> Self::Style;
+
+    /// Returns a ref counted comments. The use of a [Rc] is necessary so that [Comments] has a different
+    /// lifetime than the [crate::Formatter] to support the case where some formatter
+    /// iterates over all comments of a node and writes them to the formatter in the loop body.
+    fn comments(&self) -> Rc<Comments<L>>;
+
+    /// Consumes this context and returns a new context that uses the provided `comments` information.
+    fn with_comments(self, comments: Comments<L>) -> Self;
+}
+
+/// Defines how to format comments for a specific [Language].
+pub trait CommentStyle<L: Language> {
+    /// Returns `true` if a comment with the given `text` is formatter suppression comment.
+    fn is_suppression(&self, text: &str) -> bool;
+
+    /// Returns the kind of the comment
+    fn get_comment_kind(&self, comment: &SyntaxTriviaPieceComments<L>) -> CommentKind;
+
+    /// Returns `true` if a token with the passed `kind` marks the start of a group. Common group tokens are:
+    /// * left parentheses: `(`, `[`, `{`
+    fn is_group_start_token(&self, kind: L::Kind) -> bool;
+
+    /// Returns `true` if a token with the passed `kind` marks the end of a group. Common group end tokens are:
+    /// * right parentheses: `)`, `]`, `}`
+    /// * end of statement token: `;`
+    /// * element separator: `,` or `.`.
+    /// * end of file token: `EOF`
+    fn is_group_end_token(&self, kind: L::Kind) -> bool;
+}
+
+/// Type that stores the comments of a tree and gives access to:
+///
+/// * whether a node should be formatted as is because it has a leading suppression comment.
+/// * a node's leading and trailing comments
+/// * the dangling comments of a token
+#[derive(Debug, Default, Clone)]
+pub struct Comments<L: Language> {
+    /// Stores the nodes that have at least one leading suppression comment.
+    suppressed_nodes: HashSet<SyntaxNode<L>>,
+
+    /// Stores all nodes for which [Comments::is_suppressed] has been called.
+    /// This index of nodes that have been checked if they have a suppression comments is used to
+    /// detect format implementations that manually format a child node without previously checking if
+    /// the child has a suppression comment.
+    ///
+    /// The implementation refrains from snapshotting the checked nodes because a node gets formatted
+    /// as verbatim if its formatting fails which has the same result as formatting it as suppressed node
+    /// (thus, guarantees that the formatting isn't changed).
+    #[cfg(debug_assertions)]
+    checked_suppressions: RefCell<HashSet<SyntaxNode<L>>>,
+}
+
+impl<L: Language> Comments<L> {
+    /// Extracts all the suppressions from `root` and its child nodes.
+    pub fn from_node<Context>(root: &SyntaxNode<L>, context: &Context) -> Self
+    where
+        Context: CommentContext<L>,
+    {
+        let mut suppressed_nodes = HashSet::new();
+        let mut current_node = None;
+
+        for event in root.preorder_with_tokens(Direction::Next) {
+            match event {
+                WalkEvent::Enter(SyntaxElement::Node(node)) => {
+                    // Lists cannot have a suppression comment attached, it must
+                    // belong to either the entire parent node or one of the children
+                    if node.kind().is_root() || node.kind().is_list() {
+                        continue;
+                    }
+
+                    if current_node.is_none() {
+                        current_node = Some(node);
+                    }
+                }
+                WalkEvent::Leave(SyntaxElement::Node(node)) => {
+                    if current_node == Some(node) {
+                        current_node = None;
+                    }
+                }
+                WalkEvent::Enter(SyntaxElement::Token(token)) => {
+                    if let Some(current_node) = current_node.take() {
+                        for comment in token
+                            .leading_trivia()
+                            .pieces()
+                            .filter_map(|piece| piece.as_comments())
+                        {
+                            if context.comment_style().is_suppression(comment.text()) {
+                                suppressed_nodes.insert(current_node);
+                                break;
+                            }
+                        }
+                    }
+                }
+                WalkEvent::Leave(SyntaxElement::Token(_)) => {}
+            }
+        }
+
+        Self {
+            suppressed_nodes,
+            #[cfg(debug_assertions)]
+            checked_suppressions: RefCell::default(),
+        }
+    }
+
+    /// Returns `true` if the passed `node` has a leading suppression comment.
+    ///
+    /// Suppression comments only apply if they at the start of a node and they suppress the most
+    /// outer node.
+    ///
+    /// # Examples
+    ///
+    /// Returns `true` for the expression statement but `false` for the call expression because the
+    /// call expression is nested inside of the expression statement.
+    ///
+    /// ```javascript
+    /// // rome-ignore format: Reason
+    /// console.log("Test");
+    /// ```
+    ///
+    pub fn is_suppressed(&self, node: &SyntaxNode<L>) -> bool {
+        self.mark_suppression_checked(node);
+        self.suppressed_nodes.contains(node)
+    }
+
+    /// Marks that it isn't necessary for the given node to check if it has been suppressed or not.
+    #[inline]
+    pub fn mark_suppression_checked(&self, node: &SyntaxNode<L>) {
+        cfg_if::cfg_if! {
+            if #[cfg(debug_assertions)] {
+                let mut checked_nodes = self.checked_suppressions.borrow_mut();
+                checked_nodes.insert(node.clone());
+            } else {
+                let _ = node;
+            }
+        }
+    }
+
+    /// Verifies that [NodeSuppressions::is_suppressed] has been called for every node of `root`.
+    /// This is a no-op in builds that have the feature `debug_assertions` disabled.
+    ///
+    /// # Panics
+    /// If theres any node for which the formatting didn't very if it has a suppression comment.
+    #[inline]
+    pub(crate) fn assert_checked_all_suppressions(&self, root: &SyntaxNode<L>) {
+        cfg_if::cfg_if! {
+            if #[cfg(debug_assertions)] {
+                let checked_nodes = self.checked_suppressions.borrow();
+                for node in root.descendants() {
+                    if node.kind().is_list() || node.kind().is_root() {
+                        continue;
+                    }
+
+                    if !checked_nodes.contains(&node) {
+                        panic!(r#"
+The following node has been formatted without checking if it has suppression comments.
+Ensure that the formatter calls into the node's formatting rule by using `node.format()` or
+manually test if the node has a suppression comment using `f.context().comments().is_suppressed(node.syntax())`
+if using the node's format rule isn't an option."
+
+Node:
+{node:#?}"#
+                        );
+                    }
+                }
+            } else {
+                let _ = root;
+            }
+        }
+    }
 }

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -186,7 +186,7 @@ where
 {
     /// Take a snapshot of the state of the formatter
     #[inline]
-    pub fn state_snapshot(&self) -> FormatterSnapshot<Context::Snapshot> {
+    pub fn state_snapshot(&self) -> FormatterSnapshot {
         FormatterSnapshot {
             buffer: self.buffer.snapshot(),
             state: self.state().snapshot(),
@@ -195,7 +195,7 @@ where
 
     #[inline]
     /// Restore the state of the formatter to a previous snapshot
-    pub fn restore_state_snapshot(&mut self, snapshot: FormatterSnapshot<Context::Snapshot>) {
+    pub fn restore_state_snapshot(&mut self, snapshot: FormatterSnapshot) {
         self.state_mut().restore_snapshot(snapshot.state);
         self.buffer.restore_snapshot(snapshot.buffer);
     }
@@ -238,7 +238,7 @@ impl<Context> Buffer for Formatter<'_, Context> {
 ///
 /// In practice this only saves the set of printed tokens in debug
 /// mode and compiled to nothing in release mode
-pub struct FormatterSnapshot<Context> {
+pub struct FormatterSnapshot {
     buffer: BufferSnapshot,
-    state: FormatStateSnapshot<Context>,
+    state: FormatStateSnapshot,
 }

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -220,8 +220,8 @@ pub trait CstFormatContext: FormatContext {
     /// Having independent lifetimes is necessary to support the use case where a (formattable object)[Format]
     /// iterates over all comments and writes them into the [crate::Formatter] (mutably borrowing the [crate::Formatter] and in turn this context).
     ///
-    /// ```ignore
-    /// for leading in f.context().comments().leading_comments() {
+    /// ```block
+    /// for leading in f.context().comments().leading_comments(node) {
     ///     ^
     ///     |- Borrows comments
     ///   write!(f, [comment(leading.piece.text())])?;

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -56,7 +56,7 @@ pub use builders::{
     soft_line_break, soft_line_break_or_space, soft_line_indent_or_space, space_token, token,
     BestFitting,
 };
-pub use comments::{CommentContext, CommentKind, SourceComment};
+pub use comments::{CommentContext, CommentKind, CommentStyle, Comments, SourceComment};
 pub use format_element::{normalize_newlines, FormatElement, Token, Verbatim, LINE_TERMINATORS};
 pub use group_id::GroupId;
 use indexmap::IndexSet;
@@ -192,9 +192,6 @@ impl From<LineWidth> for u16 {
 /// Defines the common formatting options. Implementations can define additional options that
 /// are specific to formatting a specific object.
 pub trait FormatContext {
-    /// The type storing a snapshot of the context's (mutable) state.
-    type Snapshot;
-
     /// The indent style.
     fn indent_style(&self) -> IndentStyle;
 
@@ -203,12 +200,6 @@ pub trait FormatContext {
 
     /// Derives the print options from the these format options
     fn as_print_options(&self) -> PrinterOptions;
-
-    /// Snapshots the state of the context that can be restored with `restore_snapshot`.
-    fn snapshot(&self) -> Self::Snapshot;
-
-    /// Restores the contexts state to the state when the snapshot was taken.
-    fn restore_snapshot(&mut self, snapshot: Self::Snapshot);
 }
 
 #[derive(Debug, Default, Eq, PartialEq)]
@@ -218,8 +209,6 @@ pub struct SimpleFormatContext {
 }
 
 impl FormatContext for SimpleFormatContext {
-    type Snapshot = ();
-
     fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -233,10 +222,6 @@ impl FormatContext for SimpleFormatContext {
             .with_indent(self.indent_style)
             .with_print_width(self.line_width)
     }
-
-    fn snapshot(&self) -> Self::Snapshot {}
-
-    fn restore_snapshot(&mut self, _: Self::Snapshot) {}
 }
 
 /// Lightweight sourcemap marker between source and output tokens
@@ -729,7 +714,7 @@ where
 ///
 /// It returns a [Formatted] result, which the user can use to override a file.
 pub fn format_node<
-    Context: FormatContext,
+    Context: CommentContext<L>,
     L: Language,
     N: FormatWithRule<Context, Item = SyntaxNode<L>>,
 >(
@@ -737,6 +722,9 @@ pub fn format_node<
     root: &N,
 ) -> FormatResult<Formatted<Context>> {
     tracing::trace_span!("format_node").in_scope(move || {
+        let suppressions = Comments::from_node(root.item(), &context);
+        let context = context.with_comments(suppressions);
+
         let mut state = FormatState::new(context);
         let mut buffer = VecBuffer::new(&mut state);
 
@@ -745,6 +733,10 @@ pub fn format_node<
         let document = buffer.into_element();
 
         state.assert_formatted_all_tokens(root.item());
+        state
+            .context()
+            .comments()
+            .assert_checked_all_suppressions(root.item());
 
         Ok(Formatted::new(document, state.into_context()))
     })
@@ -812,7 +804,7 @@ pub fn format_range<Context, L, R, P>(
     mut predicate: P,
 ) -> FormatResult<Printed>
 where
-    Context: FormatContext,
+    Context: CommentContext<L>,
     L: Language,
     R: FormatRule<SyntaxNode<L>, Context = Context> + Default,
     P: FnMut(&SyntaxNode<L>) -> bool,
@@ -1039,7 +1031,7 @@ where
 ///
 /// It returns a [Formatted] result
 pub fn format_sub_tree<
-    C: FormatContext,
+    C: FormatContext + CommentContext<L>,
     L: Language,
     N: FormatWithRule<C, Item = SyntaxNode<L>>,
 >(
@@ -1300,9 +1292,8 @@ impl<Context> FormatState<Context>
 where
     Context: FormatContext,
 {
-    pub fn snapshot(&self) -> FormatStateSnapshot<Context::Snapshot> {
+    pub fn snapshot(&self) -> FormatStateSnapshot {
         FormatStateSnapshot {
-            context: self.context.snapshot(),
             last_content_inline_comment: self.last_content_inline_comment,
             last_token_kind: self.last_token_kind,
             manual_handled_comments_len: self.manually_formatted_comments.len(),
@@ -1311,15 +1302,22 @@ where
         }
     }
 
-    pub fn restore_snapshot(&mut self, snapshot: FormatStateSnapshot<Context::Snapshot>) {
-        self.context.restore_snapshot(snapshot.context);
-        self.last_content_inline_comment = snapshot.last_content_inline_comment;
-        self.last_token_kind = snapshot.last_token_kind;
+    pub fn restore_snapshot(&mut self, snapshot: FormatStateSnapshot) {
+        let FormatStateSnapshot {
+            last_content_inline_comment,
+            last_token_kind,
+            manual_handled_comments_len,
+            #[cfg(debug_assertions)]
+            printed_tokens,
+        } = snapshot;
+
+        self.last_content_inline_comment = last_content_inline_comment;
+        self.last_token_kind = last_token_kind;
         self.manually_formatted_comments
-            .truncate(snapshot.manual_handled_comments_len);
+            .truncate(manual_handled_comments_len);
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
-                self.printed_tokens = snapshot.printed_tokens;
+                self.printed_tokens = printed_tokens;
             }
         }
     }
@@ -1341,28 +1339,10 @@ impl LastTokenKind {
     }
 }
 
-pub struct FormatStateSnapshot<Context> {
-    context: Context,
+pub struct FormatStateSnapshot {
     last_content_inline_comment: bool,
     last_token_kind: Option<LastTokenKind>,
     manual_handled_comments_len: usize,
     #[cfg(debug_assertions)]
     printed_tokens: PrintedTokens,
-}
-
-/// Defines how to format comments for a specific [Language].
-pub trait CommentStyle<L: Language>: Copy {
-    /// Returns the kind of the comment
-    fn get_comment_kind(&self, comment: &SyntaxTriviaPieceComments<L>) -> CommentKind;
-
-    /// Returns `true` if a token with the passed `kind` marks the start of a group. Common group tokens are:
-    /// * left parentheses: `(`, `[`, `{`
-    fn is_group_start_token(&self, kind: L::Kind) -> bool;
-
-    /// Returns `true` if a token with the passed `kind` marks the end of a group. Common group end tokens are:
-    /// * right parentheses: `)`, `]`, `}`
-    /// * end of statement token: `;`
-    /// * element separator: `,` or `.`.
-    /// * end of file token: `EOF`
-    fn is_group_end_token(&self, kind: L::Kind) -> bool;
 }

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -214,9 +214,21 @@ pub trait CstFormatContext: FormatContext {
     /// Customizes how comments are formatted
     fn comment_style(&self) -> Self::Style;
 
-    /// Returns a ref counted comments. The use of a [Rc] is necessary so that [Comments] has a different
-    /// lifetime than the [crate::Formatter] to support the case where some formatter
-    /// iterates over all comments of a node and writes them to the formatter in the loop body.
+    /// Returns a ref counted [Comments].
+    ///
+    /// The use of a [Rc] is necessary to achieve that [Comments] has a lifetime that is independent of the [crate::Formatter].
+    /// Having independent lifetimes is necessary to support the use case where a (formattable object)[Format]
+    /// iterates over all comments and writes them into the [crate::Formatter] (mutably borrowing the [crate::Formatter] and in turn this context).
+    ///
+    /// ```ignore
+    /// for leading in f.context().comments().leading_comments() {
+    ///     ^
+    ///     |- Borrows comments
+    ///   write!(f, [comment(leading.piece.text())])?;
+    ///          ^
+    ///          |- Mutably borrows the formatter, state, context (and comments, if they aren't wrapped by a Rc)
+    /// }
+    /// ```
     fn comments(&self) -> Rc<Comments<Self::Language>>;
 
     /// Consumes `self` and returns a new context with the provided extracted (`comments`)[Comments].

--- a/crates/rome_formatter/src/token.rs
+++ b/crates/rome_formatter/src/token.rs
@@ -1,7 +1,7 @@
+use crate::comments::{CommentContext, CommentStyle};
 use crate::prelude::*;
 use crate::{
-    format_args, write, Argument, Arguments, CommentContext, CommentKind, CommentStyle, GroupId,
-    LastTokenKind, SourceComment,
+    format_args, write, Argument, Arguments, CommentKind, GroupId, LastTokenKind, SourceComment,
 };
 use rome_rowan::{Language, SyntaxToken, SyntaxTriviaPiece};
 

--- a/crates/rome_formatter/src/token.rs
+++ b/crates/rome_formatter/src/token.rs
@@ -1,7 +1,8 @@
-use crate::comments::{CommentContext, CommentStyle};
+use crate::comments::CommentStyle;
 use crate::prelude::*;
 use crate::{
-    format_args, write, Argument, Arguments, CommentKind, GroupId, LastTokenKind, SourceComment,
+    format_args, write, Argument, Arguments, CommentKind, CstFormatContext, GroupId, LastTokenKind,
+    SourceComment,
 };
 use rome_rowan::{Language, SyntaxToken, SyntaxTriviaPiece};
 
@@ -22,7 +23,7 @@ pub struct FormatTrimmedToken<'a, L: Language> {
 
 impl<L: Language + 'static, C> Format<C> for FormatTrimmedToken<'_, L>
 where
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
         write_space_between_comment_and_token(self.token.kind(), f)?;
@@ -56,7 +57,7 @@ where
 impl<L, C> Format<C> for FormatInserted<L>
 where
     L: Language + 'static,
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
         write_space_between_comment_and_token(self.kind, f)?;
@@ -71,7 +72,7 @@ fn write_space_between_comment_and_token<L: Language, Context>(
     f: &mut Formatter<Context>,
 ) -> FormatResult<()>
 where
-    Context: CommentContext<L>,
+    Context: CstFormatContext<Language = L>,
 {
     let is_last_content_inline_content = f.state().is_last_content_inline_comment();
 
@@ -134,7 +135,7 @@ where
 impl<Context, L> Format<Context> for FormatInsertedOpenParen<L>
 where
     L: Language + 'static,
-    Context: CommentContext<L>,
+    Context: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         let mut comments = Vec::new();
@@ -250,7 +251,7 @@ where
 impl<Context, L> Format<Context> for FormatInsertedCloseParen<L>
 where
     L: Language + 'static,
-    Context: CommentContext<L>,
+    Context: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         write!(
@@ -290,7 +291,7 @@ where
 impl<C, L> Format<C> for FormatRemoved<'_, L>
 where
     L: Language + 'static,
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
         f.state_mut().track_token(self.token);
@@ -309,7 +310,7 @@ fn write_removed_token_trivia<C, L>(
 ) -> FormatResult<()>
 where
     L: Language + 'static,
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     let mut pieces = token
         .leading_trivia()
@@ -376,7 +377,7 @@ where
 impl<L, C> Format<C> for FormatReplaced<'_, '_, L, C>
 where
     L: Language + 'static,
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
         f.state_mut().track_token(self.token);
@@ -432,7 +433,7 @@ where
 impl<L, C> Format<C> for FormatOnlyIfBreaks<'_, '_, L, C>
 where
     L: Language + 'static,
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
         // Store the last token and last trailing comment before formatting the content which will override the state.
@@ -504,7 +505,7 @@ where
 impl<L, C> Format<C> for FormatLeadingTrivia<'_, L>
 where
     L: Language,
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
         write_leading_trivia(
@@ -527,7 +528,7 @@ fn write_leading_trivia<I, L, C>(
 where
     I: IntoIterator<Item = SyntaxTriviaPiece<L>>,
     L: Language,
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     let mut lines_before = 0;
     let mut comments = Vec::new();
@@ -656,7 +657,7 @@ where
 impl<L, C> Format<C> for FormatLeadingComments<'_, L>
 where
     L: Language,
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
         let mut first = true;
@@ -778,7 +779,7 @@ where
 impl<I, L: Language, C> Format<C> for FormatTrailingTrivia<I, L>
 where
     I: Iterator<Item = SourceComment<L>> + Clone,
-    C: CommentContext<L>,
+    C: CstFormatContext<Language = L>,
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
         let comments = self.comments.clone();

--- a/crates/rome_js_formatter/Cargo.toml
+++ b/crates/rome_js_formatter/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 
 [dependencies]
 cfg-if = "1.0.0"
-indexmap = "1.8.2"
 rome_js_syntax = { path = "../rome_js_syntax" }
 rome_formatter = { path = "../rome_formatter" }
 rome_rowan = { path = "../rome_rowan" }

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -1,7 +1,9 @@
 use crate::prelude::*;
 use crate::AsFormat;
 use rome_formatter::token::{FormatInserted, FormatInsertedCloseParen, FormatInsertedOpenParen};
-use rome_formatter::{format_args, write, Argument, Arguments, GroupId, PreambleBuffer, VecBuffer};
+use rome_formatter::{
+    format_args, write, Argument, Arguments, CommentContext, GroupId, PreambleBuffer, VecBuffer,
+};
 use rome_js_syntax::{JsLanguage, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, Direction, Language, SyntaxElement, SyntaxTriviaPiece};
 
@@ -184,7 +186,7 @@ impl Format<JsFormatContext> for FormatVerbatimNode<'_> {
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
                 SyntaxElement::Node(node) => {
-                    f.context_mut().checked_suppressed(&node);
+                    f.context().comments().mark_suppression_checked(&node);
                 }
             }
         }

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::AsFormat;
 use rome_formatter::token::{FormatInserted, FormatInsertedCloseParen, FormatInsertedOpenParen};
 use rome_formatter::{
-    format_args, write, Argument, Arguments, CommentContext, GroupId, PreambleBuffer, VecBuffer,
+    format_args, write, Argument, Arguments, CstFormatContext, GroupId, PreambleBuffer, VecBuffer,
 };
 use rome_js_syntax::{JsLanguage, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, Direction, Language, SyntaxElement, SyntaxTriviaPiece};

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -1,6 +1,6 @@
 use rome_formatter::printer::PrinterOptions;
 use rome_formatter::{
-    CommentContext, CommentKind, CommentStyle, Comments, FormatContext, IndentStyle, LineWidth,
+    CommentKind, CommentStyle, Comments, CstFormatContext, FormatContext, IndentStyle, LineWidth,
 };
 use rome_js_syntax::suppression::{parse_suppression_comment, SuppressionCategory};
 use rome_js_syntax::{JsLanguage, JsSyntaxKind, SourceType};
@@ -117,7 +117,8 @@ impl fmt::Display for JsFormatContext {
     }
 }
 
-impl CommentContext<JsLanguage> for JsFormatContext {
+impl CstFormatContext for JsFormatContext {
+    type Language = JsLanguage;
     type Style = JsCommentStyle;
 
     fn comment_style(&self) -> Self::Style {
@@ -128,8 +129,8 @@ impl CommentContext<JsLanguage> for JsFormatContext {
         self.comments.clone()
     }
 
-    fn with_comments(mut self, comments: Comments<JsLanguage>) -> Self {
-        self.comments = Rc::new(comments);
+    fn with_comments(mut self, comments: Rc<Comments<JsLanguage>>) -> Self {
+        self.comments = comments;
         self
     }
 }

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -1,14 +1,13 @@
-#[cfg(debug_assertions)]
-use indexmap::IndexSet;
 use rome_formatter::printer::PrinterOptions;
 use rome_formatter::{
-    CommentContext, CommentKind, CommentStyle, FormatContext, IndentStyle, LineWidth,
+    CommentContext, CommentKind, CommentStyle, Comments, FormatContext, IndentStyle, LineWidth,
 };
-use rome_js_syntax::suppression::{has_suppressions_category, SuppressionCategory};
-use rome_js_syntax::{JsLanguage, JsSyntaxKind, JsSyntaxNode, SourceType};
+use rome_js_syntax::suppression::{parse_suppression_comment, SuppressionCategory};
+use rome_js_syntax::{JsLanguage, JsSyntaxKind, SourceType};
 use rome_rowan::SyntaxTriviaPieceComments;
 use std::fmt;
 use std::fmt::Debug;
+use std::rc::Rc;
 use std::str::FromStr;
 
 #[derive(Debug, Clone, Default)]
@@ -25,8 +24,8 @@ pub struct JsFormatContext {
     /// Information relative to the current file
     source_type: SourceType,
 
-    #[cfg(debug_assertions)]
-    checked_node_suppressions: IndexSet<JsSyntaxNode>,
+    /// The comments of the nodes and tokens in the program.
+    comments: Rc<Comments<JsLanguage>>,
 }
 
 impl JsFormatContext {
@@ -68,72 +67,6 @@ impl JsFormatContext {
     pub fn source_type(&self) -> SourceType {
         self.source_type
     }
-
-    /// Returns `true` if the passed node has a suppression comment and
-    /// tracks in debug builds that the suppression comments of this node have been checked.
-    ///
-    /// # Examples
-    /// ```
-    /// use rome_js_formatter::context::JsFormatContext;
-    /// use rome_js_formatter::prelude::*;
-    /// use rome_js_parser::parse_expression;
-    /// use rome_js_syntax::SourceType;
-    ///
-    /// let root = parse_expression(r#"
-    /// // rome-ignore format: Suppressed for testing purposes
-    /// console.log('abcd');
-    /// "#, 0).tree();
-    ///
-    /// let call_expression = root.expression().unwrap();
-    /// let mut context = JsFormatContext::new(SourceType::js_module());
-    ///
-    /// assert!(context.is_suppressed(call_expression.syntax()));
-    /// ```
-    ///
-    #[inline]
-    pub fn is_suppressed(&mut self, node: &JsSyntaxNode) -> bool {
-        self.checked_suppressed(node);
-        has_suppressions_category(SuppressionCategory::Format, node)
-    }
-
-    /// Tracks that the formatting manually checked if the passed in node has a suppression comment
-    /// in debug builds.
-    pub(crate) fn checked_suppressed(&mut self, #[allow(unused_variables)] node: &JsSyntaxNode) {
-        cfg_if::cfg_if! {
-            if #[cfg(debug_assertions)] {
-                self.checked_node_suppressions.insert(node.clone());
-            }
-        }
-    }
-
-    /// Asserts that the suppression comments of all nodes have been handled in debug builds.
-    ///
-    /// # Panics
-    /// If the suppression comments of a node have not been checked.
-    #[inline]
-    pub(crate) fn assert_checked_all_suppressions(
-        &self,
-        #[allow(unused_variables)] root: &JsSyntaxNode,
-    ) {
-        cfg_if::cfg_if! {
-            if #[cfg(debug_assertions)] {
-                for node in root.descendants() {
-                    if !self.checked_node_suppressions.contains(&node) {
-                        // No need to explicitly check nodes where the node is the first element of its parent
-                        // (in which case the suppression would suppress the parent node), or when
-                        // the node is a list for which Rome doesn't support suppression comments
-                        if node.prev_sibling_or_token().is_none() || node.kind().is_list() {
-                            continue;
-                        }
-
-                        panic!(r#"The node {node:#?} has been formatted without checking if it has suppression comments.
-Ensure that the formatter calls into the node's formatting rule by using `node.format()` or
-manually test if the node has a suppression comment using `f.context_mut().is_suppressed(node.syntax())` if using the node's format rule isn't an option"#)
-                    }
-                }
-            }
-        }
-    }
 }
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
@@ -161,8 +94,6 @@ impl JsFormatContext {
 }
 
 impl FormatContext for JsFormatContext {
-    type Snapshot = JsFormatContextSnapshot;
-
     fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -176,26 +107,6 @@ impl FormatContext for JsFormatContext {
             .with_indent(self.indent_style)
             .with_print_width(self.line_width)
     }
-
-    fn snapshot(&self) -> Self::Snapshot {
-        JsFormatContextSnapshot {
-            #[cfg(debug_assertions)]
-            node_suppressions_len: self.checked_node_suppressions.len(),
-        }
-    }
-
-    fn restore_snapshot(&mut self, #[allow(unused)] snapshot: Self::Snapshot) {
-        cfg_if::cfg_if! {
-            if #[cfg(debug_assertions)] {
-                self.checked_node_suppressions.truncate(snapshot.node_suppressions_len);
-            }
-        }
-    }
-}
-
-pub struct JsFormatContextSnapshot {
-    #[cfg(debug_assertions)]
-    node_suppressions_len: usize,
 }
 
 impl fmt::Display for JsFormatContext {
@@ -212,12 +123,27 @@ impl CommentContext<JsLanguage> for JsFormatContext {
     fn comment_style(&self) -> Self::Style {
         JsCommentStyle
     }
+
+    fn comments(&self) -> Rc<Comments<JsLanguage>> {
+        self.comments.clone()
+    }
+
+    fn with_comments(mut self, comments: Comments<JsLanguage>) -> Self {
+        self.comments = Rc::new(comments);
+        self
+    }
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Default)]
 pub struct JsCommentStyle;
 
 impl CommentStyle<JsLanguage> for JsCommentStyle {
+    fn is_suppression(&self, text: &str) -> bool {
+        parse_suppression_comment(text)
+            .flat_map(|suppression| suppression.categories)
+            .any(|(category, _)| category == SuppressionCategory::Format)
+    }
+
     fn get_comment_kind(&self, comment: &SyntaxTriviaPieceComments<JsLanguage>) -> CommentKind {
         if comment.text().starts_with("/*") {
             if comment.has_newline() {

--- a/crates/rome_js_formatter/src/js/module/import_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_named_clause.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-use rome_formatter::{write, CommentContext};
+use rome_formatter::{write, CstFormatContext};
 use rome_js_syntax::JsAnyNamedImport;
 use rome_js_syntax::JsAnyNamedImportSpecifier;
 use rome_js_syntax::JsImportNamedClause;

--- a/crates/rome_js_formatter/src/js/module/import_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_named_clause.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-use rome_formatter::write;
+use rome_formatter::{write, CommentContext};
 use rome_js_syntax::JsAnyNamedImport;
 use rome_js_syntax::JsAnyNamedImportSpecifier;
 use rome_js_syntax::JsImportNamedClause;
@@ -53,7 +53,7 @@ impl FormatNodeRule<JsImportNamedClause> for FormatJsImportNamedClause {
             match named_import {
                 JsAnyNamedImport::JsNamedImportSpecifiers(ref specifiers)
                     if specifiers.specifiers().len() == 1
-                        && !f.context_mut().is_suppressed(specifiers.syntax()) =>
+                        && !f.context().comments().is_suppressed(specifiers.syntax()) =>
                 {
                     // SAFETY: we know that the `specifiers.specifiers().len() == 1`, so unwrap `iter().next()` is safe.
                     let first_specifier = specifiers.specifiers().elements().next().unwrap();

--- a/crates/rome_js_formatter/src/js/statements/block_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/block_statement.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use rome_formatter::{write, Buffer, CommentContext, Comments};
+use rome_formatter::{write, Buffer, Comments, CstFormatContext};
 use rome_js_syntax::{JsAnyStatement, JsEmptyStatement};
 use rome_js_syntax::{JsBlockStatement, JsLanguage};
 

--- a/crates/rome_js_formatter/src/js/statements/block_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/block_statement.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
-use rome_formatter::{write, Buffer};
-use rome_js_syntax::JsBlockStatement;
+use rome_formatter::{write, Buffer, CommentContext, Comments};
 use rome_js_syntax::{JsAnyStatement, JsEmptyStatement};
+use rome_js_syntax::{JsBlockStatement, JsLanguage};
 
 use rome_js_syntax::JsBlockStatementFields;
 use rome_js_syntax::JsSyntaxKind;
@@ -18,7 +18,7 @@ impl FormatNodeRule<JsBlockStatement> for FormatJsBlockStatement {
             r_curly_token,
         } = node.as_fields();
 
-        if is_non_collapsable_empty_block(node) {
+        if is_non_collapsable_empty_block(node, &f.context().comments()) {
             for stmt in statements
                 .iter()
                 .filter_map(|stmt| JsEmptyStatement::cast(stmt.into_syntax()))
@@ -51,7 +51,10 @@ impl FormatNodeRule<JsBlockStatement> for FormatJsBlockStatement {
 // * empty block that is the 'cons' or 'alt' of an if statement: two lines `{\n}`
 // * non empty block: put each stmt on its own line: `{\nstmt1;\nstmt2;\n}`
 // * non empty block with comments (trailing comments on {, or leading comments on })
-fn is_non_collapsable_empty_block(block: &JsBlockStatement) -> bool {
+fn is_non_collapsable_empty_block(
+    block: &JsBlockStatement,
+    suppressions: &Comments<JsLanguage>,
+) -> bool {
     if block
         .l_curly_token()
         .map_or_else(|_| false, |token| token.has_trailing_comments())
@@ -88,7 +91,9 @@ fn is_non_collapsable_empty_block(block: &JsBlockStatement) -> bool {
     // ```
     if !block.statements().is_empty()
         && block.statements().iter().any(|s| {
-            !matches!(s, JsAnyStatement::JsEmptyStatement(_)) || s.syntax().has_comments_direct()
+            !matches!(s, JsAnyStatement::JsEmptyStatement(_))
+                || s.syntax().has_comments_direct()
+                || suppressions.is_suppressed(s.syntax())
         })
     {
         return false;

--- a/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
@@ -1,7 +1,7 @@
 use crate::jsx::auxiliary::space::JsxSpace;
 use crate::prelude::*;
 use crate::prelude::{format_args, write};
-use rome_formatter::{group_elements, FormatResult};
+use rome_formatter::{group_elements, CommentContext, FormatResult};
 use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsxExpressionChild, JsxExpressionChildFields,
 };
@@ -33,7 +33,10 @@ impl FormatNodeRule<JsxExpressionChild> for FormatJsxExpressionChild {
                 && !str_token.has_trailing_comments()
                 && !l_curly_token.has_trailing_comments()
                 && !r_curly_token.has_leading_non_whitespace_trivia();
-            let is_suppressed = f.context_mut().is_suppressed(string_literal.syntax());
+            let is_suppressed = f
+                .context()
+                .comments()
+                .is_suppressed(string_literal.syntax());
 
             if has_space_text && no_trivia && !is_suppressed {
                 return write![

--- a/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/expression_child.rs
@@ -1,7 +1,7 @@
 use crate::jsx::auxiliary::space::JsxSpace;
 use crate::prelude::*;
 use crate::prelude::{format_args, write};
-use rome_formatter::{group_elements, CommentContext, FormatResult};
+use rome_formatter::{group_elements, CstFormatContext, FormatResult};
 use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsxExpressionChild, JsxExpressionChildFields,
 };

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -8,7 +8,7 @@ mod ts;
 pub mod utils;
 
 use rome_formatter::prelude::*;
-use rome_formatter::write;
+use rome_formatter::{write, CommentContext};
 use rome_formatter::{Buffer, FormatOwnedWithRule, FormatRefWithRule, Formatted, Printed};
 use rome_js_syntax::{
     JsAnyDeclaration, JsAnyStatement, JsLanguage, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
@@ -170,7 +170,7 @@ where
     fn fmt(&self, node: &N, f: &mut JsFormatter) -> FormatResult<()> {
         let syntax = node.syntax();
 
-        if f.context_mut().is_suppressed(syntax) {
+        if f.context().comments().is_suppressed(syntax) {
             write!(f, [format_suppressed_node(syntax)])?;
         } else {
             self.fmt_fields(node, f)?;
@@ -266,11 +266,7 @@ pub fn format_node(
     context: JsFormatContext,
     root: &JsSyntaxNode,
 ) -> FormatResult<Formatted<JsFormatContext>> {
-    let result = rome_formatter::format_node(context, &root.format())?;
-
-    result.context().assert_checked_all_suppressions(root);
-
-    Ok(result)
+    rome_formatter::format_node(context, &root.format())
 }
 
 /// Formats a single node within a file, supported by Rome.

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -8,7 +8,7 @@ mod ts;
 pub mod utils;
 
 use rome_formatter::prelude::*;
-use rome_formatter::{write, CommentContext};
+use rome_formatter::{write, CstFormatContext};
 use rome_formatter::{Buffer, FormatOwnedWithRule, FormatRefWithRule, Formatted, Printed};
 use rome_js_syntax::{
     JsAnyDeclaration, JsAnyStatement, JsLanguage, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
@@ -235,7 +235,7 @@ pub fn format_range(
     root: &JsSyntaxNode,
     range: TextRange,
 ) -> FormatResult<Printed> {
-    rome_formatter::format_range::<_, _, FormatJsSyntaxNode, _>(
+    rome_formatter::format_range::<_, FormatJsSyntaxNode, _>(
         context,
         root,
         range,

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -369,7 +369,7 @@ impl JsAnyAssignmentLike {
             JsAnyAssignmentLike::JsPropertyObjectMember(property) => {
                 let name = property.name()?;
 
-                // It's safe to mark the name as checked here because it is at the beginning property
+                // It's safe to mark the name as checked here because it is at the beginning of the property
                 // and any suppression comment that would apply to the name applies to the property too and is,
                 // thus, handled on the property level.
                 f.context()

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -389,7 +389,7 @@ impl JsAnyAssignmentLike {
             JsAnyAssignmentLike::JsObjectAssignmentPatternProperty(property) => {
                 let member_name = property.member()?;
 
-                // It's safe to mark the name as checked here because it is at the beginning property
+                // It's safe to mark the name as checked here because it is at the beginning of the property
                 // and any suppression comment that would apply to the name applies to the property too and is,
                 // thus, handled on the property level.
                 f.context()

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::utils::member_chain::is_member_call_chain;
 use crate::utils::object::write_member_name;
 use crate::utils::JsAnyBinaryLikeExpression;
-use rome_formatter::{format_args, write, VecBuffer};
+use rome_formatter::{format_args, write, CommentContext, VecBuffer};
 use rome_js_syntax::{
     JsAnyAssignmentPattern, JsAnyBindingPattern, JsAnyCallArgument, JsAnyClassMemberName,
     JsAnyExpression, JsAnyFunctionBody, JsAnyObjectAssignmentPatternMember,
@@ -368,6 +368,14 @@ impl JsAnyAssignmentLike {
         match self {
             JsAnyAssignmentLike::JsPropertyObjectMember(property) => {
                 let name = property.name()?;
+
+                // It's safe to mark the name as checked here because it is at the beginning property
+                // and any suppression comment that would apply to the name applies to the property too and is,
+                // thus, handled on the property level.
+                f.context()
+                    .comments()
+                    .mark_suppression_checked(name.syntax());
+
                 let width = write_member_name(&name.into(), f)?;
                 let text_width_for_break =
                     (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
@@ -379,7 +387,16 @@ impl JsAnyAssignmentLike {
                 Ok(false)
             }
             JsAnyAssignmentLike::JsObjectAssignmentPatternProperty(property) => {
-                let width = write_member_name(&property.member()?.into(), f)?;
+                let member_name = property.member()?;
+
+                // It's safe to mark the name as checked here because it is at the beginning property
+                // and any suppression comment that would apply to the name applies to the property too and is,
+                // thus, handled on the property level.
+                f.context()
+                    .comments()
+                    .mark_suppression_checked(member_name.syntax());
+
+                let width = write_member_name(&member_name.into(), f)?;
                 let text_width_for_break =
                     (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
                 Ok(width < text_width_for_break)
@@ -413,8 +430,8 @@ impl JsAnyAssignmentLike {
 
                 let name = name?;
 
-                let is_short = if f.context_mut().is_suppressed(name.syntax()) {
-                    write!(f, [format_verbatim_node(name.syntax())])?;
+                let is_short = if f.context().comments().is_suppressed(name.syntax()) {
+                    write!(f, [format_suppressed_node(name.syntax())])?;
                     false
                 } else {
                     let width = write_member_name(&name.into(), f)?;
@@ -564,7 +581,7 @@ impl JsAnyAssignmentLike {
         let right = self.right()?;
 
         if let RightAssignmentLike::JsInitializerClause(initializer) = &right {
-            if f.context_mut().is_suppressed(initializer.syntax()) {
+            if f.context().comments().is_suppressed(initializer.syntax()) {
                 return Ok(AssignmentLikeLayout::SuppressedInitializer);
             }
         }

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::utils::member_chain::is_member_call_chain;
 use crate::utils::object::write_member_name;
 use crate::utils::JsAnyBinaryLikeExpression;
-use rome_formatter::{format_args, write, CommentContext, VecBuffer};
+use rome_formatter::{format_args, write, CstFormatContext, VecBuffer};
 use rome_js_syntax::{
     JsAnyAssignmentPattern, JsAnyBindingPattern, JsAnyCallArgument, JsAnyClassMemberName,
     JsAnyExpression, JsAnyFunctionBody, JsAnyObjectAssignmentPatternMember,

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use rome_formatter::{write, Buffer, CommentContext};
+use rome_formatter::{write, Buffer, CstFormatContext};
 use rome_js_syntax::{
     JsAnyExpression, JsAnyInProperty, JsBinaryExpression, JsBinaryOperator, JsInExpression,
     JsInstanceofExpression, JsLogicalExpression, JsLogicalOperator, JsPrivateName, JsSyntaxKind,

--- a/crates/rome_js_formatter/src/utils/format_conditional.rs
+++ b/crates/rome_js_formatter/src/utils/format_conditional.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use rome_formatter::{format_args, write, CommentContext};
+use rome_formatter::{format_args, write, CstFormatContext};
 use rome_js_syntax::{JsAnyExpression, JsConditionalExpression, TsConditionalType, TsType};
 use rome_rowan::AstNode;
 

--- a/crates/rome_js_formatter/src/utils/format_conditional.rs
+++ b/crates/rome_js_formatter/src/utils/format_conditional.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use rome_formatter::{format_args, write};
+use rome_formatter::{format_args, write, CommentContext};
 use rome_js_syntax::{JsAnyExpression, JsConditionalExpression, TsConditionalType, TsType};
 use rome_rowan::AstNode;
 
@@ -31,15 +31,15 @@ impl Conditional {
     fn format_head(&self, f: &mut JsFormatter) -> FormatResult<()> {
         match self {
             Conditional::Expression(expr) => {
-                if f.context_mut().is_suppressed(expr.syntax()) {
-                    write!(f, [format_verbatim_node(expr.syntax())])
+                if f.context().comments().is_suppressed(expr.syntax()) {
+                    write!(f, [format_suppressed_node(expr.syntax())])
                 } else {
                     write![f, [expr.test()?.format(), space_token(),]]
                 }
             }
             Conditional::Type(t) => {
-                if f.context_mut().is_suppressed(t.syntax()) {
-                    write!(f, [format_verbatim_node(t.syntax())])
+                if f.context().comments().is_suppressed(t.syntax()) {
+                    write!(f, [format_suppressed_node(t.syntax())])
                 } else {
                     write![
                         f,

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -5,7 +5,7 @@ mod simple_argument;
 use crate::prelude::*;
 use crate::utils::member_chain::flatten_item::FlattenItem;
 use crate::utils::member_chain::groups::{Groups, HeadGroup};
-use rome_formatter::{format_args, write, Buffer, CommentContext, Comments, PreambleBuffer};
+use rome_formatter::{format_args, write, Buffer, Comments, CstFormatContext, PreambleBuffer};
 use rome_js_syntax::{
     JsCallExpression, JsComputedMemberExpression, JsExpressionStatement, JsLanguage,
     JsStaticMemberExpression,

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -5,9 +5,10 @@ mod simple_argument;
 use crate::prelude::*;
 use crate::utils::member_chain::flatten_item::FlattenItem;
 use crate::utils::member_chain::groups::{Groups, HeadGroup};
-use rome_formatter::{format_args, write, Buffer, PreambleBuffer};
+use rome_formatter::{format_args, write, Buffer, CommentContext, Comments, PreambleBuffer};
 use rome_js_syntax::{
-    JsCallExpression, JsComputedMemberExpression, JsExpressionStatement, JsStaticMemberExpression,
+    JsCallExpression, JsComputedMemberExpression, JsExpressionStatement, JsLanguage,
+    JsStaticMemberExpression,
 };
 use rome_js_syntax::{JsSyntaxKind, JsSyntaxNode};
 use rome_rowan::{AstNode, SyntaxResult};
@@ -132,7 +133,7 @@ fn get_call_expression_groups(
         JsExpressionStatement::can_cast(parent.kind())
     });
 
-    flatten_call_expression(&mut flattened_items, syntax_node)?;
+    flatten_call_expression(&mut flattened_items, syntax_node, &f.context().comments())?;
 
     // Count the number of CallExpression in the chain,
     // will be used later to decide on how to format it
@@ -321,19 +322,27 @@ fn write_groups(
 
 /// This function tries to flatten the AST. It stores nodes and its formatted version
 /// inside an vector of [FlattenItem]. The first element of the vector is the last one.
-fn flatten_call_expression(queue: &mut Vec<FlattenItem>, node: &JsSyntaxNode) -> SyntaxResult<()> {
+fn flatten_call_expression(
+    queue: &mut Vec<FlattenItem>,
+    node: &JsSyntaxNode,
+    comments: &Comments<JsLanguage>,
+) -> SyntaxResult<()> {
+    if comments.is_suppressed(node) {
+        queue.push(FlattenItem::Node(node.clone()))
+    }
+
     match node.kind() {
         JsSyntaxKind::JS_CALL_EXPRESSION => {
             let call_expression = JsCallExpression::cast(node.clone()).unwrap();
             let callee = call_expression.callee()?;
-            flatten_call_expression(queue, callee.syntax())?;
+            flatten_call_expression(queue, callee.syntax(), comments)?;
 
             queue.push(FlattenItem::CallExpression(call_expression));
         }
         JsSyntaxKind::JS_STATIC_MEMBER_EXPRESSION => {
             let static_member = JsStaticMemberExpression::cast(node.clone()).unwrap();
             let object = static_member.object()?;
-            flatten_call_expression(queue, object.syntax())?;
+            flatten_call_expression(queue, object.syntax(), comments)?;
 
             queue.push(FlattenItem::StaticMember(static_member));
         }
@@ -341,7 +350,7 @@ fn flatten_call_expression(queue: &mut Vec<FlattenItem>, node: &JsSyntaxNode) ->
         JsSyntaxKind::JS_COMPUTED_MEMBER_EXPRESSION => {
             let computed_expression = JsComputedMemberExpression::cast(node.clone()).unwrap();
             let object = computed_expression.object()?;
-            flatten_call_expression(queue, object.syntax())?;
+            flatten_call_expression(queue, object.syntax(), comments)?;
 
             queue.push(FlattenItem::ComputedMember(computed_expression));
         }

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js
@@ -1,0 +1,4 @@
+let {
+	/* rome-ignore format: Test that the property doesn't get formatted */
+	someProperty:    alias
+} = { someProperty: 20 };

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: assignment_ignore.js
+---
+# Input
+let {
+	/* rome-ignore format: Test that the property doesn't get formatted */
+	someProperty:    alias
+} = { someProperty: 20 };
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+-----
+let {
+	/* rome-ignore format: Test that the property doesn't get formatted */
+	someProperty:    alias,
+} = { someProperty: 20 };
+

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js
@@ -26,3 +26,9 @@ a + b * c > 65;
 a + b * c > 65 + 5;
 2 > 65 << 5 + 3 >> 3;
 2 > 4 + 4 * 24 % 3 << 23;
+
+
+
+a + b + 4 +
+// rome-ignore format: Test formatting ignored binary expressions
+  -   4_444_444;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
@@ -31,6 +31,13 @@ a + b * c > 65;
 a + b * c > 65 + 5;
 2 > 65 << 5 + 3 >> 3;
 2 > 4 + 4 * 24 % 3 << 23;
+
+
+
+a + b + 4 +
+// rome-ignore format: Test formatting ignored binary expressions
+  -   4_444_444;
+
 =============================
 # Outputs
 ## Output 1
@@ -67,4 +74,10 @@ a instanceof b;
 (a + (b * c)) > (65 + 5);
 2 > (65 << 5 + 3 >> 3);
 2 > (4 + (4 * 24 % 3) << 23);
+
+a +
+	b +
+	4 +
+	// rome-ignore format: Test formatting ignored binary expressions
+  -   4_444_444;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js
@@ -1,0 +1,9 @@
+if (true) {
+	;
+}
+
+
+if (true) {
+	// rome-ignore format: Tests that ignored empty statements don't get removed
+	;
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: block_statement.js
+---
+# Input
+if (true) {
+	;
+}
+
+
+if (true) {
+	// rome-ignore format: Tests that ignored empty statements don't get removed
+	;
+}
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+-----
+if (true) {
+}
+
+if (true) {
+	// rome-ignore format: Tests that ignored empty statements don't get removed
+	;
+}
+

--- a/crates/rome_js_syntax/src/lib.rs
+++ b/crates/rome_js_syntax/src/lib.rs
@@ -24,7 +24,7 @@ pub use stmt_ext::*;
 pub use syntax_node::*;
 
 use crate::JsSyntaxKind::*;
-use rome_rowan::RawSyntaxKind;
+use rome_rowan::{AstNode, RawSyntaxKind};
 
 impl From<u16> for JsSyntaxKind {
     fn from(d: u16) -> JsSyntaxKind {
@@ -240,6 +240,14 @@ impl rome_rowan::SyntaxKind for JsSyntaxKind {
     #[inline]
     fn from_raw(raw: RawSyntaxKind) -> Self {
         Self::from(raw.0)
+    }
+
+    fn is_root(&self) -> bool {
+        JsAnyRoot::can_cast(*self)
+    }
+
+    fn is_list(&self) -> bool {
+        JsSyntaxKind::is_list(*self)
     }
 }
 

--- a/crates/rome_js_syntax/src/suppression.rs
+++ b/crates/rome_js_syntax/src/suppression.rs
@@ -1,7 +1,3 @@
-use rome_rowan::AstNode;
-
-use crate::{JsAnyRoot, JsSyntaxNode};
-
 /// Single instance of a suppression comment, with the following syntax:
 ///
 /// `// rome-ignore { <category> { (<value>) }? }+: <reason>`
@@ -118,31 +114,6 @@ impl PartialEq<SuppressionCategory> for &'_ str {
     fn eq(&self, other: &SuppressionCategory) -> bool {
         other.eq(self)
     }
-}
-
-/// Returns true if this node has a suppression comment of the provided category
-pub fn has_suppressions_category(category: SuppressionCategory, node: &JsSyntaxNode) -> bool {
-    // Lists cannot have a suppression comment attached, it must
-    // belong to either the entire parent node or one of the children
-    let kind = node.kind();
-    if JsAnyRoot::can_cast(kind) || kind.is_list() {
-        return false;
-    }
-
-    let first_token = match node.first_token() {
-        Some(token) => token,
-        None => return false,
-    };
-
-    first_token
-        .leading_trivia()
-        .pieces()
-        .filter_map(|trivia| trivia.as_comments())
-        .any(|comment| {
-            parse_suppression_comment(comment.text())
-                .flat_map(|suppression| suppression.categories)
-                .any(|entry| category == entry.0)
-        })
 }
 
 #[cfg(test)]

--- a/crates/rome_json_syntax/src/lib.rs
+++ b/crates/rome_json_syntax/src/lib.rs
@@ -50,6 +50,14 @@ impl rome_rowan::SyntaxKind for JsonSyntaxKind {
     fn from_raw(raw: RawSyntaxKind) -> Self {
         Self::from(raw.0)
     }
+
+    fn is_root(&self) -> bool {
+        matches!(self, JsonSyntaxKind::JSON_ROOT)
+    }
+
+    fn is_list(&self) -> bool {
+        JsonSyntaxKind::is_list(*self)
+    }
 }
 
 impl TryFrom<JsonSyntaxKind> for TriviaPieceKind {

--- a/crates/rome_rowan/src/raw_language.rs
+++ b/crates/rome_rowan/src/raw_language.rs
@@ -58,6 +58,17 @@ impl SyntaxKind for RawLanguageKind {
 
         unsafe { std::mem::transmute::<u16, RawLanguageKind>(raw.0) }
     }
+
+    fn is_root(&self) -> bool {
+        self == &RawLanguageKind::ROOT
+    }
+
+    fn is_list(&self) -> bool {
+        matches!(
+            self,
+            RawLanguageKind::EXPRESSION_LIST | RawLanguageKind::SEPARATED_EXPRESSION_LIST
+        )
+    }
 }
 
 #[doc(hidden)]

--- a/crates/rome_rowan/src/syntax.rs
+++ b/crates/rome_rowan/src/syntax.rs
@@ -37,6 +37,12 @@ pub trait SyntaxKind: fmt::Debug + PartialEq + Copy {
 
     /// Creates a syntax kind from a raw kind.
     fn from_raw(raw: RawSyntaxKind) -> Self;
+
+    /// Returns `true` if this kind is for a root node.
+    fn is_root(&self) -> bool;
+
+    /// Returns `true` if this kind is a list node.
+    fn is_list(&self) -> bool;
 }
 
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {


### PR DESCRIPTION
## Summary

This PR changes how the formatter extracts formatter suppression comments. The existing implementation lazily traversed to a node's first token and it checks if the token has any leading suppression comments inside of `context.is_suppressed()`.

This PR iterates over the CST before starting the actual formatting to extract all suppressed nodes and it stores them in an index that can be queried during formatting.

This is mainly preparing for the migration to extract leading and trailing node comments with the re-work of the comments handling. Determining if a node is suppressed then becomes as simple as iterating over the leading comments of a node and determining if it has any suppression comment. 

This change also shows that the current implementation that calls `node.first_token` is roughly as expensive as iterating the whole tree ahead of time and computing the (suppression) comments. 

This change has the added benefit that suppressions are now a core formatter concept.

Part of #2768 

## Other changes
This PR further fixes a few places where the formatter didn't correctly check if a node has any suppression comment and if so, prevents it from changing the formatting.

### Why add suppressions to the `FormatContext`
The main reason for storing the suppressions on the context rather than on the `state` is that the context, unlike the `FormatState`, is language specific, and thus, it's possible to have a `Language` type parameter on the `Suppressions` type.

The one thing I dislike about adding it to the context is that the context is changed AFTER its creation.

## Performance

The performance of the two approaches is roughly the same.

### Future improvement
It would be possible to improve Rome's overall performance if the workspace provides a way to combine the visitors run for the linter and the visitor for computing the suppression comments.

## Test Plan

`cargo test`
