### PR TITLE
feat(rome_service): support for recommendation of rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -560,13 +560,9 @@ impl<'analysis> AnalysisFilter<'analysis> {
             })
     }
 
-    pub fn new_from_filters(
-        enabled_rules: Option<&'analysis [RuleFilter<'analysis>]>,
-        disabled_rules: Option<&'analysis [RuleFilter<'analysis>]>,
-    ) -> Self {
+    pub fn from_enabled_rules(enabled_rules: Option<&'analysis [RuleFilter<'analysis>]>) -> Self {
         Self {
             enabled_rules,
-            disabled_rules,
             ..AnalysisFilter::default()
         }
     }

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -506,7 +506,7 @@ type SuppressionParser = fn(&str) -> Vec<Option<&str>>;
 type SignalHandler<'a, L, Break> = &'a mut dyn FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<Break>;
 
 /// Allow filtering a single rule or group of rules by their names
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum RuleFilter<'a> {
     Group(&'a str),
     Rule(&'a str, &'a str),
@@ -540,7 +540,7 @@ pub struct AnalysisFilter<'a> {
     pub range: Option<TextRange>,
 }
 
-impl AnalysisFilter<'_> {
+impl<'analysis> AnalysisFilter<'analysis> {
     /// Return `true` if the rule `R` matches this filter
     pub fn match_rule<G, R>(&self) -> bool
     where
@@ -558,6 +558,17 @@ impl AnalysisFilter<'_> {
                     .iter()
                     .any(|filter| filter.match_rule::<G, R>())
             })
+    }
+
+    pub fn new_from_filters(
+        enabled_rules: Option<&'analysis [RuleFilter<'analysis>]>,
+        disabled_rules: Option<&'analysis [RuleFilter<'analysis>]>,
+    ) -> Self {
+        Self {
+            enabled_rules,
+            disabled_rules,
+            ..AnalysisFilter::default()
+        }
     }
 }
 

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -560,16 +560,10 @@ impl<'analysis> AnalysisFilter<'analysis> {
             })
     }
 
+    /// It creates a new filter with the set of [enabled rules](RuleFilter) passed as argument
     pub fn from_enabled_rules(enabled_rules: Option<&'analysis [RuleFilter<'analysis>]>) -> Self {
         Self {
             enabled_rules,
-            ..AnalysisFilter::default()
-        }
-    }
-
-    pub fn from_disabled_rules(disabled_rules: Option<&'analysis [RuleFilter<'analysis>]>) -> Self {
-        Self {
-            disabled_rules,
             ..AnalysisFilter::default()
         }
     }

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -566,6 +566,13 @@ impl<'analysis> AnalysisFilter<'analysis> {
             ..AnalysisFilter::default()
         }
     }
+
+    pub fn from_disabled_rules(disabled_rules: Option<&'analysis [RuleFilter<'analysis>]>) -> Self {
+        Self {
+            disabled_rules,
+            ..AnalysisFilter::default()
+        }
+    }
 }
 
 /// Utility type to be used as a default value for the `B` generic type on

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -113,6 +113,7 @@ impl<L: Language + Default> RuleRegistry<L> {
                 version: R::VERSION,
                 docs: R::DOCS,
                 deprecated: R::DEPRECATED,
+                recommended: R::RECOMMENDED,
             },
         );
     }
@@ -128,6 +129,7 @@ impl<L: Language + Default> RuleRegistry<L> {
                 docs: value.docs,
                 version: value.version,
                 deprecated: value.deprecated,
+                recommended: value.recommended,
             }
         })
     }
@@ -218,6 +220,7 @@ struct MetadataValue {
     version: &'static str,
     docs: &'static str,
     deprecated: Option<&'static str>,
+    recommended: bool,
 }
 
 /// Metadata entry for a rule in the registry
@@ -227,6 +230,7 @@ pub struct RuleMetadata {
     pub docs: &'static str,
     pub version: &'static str,
     pub deprecated: Option<&'static str>,
+    pub recommended: bool,
 }
 
 /// Internal representation of a single rule in the registry

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -19,6 +19,8 @@ pub trait RuleMeta {
     const NAME: &'static str;
     /// The content of the documentation comments for this rule
     const DOCS: &'static str;
+    /// Whether a rule is recommended or not
+    const RECOMMENDED: bool;
 }
 
 /// This macro is used to declare an analyzer rule type, and implement the
@@ -113,7 +115,11 @@ pub trait RuleMeta {
 ///
 #[macro_export]
 macro_rules! declare_rule {
-    ( $( #[doc = $doc:literal] )+ $vis:vis $id:ident { version: $version:literal, name: $name:literal } ) => {
+    ( $( #[doc = $doc:literal] )+ $vis:vis $id:ident {
+        version: $version:literal,
+        name: $name:literal,
+        recommended: $recommended:literal
+    } ) => {
         $( #[doc = $doc] )*
         $vis enum $id {}
 
@@ -121,10 +127,16 @@ macro_rules! declare_rule {
             const DEPRECATED: Option<&'static str> = None;
             const VERSION: &'static str = $version;
             const NAME: &'static str = $name;
+            const RECOMMENDED: bool = $recommended;
             const DOCS: &'static str = concat!( $( $doc, "\n", )* );
         }
     };
-    ( $( #[doc = $doc:literal] )+ $vis:vis $id:ident { version: $version:literal, name: $name:literal, deprecated: $deprecated:literal, } ) => {
+    ( $( #[doc = $doc:literal] )+ $vis:vis $id:ident {
+        version: $version:literal,
+        name: $name:literal,
+        recommended: $recommended:literal,
+        deprecated: $deprecated:literal
+    } ) => {
         $( #[doc = $doc] )*
         $vis enum $id {}
 
@@ -132,6 +144,7 @@ macro_rules! declare_rule {
             const DEPRECATED: Option<&'static str> = Some($deprecated);
             const VERSION: &'static str = $version;
             const NAME: &'static str = $name;
+            const RECOMMENDED: bool = $recommended;
             const DOCS: &'static str = concat!( $( $doc, "\n", )* );
         }
     };

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -500,14 +500,14 @@ fn process_file(ctx: &TraversalOptions, path: &Path, file_id: FileId) -> FileRes
         }
 
         let is_format = matches!(ctx.mode, TraversalMode::Format { .. });
-        let filter = if is_format {
+        let categories = if is_format {
             RuleCategories::SYNTAX
         } else {
             RuleCategories::SYNTAX | RuleCategories::LINT
         };
 
         let result = file_guard
-            .pull_diagnostics(filter)
+            .pull_diagnostics(categories)
             .with_file_id_and_code(file_id, "Lint")?;
 
         let has_errors = result

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -98,7 +98,6 @@ pub const CONFIG_INCORRECT_GLOBALS: &str = r#"{
 }"#;
 
 pub const CONFIG_LINTER_SUPPRESSED_RULE: &str = r#"{
-  "root": true,
   "linter": {
     "rules": {
         "recommended": true,
@@ -106,6 +105,17 @@ pub const CONFIG_LINTER_SUPPRESSED_RULE: &str = r#"{
             "rules": {
                 "noDebugger": "off"
             }
+        }
+    }
+  }
+}"#;
+
+pub const CONFIG_LINTER_SUPPRESSED_GROUP: &str = r#"{
+  "linter": {
+    "rules": {
+        "recommended": true,
+        "js": {
+            "recommended": false
         }
     }
   }

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -10,7 +10,10 @@ pub const CONFIG_FORMAT: &str = r#"{
 
 pub const CONFIG_INIT_DEFAULT: &str = r#"{
   "linter": {
-    "enabled": true
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
   }
 }"#;
 
@@ -33,14 +36,16 @@ pub const CONFIG_ALL_FIELDS: &str = r#"{
     "enabled": true,
     "rules": {
         "js": {
-            "noDeadCode": "off",
-            "useSimplifiedLogicExpression": "warn",
-            "noCatchAssign": "error",
-            "noLabelVar": {
-                "level": "warn"
-            },
-            "useTemplate": {
-                "level": "error"
+            "rules": {
+                "noDeadCode": "off",
+                "useSimplifiedLogicExpression": "warn",
+                "noCatchAssign": "error",
+                "noLabelVar": {
+                    "level": "warn"
+                },
+                "useTemplate": {
+                    "level": "error"
+                }
             }
         }
     }
@@ -70,10 +75,14 @@ pub const CONFIG_LINTER_WRONG_RULE: &str = r#"{
     "enabled": true,
     "rules": {
         "js": {
-            "foo_rule": "off"
+            "rules": {
+                "foo_rule": "off"
+            }
         },
         "jsx": {
-            "what_the_hell": "off"
+            "rules": {
+                "what_the_hell": "off"
+            }
         }
     }
   }
@@ -85,5 +94,19 @@ pub const CONFIG_INCORRECT_GLOBALS: &str = r#"{
   },
   "javascript": {
     "globals": [false]
+  }
+}"#;
+
+pub const CONFIG_LINTER_SUPPRESSED_RULE: &str = r#"{
+  "root": true,
+  "linter": {
+    "rules": {
+        "recommended": true,
+        "js": {
+            "rules": {
+                "noDebugger": "off"
+            }
+        }
+    }
   }
 }"#;

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -56,9 +56,18 @@ const CUSTOM_FORMAT_AFTER: &str = r#"function f() {
 
 const NO_DEBUGGER: &str = "debugger;";
 
+const JS_ERRORS: &str = r#"try {
+    !a && !b
+} catch (err) {
+    err = 24;
+}
+"#;
+
 mod check {
     use super::*;
-    use crate::configs::{CONFIG_LINTER_DISABLED, CONFIG_LINTER_SUPPRESSED_RULE};
+    use crate::configs::{
+        CONFIG_LINTER_DISABLED, CONFIG_LINTER_SUPPRESSED_GROUP, CONFIG_LINTER_SUPPRESSED_RULE,
+    };
     use rome_console::LogLevel;
     use rome_fs::FileSystemExt;
 
@@ -316,6 +325,43 @@ mod check {
             .unwrap();
 
         assert_eq!(buffer, NO_DEBUGGER);
+    }
+
+    #[test]
+    fn should_disable_a_rule_group() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("fix.js");
+        fs.insert(file_path.into(), JS_ERRORS.as_bytes());
+
+        let config_path = Path::new("rome.json");
+        fs.insert(
+            config_path.into(),
+            CONFIG_LINTER_SUPPRESSED_GROUP.as_bytes(),
+        );
+
+        let result = run_cli(CliSession {
+            app: App::with_filesystem_and_console(
+                DynRef::Borrowed(&mut fs),
+                DynRef::Borrowed(&mut console),
+            ),
+            args: Arguments::from_vec(vec![
+                OsString::from("check"),
+                OsString::from("--apply"),
+                file_path.as_os_str().into(),
+            ]),
+        });
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        let mut buffer = String::new();
+        fs.open(file_path)
+            .unwrap()
+            .read_to_string(&mut buffer)
+            .unwrap();
+
+        assert_eq!(buffer, JS_ERRORS);
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_async_promise_executor.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_async_promise_executor.rs
@@ -36,7 +36,8 @@ declare_rule! {
     /// ```
     pub(crate) NoAsyncPromiseExecutor {
         version: "0.7.0",
-        name: "noAsyncPromiseExecutor"
+        name: "noAsyncPromiseExecutor",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_compare_neg_zero.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_compare_neg_zero.rs
@@ -35,7 +35,8 @@ declare_rule! {
     ///```
     pub(crate) NoCompareNegZero {
         version: "0.7.0",
-        name: "noCompareNegZero"
+        name: "noCompareNegZero",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_dead_code.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_dead_code.rs
@@ -42,7 +42,8 @@ declare_rule! {
     /// ```
     pub(crate) NoDeadCode {
         version: "0.7.0",
-        name: "noDeadCode"
+        name: "noDeadCode",
+        recommended: false
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_debugger.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_debugger.rs
@@ -28,7 +28,8 @@ declare_rule! {
     ///```
     pub(crate) NoDebugger {
         version: "0.7.0",
-        name: "noDebugger"
+        name: "noDebugger",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_delete.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_delete.rs
@@ -38,7 +38,8 @@ declare_rule! {
     ///```
     pub(crate) NoDelete {
         version: "0.7.0",
-        name: "noDelete"
+        name: "noDelete",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_double_equals.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_double_equals.rs
@@ -48,7 +48,8 @@ declare_rule! {
     ///```
     pub(crate) NoDoubleEquals {
         version: "0.7.0",
-        name: "noDoubleEquals"
+        name: "noDoubleEquals",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_empty_pattern.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_empty_pattern.rs
@@ -34,7 +34,8 @@ declare_rule! {
     /// ```
     pub(crate) NoEmptyPattern {
         version: "0.7.0",
-        name: "noEmptyPattern"
+        name: "noEmptyPattern",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_negation_else.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_negation_else.rs
@@ -37,7 +37,8 @@ declare_rule! {
     ///```
     pub(crate) NoNegationElse {
         version: "0.7.0",
-        name: "noNegationElse"
+        name: "noNegationElse",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_sparse_array.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_sparse_array.rs
@@ -21,7 +21,8 @@ declare_rule! {
     /// ```
     pub(crate) NoSparseArray {
         version: "0.7.0",
-        name: "noSparseArray"
+        name: "noSparseArray",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_unnecessary_continue.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_unnecessary_continue.rs
@@ -73,7 +73,8 @@ declare_rule! {
     /// ```
     pub(crate) NoUnnecessaryContinue {
         version: "0.7.0",
-        name: "noUnnecessaryContinue"
+        name: "noUnnecessaryContinue",
+        recommended: true
     }
 
 }

--- a/crates/rome_js_analyze/src/analyzers/js/no_unsafe_negation.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_unsafe_negation.rs
@@ -34,7 +34,8 @@ declare_rule! {
     /// ```
     pub(crate) NoUnsafeNegation {
         version: "0.7.0",
-        name: "noUnsafeNegation"
+        name: "noUnsafeNegation",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_unused_template_literal.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_unused_template_literal.rs
@@ -38,7 +38,8 @@ declare_rule! {
     /// ```
     pub(crate) NoUnusedTemplateLiteral {
         version: "0.7.0",
-        name: "noUnusedTemplateLiteral"
+        name: "noUnusedTemplateLiteral",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_block_statements.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_block_statements.rs
@@ -64,7 +64,8 @@ declare_rule! {
     /// ```
     pub(crate) UseBlockStatements {
         version: "0.7.0",
-        name: "useBlockStatements"
+        name: "useBlockStatements",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_simplified_logic_expression.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_simplified_logic_expression.rs
@@ -51,7 +51,8 @@ declare_rule! {
     ///
     pub(crate) UseSimplifiedLogicExpression {
         version: "0.7.0",
-        name: "useSimplifiedLogicExpression"
+        name: "useSimplifiedLogicExpression",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_single_case_statement.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_single_case_statement.rs
@@ -43,7 +43,8 @@ declare_rule! {
     /// ```
     pub(crate) UseSingleCaseStatement {
         version: "0.7.0",
-        name: "useSingleCaseStatement"
+        name: "useSingleCaseStatement",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_single_var_declarator.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_single_var_declarator.rs
@@ -32,7 +32,8 @@ declare_rule! {
     /// ```
     pub(crate) UseSingleVarDeclarator {
         version: "0.7.0",
-        name: "useSingleVarDeclarator"
+        name: "useSingleVarDeclarator",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_template.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_template.rs
@@ -49,7 +49,8 @@ declare_rule! {
     /// ```
     pub(crate) UseTemplate {
         version: "0.7.0",
-        name: "useTemplate"
+        name: "useTemplate",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_valid_typeof.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_valid_typeof.rs
@@ -72,7 +72,8 @@ declare_rule! {
     /// ```
     pub(crate) UseValidTypeof {
         version: "0.7.0",
-        name: "useValidTypeof"
+        name: "useValidTypeof",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_while.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_while.rs
@@ -24,7 +24,8 @@ declare_rule! {
     /// ```
     pub(crate) UseWhile {
         version: "0.7.0",
-        name: "useWhile"
+        name: "useWhile",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/jsx/no_comment_text.rs
+++ b/crates/rome_js_analyze/src/analyzers/jsx/no_comment_text.rs
@@ -36,7 +36,8 @@ declare_rule! {
     /// ```
     pub(crate) NoCommentText {
         version: "0.7.0",
-        name: "noCommentText"
+        name: "noCommentText",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/jsx/no_implicit_boolean.rs
+++ b/crates/rome_js_analyze/src/analyzers/jsx/no_implicit_boolean.rs
@@ -45,7 +45,8 @@ declare_rule! {
     ///```
     pub(crate) NoImplicitBoolean {
         version: "0.7.0",
-        name: "noImplicitBoolean"
+        name: "noImplicitBoolean",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/jsx/use_self_closing_elements.rs
+++ b/crates/rome_js_analyze/src/analyzers/jsx/use_self_closing_elements.rs
@@ -55,7 +55,8 @@ declare_rule! {
     ///```
     pub(crate) UseSelfClosingElements {
         version: "0.7.0",
-        name: "useSelfClosingElements"
+        name: "useSelfClosingElements",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/regex/no_multiple_spaces_in_regular_expression_literals.rs
+++ b/crates/rome_js_analyze/src/analyzers/regex/no_multiple_spaces_in_regular_expression_literals.rs
@@ -59,7 +59,8 @@ declare_rule! {
     ///```
     pub(crate) NoMultipleSpacesInRegularExpressionLiterals {
         version: "0.7.0",
-        name: "noMultipleSpacesInRegularExpressionLiterals"
+        name: "noMultipleSpacesInRegularExpressionLiterals",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/ts/use_shorthand_array_type.rs
+++ b/crates/rome_js_analyze/src/analyzers/ts/use_shorthand_array_type.rs
@@ -44,7 +44,8 @@ declare_rule! {
     /// ```
     pub(crate) UseShorthandArrayType  {
         version: "0.7.0",
-        name: "useShorthandArrayType"
+        name: "useShorthandArrayType",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/assists/js/flip_bin_exp.rs
+++ b/crates/rome_js_analyze/src/assists/js/flip_bin_exp.rs
@@ -19,7 +19,8 @@ declare_rule! {
     /// ```
     pub(crate) FlipBinExp {
         version: "0.7.0",
-        name: "flipBinExp"
+        name: "flipBinExp",
+        recommended: false
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_arguments.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_arguments.rs
@@ -27,7 +27,8 @@ declare_rule! {
     /// ```
     pub(crate) NoArguments {
         version: "0.7.0",
-        name: "noArguments"
+        name: "noArguments",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_catch_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_catch_assign.rs
@@ -32,7 +32,8 @@ declare_rule! {
     /// ```
     pub(crate) NoCatchAssign {
         version: "0.7.0",
-        name: "noCatchAssign"
+        name: "noCatchAssign",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_function_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_function_assign.rs
@@ -95,7 +95,8 @@ declare_rule! {
     /// ```
     pub(crate) NoFunctionAssign {
         version: "0.7.0",
-        name: "noFunctionAssign"
+        name: "noFunctionAssign",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_label_var.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_label_var.rs
@@ -24,7 +24,8 @@ declare_rule! {
     /// ```
     pub(crate) NoLabelVar {
         version: "0.7.0",
-        name: "noLabelVar"
+        name: "noLabelVar",
+        recommended: true
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
@@ -25,7 +25,8 @@ declare_rule! {
     /// ```
     pub(crate) NoShoutyConstants {
         version: "0.7.0",
-        name: "noShoutyConstants"
+        name: "noShoutyConstants",
+        recommended: true
     }
 }
 

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -23,7 +23,7 @@ rome_js_formatter = { path = "../rome_js_formatter" }
 rome_js_semantic = { path = "../rome_js_semantic" }
 rome_rowan = { path = "../rome_rowan" }
 rome_text_edit = { path = "../rome_text_edit" }
-indexmap = "1.9.1"
+indexmap = { version = "1.9.1", features = ["serde"] }
 
 [features]
 serde_workspace = [

--- a/crates/rome_service/src/configuration/formatter.rs
+++ b/crates/rome_service/src/configuration/formatter.rs
@@ -39,8 +39,8 @@ impl Default for FormatterConfiguration {
     }
 }
 
-impl From<&FormatterConfiguration> for FormatSettings {
-    fn from(conf: &FormatterConfiguration) -> Self {
+impl From<FormatterConfiguration> for FormatSettings {
+    fn from(conf: FormatterConfiguration) -> Self {
         let indent_style = match conf.indent_style {
             PlainIndentStyle::Tab => IndentStyle::Tab,
             PlainIndentStyle::Space => IndentStyle::Space(conf.indent_size),

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -36,7 +36,7 @@ impl Rules {
     #[doc = r" while the second element are the disabled filters."]
     #[doc = r""]
     #[doc = r" The enabled filters are calculated from the difference with the disabled filters."]
-    pub fn as_analysis_filters(&self) -> (IndexSet<RuleFilter>, IndexSet<RuleFilter>) {
+    pub fn as_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut enabled_rules = IndexSet::new();
         let mut disabled_rules = IndexSet::new();
         if self.is_recommended() {
@@ -101,8 +101,7 @@ impl Rules {
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
         }
-        let enabled_rules = enabled_rules.difference(&disabled_rules).cloned().collect();
-        (enabled_rules, disabled_rules)
+        enabled_rules.difference(&disabled_rules).cloned().collect()
     }
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Rules {
-    #[doc = r" It enables a preset of rules of any group recommended by Rome. `true` by default."]
+    #[doc = r" It enables the lint rules recommended by Rome. `true` by default."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recommended: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -38,81 +38,82 @@ impl Rules {
     #[doc = r" Only one element of the tuple is [Some] at the time."]
     #[doc = r""]
     #[doc = r" The enabled rules are calculated from the difference with the disabled rules."]
-    pub fn as_analysis_filters(
-        &self,
-    ) -> (Option<IndexSet<RuleFilter>>, Option<IndexSet<RuleFilter>>) {
+    pub fn as_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut enabled_rules = IndexSet::new();
         let mut disabled_rules = IndexSet::new();
-        if self.is_recommended() {
+        if let Some(group) = self.js.as_ref() {
+            if self.is_recommended() && group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        } else if self.is_recommended() {
             enabled_rules.extend(Js::RECOMMENDED_RULES);
+        }
+        if let Some(group) = self.jsx.as_ref() {
+            if self.is_recommended() && group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        } else if self.is_recommended() {
             enabled_rules.extend(Jsx::RECOMMENDED_RULES);
+        }
+        if let Some(group) = self.regex.as_ref() {
+            if self.is_recommended() && group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        } else if self.is_recommended() {
             enabled_rules.extend(Regex::RECOMMENDED_RULES);
+        }
+        if let Some(group) = self.ts.as_ref() {
+            if self.is_recommended() && group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        } else if self.is_recommended() {
             enabled_rules.extend(Ts::RECOMMENDED_RULES);
         }
         if let Some(group) = self.js.as_ref() {
-            if group.is_recommended() {
+            if self.is_recommended() && group.is_recommended() {
                 enabled_rules.extend(&Js::RECOMMENDED_RULES);
             }
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
+        } else if self.is_recommended() {
+            enabled_rules.extend(Js::RECOMMENDED_RULES);
         }
         if let Some(group) = self.jsx.as_ref() {
-            if group.is_recommended() {
+            if self.is_recommended() && group.is_recommended() {
                 enabled_rules.extend(&Js::RECOMMENDED_RULES);
             }
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
+        } else if self.is_recommended() {
+            enabled_rules.extend(Jsx::RECOMMENDED_RULES);
         }
         if let Some(group) = self.regex.as_ref() {
-            if group.is_recommended() {
+            if self.is_recommended() && group.is_recommended() {
                 enabled_rules.extend(&Js::RECOMMENDED_RULES);
             }
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
+        } else if self.is_recommended() {
+            enabled_rules.extend(Regex::RECOMMENDED_RULES);
         }
         if let Some(group) = self.ts.as_ref() {
-            if group.is_recommended() {
+            if self.is_recommended() && group.is_recommended() {
                 enabled_rules.extend(&Js::RECOMMENDED_RULES);
             }
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
+        } else if self.is_recommended() {
+            enabled_rules.extend(Ts::RECOMMENDED_RULES);
         }
-        if let Some(group) = self.js.as_ref() {
-            if group.is_recommended() {
-                enabled_rules.extend(&Js::RECOMMENDED_RULES);
-            }
-            enabled_rules.extend(&group.get_enabled_rules());
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.jsx.as_ref() {
-            if group.is_recommended() {
-                enabled_rules.extend(&Js::RECOMMENDED_RULES);
-            }
-            enabled_rules.extend(&group.get_enabled_rules());
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.regex.as_ref() {
-            if group.is_recommended() {
-                enabled_rules.extend(&Js::RECOMMENDED_RULES);
-            }
-            enabled_rules.extend(&group.get_enabled_rules());
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if let Some(group) = self.ts.as_ref() {
-            if group.is_recommended() {
-                enabled_rules.extend(&Js::RECOMMENDED_RULES);
-            }
-            enabled_rules.extend(&group.get_enabled_rules());
-            disabled_rules.extend(&group.get_disabled_rules());
-        }
-        if enabled_rules.len() > disabled_rules.len() {
-            (None, Some(disabled_rules))
-        } else {
-            (
-                Some(enabled_rules.difference(&disabled_rules).cloned().collect()),
-                None,
-            )
-        }
+        enabled_rules.difference(&disabled_rules).cloned().collect()
     }
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -1,100 +1,387 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::RuleConfiguration;
+use crate::{ConfigurationError, RomeError, RuleConfiguration};
+use indexmap::{IndexMap, IndexSet};
+use rome_analyze::RuleFilter;
 use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Rules {
+    #[doc = r" It enables a preset of rules of any group recommended by Rome. `true` by default."]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub js: Option<JsRules>,
+    pub recommended: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jsx: Option<JsxRules>,
+    pub js: Option<Js>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regex: Option<RegexRules>,
+    pub jsx: Option<Jsx>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ts: Option<TsRules>,
+    pub regex: Option<Regex>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ts: Option<Ts>,
 }
 impl Default for Rules {
     fn default() -> Self {
         Self {
-            js: Some(JsRules::default()),
-            jsx: Some(JsxRules::default()),
-            regex: Some(RegexRules::default()),
-            ts: Some(TsRules::default()),
+            recommended: Some(true),
+            js: None,
+            jsx: None,
+            regex: None,
+            ts: None,
         }
+    }
+}
+impl Rules {
+    pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
+    #[doc = r" It returns a tuple of filters. The first element of the tuple are the enabled filters,"]
+    #[doc = r" while the second element are the disabled filters."]
+    #[doc = r""]
+    #[doc = r" The enabled filters are calculated from the difference with the disabled filters."]
+    pub fn as_analysis_filters(&self) -> (IndexSet<RuleFilter>, IndexSet<RuleFilter>) {
+        let mut enabled_rules = IndexSet::new();
+        let mut disabled_rules = IndexSet::new();
+        if self.is_recommended() {
+            enabled_rules.extend(Js::RECOMMENDED_RULES);
+            enabled_rules.extend(Jsx::RECOMMENDED_RULES);
+            enabled_rules.extend(Regex::RECOMMENDED_RULES);
+            enabled_rules.extend(Ts::RECOMMENDED_RULES);
+        }
+        if let Some(group) = self.js.as_ref() {
+            if group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        }
+        if let Some(group) = self.jsx.as_ref() {
+            if group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        }
+        if let Some(group) = self.regex.as_ref() {
+            if group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        }
+        if let Some(group) = self.ts.as_ref() {
+            if group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        }
+        if let Some(group) = self.js.as_ref() {
+            if group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        }
+        if let Some(group) = self.jsx.as_ref() {
+            if group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        }
+        if let Some(group) = self.regex.as_ref() {
+            if group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        }
+        if let Some(group) = self.ts.as_ref() {
+            if group.is_recommended() {
+                enabled_rules.extend(&Js::RECOMMENDED_RULES);
+            }
+            enabled_rules.extend(&group.get_enabled_rules());
+            disabled_rules.extend(&group.get_disabled_rules());
+        }
+        let enabled_rules = enabled_rules.difference(&disabled_rules).cloned().collect();
+        (enabled_rules, disabled_rules)
     }
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-pub struct JsRules {
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_arguments: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_async_promise_executor: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_catch_assign: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_compare_neg_zero: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_dead_code: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_debugger: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_delete: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_double_equals: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_empty_pattern: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_function_assign: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_label_var: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_negation_else: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_shouty_constants: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_sparse_array: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_unnecessary_continue: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_unsafe_negation: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_unused_template_literal: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub use_block_statements: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub use_simplified_logic_expression: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub use_single_case_statement: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub use_single_var_declarator: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub use_template: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub use_valid_typeof: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub use_while: RuleConfiguration,
+pub struct Js {
+    #[doc = r" It enables the recommended rules for this group"]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended: Option<bool>,
+    #[doc = r" List of rules for the current group"]
+    #[serde(
+        skip_serializing_if = "IndexMap::is_empty",
+        deserialize_with = "deserialize_js_rules"
+    )]
+    pub rules: IndexMap<String, RuleConfiguration>,
+}
+impl Js {
+    const GROUP_NAME: &'static str = "js";
+    pub(crate) const GROUP_RULES: [&'static str; 24] = [
+        "noArguments",
+        "noAsyncPromiseExecutor",
+        "noCatchAssign",
+        "noCompareNegZero",
+        "noDeadCode",
+        "noDebugger",
+        "noDelete",
+        "noDoubleEquals",
+        "noEmptyPattern",
+        "noFunctionAssign",
+        "noLabelVar",
+        "noNegationElse",
+        "noShoutyConstants",
+        "noSparseArray",
+        "noUnnecessaryContinue",
+        "noUnsafeNegation",
+        "noUnusedTemplateLiteral",
+        "useBlockStatements",
+        "useSimplifiedLogicExpression",
+        "useSingleCaseStatement",
+        "useSingleVarDeclarator",
+        "useTemplate",
+        "useValidTypeof",
+        "useWhile",
+    ];
+    const RECOMMENDED_RULES: [RuleFilter<'static>; 23] = [
+        RuleFilter::Rule("js", Self::GROUP_RULES[0]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[1]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[2]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[3]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[5]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[6]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[7]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[8]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[9]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[10]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[11]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[12]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[13]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[14]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[15]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[16]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[17]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[18]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[19]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[20]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[21]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[22]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[23]),
+    ];
+    pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
+    pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
+        IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+            if conf.is_enabled() {
+                Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+            } else {
+                None
+            }
+        }))
+    }
+    pub(crate) fn get_disabled_rules(&self) -> IndexSet<RuleFilter> {
+        IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+            if conf.is_disabled() {
+                Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+            } else {
+                None
+            }
+        }))
+    }
+}
+fn deserialize_js_rules<'de, D>(
+    deserializer: D,
+) -> Result<IndexMap<String, RuleConfiguration>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let value: IndexMap<String, RuleConfiguration> = Deserialize::deserialize(deserializer)?;
+    for rule_name in value.keys() {
+        if !Js::GROUP_RULES.contains(&rule_name.as_str()) {
+            return Err(serde::de::Error::custom(RomeError::Configuration(
+                ConfigurationError::DeserializationError(format!(
+                    "Invalid rule name `{rule_name}`"
+                )),
+            )));
+        }
+    }
+    Ok(value)
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-pub struct JsxRules {
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_comment_text: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_implicit_boolean: RuleConfiguration,
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub use_self_closing_elements: RuleConfiguration,
+pub struct Jsx {
+    #[doc = r" It enables the recommended rules for this group"]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended: Option<bool>,
+    #[doc = r" List of rules for the current group"]
+    #[serde(
+        skip_serializing_if = "IndexMap::is_empty",
+        deserialize_with = "deserialize_jsx_rules"
+    )]
+    pub rules: IndexMap<String, RuleConfiguration>,
+}
+impl Jsx {
+    const GROUP_NAME: &'static str = "jsx";
+    pub(crate) const GROUP_RULES: [&'static str; 3] = [
+        "noCommentText",
+        "noImplicitBoolean",
+        "useSelfClosingElements",
+    ];
+    const RECOMMENDED_RULES: [RuleFilter<'static>; 3] = [
+        RuleFilter::Rule("jsx", Self::GROUP_RULES[0]),
+        RuleFilter::Rule("jsx", Self::GROUP_RULES[1]),
+        RuleFilter::Rule("jsx", Self::GROUP_RULES[2]),
+    ];
+    pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
+    pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
+        IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+            if conf.is_enabled() {
+                Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+            } else {
+                None
+            }
+        }))
+    }
+    pub(crate) fn get_disabled_rules(&self) -> IndexSet<RuleFilter> {
+        IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+            if conf.is_disabled() {
+                Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+            } else {
+                None
+            }
+        }))
+    }
+}
+fn deserialize_jsx_rules<'de, D>(
+    deserializer: D,
+) -> Result<IndexMap<String, RuleConfiguration>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let value: IndexMap<String, RuleConfiguration> = Deserialize::deserialize(deserializer)?;
+    for rule_name in value.keys() {
+        if !Jsx::GROUP_RULES.contains(&rule_name.as_str()) {
+            return Err(serde::de::Error::custom(RomeError::Configuration(
+                ConfigurationError::DeserializationError(format!(
+                    "Invalid rule name `{rule_name}`"
+                )),
+            )));
+        }
+    }
+    Ok(value)
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-pub struct RegexRules {
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub no_multiple_spaces_in_regular_expression_literals: RuleConfiguration,
+pub struct Regex {
+    #[doc = r" It enables the recommended rules for this group"]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended: Option<bool>,
+    #[doc = r" List of rules for the current group"]
+    #[serde(
+        skip_serializing_if = "IndexMap::is_empty",
+        deserialize_with = "deserialize_regex_rules"
+    )]
+    pub rules: IndexMap<String, RuleConfiguration>,
+}
+impl Regex {
+    const GROUP_NAME: &'static str = "regex";
+    pub(crate) const GROUP_RULES: [&'static str; 1] =
+        ["noMultipleSpacesInRegularExpressionLiterals"];
+    const RECOMMENDED_RULES: [RuleFilter<'static>; 1] =
+        [RuleFilter::Rule("regex", Self::GROUP_RULES[0])];
+    pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
+    pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
+        IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+            if conf.is_enabled() {
+                Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+            } else {
+                None
+            }
+        }))
+    }
+    pub(crate) fn get_disabled_rules(&self) -> IndexSet<RuleFilter> {
+        IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+            if conf.is_disabled() {
+                Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+            } else {
+                None
+            }
+        }))
+    }
+}
+fn deserialize_regex_rules<'de, D>(
+    deserializer: D,
+) -> Result<IndexMap<String, RuleConfiguration>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let value: IndexMap<String, RuleConfiguration> = Deserialize::deserialize(deserializer)?;
+    for rule_name in value.keys() {
+        if !Regex::GROUP_RULES.contains(&rule_name.as_str()) {
+            return Err(serde::de::Error::custom(RomeError::Configuration(
+                ConfigurationError::DeserializationError(format!(
+                    "Invalid rule name `{rule_name}`"
+                )),
+            )));
+        }
+    }
+    Ok(value)
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-pub struct TsRules {
-    #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-    pub use_shorthand_array_type: RuleConfiguration,
+pub struct Ts {
+    #[doc = r" It enables the recommended rules for this group"]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended: Option<bool>,
+    #[doc = r" List of rules for the current group"]
+    #[serde(
+        skip_serializing_if = "IndexMap::is_empty",
+        deserialize_with = "deserialize_ts_rules"
+    )]
+    pub rules: IndexMap<String, RuleConfiguration>,
+}
+impl Ts {
+    const GROUP_NAME: &'static str = "ts";
+    pub(crate) const GROUP_RULES: [&'static str; 1] = ["useShorthandArrayType"];
+    const RECOMMENDED_RULES: [RuleFilter<'static>; 1] =
+        [RuleFilter::Rule("ts", Self::GROUP_RULES[0])];
+    pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
+    pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
+        IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+            if conf.is_enabled() {
+                Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+            } else {
+                None
+            }
+        }))
+    }
+    pub(crate) fn get_disabled_rules(&self) -> IndexSet<RuleFilter> {
+        IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+            if conf.is_disabled() {
+                Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+            } else {
+                None
+            }
+        }))
+    }
+}
+fn deserialize_ts_rules<'de, D>(
+    deserializer: D,
+) -> Result<IndexMap<String, RuleConfiguration>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let value: IndexMap<String, RuleConfiguration> = Deserialize::deserialize(deserializer)?;
+    for rule_name in value.keys() {
+        if !Ts::GROUP_RULES.contains(&rule_name.as_str()) {
+            return Err(serde::de::Error::custom(RomeError::Configuration(
+                ConfigurationError::DeserializationError(format!(
+                    "Invalid rule name `{rule_name}`"
+                )),
+            )));
+        }
+    }
+    Ok(value)
 }

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -32,11 +32,15 @@ impl Default for Rules {
 }
 impl Rules {
     pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
-    #[doc = r" It returns a tuple of filters. The first element of the tuple are the enabled filters,"]
-    #[doc = r" while the second element are the disabled filters."]
+    #[doc = r" It returns a tuple of filters. The first element of the tuple are the enabled rules,"]
+    #[doc = r" while the second element are the disabled rules."]
     #[doc = r""]
-    #[doc = r" The enabled filters are calculated from the difference with the disabled filters."]
-    pub fn as_enabled_rules(&self) -> IndexSet<RuleFilter> {
+    #[doc = r" Only one element of the tuple is [Some] at the time."]
+    #[doc = r""]
+    #[doc = r" The enabled rules are calculated from the difference with the disabled rules."]
+    pub fn as_analysis_filters(
+        &self,
+    ) -> (Option<IndexSet<RuleFilter>>, Option<IndexSet<RuleFilter>>) {
         let mut enabled_rules = IndexSet::new();
         let mut disabled_rules = IndexSet::new();
         if self.is_recommended() {
@@ -101,7 +105,14 @@ impl Rules {
             enabled_rules.extend(&group.get_enabled_rules());
             disabled_rules.extend(&group.get_disabled_rules());
         }
-        enabled_rules.difference(&disabled_rules).cloned().collect()
+        if enabled_rules.len() > disabled_rules.len() {
+            (None, Some(disabled_rules))
+        } else {
+            (
+                Some(enabled_rules.difference(&disabled_rules).cloned().collect()),
+                None,
+            )
+        }
     }
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -126,28 +126,9 @@ fn debug_print(_rome_path: &RomePath, parse: AnyParse) -> String {
     format!("{tree:#?}")
 }
 
-fn lint(
-    rome_path: &RomePath,
-    parse: AnyParse,
-    categories: RuleCategories,
-    rules: Option<&Rules>,
-) -> Vec<Diagnostic> {
+fn lint(rome_path: &RomePath, parse: AnyParse, filter: AnalysisFilter) -> Vec<Diagnostic> {
     let tree = parse.tree();
     let mut diagnostics = parse.into_diagnostics();
-
-    let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
-        let enabled: IndexSet<RuleFilter> = rules.as_enabled_rules();
-        Some(enabled.into_iter().collect())
-    } else {
-        None
-    };
-
-    let mut filter = match &enabled_rules {
-        Some(rules) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
-        _ => AnalysisFilter::default(),
-    };
-
-    filter.categories = categories;
 
     let file_id = rome_path.file_id();
     analyze(file_id, &tree, filter, |signal| {

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -129,27 +129,20 @@ fn lint(
     rome_path: &RomePath,
     parse: AnyParse,
     categories: RuleCategories,
-    rules: &Option<Rules>,
+    rules: Option<&Rules>,
 ) -> Vec<Diagnostic> {
     let tree = parse.tree();
     let mut diagnostics = parse.into_diagnostics();
 
     let mut enabled_rules = Vec::new();
-    let mut disabled_rules = Vec::new();
 
     if let Some(rules) = rules {
-        let (enabled, disabled) = rules.as_analysis_filters();
+        let enabled = rules.as_enabled_rules();
         for enabled_rule in enabled {
             enabled_rules.push(enabled_rule)
         }
-        for disabled_rule in disabled {
-            disabled_rules.push(disabled_rule)
-        }
     }
-    let mut filter = AnalysisFilter::new_from_filters(
-        Some(enabled_rules.as_slice()),
-        Some(disabled_rules.as_slice()),
-    );
+    let mut filter = AnalysisFilter::from_enabled_rules(Some(enabled_rules.as_slice()));
 
     filter.categories = categories;
 
@@ -173,27 +166,20 @@ fn code_actions(
     rome_path: &RomePath,
     parse: AnyParse,
     range: TextRange,
-    rules: &Option<Rules>,
+    rules: Option<&Rules>,
 ) -> PullActionsResult {
     let tree = parse.tree();
 
     let mut enabled_rules = Vec::new();
-    let mut disabled_rules = Vec::new();
     let mut actions = Vec::new();
 
     if let Some(rules) = rules {
-        let (enabled, disabled) = rules.as_analysis_filters();
+        let enabled = rules.as_enabled_rules();
         for enabled_rule in enabled {
             enabled_rules.push(enabled_rule)
         }
-        for disabled_rule in disabled {
-            disabled_rules.push(disabled_rule)
-        }
     }
-    let mut filter = AnalysisFilter::new_from_filters(
-        Some(enabled_rules.as_slice()),
-        Some(disabled_rules.as_slice()),
-    );
+    let mut filter = AnalysisFilter::from_enabled_rules(Some(enabled_rules.as_slice()));
 
     filter.categories = RuleCategories::default();
     filter.range = Some(range);
@@ -217,26 +203,19 @@ fn code_actions(
 fn fix_all(
     rome_path: &RomePath,
     parse: AnyParse,
-    configuration_rules: &Option<Rules>,
+    configuration_rules: Option<&Rules>,
 ) -> FixFileResult {
     let mut tree: JsAnyRoot = parse.tree();
     let mut actions = Vec::new();
     let mut enabled_rules = Vec::new();
-    let mut disabled_rules = Vec::new();
 
     if let Some(rules) = configuration_rules {
-        let (enabled, disabled) = rules.as_analysis_filters();
+        let enabled = rules.as_enabled_rules();
         for enabled_rule in enabled {
             enabled_rules.push(enabled_rule)
         }
-        for disabled_rule in disabled {
-            disabled_rules.push(disabled_rule)
-        }
     }
-    let mut filter = AnalysisFilter::new_from_filters(
-        Some(enabled_rules.as_slice()),
-        Some(disabled_rules.as_slice()),
-    );
+    let mut filter = AnalysisFilter::from_enabled_rules(Some(enabled_rules.as_slice()));
 
     filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -1,4 +1,4 @@
-use rome_analyze::{AnalysisFilter, ControlFlow, Never, RuleCategories};
+use rome_analyze::{AnalysisFilter, ControlFlow, Never, RuleCategories, RuleFilter};
 use rome_diagnostics::{Applicability, CodeSuggestion, Diagnostic};
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
@@ -19,6 +19,7 @@ use crate::{
 };
 
 use super::{ExtensionHandler, Mime};
+use indexmap::IndexSet;
 use std::borrow::Cow;
 use std::fmt::Debug;
 
@@ -134,16 +135,23 @@ fn lint(
     let tree = parse.tree();
     let mut diagnostics = parse.into_diagnostics();
 
-    let mut enabled_rules = Vec::new();
+    let (enabled_rules, disabled_rules): (Option<Vec<RuleFilter>>, Option<Vec<RuleFilter>>) =
+        if let Some(rules) = rules {
+            let (enabled, disabled): (Option<IndexSet<RuleFilter>>, Option<IndexSet<RuleFilter>>) =
+                rules.as_analysis_filters();
+            (
+                enabled.map(|rules| rules.into_iter().collect()),
+                disabled.map(|rules| rules.into_iter().collect::<Vec<RuleFilter>>()),
+            )
+        } else {
+            (None, None)
+        };
 
-    if let Some(rules) = rules {
-        let enabled = rules.as_enabled_rules();
-        for enabled_rule in enabled {
-            enabled_rules.push(enabled_rule)
-        }
-    }
-    let mut filter = AnalysisFilter::from_enabled_rules(Some(enabled_rules.as_slice()));
-
+    let mut filter = match (&enabled_rules, &disabled_rules) {
+        (None, Some(rules)) => AnalysisFilter::from_disabled_rules(Some(rules.as_slice())),
+        (Some(rules), None) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
+        _ => AnalysisFilter::default(),
+    };
     filter.categories = categories;
 
     let file_id = rome_path.file_id();
@@ -170,16 +178,25 @@ fn code_actions(
 ) -> PullActionsResult {
     let tree = parse.tree();
 
-    let mut enabled_rules = Vec::new();
     let mut actions = Vec::new();
 
-    if let Some(rules) = rules {
-        let enabled = rules.as_enabled_rules();
-        for enabled_rule in enabled {
-            enabled_rules.push(enabled_rule)
-        }
-    }
-    let mut filter = AnalysisFilter::from_enabled_rules(Some(enabled_rules.as_slice()));
+    let (enabled_rules, disabled_rules): (Option<Vec<RuleFilter>>, Option<Vec<RuleFilter>>) =
+        if let Some(rules) = rules {
+            let (enabled, disabled): (Option<IndexSet<RuleFilter>>, Option<IndexSet<RuleFilter>>) =
+                rules.as_analysis_filters();
+            (
+                enabled.map(|rules| rules.into_iter().collect()),
+                disabled.map(|rules| rules.into_iter().collect::<Vec<RuleFilter>>()),
+            )
+        } else {
+            (None, None)
+        };
+
+    let mut filter = match (&enabled_rules, &disabled_rules) {
+        (None, Some(rules)) => AnalysisFilter::from_disabled_rules(Some(rules.as_slice())),
+        (Some(rules), None) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
+        _ => AnalysisFilter::default(),
+    };
 
     filter.categories = RuleCategories::default();
     filter.range = Some(range);
@@ -207,16 +224,24 @@ fn fix_all(
 ) -> FixFileResult {
     let mut tree: JsAnyRoot = parse.tree();
     let mut actions = Vec::new();
-    let mut enabled_rules = Vec::new();
 
-    if let Some(rules) = configuration_rules {
-        let enabled = rules.as_enabled_rules();
-        for enabled_rule in enabled {
-            enabled_rules.push(enabled_rule)
-        }
-    }
-    let mut filter = AnalysisFilter::from_enabled_rules(Some(enabled_rules.as_slice()));
+    let (enabled_rules, disabled_rules): (Option<Vec<RuleFilter>>, Option<Vec<RuleFilter>>) =
+        if let Some(rules) = configuration_rules {
+            let (enabled, disabled): (Option<IndexSet<RuleFilter>>, Option<IndexSet<RuleFilter>>) =
+                rules.as_analysis_filters();
+            (
+                enabled.map(|rules| rules.into_iter().collect()),
+                disabled.map(|rules| rules.into_iter().collect::<Vec<RuleFilter>>()),
+            )
+        } else {
+            (None, None)
+        };
 
+    let mut filter = match (&enabled_rules, &disabled_rules) {
+        (Some(rules), None) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
+        (None, Some(rules)) => AnalysisFilter::from_disabled_rules(Some(rules.as_slice())),
+        _ => AnalysisFilter::default(),
+    };
     filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
 
     let file_id = rome_path.file_id();

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -135,23 +135,18 @@ fn lint(
     let tree = parse.tree();
     let mut diagnostics = parse.into_diagnostics();
 
-    let (enabled_rules, disabled_rules): (Option<Vec<RuleFilter>>, Option<Vec<RuleFilter>>) =
-        if let Some(rules) = rules {
-            let (enabled, disabled): (Option<IndexSet<RuleFilter>>, Option<IndexSet<RuleFilter>>) =
-                rules.as_analysis_filters();
-            (
-                enabled.map(|rules| rules.into_iter().collect()),
-                disabled.map(|rules| rules.into_iter().collect::<Vec<RuleFilter>>()),
-            )
-        } else {
-            (None, None)
-        };
+    let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
+        let enabled: IndexSet<RuleFilter> = rules.as_enabled_rules();
+        Some(enabled.into_iter().collect())
+    } else {
+        None
+    };
 
-    let mut filter = match (&enabled_rules, &disabled_rules) {
-        (None, Some(rules)) => AnalysisFilter::from_disabled_rules(Some(rules.as_slice())),
-        (Some(rules), None) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
+    let mut filter = match &enabled_rules {
+        Some(rules) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
         _ => AnalysisFilter::default(),
     };
+
     filter.categories = categories;
 
     let file_id = rome_path.file_id();
@@ -180,21 +175,15 @@ fn code_actions(
 
     let mut actions = Vec::new();
 
-    let (enabled_rules, disabled_rules): (Option<Vec<RuleFilter>>, Option<Vec<RuleFilter>>) =
-        if let Some(rules) = rules {
-            let (enabled, disabled): (Option<IndexSet<RuleFilter>>, Option<IndexSet<RuleFilter>>) =
-                rules.as_analysis_filters();
-            (
-                enabled.map(|rules| rules.into_iter().collect()),
-                disabled.map(|rules| rules.into_iter().collect::<Vec<RuleFilter>>()),
-            )
-        } else {
-            (None, None)
-        };
+    let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
+        let enabled: IndexSet<RuleFilter> = rules.as_enabled_rules();
+        Some(enabled.into_iter().collect())
+    } else {
+        None
+    };
 
-    let mut filter = match (&enabled_rules, &disabled_rules) {
-        (None, Some(rules)) => AnalysisFilter::from_disabled_rules(Some(rules.as_slice())),
-        (Some(rules), None) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
+    let mut filter = match &enabled_rules {
+        Some(rules) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
         _ => AnalysisFilter::default(),
     };
 
@@ -225,23 +214,18 @@ fn fix_all(
     let mut tree: JsAnyRoot = parse.tree();
     let mut actions = Vec::new();
 
-    let (enabled_rules, disabled_rules): (Option<Vec<RuleFilter>>, Option<Vec<RuleFilter>>) =
-        if let Some(rules) = configuration_rules {
-            let (enabled, disabled): (Option<IndexSet<RuleFilter>>, Option<IndexSet<RuleFilter>>) =
-                rules.as_analysis_filters();
-            (
-                enabled.map(|rules| rules.into_iter().collect()),
-                disabled.map(|rules| rules.into_iter().collect::<Vec<RuleFilter>>()),
-            )
-        } else {
-            (None, None)
-        };
+    let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = configuration_rules {
+        let enabled: IndexSet<RuleFilter> = rules.as_enabled_rules();
+        Some(enabled.into_iter().collect())
+    } else {
+        None
+    };
 
-    let mut filter = match (&enabled_rules, &disabled_rules) {
-        (Some(rules), None) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
-        (None, Some(rules)) => AnalysisFilter::from_disabled_rules(Some(rules.as_slice())),
+    let mut filter = match &enabled_rules {
+        Some(rules) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
         _ => AnalysisFilter::default(),
     };
+
     filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
 
     let file_id = rome_path.file_id();

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -1,6 +1,6 @@
 use rome_analyze::{AnalysisFilter, ControlFlow, Never, RuleCategories};
 use rome_diagnostics::{Applicability, CodeSuggestion, Diagnostic};
-use rome_formatter::{IndentStyle, LineWidth, Printed};
+use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
 use rome_js_analyze::analyze;
 use rome_js_analyze::utils::rename::RenameError;
@@ -15,7 +15,7 @@ use crate::workspace::{CodeAction, FixAction, FixFileResult, PullActionsResult, 
 use crate::{
     settings::{FormatSettings, Language, LanguageSettings, LanguagesSettings, SettingsHandle},
     workspace::server::AnyParse,
-    RomeError,
+    RomeError, Rules,
 };
 
 use super::{ExtensionHandler, Mime};
@@ -28,8 +28,6 @@ use std::fmt::Debug;
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct JsFormatSettings {
-    pub indent_style: Option<IndentStyle>,
-    pub line_width: Option<LineWidth>,
     pub quote_style: Option<QuoteStyle>,
 }
 
@@ -58,18 +56,8 @@ impl Language for JsLanguage {
         path: &RomePath,
     ) -> JsFormatContext {
         JsFormatContext::new(path.as_path().try_into().unwrap_or_default())
-            .with_indent_style(
-                language
-                    .indent_style
-                    .or(global.indent_style)
-                    .unwrap_or(editor),
-            )
-            .with_line_width(
-                language
-                    .line_width
-                    .or(global.line_width)
-                    .unwrap_or_default(),
-            )
+            .with_indent_style(global.indent_style.unwrap_or(editor))
+            .with_line_width(global.line_width.unwrap_or_default())
             .with_quote_style(language.quote_style.unwrap_or_default())
     }
 }
@@ -137,14 +125,33 @@ fn debug_print(_rome_path: &RomePath, parse: AnyParse) -> String {
     format!("{tree:#?}")
 }
 
-fn lint(rome_path: &RomePath, parse: AnyParse, categories: RuleCategories) -> Vec<Diagnostic> {
+fn lint(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    categories: RuleCategories,
+    rules: &Option<Rules>,
+) -> Vec<Diagnostic> {
     let tree = parse.tree();
     let mut diagnostics = parse.into_diagnostics();
 
-    let filter = AnalysisFilter {
-        categories,
-        ..AnalysisFilter::default()
-    };
+    let mut enabled_rules = Vec::new();
+    let mut disabled_rules = Vec::new();
+
+    if let Some(rules) = rules {
+        let (enabled, disabled) = rules.as_analysis_filters();
+        for enabled_rule in enabled {
+            enabled_rules.push(enabled_rule)
+        }
+        for disabled_rule in disabled {
+            disabled_rules.push(disabled_rule)
+        }
+    }
+    let mut filter = AnalysisFilter::new_from_filters(
+        Some(enabled_rules.as_slice()),
+        Some(disabled_rules.as_slice()),
+    );
+
+    filter.categories = categories;
 
     let file_id = rome_path.file_id();
     analyze(file_id, &tree, filter, |signal| {
@@ -162,15 +169,34 @@ fn lint(rome_path: &RomePath, parse: AnyParse, categories: RuleCategories) -> Ve
     diagnostics
 }
 
-fn code_actions(rome_path: &RomePath, parse: AnyParse, range: TextRange) -> PullActionsResult {
+fn code_actions(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    range: TextRange,
+    rules: &Option<Rules>,
+) -> PullActionsResult {
     let tree = parse.tree();
 
+    let mut enabled_rules = Vec::new();
+    let mut disabled_rules = Vec::new();
     let mut actions = Vec::new();
 
-    let filter = AnalysisFilter {
-        range: Some(range),
-        ..AnalysisFilter::default()
-    };
+    if let Some(rules) = rules {
+        let (enabled, disabled) = rules.as_analysis_filters();
+        for enabled_rule in enabled {
+            enabled_rules.push(enabled_rule)
+        }
+        for disabled_rule in disabled {
+            disabled_rules.push(disabled_rule)
+        }
+    }
+    let mut filter = AnalysisFilter::new_from_filters(
+        Some(enabled_rules.as_slice()),
+        Some(disabled_rules.as_slice()),
+    );
+
+    filter.categories = RuleCategories::default();
+    filter.range = Some(range);
 
     let file_id = rome_path.file_id();
     analyze(file_id, &tree, filter, |signal| {
@@ -188,14 +214,31 @@ fn code_actions(rome_path: &RomePath, parse: AnyParse, range: TextRange) -> Pull
     PullActionsResult { actions }
 }
 
-fn fix_all(rome_path: &RomePath, parse: AnyParse) -> FixFileResult {
+fn fix_all(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    configuration_rules: &Option<Rules>,
+) -> FixFileResult {
     let mut tree: JsAnyRoot = parse.tree();
     let mut actions = Vec::new();
+    let mut enabled_rules = Vec::new();
+    let mut disabled_rules = Vec::new();
 
-    let filter = AnalysisFilter {
-        categories: RuleCategories::SYNTAX | RuleCategories::LINT,
-        ..AnalysisFilter::default()
-    };
+    if let Some(rules) = configuration_rules {
+        let (enabled, disabled) = rules.as_analysis_filters();
+        for enabled_rule in enabled {
+            enabled_rules.push(enabled_rule)
+        }
+        for disabled_rule in disabled {
+            disabled_rules.push(disabled_rule)
+        }
+    }
+    let mut filter = AnalysisFilter::new_from_filters(
+        Some(enabled_rules.as_slice()),
+        Some(disabled_rules.as_slice()),
+    );
+
+    filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
 
     let file_id = rome_path.file_id();
 

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{TextRange, TextSize};
 use crate::{
     settings::SettingsHandle,
     workspace::{server::AnyParse, FixFileResult, PullActionsResult, RenameResult},
-    RomeError,
+    RomeError, Rules,
 };
 
 use self::{javascript::JsFileHandler, json::JsonFileHandler, unknown::UnknownFileHandler};
@@ -73,9 +73,9 @@ impl std::fmt::Display for Mime {
 
 type Parse = fn(&RomePath, &str) -> AnyParse;
 type DebugPrint = fn(&RomePath, AnyParse) -> String;
-type Lint = fn(&RomePath, AnyParse, RuleCategories) -> Vec<Diagnostic>;
-type CodeActions = fn(&RomePath, AnyParse, TextRange) -> PullActionsResult;
-type FixAll = fn(&RomePath, AnyParse) -> FixFileResult;
+type Lint = fn(&RomePath, AnyParse, RuleCategories, &Option<Rules>) -> Vec<Diagnostic>;
+type CodeActions = fn(&RomePath, AnyParse, TextRange, &Option<Rules>) -> PullActionsResult;
+type FixAll = fn(&RomePath, AnyParse, &Option<Rules>) -> FixFileResult;
 type Format = fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>) -> Result<Printed, RomeError>;
 type FormatRange =
     fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>, TextRange) -> Result<Printed, RomeError>;

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -73,9 +73,9 @@ impl std::fmt::Display for Mime {
 
 type Parse = fn(&RomePath, &str) -> AnyParse;
 type DebugPrint = fn(&RomePath, AnyParse) -> String;
-type Lint = fn(&RomePath, AnyParse, RuleCategories, &Option<Rules>) -> Vec<Diagnostic>;
-type CodeActions = fn(&RomePath, AnyParse, TextRange, &Option<Rules>) -> PullActionsResult;
-type FixAll = fn(&RomePath, AnyParse, &Option<Rules>) -> FixFileResult;
+type Lint = fn(&RomePath, AnyParse, RuleCategories, Option<&Rules>) -> Vec<Diagnostic>;
+type CodeActions = fn(&RomePath, AnyParse, TextRange, Option<&Rules>) -> PullActionsResult;
+type FixAll = fn(&RomePath, AnyParse, Option<&Rules>) -> FixFileResult;
 type Format = fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>) -> Result<Printed, RomeError>;
 type FormatRange =
     fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>, TextRange) -> Result<Printed, RomeError>;

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -1,10 +1,9 @@
-use std::ffi::OsStr;
-
-use rome_analyze::RuleCategories;
+use rome_analyze::AnalysisFilter;
 use rome_diagnostics::Diagnostic;
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
 use rome_js_syntax::{TextRange, TextSize};
+use std::ffi::OsStr;
 
 use crate::{
     settings::SettingsHandle,
@@ -73,7 +72,7 @@ impl std::fmt::Display for Mime {
 
 type Parse = fn(&RomePath, &str) -> AnyParse;
 type DebugPrint = fn(&RomePath, AnyParse) -> String;
-type Lint = fn(&RomePath, AnyParse, RuleCategories, Option<&Rules>) -> Vec<Diagnostic>;
+type Lint = fn(&RomePath, AnyParse, AnalysisFilter) -> Vec<Diagnostic>;
 type CodeActions = fn(&RomePath, AnyParse, TextRange, Option<&Rules>) -> PullActionsResult;
 type FixAll = fn(&RomePath, AnyParse, Option<&Rules>) -> FixFileResult;
 type Format = fn(&RomePath, AnyParse, SettingsHandle<IndentStyle>) -> Result<Printed, RomeError>;

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -1,10 +1,9 @@
-use indexmap::IndexSet;
-use std::sync::{RwLock, RwLockReadGuard};
-
 use crate::{Configuration, Rules};
+use indexmap::IndexSet;
 use rome_formatter::{IndentStyle, LineWidth};
 use rome_fs::RomePath;
 use rome_js_syntax::JsLanguage;
+use std::sync::{RwLock, RwLockReadGuard};
 
 /// Global settings for the entire workspace
 #[derive(Debug, Default)]
@@ -25,7 +24,7 @@ impl WorkspaceSettings {
     /// The (configuration)[Configuration] is merged into the workspace
     pub fn merge_with_configuration(&mut self, configuration: Configuration) {
         // formatter part
-        if let Some(formatter) = &configuration.formatter {
+        if let Some(formatter) = configuration.formatter {
             self.format = FormatSettings::from(formatter);
         }
         let formatter = configuration
@@ -37,7 +36,7 @@ impl WorkspaceSettings {
         }
 
         // linter part
-        if let Some(linter) = &configuration.linter {
+        if let Some(linter) = configuration.linter {
             self.linter = LinterSettings::from(linter)
         }
 

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -51,18 +51,13 @@
 //! document does not implement the required capability: for instance trying to
 //! format a file with a language that does not have a formatter
 
-use std::{borrow::Cow, panic::RefUnwindSafe};
-
 use rome_analyze::ActionCategory;
 use rome_diagnostics::{CodeSuggestion, Diagnostic};
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
 use rome_js_syntax::{TextRange, TextSize};
 use rome_text_edit::Indel;
-
-use crate::{settings::WorkspaceSettings, RomeError};
-
-pub use rome_analyze::RuleCategories;
+use std::{borrow::Cow, panic::RefUnwindSafe};
 
 pub(crate) mod server;
 

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -51,7 +51,10 @@
 //! document does not implement the required capability: for instance trying to
 //! format a file with a language that does not have a formatter
 
+use crate::settings::WorkspaceSettings;
+use crate::RomeError;
 use rome_analyze::ActionCategory;
+pub use rome_analyze::RuleCategories;
 use rome_diagnostics::{CodeSuggestion, Diagnostic};
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -216,7 +216,7 @@ impl Workspace for WorkspaceServer {
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings.read().unwrap();
-        let rules = &settings.linter.rules;
+        let rules = settings.linter.rules.as_ref();
         let diagnostics = linter(&params.path, parse, params.categories, rules);
 
         Ok(PullDiagnosticsResult { diagnostics })
@@ -233,7 +233,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
 
         let settings = self.settings.read().unwrap();
-        let rules = &settings.linter.rules;
+        let rules = settings.linter.rules.as_ref();
 
         Ok(code_actions(&params.path, parse, params.range, rules))
     }
@@ -296,7 +296,7 @@ impl Workspace for WorkspaceServer {
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings.read().unwrap();
-        let rules = &settings.linter.rules;
+        let rules = settings.linter.rules.as_ref();
         Ok(fix_all(&params.path, parse, rules))
     }
 

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -215,7 +215,9 @@ impl Workspace for WorkspaceServer {
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
         let parse = self.get_parse(params.path.clone())?;
-        let diagnostics = linter(&params.path, parse, params.categories);
+        let settings = self.settings.read().unwrap();
+        let rules = &settings.linter.rules;
+        let diagnostics = linter(&params.path, parse, params.categories, rules);
 
         Ok(PullDiagnosticsResult { diagnostics })
     }
@@ -230,7 +232,10 @@ impl Workspace for WorkspaceServer {
 
         let parse = self.get_parse(params.path.clone())?;
 
-        Ok(code_actions(&params.path, parse, params.range))
+        let settings = self.settings.read().unwrap();
+        let rules = &settings.linter.rules;
+
+        Ok(code_actions(&params.path, parse, params.range, rules))
     }
 
     /// Runs the given file through the formatter using the provided options
@@ -290,8 +295,9 @@ impl Workspace for WorkspaceServer {
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
         let parse = self.get_parse(params.path.clone())?;
-
-        Ok(fix_all(&params.path, parse))
+        let settings = self.settings.read().unwrap();
+        let rules = &settings.linter.rules;
+        Ok(fix_all(&params.path, parse, rules))
     }
 
     fn rename(&self, params: super::RenameParams) -> Result<RenameResult, RomeError> {

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -1,5 +1,5 @@
 use case::CaseExt;
-use proc_macro2::{Ident, Span};
+use proc_macro2::{Ident, Literal, Span};
 use quote::quote;
 use rome_analyze::{AnalysisFilter, RuleCategories};
 use rome_js_analyze::metadata;
@@ -21,71 +21,187 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
         groups
             .entry(meta.group)
             .or_insert_with(BTreeMap::new)
-            .insert(meta.name, meta.docs);
+            .insert(meta.name, meta.recommended);
     }
 
     let mut struct_groups = Vec::new();
     let mut line_groups = Vec::new();
     let mut default_for_groups = Vec::new();
+    let mut group_line_recommended_rules = Vec::new();
+    let mut group_rules_union = Vec::new();
     for (group, rules) in groups {
+        let mut lines_recommended_rule = Vec::new();
         let mut declarations = Vec::new();
-
-        for (rule, _) in rules {
-            let rule = Ident::new(&to_lower_snake_case(rule), Span::call_site());
-            let declaration = quote! {
-                #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
-                pub #rule: RuleConfiguration
-            };
-            declarations.push(declaration);
-        }
-
+        let mut lines_rule = Vec::new();
         let property_group_name = Ident::new(&to_lower_snake_case(group), Span::call_site());
 
-        let struct_group_name = Ident::new(
-            &format!("{}Rules", group.to_capitalized()),
-            Span::call_site(),
-        );
+        let mut number_of_recommended_rules: u8 = 0;
+        let number_of_rules = Literal::u8_unsuffixed(rules.len() as u8);
+        for (index, (rule, recommended)) in rules.iter().enumerate() {
+            let rule_position = Literal::u8_unsuffixed(index as u8);
+            let rule_identifier = Ident::new(&to_lower_snake_case(rule), Span::call_site());
+            let declaration = quote! {
+                #[serde(skip_serializing_if = "RuleConfiguration::is_err")]
+                pub #rule_identifier: RuleConfiguration
+            };
+            declarations.push(declaration);
+            if *recommended {
+                lines_recommended_rule.push(quote! {
+                    RuleFilter::Rule(#group, Self::GROUP_RULES[#rule_position])
+                });
+                number_of_recommended_rules += 1;
+            }
+            lines_rule.push(quote! {
+                 #rule
+            });
+        }
 
-        let the_struct = quote! {
+        let group_struct_name = Ident::new(&group.to_capitalized().to_string(), Span::call_site());
 
+        let number_of_recommended_rules = Literal::u8_unsuffixed(number_of_recommended_rules);
+        let deserialize_function_string = Literal::string(&format!("deserialize_{}_rules", group));
+        let deserialize_function_ident =
+            Ident::new(&format!("deserialize_{}_rules", group), Span::call_site());
+
+        let group_struct = quote! {
             #[derive(Deserialize, Default, Serialize, Debug, Clone)]
             #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-            pub struct #struct_group_name {
-                #( #declarations ),*
+            pub struct #group_struct_name {
+                /// It enables the recommended rules for this group
+                #[serde(skip_serializing_if = "Option::is_none")]
+                pub recommended: Option<bool>,
+
+                /// List of rules for the current group
+                #[serde(skip_serializing_if = "IndexMap::is_empty", deserialize_with = #deserialize_function_string)]
+                pub rules: IndexMap<String, RuleConfiguration>,
             }
 
+
+            impl #group_struct_name {
+
+                const GROUP_NAME: &'static str = #group;
+                pub(crate) const GROUP_RULES: [&'static str; #number_of_rules] = [
+                    #( #lines_rule ),*
+                ];
+
+                const RECOMMENDED_RULES: [RuleFilter<'static>; #number_of_recommended_rules] = [
+                    #( #lines_recommended_rule ),*
+                ];
+
+                pub(crate) fn is_recommended(&self) -> bool {
+                    matches!(self.recommended, Some(true))
+                }
+
+
+                pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
+                   IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+                        if conf.is_enabled() {
+                            Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+                        } else {
+                            None
+                        }
+                    }))
+                }
+
+                pub(crate) fn get_disabled_rules(&self) -> IndexSet<RuleFilter> {
+                   IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
+                        if conf.is_disabled() {
+                            Some(RuleFilter::Rule(Self::GROUP_NAME, key))
+                        } else {
+                            None
+                        }
+                    }))
+                }
+            }
+
+            fn #deserialize_function_ident<'de, D>(
+                deserializer: D,
+            ) -> Result<IndexMap<String, RuleConfiguration>, D::Error>
+            where
+                D: serde::de::Deserializer<'de>,
+            {
+                let value: IndexMap<String, RuleConfiguration> = Deserialize::deserialize(deserializer)?;
+                for rule_name in value.keys() {
+                    if !#group_struct_name::GROUP_RULES.contains(&rule_name.as_str()) {
+                        return Err(serde::de::Error::custom(RomeError::Configuration(
+                            ConfigurationError::DeserializationError(format!("Invalid rule name `{rule_name}`")),
+                        )));
+                    }
+                }
+                Ok(value)
+            }
         };
 
-        let line = quote! {
+        struct_groups.push(group_struct);
+        line_groups.push(quote! {
             #[serde(skip_serializing_if = "Option::is_none")]
-            pub #property_group_name: Option<#struct_group_name>
-        };
-
-        let default = quote! {
-            #property_group_name: Some(#struct_group_name::default())
-        };
-
-        struct_groups.push(the_struct);
-        line_groups.push(line);
-        default_for_groups.push(default);
+            pub #property_group_name: Option<#group_struct_name>
+        });
+        default_for_groups.push(quote! {
+            #property_group_name: None
+        });
+        group_line_recommended_rules.push(quote! {
+            enabled_rules.extend(#group_struct_name::RECOMMENDED_RULES);
+        });
+        group_rules_union.push(quote! {
+            if let Some(group) = self.#property_group_name.as_ref() {
+                if group.is_recommended() {
+                    enabled_rules.extend(&Js::RECOMMENDED_RULES);
+                }
+                enabled_rules.extend(&group.get_enabled_rules());
+                disabled_rules.extend(&group.get_disabled_rules());
+            }
+        });
     }
 
     let groups = quote! {
         use serde::{Deserialize, Serialize};
-        use crate::RuleConfiguration;
-
+        use crate::{ConfigurationError, RomeError, RuleConfiguration};
+        use rome_analyze::RuleFilter;
+        use indexmap::{IndexMap, IndexSet};
 
         #[derive(Deserialize, Serialize, Debug, Clone)]
         #[serde(rename_all = "camelCase", deny_unknown_fields)]
         pub struct Rules {
+            /// It enables a preset of rules of any group recommended by Rome. `true` by default.
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub recommended: Option<bool>,
+
             #( #line_groups ),*
         }
 
         impl Default for Rules {
             fn default() -> Self {
                 Self {
+                    recommended: Some(true),
                     #( #default_for_groups ),*
                 }
+            }
+        }
+        impl Rules {
+            pub(crate) fn is_recommended(&self) -> bool {
+                matches!(self.recommended, Some(true))
+            }
+
+            /// It returns a tuple of filters. The first element of the tuple are the enabled filters,
+            /// while the second element are the disabled filters.
+            ///
+            /// The enabled filters are calculated from the difference with the disabled filters.
+            pub fn as_analysis_filters(&self) -> (IndexSet<RuleFilter>, IndexSet<RuleFilter>) {
+                let mut enabled_rules = IndexSet::new();
+                let mut disabled_rules = IndexSet::new();
+                if self.is_recommended() {
+                    #( #group_line_recommended_rules );*
+                }
+                // computing the disabled rules
+                #( #group_rules_union )*
+
+                // computing the enabled rules
+                #( #group_rules_union )*
+
+                let enabled_rules = enabled_rules.difference(&disabled_rules).cloned().collect();
+                (enabled_rules, disabled_rules)
+
             }
         }
 

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -183,11 +183,13 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 matches!(self.recommended, Some(true))
             }
 
-            /// It returns a tuple of filters. The first element of the tuple are the enabled filters,
-            /// while the second element are the disabled filters.
+            /// It returns a tuple of filters. The first element of the tuple are the enabled rules,
+            /// while the second element are the disabled rules.
             ///
-            /// The enabled filters are calculated from the difference with the disabled filters.
-            pub fn as_enabled_rules(&self) -> IndexSet<RuleFilter> {
+            /// Only one element of the tuple is [Some] at the time.
+            ///
+            /// The enabled rules are calculated from the difference with the disabled rules.
+            pub fn as_analysis_filters(&self) -> (Option<IndexSet<RuleFilter>>, Option<IndexSet<RuleFilter>>) {
                 let mut enabled_rules = IndexSet::new();
                 let mut disabled_rules = IndexSet::new();
                 if self.is_recommended() {
@@ -199,8 +201,14 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 // computing the enabled rules
                 #( #group_rules_union )*
 
-                enabled_rules.difference(&disabled_rules).cloned().collect()
-
+                if enabled_rules.len() > disabled_rules.len() {
+                    (None, Some(disabled_rules))
+                } else {
+                    (
+                        Some(enabled_rules.difference(&disabled_rules).cloned().collect()),
+                        None,
+                    )
+                }
             }
         }
 

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -187,7 +187,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
             /// while the second element are the disabled filters.
             ///
             /// The enabled filters are calculated from the difference with the disabled filters.
-            pub fn as_analysis_filters(&self) -> (IndexSet<RuleFilter>, IndexSet<RuleFilter>) {
+            pub fn as_enabled_rules(&self) -> IndexSet<RuleFilter> {
                 let mut enabled_rules = IndexSet::new();
                 let mut disabled_rules = IndexSet::new();
                 if self.is_recommended() {
@@ -199,8 +199,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 // computing the enabled rules
                 #( #group_rules_union )*
 
-                let enabled_rules = enabled_rules.difference(&disabled_rules).cloned().collect();
-                (enabled_rules, disabled_rules)
+                enabled_rules.difference(&disabled_rules).cloned().collect()
 
             }
         }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #2912 

This PR enables a new feature in the configuration, which is the possibility to opt-in the recommended rules suggested by the Rome team.

### Configuration changes

It's possible to opt-in rules in two different way:

- Globally
```json
{
	"linter": {
		"recommended": true
	}
}
```

- Group level

```json
{
	"linter": {
		"rules": {
			"js" {
				"recommended": true
			},
			"jsx" {
				"recommended": false
			}
		}
	}
}
```

### De-serialization of rules

While we desarialize rules, we also validate that the rules we have in the configuration rules are valid for the current group. If not, we emit a `ConfigurationError`. We do so by saving an array of all the rules that belong to a certain group.

**The serialization is out of scope, because we don't have an use case yet**. But the serialization will need to be custom, because we want to keep the order of the original map. 

### Code generation

All the new code (configuration shape, de-serialization and methods) are code generated from the metadata of the rules. 

- all rules that belong to a group, are stored into an array 
- the recommended rules are also stored into a `const` inside the struct, and they represented as an array of `RuleFilter`. The name of the rule is taken from `Self::GROUP_RULES`, so we don't repeat the static strings
- the struct `Rules` has now a method called `as_analysis_filters` which will emit two `IndexSet` of enabled filters and disabled. The reason why `IndexSet` was used is because the enabled filters needs to be computed from the difference with the disabled filters. Here's an example:

```json
{
  "root": true,
  "linter": {
    "rules": {
        "recommended": true,
        "js": {
            "rules": {
                "noDebugger": "off"
            }
        }
    }
  }
}
```
In this example we need pull all the recommended rules, but then we have to remove the rules that have been turned off. `IndexSet` allows us to do so with a simple `.difference` function.

### Computation of `AnalysisFilter`

Here's there have been some limitations, due to how `RuleFilter` is designed (all references), and because of that the creation of the `AnalysisFilter` object must be done in place, right before being used. This caused a bit of repetition of code. If you have a solution to avoid this repetition of code, it would be great

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I updated some existing test and added new ones, some happy path and error path.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
