### PR TITLE
feat(rome_lsp): renaming symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,6 +1643,7 @@ dependencies = [
  "rome_js_analyze",
  "rome_js_formatter",
  "rome_js_parser",
+ "rome_js_semantic",
  "rome_js_syntax",
  "rome_rowan",
  "serde",

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -15,7 +15,7 @@ mod control_flow;
 mod registry;
 mod semantic_analyzers;
 mod semantic_services;
-pub(crate) mod utils;
+pub mod utils;
 
 use crate::{registry::build_registry, semantic_services::SemanticModelBuilderVisitor};
 

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -2,30 +2,6 @@ pub mod rename;
 #[cfg(test)]
 pub mod tests;
 
-#[macro_export]
-macro_rules! assert_rename_ok {
-    ($(#[$attr:meta])* $($name:ident, $before:expr, $expected:expr,)*) => {
-        $(
-            #[test]
-            pub fn $name() {
-                $crate::utils::tests::assert_rename_ok($before, $expected);
-            }
-        )*
-    };
-}
-
-#[macro_export]
-macro_rules! assert_rename_nok {
-    ($(#[$attr:meta])* $($name:ident, $before:expr,)*) => {
-        $(
-            #[test]
-            pub fn $name() {
-                $crate::utils::tests::assert_rename_nok($before);
-            }
-        )*
-    };
-}
-
 #[derive(Debug, PartialEq)]
 pub(crate) enum EscapeError {
     EscapeAtEndOfString,

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -27,7 +27,7 @@ macro_rules! assert_rename_nok {
 }
 
 #[derive(Debug, PartialEq)]
-pub enum EscapeError {
+pub(crate) enum EscapeError {
     EscapeAtEndOfString,
     InvalidEscapedChar(char),
 }
@@ -54,6 +54,6 @@ impl<'a> Iterator for InterpretEscapedString<'a> {
 
 /// unescape   
 ///
-pub fn escape_string(s: &str) -> Result<String, EscapeError> {
+pub(crate) fn escape_string(s: &str) -> Result<String, EscapeError> {
     (InterpretEscapedString { s: s.chars() }).collect()
 }

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -1,3 +1,31 @@
+pub mod rename;
+#[cfg(test)]
+pub mod tests;
+
+#[macro_export]
+macro_rules! assert_rename_ok {
+    ($(#[$attr:meta])* $($name:ident, $before:expr, $expected:expr,)*) => {
+        $(
+            #[test]
+            pub fn $name() {
+                crate::utils::tests::assert_rename_ok($before, $expected);
+            }
+        )*
+    };
+}
+
+#[macro_export]
+macro_rules! assert_rename_nok {
+    ($(#[$attr:meta])* $($name:ident, $before:expr,)*) => {
+        $(
+            #[test]
+            pub fn $name() {
+                crate::utils::tests::assert_rename_nok($before);
+            }
+        )*
+    };
+}
+
 #[derive(Debug, PartialEq)]
 pub enum EscapeError {
     EscapeAtEndOfString,

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -8,7 +8,7 @@ macro_rules! assert_rename_ok {
         $(
             #[test]
             pub fn $name() {
-                crate::utils::tests::assert_rename_ok($before, $expected);
+                $crate::utils::tests::assert_rename_ok($before, $expected);
             }
         )*
     };
@@ -20,7 +20,7 @@ macro_rules! assert_rename_nok {
         $(
             #[test]
             pub fn $name() {
-                crate::utils::tests::assert_rename_nok($before);
+                $crate::utils::tests::assert_rename_nok($before);
             }
         )*
     };

--- a/crates/rome_js_analyze/src/utils/rename.rs
+++ b/crates/rome_js_analyze/src/utils/rename.rs
@@ -1,0 +1,135 @@
+use crate::{assert_rename_nok, assert_rename_ok};
+use rome_js_semantic::{AllReferencesExtensions, SemanticModel};
+use rome_js_syntax::{
+    JsIdentifierAssignment, JsIdentifierBinding, JsLanguage, JsReferenceIdentifier, JsSyntaxKind,
+    JsSyntaxToken,
+};
+use rome_rowan::{AstNode, BatchMutation, SyntaxNodeCast, TriviaPiece};
+
+pub trait RenameSymbolExtensions {
+    fn rename(
+        &mut self,
+        model: &SemanticModel,
+        binding: JsIdentifierBinding,
+        new_name: &str,
+    ) -> bool;
+}
+
+fn token_with_new_text(token: &JsSyntaxToken, new_text: &str) -> JsSyntaxToken {
+    let new_text = format!(
+        "{}{}{}",
+        token.leading_trivia().text(),
+        new_text,
+        token.trailing_trivia().text()
+    );
+
+    let leading = token
+        .leading_trivia()
+        .pieces()
+        .map(|item| TriviaPiece::new(item.kind(), item.text_len()))
+        .collect::<Vec<_>>();
+    let trailing = token
+        .trailing_trivia()
+        .pieces()
+        .map(|item| TriviaPiece::new(item.kind(), item.text_len()))
+        .collect::<Vec<_>>();
+
+    JsSyntaxToken::new_detached(JsSyntaxKind::IDENT, new_text.as_str(), leading, trailing)
+}
+
+impl<N: AstNode<Language = JsLanguage>> RenameSymbolExtensions for BatchMutation<JsLanguage, N> {
+    /// Rename the binding and all its references to the new_name.
+    /// If we can´t rename the binding, the [BatchMutation] is never changes and it is left
+    /// intact.
+    fn rename(
+        &mut self,
+        model: &SemanticModel,
+        prev_binding: JsIdentifierBinding,
+        new_name: &str,
+    ) -> bool {
+        // We can rename a binding if there is no conflicts in the current scope.
+        // We can shadow parent scopes, so we don´t check them.
+
+        let scope = model.scope(prev_binding.syntax());
+        if scope.get_binding(new_name).is_some() {
+            return false;
+        }
+
+        let name_token = match prev_binding.name_token() {
+            Ok(name_token) => name_token,
+            Err(_) => return false,
+        };
+
+        // We can rename references, if there is no conflicts in any scope
+        // until the root.
+
+        let all_references: Vec<_> = prev_binding.all_references(model).collect();
+        let mut changes = Vec::with_capacity(all_references.len());
+
+        for reference in all_references.iter() {
+            let scope = reference.scope();
+            if scope
+                .ancestors()
+                .filter_map(|scope| scope.get_binding(new_name))
+                .next()
+                .is_some()
+            {
+                return false;
+            }
+
+            let prev_token = match reference.node().kind() {
+                JsSyntaxKind::JS_REFERENCE_IDENTIFIER => reference
+                    .node()
+                    .clone()
+                    .cast::<JsReferenceIdentifier>()
+                    .and_then(|node| node.value_token().ok()),
+                JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT => reference
+                    .node()
+                    .clone()
+                    .cast::<JsIdentifierAssignment>()
+                    .and_then(|node| node.name_token().ok()),
+                _ => None,
+            };
+
+            if let Some(prev_token) = prev_token {
+                let next_token = token_with_new_text(&prev_token, new_name);
+                changes.push((prev_token, next_token));
+            }
+        }
+
+        // Now it is safe to pish changes to the batch mutation
+        // Rename binding
+
+        let next_name_token = token_with_new_text(&name_token, new_name);
+        let next_binding = prev_binding.clone().with_name_token(next_name_token);
+        self.replace_node(prev_binding, next_binding);
+
+        // Rename all references
+
+        for (prev_token, next_token) in changes {
+            self.replace_token(prev_token, next_token);
+        }
+
+        true
+    }
+}
+
+assert_rename_ok! {
+    ok_rename_declaration, "let a;", "let b;",
+    ok_rename_declaration_inner_scope, "let b; if (true) { let a; }", "let b; if (true) { let b; }",
+    ok_rename_read_reference, "let a; a + 1;", "let b; b + 1;",
+    ok_rename_read_before_initit, "function f() { console.log(a); let a; }", "function f() { console.log(b); let b; }",
+    ok_rename_write_reference, "let a; a = 1;", "let b; b = 1;",
+    ok_rename_write_before_init, "function f() { a = 1; let a; }", "function f() { b = 1; let b; }",
+    ok_rename_trivia_is_kept, "let /*1*/a/*2*/; /*3*/a/*4*/ = 1; /*5*/a/*6*/ + 1", "let /*1*/b/*2*/; /*3*/b/*4*/ = 1; /*5*/b/*6*/ + 1",
+}
+
+assert_rename_nok! {
+    nok_rename_declaration_conflict_before, "let b; let a;",
+    nok_rename_declaration_conflict_after, "let a; let b;",
+    nok_rename_read_reference, "let a; if (true) { let b; a + 1 }",
+    nok_rename_read_reference_conflict_hoisting_same_scope, "let a; if (true) { a + 1; var b; }",
+    nok_rename_read_reference_conflict_hoisting_outer_scope, "let a; if (true) { a + 1; } var b;",
+    nok_rename_write_reference, "let a; if (true) { let b; a = 1 }",
+    nok_rename_read_reference_parent_scope_conflict, "function f() { let b; if(true) { console.log(a); } } var a;",
+}

--- a/crates/rome_js_analyze/src/utils/rename.rs
+++ b/crates/rome_js_analyze/src/utils/rename.rs
@@ -1,4 +1,3 @@
-use crate::{assert_rename_nok, assert_rename_ok};
 use rome_js_semantic::{AllReferencesExtensions, SemanticModel};
 use rome_js_syntax::{
     JsIdentifierAssignment, JsIdentifierBinding, JsLanguage, JsReferenceIdentifier, JsSyntaxKind,
@@ -141,7 +140,7 @@ impl<N: AstNode<Language = JsLanguage>> RenameSymbolExtensions for BatchMutation
         let all_references: Vec<_> = prev_binding.all_references(model).collect();
         let mut changes = Vec::with_capacity(all_references.len());
 
-        for reference in all_references.iter() {
+        for reference in all_references {
             let scope = reference.scope();
             if scope
                 .ancestors()
@@ -172,7 +171,7 @@ impl<N: AstNode<Language = JsLanguage>> RenameSymbolExtensions for BatchMutation
             }
         }
 
-        // Now it is safe to pish changes to the batch mutation
+        // Now it is safe to push changes to the batch mutation
         // Rename binding
 
         let next_name_token = token_with_new_text(&name_token, new_name);
@@ -189,22 +188,27 @@ impl<N: AstNode<Language = JsLanguage>> RenameSymbolExtensions for BatchMutation
     }
 }
 
-assert_rename_ok! {
-    ok_rename_declaration, "let a;", "let b;",
-    ok_rename_declaration_inner_scope, "let b; if (true) { let a; }", "let b; if (true) { let b; }",
-    ok_rename_read_reference, "let a; a + 1;", "let b; b + 1;",
-    ok_rename_read_before_initit, "function f() { console.log(a); let a; }", "function f() { console.log(b); let b; }",
-    ok_rename_write_reference, "let a; a = 1;", "let b; b = 1;",
-    ok_rename_write_before_init, "function f() { a = 1; let a; }", "function f() { b = 1; let b; }",
-    ok_rename_trivia_is_kept, "let /*1*/a/*2*/; /*3*/a/*4*/ = 1; /*5*/a/*6*/ + 1", "let /*1*/b/*2*/; /*3*/b/*4*/ = 1; /*5*/b/*6*/ + 1",
-}
+#[cfg(test)]
+mod tests {
+    use crate::{assert_rename_nok, assert_rename_ok};
 
-assert_rename_nok! {
-    nok_rename_declaration_conflict_before, "let b; let a;",
-    nok_rename_declaration_conflict_after, "let a; let b;",
-    nok_rename_read_reference, "let a; if (true) { let b; a + 1 }",
-    nok_rename_read_reference_conflict_hoisting_same_scope, "let a; if (true) { a + 1; var b; }",
-    nok_rename_read_reference_conflict_hoisting_outer_scope, "let a; if (true) { a + 1; } var b;",
-    nok_rename_write_reference, "let a; if (true) { let b; a = 1 }",
-    nok_rename_read_reference_parent_scope_conflict, "function f() { let b; if(true) { console.log(a); } } var a;",
+    assert_rename_ok! {
+        ok_rename_declaration, "let a;", "let b;",
+        ok_rename_declaration_inner_scope, "let b; if (true) { let a; }", "let b; if (true) { let b; }",
+        ok_rename_read_reference, "let a; a + 1;", "let b; b + 1;",
+        ok_rename_read_before_initit, "function f() { console.log(a); let a; }", "function f() { console.log(b); let b; }",
+        ok_rename_write_reference, "let a; a = 1;", "let b; b = 1;",
+        ok_rename_write_before_init, "function f() { a = 1; let a; }", "function f() { b = 1; let b; }",
+        ok_rename_trivia_is_kept, "let /*1*/a/*2*/; /*3*/a/*4*/ = 1; /*5*/a/*6*/ + 1", "let /*1*/b/*2*/; /*3*/b/*4*/ = 1; /*5*/b/*6*/ + 1",
+    }
+
+    assert_rename_nok! {
+        nok_rename_declaration_conflict_before, "let b; let a;",
+        nok_rename_declaration_conflict_after, "let a; let b;",
+        nok_rename_read_reference, "let a; if (true) { let b; a + 1 }",
+        nok_rename_read_reference_conflict_hoisting_same_scope, "let a; if (true) { a + 1; var b; }",
+        nok_rename_read_reference_conflict_hoisting_outer_scope, "let a; if (true) { a + 1; } var b;",
+        nok_rename_write_reference, "let a; if (true) { let b; a = 1 }",
+        nok_rename_read_reference_parent_scope_conflict, "function f() { let b; if(true) { console.log(a); } } var a;",
+    }
 }

--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -13,8 +13,7 @@ pub fn assert_rename_ok(before: &str, expected: &str) {
         .syntax()
         .descendants()
         .filter_map(|x| x.cast::<JsIdentifierBinding>())
-        .filter(|x| x.text() == "a")
-        .next()
+        .find(|x| x.text() == "a")
         .unwrap();
 
     let mut batch = r.tree().begin();
@@ -35,8 +34,7 @@ pub fn assert_rename_nok(before: &str) {
         .syntax()
         .descendants()
         .filter_map(|x| x.cast::<JsIdentifierBinding>())
-        .filter(|x| x.text() == "a")
-        .next()
+        .find(|x| x.text() == "a")
         .unwrap();
 
     let mut batch = r.tree().begin();

--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -40,3 +40,27 @@ pub fn assert_rename_nok(before: &str) {
     let mut batch = r.tree().begin();
     assert!(!batch.rename(&model, binding_a, "b"));
 }
+
+#[macro_export]
+macro_rules! assert_rename_ok {
+    ($(#[$attr:meta])* $($name:ident, $before:expr, $expected:expr,)*) => {
+        $(
+            #[test]
+            pub fn $name() {
+                $crate::utils::tests::assert_rename_ok($before, $expected);
+            }
+        )*
+    };
+}
+
+#[macro_export]
+macro_rules! assert_rename_nok {
+    ($(#[$attr:meta])* $($name:ident, $before:expr,)*) => {
+        $(
+            #[test]
+            pub fn $name() {
+                $crate::utils::tests::assert_rename_nok($before);
+            }
+        )*
+    };
+}

--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -1,0 +1,44 @@
+use super::rename::*;
+use rome_js_semantic::semantic_model;
+use rome_js_syntax::{JsIdentifierBinding, SourceType};
+use rome_rowan::{AstNode, BatchMutationExt, SyntaxNodeCast};
+
+/// Search and renames a binding named "a" to "b".
+/// Asserts the renaming worked.
+pub fn assert_rename_ok(before: &str, expected: &str) {
+    let r = rome_js_parser::parse(before, 0, SourceType::js_module());
+    let model = semantic_model(&r.tree());
+
+    let binding_a = r
+        .syntax()
+        .descendants()
+        .filter_map(|x| x.cast::<JsIdentifierBinding>())
+        .filter(|x| x.text() == "a")
+        .next()
+        .unwrap();
+
+    let mut batch = r.tree().begin();
+    assert!(batch.rename(&model, binding_a, "b"));
+    let root = batch.commit();
+
+    let after = root.to_string();
+    assert_eq!(expected, after.as_str());
+}
+
+/// Search and renames a binding named "a" to "b".
+/// Asserts the renaming to fail.
+pub fn assert_rename_nok(before: &str) {
+    let r = rome_js_parser::parse(before, 0, SourceType::js_module());
+    let model = semantic_model(&r.tree());
+
+    let binding_a = r
+        .syntax()
+        .descendants()
+        .filter_map(|x| x.cast::<JsIdentifierBinding>())
+        .filter(|x| x.text() == "a")
+        .next()
+        .unwrap();
+
+    let mut batch = r.tree().begin();
+    assert!(!batch.rename(&model, binding_a, "b"));
+}

--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -17,7 +17,7 @@ pub fn assert_rename_ok(before: &str, expected: &str) {
         .unwrap();
 
     let mut batch = r.tree().begin();
-    assert!(batch.rename(&model, binding_a, "b"));
+    assert!(batch.rename_node_declaration(&model, binding_a, "b"));
     let root = batch.commit();
 
     let after = root.to_string();
@@ -38,7 +38,7 @@ pub fn assert_rename_nok(before: &str) {
         .unwrap();
 
     let mut batch = r.tree().begin();
-    assert!(!batch.rename(&model, binding_a, "b"));
+    assert!(!batch.rename_node_declaration(&model, binding_a, "b"));
 }
 
 #[macro_export]

--- a/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
+++ b/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
@@ -1,6 +1,6 @@
-const FOO = "FOO";
-console.log(FOO, FOO2);
+const FOOB = "FOO";
+console.log(FOOB, FOO2);
 
 const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
 
-console.log(FOO, FOO4);
+console.log(FOOB, FOO4);

--- a/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
+++ b/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
@@ -1,6 +1,6 @@
-const FOOB = "FOO";
-console.log(FOOB, FOO2);
+const FOO = "FOO";
+console.log(FOO, FOO2);
 
 const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
 
-console.log(FOOB, FOO4);
+console.log(FOO, FOO4);

--- a/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js.snap
@@ -10,6 +10,7 @@ console.log(FOO, FOO2);
 const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
 
 console.log(FOO, FOO4);
+
 ```
 
 # Diagnostics

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -56,7 +56,7 @@ struct SemanticModelData {
 }
 
 impl SemanticModelData {
-    pub fn scope(&self, range: &TextRange) -> usize {
+    fn scope(&self, range: &TextRange) -> usize {
         let scopes = self
             .scope_by_range
             .find(range.start().into(), range.end().into());

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -64,7 +64,7 @@ impl SemanticModelData {
         match scopes.last() {
             Some(interval) => interval.val,
             // We always have at least one scope, the global one.
-            None => unreachable!(),
+            None => unreachable!("Expected global scope not present"),
         }
     }
 

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -56,6 +56,18 @@ struct SemanticModelData {
 }
 
 impl SemanticModelData {
+    pub fn scope(&self, range: &TextRange) -> usize {
+        let scopes = self
+            .scope_by_range
+            .find(range.start().into(), range.end().into());
+
+        match scopes.last() {
+            Some(interval) => interval.val,
+            // We always have at least one scope, the global one.
+            None => unreachable!(),
+        }
+    }
+
     pub fn all_references_iter(
         &self,
         range: &TextRange,
@@ -200,6 +212,16 @@ pub struct Binding {
 }
 
 impl Binding {
+    /// Returns the scope of this binding
+    pub fn scope(&self) -> Scope {
+        let range = self.node.text_range();
+        let id = self.data.scope(&range);
+        Scope {
+            data: self.data.clone(),
+            id,
+        }
+    }
+
     /// Returns the syntax node associated with the binding.
     pub fn syntax(&self) -> &JsSyntaxNode {
         &self.node
@@ -248,6 +270,15 @@ pub struct Reference {
 }
 
 impl Reference {
+    /// Returns the scope of this reference
+    pub fn scope(&self) -> Scope {
+        let id = self.data.scope(&self.range);
+        Scope {
+            data: self.data.clone(),
+            id,
+        }
+    }
+
     pub fn node(&self) -> &JsSyntaxNode {
         &self.node
     }

--- a/crates/rome_lsp/src/capabilities.rs
+++ b/crates/rome_lsp/src/capabilities.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::{
-    CodeActionProviderCapability, DocumentOnTypeFormattingOptions, OneOf, ServerCapabilities,
-    TextDocumentSyncCapability, TextDocumentSyncKind,
+    CodeActionProviderCapability, DocumentOnTypeFormattingOptions, OneOf, RenameOptions,
+    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions,
 };
 
 /// The capabilities to send from server as part of [`InitializeResult`]
@@ -16,6 +16,12 @@ pub(crate) fn server_capabilities() -> ServerCapabilities {
             first_trigger_character: String::from("}"),
             more_trigger_character: Some(vec![String::from("]"), String::from(")")]),
         }),
+        rename_provider: Some(OneOf::Right(RenameOptions {
+            prepare_provider: None,
+            work_done_progress_options: WorkDoneProgressOptions {
+                work_done_progress: None,
+            },
+        })),
         ..Default::default()
     }
 }

--- a/crates/rome_lsp/src/handlers.rs
+++ b/crates/rome_lsp/src/handlers.rs
@@ -1,3 +1,4 @@
 pub mod analysis;
 pub mod formatting;
+pub mod rename;
 pub mod text_document;

--- a/crates/rome_lsp/src/handlers/rename.rs
+++ b/crates/rome_lsp/src/handlers/rename.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+
+use crate::session::Session;
+use anyhow::Result;
+use tower_lsp::lsp_types::{Position, Range, RenameParams, TextEdit, WorkspaceEdit};
+use tracing::trace;
+
+pub(crate) fn rename(session: &Session, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+    let url = params.text_document_position.text_document.uri;
+    let rome_path = session.file_path(&url);
+
+    trace!("Renaming...");
+
+    let doc = session.document(&url)?;
+    let cursor_range =
+        crate::utils::offset(&doc.line_index, params.text_document_position.position);
+
+    let result = session
+        .workspace
+        .rename(rome_service::workspace::RenameParams {
+            path: rome_path,
+            symbol_at: cursor_range,
+            new_name: params.new_name,
+        })?;
+
+    let num_lines: u32 = doc.line_index.newlines.len().try_into()?;
+    let range = Range {
+        start: Position::default(),
+        end: Position {
+            line: num_lines,
+            character: 0,
+        },
+    };
+
+    let mut changes = HashMap::new();
+    changes.insert(
+        url,
+        vec![TextEdit {
+            range,
+            new_text: result.code,
+        }],
+    );
+
+    let workspace_edit = WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+        change_annotations: None,
+    };
+
+    Ok(Some(workspace_edit))
+}

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -160,6 +160,10 @@ impl LanguageServer for LSPServer {
             .await
             .ok();
     }
+
+    async fn rename(&self, params: RenameParams) -> LspResult<Option<WorkspaceEdit>> {
+        handlers::rename::rename(&self.session, params).map_err(into_lsp_error)
+    }
 }
 
 pub fn build_server() -> (LspService<LSPServer>, ClientSocket) {

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -122,6 +122,24 @@ where
         });
     }
 
+    pub fn replace_token(&mut self, prev_token: SyntaxToken<L>, next_token: SyntaxToken<L>) {
+        let new_token_slot = prev_token.index();
+        let parent = prev_token.parent();
+        let parent_range: Option<(u32, u32)> = parent.as_ref().map(|p| {
+            let range = p.text_range();
+            (range.start().into(), range.end().into())
+        });
+        let parent_depth = parent.as_ref().map(|p| p.ancestors().count()).unwrap_or(0);
+
+        self.changes.push(CommitChange {
+            parent_depth,
+            parent,
+            parent_range,
+            new_node_slot: new_token_slot,
+            new_node: Some(SyntaxElement::Token(next_token)),
+        });
+    }
+
     pub fn replace_node<T>(&mut self, prev_node: T, next_node: T)
     where
         T: AstNode<Language = L>,

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -82,6 +82,9 @@ where
     L: Language,
     N: AstNode<Language = L>,
 {
+    /// Push a change to remove the specified token.
+    ///
+    /// Changes to take effect must be commited.
     pub fn remove_token(&mut self, prev_token: SyntaxToken<L>) {
         let new_node_slot = prev_token.index();
         let parent = prev_token.parent();
@@ -100,6 +103,9 @@ where
         });
     }
 
+    /// Push a change to remove the specified node.
+    ///
+    /// Changes to take effect must be commited.
     pub fn remove_node<T>(&mut self, prev_node: T)
     where
         T: AstNode<Language = L>,
@@ -122,6 +128,10 @@ where
         });
     }
 
+    /// Push a change to replace the "prev_token" with "next_token".
+    /// Trivia to be kept must be manually copied to "next_token".
+    ///
+    /// Changes to take effect must be commited.
     pub fn replace_token(&mut self, prev_token: SyntaxToken<L>, next_token: SyntaxToken<L>) {
         let new_token_slot = prev_token.index();
         let parent = prev_token.parent();
@@ -140,6 +150,9 @@ where
         });
     }
 
+    /// Push a change to replace the "prev_node" with "next_node".
+    ///
+    /// Changes to take effect must be commited.
     pub fn replace_node<T>(&mut self, prev_node: T, next_node: T)
     where
         T: AstNode<Language = L>,

--- a/crates/rome_rowan/src/syntax/trivia.rs
+++ b/crates/rome_rowan/src/syntax/trivia.rs
@@ -498,6 +498,10 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     pub fn token(&self) -> SyntaxToken<L> {
         SyntaxToken::from(self.raw.token().clone())
     }
+
+    pub fn piece(&self) -> TriviaPiece {
+        self.trivia
+    }
 }
 
 impl<L: Language> fmt::Debug for SyntaxTriviaPiece<L> {

--- a/crates/rome_rowan/src/syntax/trivia.rs
+++ b/crates/rome_rowan/src/syntax/trivia.rs
@@ -498,10 +498,6 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     pub fn token(&self) -> SyntaxToken<L> {
         SyntaxToken::from(self.raw.token().clone())
     }
-
-    pub fn piece(&self) -> TriviaPiece {
-        self.trivia
-    }
 }
 
 impl<L: Language> fmt::Debug for SyntaxTriviaPiece<L> {

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -20,4 +20,5 @@ rome_js_analyze = { path = "../rome_js_analyze" }
 rome_js_syntax = { path = "../rome_js_syntax" }
 rome_js_parser = { path = "../rome_js_parser" }
 rome_js_formatter = { path = "../rome_js_formatter" }
+rome_js_semantic = { path = "../rome_js_semantic" }
 rome_rowan = { path = "../rome_rowan" }

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -281,12 +281,16 @@ fn rename(
         .find(|token| token.text_range().contains(symbol_at))
         .and_then(|token| token.parent())
     {
+        let original_name = node.text_trimmed();
         match node.try_into() {
             Ok(node) => {
                 let mut batch = root.begin();
                 let result = batch.rename_with_any_can_be_renamed(&model, node, &new_name);
                 if !result {
-                    Err(RomeError::RenameError(RenameError::CannotBeRenamed))
+                    Err(RomeError::RenameError(RenameError::CannotBeRenamed {
+                        original_name: original_name.to_string(),
+                        new_name,
+                    }))
                 } else {
                     let root = batch.commit();
                     Ok(root.to_string())
@@ -295,6 +299,6 @@ fn rename(
             Err(err) => Err(RomeError::RenameError(err)),
         }
     } else {
-        Err(RomeError::RenameError(RenameError::CannotBeRenamed))
+        Err(RomeError::RenameError(RenameError::CannotFindDeclaration))
     }
 }

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -267,7 +267,7 @@ fn format_on_type(
 }
 
 fn rename(
-    rome_path: &RomePath,
+    _rome_path: &RomePath,
     parse: AnyParse,
     symbol_at: TextSize,
     new_name: String,
@@ -287,17 +287,17 @@ fn rename(
             JsSyntaxKind::JS_IDENTIFIER_BINDING => node.cast::<JsIdentifierBinding>(),
             JsSyntaxKind::JS_REFERENCE_IDENTIFIER => node
                 .cast::<JsReferenceIdentifier>()
-                .ok_or_else(|| RomeError::RenameError)?
+                .ok_or(RomeError::RenameError)?
                 .declaration(&model)
-                .ok_or_else(|| RomeError::RenameError)?
+                .ok_or(RomeError::RenameError)?
                 .syntax()
                 .clone()
                 .cast::<JsIdentifierBinding>(),
             JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT => node
                 .cast::<JsIdentifierAssignment>()
-                .ok_or_else(|| RomeError::RenameError)?
+                .ok_or(RomeError::RenameError)?
                 .declaration(&model)
-                .ok_or_else(|| RomeError::RenameError)?
+                .ok_or(RomeError::RenameError)?
                 .syntax()
                 .clone()
                 .cast::<JsIdentifierBinding>(),

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -285,7 +285,7 @@ fn rename(
         match node.try_into() {
             Ok(node) => {
                 let mut batch = root.begin();
-                let result = batch.rename_with_any_can_be_renamed(&model, node, &new_name);
+                let result = batch.rename_any_renamable_node(&model, node, &new_name);
                 if !result {
                     Err(RomeError::RenameError(RenameError::CannotBeRenamed {
                         original_name: original_name.to_string(),

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -284,9 +284,13 @@ fn rename(
         match node.try_into() {
             Ok(node) => {
                 let mut batch = root.begin();
-                batch.rename_with_any_can_be_renamed(&model, node, &new_name);
-                let root = batch.commit();
-                Ok(root.to_string())
+                let result = batch.rename_with_any_can_be_renamed(&model, node, &new_name);
+                if !result {
+                    Err(RomeError::RenameError(RenameError::CannotBeRenamed))
+                } else {
+                    let root = batch.commit();
+                    Ok(root.to_string())
+                }
             }
             Err(err) => Err(RomeError::RenameError(err)),
         }

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -13,6 +13,7 @@ impl ExtensionHandler for JsonFileHandler {
             fix_all: None,
             format_range: None,
             format_on_type: None,
+            rename: None,
         }
     }
 

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -81,6 +81,7 @@ type FormatRange =
     fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>, TextRange) -> Result<Printed, RomeError>;
 type FormatOnType =
     fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>, TextSize) -> Result<Printed, RomeError>;
+type Rename = fn(&RomePath, AnyParse, TextSize, String) -> Result<String, RomeError>;
 
 pub(crate) struct Capabilities {
     pub(crate) parse: Option<Parse>,
@@ -91,6 +92,7 @@ pub(crate) struct Capabilities {
     pub(crate) format: Option<Format>,
     pub(crate) format_range: Option<FormatRange>,
     pub(crate) format_on_type: Option<FormatOnType>,
+    pub(crate) rename: Option<Rename>,
 }
 
 /// Main trait to use to add a new language to Rome
@@ -118,6 +120,7 @@ pub(crate) trait ExtensionHandler {
             fix_all: None,
             format_range: None,
             format_on_type: None,
+            rename: None,
         }
     }
 

--- a/crates/rome_service/src/file_handlers/unknown.rs
+++ b/crates/rome_service/src/file_handlers/unknown.rs
@@ -14,6 +14,7 @@ impl ExtensionHandler for UnknownFileHandler {
             fix_all: None,
             format_range: None,
             format_on_type: None,
+            rename: None,
         }
     }
 

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -39,14 +39,13 @@ pub enum RomeError {
     FormatError(FormatError),
     /// The file could not be formatted since it has syntax errors and `format_with_errors` is disabled
     FormatWithErrorsDisabled,
-    /// Thrown when a rome can't read a generic directory
+    /// Thrown when Rome can't read a generic directory
     CantReadDirectory(PathBuf),
-    /// Thrown when a rome can't read a generic file
+    /// Thrown when Rome can't read a generic file
     CantReadFile(PathBuf),
-
     /// Error thrown when validating the configuration. Once deserialized, further checks have to be done.
     Configuration(ConfigurationError),
-
+    /// Error thrown when Rome cannot rename a symbol.
     RenameError(RenameError),
 }
 
@@ -110,8 +109,21 @@ impl Display for RomeError {
                 write!(f, "Uncommitted changes in repository")
             }
             RomeError::RenameError(error) => match error {
-                RenameError::CannotBeRenamed => {
-                    write!(f, "encountered an error while renaming a symbol",)
+                RenameError::CannotBeRenamed {
+                    original_name,
+                    new_name,
+                } => {
+                    write!(
+                        f,
+                        "encountered an error while renaming the symbol \"{}\" to \"{}\"",
+                        original_name, new_name
+                    )
+                }
+                RenameError::CannotFindDeclaration => {
+                    write!(
+                        f,
+                        "encountered an error finding a declaration at the specified position"
+                    )
                 }
             },
         }

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -45,6 +45,8 @@ pub enum RomeError {
 
     /// Error thrown when validating the configuration. Once deserialized, further checks have to be done.
     Configuration(ConfigurationError),
+
+    RenameError,
 }
 
 impl Debug for RomeError {
@@ -58,6 +60,7 @@ impl Debug for RomeError {
             RomeError::CantReadFile(_) => std::fmt::Display::fmt(self, f),
             RomeError::Configuration(_) => std::fmt::Display::fmt(self, f),
             RomeError::DirtyWorkspace => std::fmt::Display::fmt(self, f),
+            RomeError::RenameError => std::fmt::Display::fmt(self, f),
         }
     }
 }
@@ -104,6 +107,9 @@ impl Display for RomeError {
             RomeError::Configuration(error) => std::fmt::Display::fmt(error, f),
             RomeError::DirtyWorkspace => {
                 write!(f, "Uncommitted changes in repository")
+            }
+            RomeError::RenameError => {
+                write!(f, "encountered an error while renaming symbol",)
             }
         }
     }

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -1,6 +1,7 @@
 use rome_console::{Console, EnvConsole};
 use rome_formatter::FormatError;
 use rome_fs::{FileSystem, OsFileSystem, RomePath};
+use rome_js_analyze::utils::rename::RenameError;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::{Deref, DerefMut};
@@ -46,7 +47,7 @@ pub enum RomeError {
     /// Error thrown when validating the configuration. Once deserialized, further checks have to be done.
     Configuration(ConfigurationError),
 
-    RenameError,
+    RenameError(RenameError),
 }
 
 impl Debug for RomeError {
@@ -60,7 +61,7 @@ impl Debug for RomeError {
             RomeError::CantReadFile(_) => std::fmt::Display::fmt(self, f),
             RomeError::Configuration(_) => std::fmt::Display::fmt(self, f),
             RomeError::DirtyWorkspace => std::fmt::Display::fmt(self, f),
-            RomeError::RenameError => std::fmt::Display::fmt(self, f),
+            RomeError::RenameError(_) => std::fmt::Display::fmt(self, f),
         }
     }
 }
@@ -108,9 +109,11 @@ impl Display for RomeError {
             RomeError::DirtyWorkspace => {
                 write!(f, "Uncommitted changes in repository")
             }
-            RomeError::RenameError => {
-                write!(f, "encountered an error while renaming symbol",)
-            }
+            RomeError::RenameError(error) => match error {
+                RenameError::CannotBeRenamed => {
+                    write!(f, "encountered an error while renaming a symbol",)
+                }
+            },
         }
     }
 }

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -137,6 +137,17 @@ pub struct FixFileResult {
     pub rules: Vec<(&'static str, TextRange)>,
 }
 
+pub struct RenameParams {
+    pub path: RomePath,
+    pub symbol_at: TextSize,
+    pub new_name: String,
+}
+
+pub struct RenameResult {
+    /// New source code for the file with all fixes applied
+    pub code: String,
+}
+
 pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// Checks whether a certain feature is supported. There are different conditions:
     /// - Rome doesn't recognize a file, so it can provide the feature;
@@ -182,6 +193,9 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
 
     /// Return the content of the file with all safe code actions applied
     fn fix_file(&self, params: FixFileParams) -> Result<FixFileResult, RomeError>;
+
+    /// Return the content of the file after renaming a symbol
+    fn rename(&self, params: RenameParams) -> Result<RenameResult, RomeError>;
 }
 
 /// Convenience function for constructing a server instance of [Workspace]

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -1,4 +1,4 @@
-use std::{any::type_name, fs::rename, panic::RefUnwindSafe, sync::RwLock};
+use std::{any::type_name, panic::RefUnwindSafe, sync::RwLock};
 
 use dashmap::{mapref::entry::Entry, DashMap};
 use rome_analyze::AnalyzerAction;
@@ -17,7 +17,7 @@ use crate::{
 use super::{
     ChangeFileParams, CloseFileParams, FeatureName, FixFileResult, FormatFileParams,
     FormatOnTypeParams, FormatRangeParams, GetSyntaxTreeParams, OpenFileParams, PullActionsParams,
-    PullDiagnosticsParams, RenameParams, RenameResult, SupportsFeatureParams, UpdateSettingsParams,
+    PullDiagnosticsParams, RenameResult, SupportsFeatureParams, UpdateSettingsParams,
 };
 
 pub(super) struct WorkspaceServer {


### PR DESCRIPTION
## Summary

This PR is the first step to implementing https://github.com/rome/tools/issues/2903.
It introduces an ```rename``` extension method to the ```BatchMutation```.

I still need to understand what to do when the cursor is not at a symbol.

## Test Plan

```
> cargo test -p rome_js_analyze -- rename
```

or directly using the lsp.

![image](https://user-images.githubusercontent.com/83425/180088252-4351c7de-145e-4acc-8749-bf5a81f21038.png)

