### PR TITLE
feat(rome_analyze): allow rules to dynamically emit local suppressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,7 @@ dependencies = [
  "rome_js_factory",
  "rome_js_syntax",
  "rome_rowan",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -13,6 +13,7 @@ rome_control_flow = { path = "../rome_control_flow" }
 rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 bitflags = "1.3.2"
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 rome_js_syntax = { path = "../rome_js_syntax" }

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -18,7 +18,9 @@ mod visitor;
 pub use crate::categories::{ActionCategory, RuleCategories, RuleCategory};
 pub use crate::matcher::{QueryMatcher, RuleKey, SignalEntry};
 pub use crate::query::{Ast, QueryKey, QueryMatch, Queryable};
-pub use crate::registry::{LanguageRoot, Phase, Phases, RuleMetadata, RuleRegistry};
+pub use crate::registry::{
+    LanguageRoot, Phase, Phases, RuleMetadata, RuleRegistry, RuleSuppressions,
+};
 pub use crate::rule::{GroupLanguage, Rule, RuleAction, RuleDiagnostic, RuleGroup, RuleMeta};
 pub use crate::services::{CannotCreateServicesError, FromServices, ServiceBag};
 use crate::signals::DiagnosticSignal;

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -7,7 +7,7 @@ use rome_rowan::{Language, TextRange};
 
 use crate::categories::{ActionCategory, RuleCategory};
 use crate::context::RuleContext;
-use crate::registry::RuleLanguage;
+use crate::registry::{RuleLanguage, RuleSuppressions};
 use crate::{AnalysisFilter, LanguageRoot, Phase, Phases, Queryable, RuleRegistry};
 
 pub trait RuleMeta {
@@ -239,6 +239,18 @@ pub trait Rule: RuleMeta {
         Self::diagnostic(ctx, state).map(|diag| diag.span())
     }
 
+    /// Allows the rule to suppress a set of syntax nodes to prevent them from
+    /// matching the `Query`. This is useful for rules that implement a code
+    /// action that recursively modifies multiple nodes at once, this hook
+    /// allows these rules to avoid matching on those nodes again.
+    fn suppressed_nodes(
+        ctx: &RuleContext<Self>,
+        state: &Self::State,
+        suppressions: &mut RuleSuppressions<RuleLanguage<Self>>,
+    ) {
+        let (..) = (ctx, state, suppressions);
+    }
+
     /// Called by the consumer of the analyzer to try to generate a diagnostic
     /// from a signal raised by `run`
     ///
@@ -252,9 +264,10 @@ pub trait Rule: RuleMeta {
     ///
     /// The default implementation returns None
     fn action(
-        _ctx: &RuleContext<Self>,
-        _state: &Self::State,
+        ctx: &RuleContext<Self>,
+        state: &Self::State,
     ) -> Option<RuleAction<RuleLanguage<Self>>> {
+        let (..) = (ctx, state);
         None
     }
 }

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -243,6 +243,32 @@ pub trait Rule: RuleMeta {
     /// matching the `Query`. This is useful for rules that implement a code
     /// action that recursively modifies multiple nodes at once, this hook
     /// allows these rules to avoid matching on those nodes again.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// impl Rule for SimplifyExpression {
+    ///     type Query = BinaryExpression;
+    ///
+    ///     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+    ///         // Recursively check this expression and its children for simplification
+    ///         // opportunities
+    ///         check_can_simplify(ctx.query())
+    ///     }
+    ///
+    ///     fn suppressed_nodes(
+    ///         _ctx: &RuleContext<Self>,
+    ///         state: &Self::State,
+    ///         suppressions: &mut RuleSuppressions<RuleLanguage<Self>>
+    ///     ) {
+    ///         // Prevent this rule from matching again on nodes that were already checked by
+    ///         // `check_can_simplify`
+    ///         for node in &state.nodes {
+    ///             suppressions.suppress_node(node.clone());
+    ///         }
+    ///     }
+    /// }
+    /// ```
     fn suppressed_nodes(
         ctx: &RuleContext<Self>,
         state: &Self::State,


### PR DESCRIPTION
## Summary

This PR adds a new `suppressed_nodes` method to the `Rule` trait. This hook allows lint rules to emit dynamic node suppressions for their own query, for instance to prevent the rule from matching again on a node that would be removed by a previously-emitted code action.

## Test Plan

I've modified the `UseTemplate` rule to use this new method instead of recursively checking for nested binary expressions, this rule has tests checking the rule does not trigger again on recursive string concatenation expressions
