### PR TITLE
feat(rome_analyze): refactor code actions to use batch mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,6 +1351,7 @@ dependencies = [
  "rome_js_factory",
  "rome_js_syntax",
  "rome_rowan",
+ "rome_text_edit",
  "rustc-hash",
 ]
 
@@ -1469,6 +1470,7 @@ dependencies = [
  "rome_js_semantic",
  "rome_js_syntax",
  "rome_rowan",
+ "rome_text_edit",
  "rustc-hash",
  "tests_macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,7 +1351,6 @@ dependencies = [
  "rome_js_factory",
  "rome_js_syntax",
  "rome_rowan",
- "rome_text_edit",
  "rustc-hash",
 ]
 
@@ -1633,6 +1632,7 @@ dependencies = [
  "memoffset",
  "quickcheck",
  "quickcheck_macros",
+ "rome_text_edit",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1656,6 +1656,7 @@ dependencies = [
  "rome_js_semantic",
  "rome_js_syntax",
  "rome_rowan",
+ "rome_text_edit",
  "serde",
  "serde_json",
 ]
@@ -1664,7 +1665,7 @@ dependencies = [
 name = "rome_text_edit"
 version = "0.0.0"
 dependencies = [
- "rome_rowan",
+ "text-size",
 ]
 
 [[package]]

--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -12,6 +12,7 @@ rome_rowan = { path = "../rome_rowan" }
 rome_control_flow = { path = "../rome_control_flow" }
 rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
+rome_text_edit = { path = "../rome_text_edit" }
 bitflags = "1.3.2"
 rustc-hash = "1.1.0"
 

--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -12,7 +12,6 @@ rome_rowan = { path = "../rome_rowan" }
 rome_control_flow = { path = "../rome_control_flow" }
 rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
-rome_text_edit = { path = "../rome_text_edit" }
 bitflags = "1.3.2"
 rustc-hash = "1.1.0"
 

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -3,7 +3,7 @@ use rome_console::{markup, MarkupBuf};
 use rome_diagnostics::file::FileSpan;
 use rome_diagnostics::{file::FileId, Applicability, Severity};
 use rome_diagnostics::{Diagnostic, DiagnosticTag, Footer, Span, SubDiagnostic};
-use rome_rowan::{Language, TextRange};
+use rome_rowan::{BatchMutation, Language, TextRange};
 
 use crate::categories::{ActionCategory, RuleCategory};
 use crate::context::RuleContext;
@@ -479,5 +479,5 @@ pub struct RuleAction<L: Language> {
     pub category: ActionCategory,
     pub applicability: Applicability,
     pub message: MarkupBuf,
-    pub root: LanguageRoot<L>,
+    pub mutation: BatchMutation<L, LanguageRoot<L>>,
 }

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -1,14 +1,12 @@
-use std::{collections::VecDeque, marker::PhantomData};
+use std::marker::PhantomData;
 
 use rome_console::MarkupBuf;
 use rome_diagnostics::{
     file::{FileId, FileSpan},
     Applicability, CodeSuggestion, Diagnostic, SuggestionChange, SuggestionStyle,
 };
-use rome_rowan::{
-    AstNode, Direction, Language, SyntaxElement, SyntaxNode, SyntaxSlot, TextRange, TextSize,
-    WalkEvent,
-};
+use rome_rowan::{BatchMutation, Language};
+use rome_text_edit::Indel;
 
 use crate::{
     categories::ActionCategory,
@@ -58,7 +56,7 @@ where
 ///
 /// This struct can be converted into a [CodeSuggestion] and injected into
 /// a diagnostic emitted by the same signal
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct AnalyzerAction<L: Language> {
     pub group_name: &'static str,
     pub rule_name: &'static str,
@@ -66,11 +64,25 @@ pub struct AnalyzerAction<L: Language> {
     pub category: ActionCategory,
     pub applicability: Applicability,
     pub message: MarkupBuf,
-    /// Range of the original document being modified by this action
-    pub original_range: TextRange,
-    /// Range of the new document that differs from the original document
-    pub new_range: TextRange,
-    pub root: LanguageRoot<L>,
+    pub mutation: BatchMutation<L, LanguageRoot<L>>,
+}
+
+impl<L> AnalyzerAction<L>
+where
+    L: Language,
+{
+    /// Generates a list of [Indel] from the mutation applied by this action
+    pub fn as_indels(&self) -> Vec<Indel> {
+        let mut result: Vec<_> = self
+            .mutation
+            .as_text_edits()
+            .map(|(delete, insert)| Indel { insert, delete })
+            .collect();
+
+        result.sort_unstable_by(|a, b| a.delete.ordering(b.delete));
+
+        result
+    }
 }
 
 impl<L> From<AnalyzerAction<L>> for CodeSuggestion
@@ -78,41 +90,18 @@ where
     L: Language,
 {
     fn from(action: AnalyzerAction<L>) -> Self {
-        // Only print the relevant subset of tokens
-        let mut code = String::new();
+        let indels = action.as_indels();
 
-        let mut iter = action.root.syntax().preorder_with_tokens(Direction::Next);
-        while let Some(event) = iter.next() {
-            let elem = match event {
-                WalkEvent::Enter(elem) => elem,
-                WalkEvent::Leave(_) => continue,
-            };
-
-            let range = elem.text_range();
-            let has_intersection = range
-                .intersect(action.new_range)
-                .filter(|range| !range.is_empty())
-                .is_some();
-
-            match elem {
-                SyntaxElement::Node(_) => {
-                    if !has_intersection {
-                        iter.skip_subtree();
-                    }
-                }
-                SyntaxElement::Token(token) => {
-                    if has_intersection {
-                        code.push_str(token.text());
-                    }
-                }
-            }
-        }
+        let range = indels.iter().fold(None, |state, indel| match state {
+            None => Some(indel.delete),
+            Some(state) => Some(state.cover(indel.delete)),
+        });
 
         CodeSuggestion {
-            substitution: SuggestionChange::String(code),
+            substitution: SuggestionChange::Indels(indels),
             span: FileSpan {
                 file: action.file_id,
-                range: action.original_range,
+                range: range.unwrap_or_default(),
             },
             applicability: action.applicability,
             msg: action.message,
@@ -174,230 +163,14 @@ where
     fn action(&self) -> Option<AnalyzerAction<RuleLanguage<R>>> {
         let ctx = RuleContext::new(&self.query_result, self.root, self.services).ok()?;
 
-        R::action(&ctx, &self.state).and_then(|action| {
-            let (original_range, new_range) =
-                find_diff_range(self.root.syntax(), action.root.syntax())?;
-            Some(AnalyzerAction {
-                group_name: G::NAME,
-                rule_name: R::NAME,
-                file_id: self.file_id,
-                category: action.category,
-                applicability: action.applicability,
-                message: action.message,
-                original_range,
-                new_range,
-                root: action.root,
-            })
+        R::action(&ctx, &self.state).map(|action| AnalyzerAction {
+            group_name: G::NAME,
+            rule_name: R::NAME,
+            file_id: self.file_id,
+            category: action.category,
+            applicability: action.applicability,
+            message: action.message,
+            mutation: action.mutation,
         })
-    }
-}
-
-/// Compares two revisions of the same syntax tree and find the narrowest text
-/// range that differs between the two
-fn find_diff_range<L>(prev: &SyntaxNode<L>, next: &SyntaxNode<L>) -> Option<(TextRange, TextRange)>
-where
-    L: Language,
-{
-    let mut result: Option<(TextRange, TextRange)> = None;
-    let mut queue = VecDeque::new();
-
-    if prev.key().0 != next.key().0 {
-        queue.push_back((prev.clone(), next.clone()));
-    }
-
-    // These buffers are kept between loops to amortize their allocation over the whole algorithm
-    let mut prev_children = Vec::new();
-    let mut next_children = Vec::new();
-
-    while let Some((prev, next)) = queue.pop_front() {
-        // Collect all `SyntaxElement` slots into two vectors
-        // (makes it easier to implement backwards iteration + peeking)
-        prev_children.clear();
-        prev_children.extend(prev.slots().filter_map(SyntaxSlot::into_syntax_element));
-
-        next_children.clear();
-        next_children.extend(next.slots().filter_map(SyntaxSlot::into_syntax_element));
-
-        // Remove identical children from the end of the vectors, keeping track
-        // of the truncated range end for the sub-slice of children that differ
-        let mut prev_end = prev.text_range().end();
-        let mut next_end = next.text_range().end();
-
-        while let (Some(prev), Some(next)) = (prev_children.last(), next_children.last()) {
-            if prev.key().0 == next.key().0 {
-                prev_end = prev_end.min(prev.text_range().start());
-                next_end = next_end.min(next.text_range().start());
-                prev_children.pop().unwrap();
-                next_children.pop().unwrap();
-            } else {
-                break;
-            }
-        }
-
-        // Zip the two vectors from the start and compare the previous and next version of each child
-        let mut prev_children = prev_children.drain(..);
-        let mut next_children = next_children.drain(..);
-
-        loop {
-            let (prev_range, next_range) = match (prev_children.next(), next_children.next()) {
-                // The previous and next child are both nodes, push them to the
-                // comparison queue if they differ
-                (Some(SyntaxElement::Node(prev)), Some(SyntaxElement::Node(next))) => {
-                    if prev.key().0 != next.key().0 {
-                        queue.push_back((prev, next));
-                    }
-
-                    continue;
-                }
-
-                // The previous and next child are both tokens, extend the diff
-                // range to their position if they differ
-                (Some(SyntaxElement::Token(prev)), Some(SyntaxElement::Token(next))) => {
-                    if prev.key().0 == next.key().0 {
-                        continue;
-                    }
-
-                    (prev.text_range(), next.text_range())
-                }
-
-                // `(Some(Token), Some(Node))` or `(Some(Node), Some(Token))`
-                (Some(prev), Some(next)) => (prev.text_range(), next.text_range()),
-
-                // One children list is longer than the other
-                (Some(prev), None) => (
-                    prev.text_range(),
-                    TextRange::at(next_end, TextSize::from(0)),
-                ),
-                (None, Some(next)) => (
-                    TextRange::at(prev_end, TextSize::from(0)),
-                    next.text_range(),
-                ),
-
-                (None, None) => break,
-            };
-
-            // Either extend the existing range or initialize it with the new values
-            let new_result = match result {
-                Some((prev, next)) => (prev.cover(prev_range), next.cover(next_range)),
-                None => (prev_range, next_range),
-            };
-
-            result = Some(new_result);
-        }
-    }
-
-    result
-}
-
-#[cfg(test)]
-mod tests {
-    use rome_js_factory::make;
-    use rome_js_syntax::{JsAnyExpression, JsAnyStatement, TextRange, TextSize, T};
-    use rome_rowan::{AstNode, AstNodeListExt};
-
-    use super::find_diff_range;
-
-    #[test]
-    /// Checks the [find_diff_range] function returns the correct result when
-    /// tokens are reused from the input in the middle of the range
-    fn diff_range_split() {
-        let before = make::js_if_statement(
-            make::token(T![if]),
-            make::token(T!['(']),
-            JsAnyExpression::JsIdentifierExpression(make::js_identifier_expression(
-                make::js_reference_identifier(make::ident("test")),
-            )),
-            make::token(T![')']),
-            JsAnyStatement::JsExpressionStatement(
-                make::js_expression_statement(JsAnyExpression::JsIdentifierExpression(
-                    make::js_identifier_expression(make::js_reference_identifier(make::ident(
-                        "consequent",
-                    ))),
-                ))
-                .with_semicolon_token(make::token(T![;]))
-                .build(),
-            ),
-        )
-        .with_else_clause(make::js_else_clause(
-            make::token(T![else]),
-            JsAnyStatement::JsExpressionStatement(
-                make::js_expression_statement(JsAnyExpression::JsIdentifierExpression(
-                    make::js_identifier_expression(make::js_reference_identifier(make::ident(
-                        "alternate",
-                    ))),
-                ))
-                .with_semicolon_token(make::token(T![;]))
-                .build(),
-            ),
-        ))
-        .build();
-
-        let consequent = before.consequent().unwrap();
-        let else_clause = before.else_clause().unwrap();
-        let alternate = else_clause.alternate().unwrap();
-
-        let after = before
-            .clone()
-            .with_consequent(alternate)
-            .with_else_clause(Some(else_clause.with_alternate(consequent)));
-
-        let diff = find_diff_range(before.syntax(), after.syntax())
-            .expect("failed to calculate diff range");
-
-        let start = TextSize::of("if(test)");
-        let end = TextSize::of("if(test)consequent;elsealternate;");
-
-        assert_eq!(
-            diff,
-            (TextRange::new(start, end), TextRange::new(start, end))
-        );
-    }
-
-    #[test]
-    /// Checks the [find_diff_range] function returns the correct result when
-    /// tokens are removed from the input
-    fn diff_range_remove() {
-        let before = make::js_statement_list(vec![
-            JsAnyStatement::JsExpressionStatement(
-                make::js_expression_statement(JsAnyExpression::JsIdentifierExpression(
-                    make::js_identifier_expression(make::js_reference_identifier(make::ident(
-                        "statement1",
-                    ))),
-                ))
-                .with_semicolon_token(make::token(T![;]))
-                .build(),
-            ),
-            JsAnyStatement::JsExpressionStatement(
-                make::js_expression_statement(JsAnyExpression::JsIdentifierExpression(
-                    make::js_identifier_expression(make::js_reference_identifier(make::ident(
-                        "statement2",
-                    ))),
-                ))
-                .with_semicolon_token(make::token(T![;]))
-                .build(),
-            ),
-            JsAnyStatement::JsExpressionStatement(
-                make::js_expression_statement(JsAnyExpression::JsIdentifierExpression(
-                    make::js_identifier_expression(make::js_reference_identifier(make::ident(
-                        "statement3",
-                    ))),
-                ))
-                .with_semicolon_token(make::token(T![;]))
-                .build(),
-            ),
-        ]);
-
-        let after = before.clone().splice(1..=1, None);
-
-        let diff = find_diff_range(before.syntax(), after.syntax())
-            .expect("failed to calculate diff range");
-
-        let start = TextSize::of("statement1;");
-        let end = TextSize::of("statement1;statement2;");
-
-        assert_eq!(
-            diff,
-            (TextRange::new(start, end), TextRange::new(start, start))
-        );
     }
 }

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -136,6 +136,8 @@ mod check {
             args: Arguments::from_vec(vec![OsString::from("check"), file_path.as_os_str().into()]),
         });
 
+        eprintln!("{:?}", console.buffer);
+
         // TODO lint errors are disabled until the linter is stable
         assert!(result.is_ok());
 
@@ -369,13 +371,16 @@ mod ci {
         let file_path = Path::new("ci.js");
         fs.insert(file_path.into(), LINT_ERROR.as_bytes());
 
+        let mut console = BufferConsole::default();
         let result = run_cli(CliSession {
             app: App::with_filesystem_and_console(
                 DynRef::Owned(Box::new(fs)),
-                DynRef::Owned(Box::new(BufferConsole::default())),
+                DynRef::Borrowed(&mut console),
             ),
             args: Arguments::from_vec(vec![OsString::from("ci"), file_path.as_os_str().into()]),
         });
+
+        eprintln!("{:?}", console.buffer);
 
         match result {
             Err(Termination::CheckError) => {}

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -22,5 +22,6 @@ rustc-hash = "1.1.0"
 
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }
+rome_text_edit = { path = "../rome_text_edit" }
 insta = { version = "1.10.0", features = ["glob"] }
 countme = { version = "3.0.0", features = ["enable"] }

--- a/crates/rome_js_analyze/src/analyzers/js/use_single_case_statement.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_single_case_statement.rs
@@ -9,7 +9,7 @@ use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyStatement, JsCaseClause, JsCaseClauseFields, JsSyntaxToken, TriviaPieceKind, T,
 };
-use rome_rowan::{AstNode, AstNodeExt, AstNodeList, TriviaPiece};
+use rome_rowan::{AstNode, AstNodeList, BatchMutationExt, TriviaPiece};
 
 use crate::JsRuleAction;
 
@@ -76,6 +76,7 @@ impl Rule for UseSingleCaseStatement {
 
     fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
         let n = ctx.query();
+        let mut mutation = ctx.root().begin();
 
         let JsCaseClauseFields {
             case_token,
@@ -139,16 +140,13 @@ impl Rule for UseSingleCaseStatement {
             node
         };
 
-        let root = ctx
-            .root()
-            .replace_node(n.clone(), node)
-            .expect("failed to replace node");
+        mutation.replace_node(n.clone(), node);
 
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,
             applicability: Applicability::MaybeIncorrect,
             message: markup! { "Wrap the statements in a block" }.to_owned(),
-            root,
+            mutation,
         })
     }
 }

--- a/crates/rome_js_analyze/src/analyzers/jsx/no_implicit_boolean.rs
+++ b/crates/rome_js_analyze/src/analyzers/jsx/no_implicit_boolean.rs
@@ -7,7 +7,7 @@ use rome_js_factory::make;
 use rome_js_syntax::{
     JsAnyLiteralExpression, JsSyntaxKind, JsxAnyAttributeValue, JsxAttribute, JsxAttributeFields, T,
 };
-use rome_rowan::{AstNode, AstNodeExt};
+use rome_rowan::{AstNode, AstNodeExt, BatchMutationExt};
 
 use crate::JsRuleAction;
 
@@ -79,6 +79,7 @@ impl Rule for NoImplicitBoolean {
 
     fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
         let n = ctx.query();
+        let mut mutation = ctx.root().begin();
 
         let JsxAttributeFields {
             name,
@@ -120,12 +121,13 @@ impl Rule for NoImplicitBoolean {
         );
         let next_attr = next_attr.build();
 
-        let root = ctx.root().replace_node(n.clone(), next_attr)?;
+        mutation.replace_node(n.clone(), next_attr);
+
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,
             applicability: Applicability::Always,
             message: markup! { "Add explicit `true` literal for this attribute" }.to_owned(),
-            root,
+            mutation,
         })
     }
 }

--- a/crates/rome_js_analyze/src/analyzers/ts/use_shorthand_array_type.rs
+++ b/crates/rome_js_analyze/src/analyzers/ts/use_shorthand_array_type.rs
@@ -5,7 +5,7 @@ use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{TriviaPieceKind, TsReferenceType, TsType, TsTypeArguments, T};
-use rome_rowan::{AstNode, AstNodeExt, AstSeparatedList};
+use rome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
 
 use crate::JsRuleAction;
 
@@ -80,15 +80,17 @@ impl Rule for UseShorthandArrayType {
     }
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
-        let root = ctx.root();
         let node = ctx.query();
-        let root = root.replace_node(TsType::TsReferenceType(node.clone()), state.clone())?;
+        let mut mutation = ctx.root().begin();
+
+        mutation.replace_node(TsType::TsReferenceType(node.clone()), state.clone());
+
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,
             applicability: Applicability::MaybeIncorrect,
             message: markup! { "Use "<Emphasis>"shorthand T[] syntax"</Emphasis>" to replace" }
                 .to_owned(),
-            root,
+            mutation,
         })
     }
 }

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
@@ -178,7 +178,7 @@ impl Rule for NoShoutyConstants {
             category: ActionCategory::Refactor,
             applicability: Applicability::Unspecified,
             message: markup! { "Use the constant value directly" }.to_owned(),
-            root: batch.commit(),
+            mutation: batch,
         })
     }
 }

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -10,7 +10,8 @@ use rome_console::{
 };
 use rome_diagnostics::{file::SimpleFile, termcolor::NoColor, Diagnostic};
 use rome_js_parser::parse;
-use rome_rowan::{AstNode, Language};
+use rome_rowan::Language;
+use rome_text_edit::apply_indels;
 
 tests_macros::gen_tests! {"tests/specs/**/*.{cjs,js,jsx,tsx,ts}", crate::run_test, "module"}
 
@@ -133,7 +134,11 @@ fn code_fix_to_string<L>(source: &str, action: AnalyzerAction<L>) -> String
 where
     L: Language,
 {
-    let output = action.root.syntax().to_string();
+    let mut output = source.to_string();
+    let indels = action.as_indels();
+
+    apply_indels(&indels, &mut output);
+
     markup_to_string(markup! {
         {Diff { mode: DiffMode::Unified, left: source, right: &output }}
     })

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -135,7 +135,7 @@ where
     L: Language,
 {
     let mut output = source.to_string();
-    let indels = action.as_indels();
+    let (_, indels) = action.mutation.as_text_edits().unwrap_or_default();
 
     apply_indels(&indels, &mut output);
 

--- a/crates/rome_js_parser/src/lib.rs
+++ b/crates/rome_js_parser/src/lib.rs
@@ -130,7 +130,7 @@
 //! ### Parse children
 //! The parse rules will guide you in how to write your implementation and the parser infrastructure provides the following convenience APIs:
 //!
-//! * Optional token `'ident'?`: Use `p.eat(token)`. It eats the next token if it matches the passed-in token. 
+//! * Optional token `'ident'?`: Use `p.eat(token)`. It eats the next token if it matches the passed-in token.
 //! * Required token `'ident'`: Use`p.expect(token)`. It eats the next token if it matches the passed-in token.
 //! It adds an `Expected 'x' but found 'y' instead` error and a missing marker if the token isn't present in the source code.
 //! * Optional node `body: JsBlockStatement?`: Use`parse_block_statement(p).or_missing(p)`. It parses the block if it is present in the source code and adds a missing marker if it isn't.
@@ -295,7 +295,7 @@
 //! ## Summary
 //!
 //! * Parse rules are named `parse_rule_name`
-//! * The parse rules should return a `ParsedSyntax` 
+//! * The parse rules should return a `ParsedSyntax`
 //! * The rule must return `Present` if it consumes any token and, therefore, can parse the node with at least some of its children.
 //! * It returns `Absent` otherwise and must not progress parsing nor add any errors.
 //! * Lists must perform error recovery to avoid infinite loops.

--- a/crates/rome_rowan/Cargo.toml
+++ b/crates/rome_rowan/Cargo.toml
@@ -16,6 +16,7 @@ text-size = "1.1.0"
 memoffset = "0.6.5"
 countme = "3.0.0"
 serde_crate = { package = "serde", version = "1.0.133", optional = true, default-features = false }
+rome_text_edit = { path = "../rome_text_edit" }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/crates/rome_rowan/src/syntax/element.rs
+++ b/crates/rome_rowan/src/syntax/element.rs
@@ -56,6 +56,13 @@ impl<L: Language> SyntaxElement<L> {
         }
     }
 
+    pub(crate) fn index(&self) -> usize {
+        match self {
+            NodeOrToken::Node(it) => it.index(),
+            NodeOrToken::Token(it) => it.index(),
+        }
+    }
+
     pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
         let first = match self {
             NodeOrToken::Node(it) => Some(it.clone()),

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -22,4 +22,5 @@ rome_js_parser = { path = "../rome_js_parser" }
 rome_js_formatter = { path = "../rome_js_formatter" }
 rome_js_semantic = { path = "../rome_js_semantic" }
 rome_rowan = { path = "../rome_rowan" }
+rome_text_edit = { path = "../rome_text_edit" }
 indexmap = "1.9.1"

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::{JsLanguage, TextRange, TextSize};
 
 use crate::{
     settings::SettingsHandle,
-    workspace::{server::AnyParse, FixFileResult},
+    workspace::{server::AnyParse, FixFileResult, RenameResult},
     RomeError,
 };
 
@@ -81,7 +81,7 @@ type FormatRange =
     fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>, TextRange) -> Result<Printed, RomeError>;
 type FormatOnType =
     fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>, TextSize) -> Result<Printed, RomeError>;
-type Rename = fn(&RomePath, AnyParse, TextSize, String) -> Result<String, RomeError>;
+type Rename = fn(&RomePath, AnyParse, TextSize, String) -> Result<RenameResult, RomeError>;
 
 pub(crate) struct Capabilities {
     pub(crate) parse: Option<Parse>,

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -58,6 +58,7 @@ use rome_diagnostics::Diagnostic;
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
 use rome_js_syntax::{JsLanguage, TextRange, TextSize};
+use rome_text_edit::Indel;
 
 use crate::{settings::WorkspaceSettings, RomeError};
 
@@ -144,8 +145,10 @@ pub struct RenameParams {
 }
 
 pub struct RenameResult {
-    /// New source code for the file with all fixes applied
-    pub code: String,
+    /// Range of source code modified by this rename operation
+    pub range: TextRange,
+    /// List of text edit operations to apply on the source code
+    pub indels: Vec<Indel>,
 }
 
 pub trait Workspace: Send + Sync + RefUnwindSafe {

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -304,8 +304,8 @@ impl Workspace for WorkspaceServer {
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
         let parse = self.get_parse(params.path.clone())?;
-        let code = rename(&params.path, parse, params.symbol_at, params.new_name)?;
+        let result = rename(&params.path, parse, params.symbol_at, params.new_name)?;
 
-        Ok(RenameResult { code })
+        Ok(result)
     }
 }

--- a/crates/rome_text_edit/Cargo.toml
+++ b/crates/rome_text_edit/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT"
 description = "Simple text editing crate ported from rust-analyzer for the RSLint project"
 
 [dependencies]
-rome_rowan = { path = "../rome_rowan"}
+text-size = "1.1.0"

--- a/crates/rome_text_edit/src/lib.rs
+++ b/crates/rome_text_edit/src/lib.rs
@@ -1,7 +1,7 @@
 //! Representation of a text edits.
 //!
 //! This is taken from [rust-analyzer's text_edit crate](https://rust-analyzer.github.io/rust-analyzer/text_edit/index.html)
-pub use rome_rowan::{TextRange, TextSize};
+pub use text_size::{TextRange, TextSize};
 
 /// `InsertDelete` -- a single "atomic" change to text
 ///


### PR DESCRIPTION
## Summary

This PR refactors the `RuleAction` and `AnalyzerAction` to have lint rules provide code actions in the form of `BatchMutation` objects instead of returning a mutated syntax tree. In addition to possible improvements to performances unlocked by batching the mutations, this change allows the set of changes to be inspected in order to efficiently generate smaller text diffs that directly represent the mutation operations that were executed on the syntax tree using `rome_text_edit` (in fact for most use-cases code actions can directly be turned into a text-based diff operation without having to go through the mutation commit operation to build the mutated syntax tree)

In order to support this I had to extend the `BatchMutation` to support additional mutation operations that were used by existing lint rules, as well as replicating the "automatic trivia transfer" feature of the `replace_node` and `replace_token` method of the `AstNode` mutation extensions

## Test Plan

The lint rules test suite has been adapted to the new internal representation of code actions with no changes to the content of snapshots, from a user perspective all rules continue to emit the exact same code actions as before the change
