### PR TITLE
feat(rome_js_analyze): useCamelCase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,9 @@ dependencies = [
 name = "rome_js_analyze"
 version = "0.0.0"
 dependencies = [
+ "case",
  "countme",
+ "iai",
  "insta",
  "roaring",
  "rome_analyze",

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -19,9 +19,15 @@ rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 roaring = "0.9.0"
 rustc-hash = "1.1.0"
+iai = "0.1.1"
 
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }
 rome_text_edit = { path = "../rome_text_edit" }
 insta = { version = "1.10.0", features = ["glob"] }
 countme = { version = "3.0.0", features = ["enable"] }
+case = "1.0.0"
+
+[[bench]]
+name = "iai"
+harness = false

--- a/crates/rome_js_analyze/benches/iai.rs
+++ b/crates/rome_js_analyze/benches/iai.rs
@@ -1,0 +1,32 @@
+fn rome_all_lowercase() {
+    let _ = rome_js_analyze::utils::to_camel_case(iai::black_box("lowercase"));
+}
+
+fn case_all_lowercase() {
+    let _ = case::CaseExt::to_camel(iai::black_box("lowercase"));
+}
+
+fn rome_already_camel_case() {
+    let _ = rome_js_analyze::utils::to_camel_case(iai::black_box("camelCase"));
+}
+
+fn case_already_camel_case() {
+    let _ = case::CaseExt::to_camel(iai::black_box("camelCase"));
+}
+
+fn rome_pascal_case() {
+    let _ = rome_js_analyze::utils::to_camel_case(iai::black_box("CamelCase"));
+}
+
+fn case_pascal_case() {
+    let _ = case::CaseExt::to_camel(iai::black_box("CamelCase"));
+}
+
+iai::main!(
+    rome_all_lowercase,
+    case_all_lowercase,
+    rome_already_camel_case,
+    case_already_camel_case,
+    rome_pascal_case,
+    case_pascal_case
+);

--- a/crates/rome_js_analyze/src/semantic_analyzers/js.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js.rs
@@ -6,4 +6,5 @@ mod no_catch_assign;
 mod no_function_assign;
 mod no_label_var;
 mod no_shouty_constants;
-declare_group! { pub (crate) Js { name : "js" , rules : [no_arguments :: NoArguments , no_catch_assign :: NoCatchAssign , no_function_assign :: NoFunctionAssign , no_label_var :: NoLabelVar , no_shouty_constants :: NoShoutyConstants ,] } }
+mod use_camel_case;
+declare_group! { pub (crate) Js { name : "js" , rules : [no_arguments :: NoArguments , no_catch_assign :: NoCatchAssign , no_function_assign :: NoFunctionAssign , no_label_var :: NoLabelVar , no_shouty_constants :: NoShoutyConstants , use_camel_case :: UseCamelCase ,] } }

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
@@ -27,6 +27,9 @@ declare_rule! {
     ///
     /// ```js,expect_diagnostic
     /// let snake_case;
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
     /// let PascalCase;
     /// ```
     ///

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
@@ -1,8 +1,6 @@
-use std::borrow::Cow;
-
 use crate::{
     semantic_services::Semantic,
-    utils::{rename::RenameSymbolExtensions, to_camel_case, ToCamelCase},
+    utils::{rename::RenameSymbolExtensions, ToCamelCase},
     JsRuleAction,
 };
 use rome_analyze::{
@@ -11,12 +9,9 @@ use rome_analyze::{
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_semantic::{AllReferencesExtensions, Reference};
-use rome_js_syntax::{
-    JsAnyExpression, JsAnyLiteralExpression, JsAnyRoot, JsFormalParameter, JsIdentifierBinding,
-    JsIdentifierExpression, JsLanguage, JsParameterList, JsStringLiteralExpression,
-    JsVariableDeclaration, JsVariableDeclarator, JsVariableDeclaratorList, JsVariableStatement,
-};
-use rome_rowan::{AstNode, AstSeparatedList, BatchMutation, BatchMutationExt, SyntaxNodeCast};
+use rome_js_syntax::{JsFormalParameter, JsIdentifierBinding, JsVariableDeclarator};
+use rome_rowan::{AstNode, BatchMutationExt};
+use std::borrow::Cow;
 
 declare_rule! {
     /// Enforce camel case naming convention.
@@ -90,6 +85,7 @@ impl Rule for UseCamelCase {
     }
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
+        let model = ctx.model();
         let mut batch = ctx.root().begin();
 
         // Avoid renaming conflicts
@@ -100,7 +96,7 @@ impl Rule for UseCamelCase {
             } else {
                 format!("{}{}", state.0, suffix)
             };
-            if batch.rename_node_declaration(&ctx.model(), ctx.query().clone(), &new_name) {
+            if batch.rename_node_declaration(model, ctx.query().clone(), &new_name) {
                 return Some(JsRuleAction {
                     category: ActionCategory::Refactor,
                     applicability: Applicability::Always,

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
@@ -1,0 +1,112 @@
+use std::borrow::Cow;
+
+use crate::{
+    semantic_services::Semantic,
+    utils::{rename::RenameSymbolExtensions, to_camel_case, ToCamelCase},
+    JsRuleAction,
+};
+use rome_analyze::{
+    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
+};
+use rome_console::markup;
+use rome_diagnostics::Applicability;
+use rome_js_semantic::{AllReferencesExtensions, Reference};
+use rome_js_syntax::{
+    JsAnyExpression, JsAnyLiteralExpression, JsAnyRoot, JsFormalParameter, JsIdentifierBinding,
+    JsIdentifierExpression, JsLanguage, JsParameterList, JsStringLiteralExpression,
+    JsVariableDeclaration, JsVariableDeclarator, JsVariableDeclaratorList, JsVariableStatement,
+};
+use rome_rowan::{AstNode, AstSeparatedList, BatchMutation, BatchMutationExt, SyntaxNodeCast};
+
+declare_rule! {
+    /// Enforce camel case naming convention.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// let snake_case;
+    /// let PascalCase;
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```js
+    /// let camelCase;
+    /// ```
+    pub(crate) UseCamelCase {
+        version: "0.8.0",
+        name: "useCamelCase"
+    }
+}
+
+impl Rule for UseCamelCase {
+    const CATEGORY: RuleCategory = RuleCategory::Lint;
+
+    type Query = Semantic<JsIdentifierBinding>;
+    type State = (String, Vec<Reference>);
+    type Signals = Option<Self::State>;
+
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        let binding = ctx.query();
+
+        let is_variable = binding.parent::<JsVariableDeclarator>().is_some();
+        let is_parameter = binding.parent::<JsFormalParameter>().is_some();
+        if is_variable || is_parameter {
+            let name = binding.name_token().ok()?;
+            let name = name.text().to_camel_case();
+
+            match name {
+                Cow::Borrowed(_) => None,
+                Cow::Owned(new_name) => {
+                    Some((new_name, binding.all_references(ctx.model()).collect()))
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let declarator = ctx.query();
+
+        let mut diag = RuleDiagnostic::warning(
+            declarator.syntax().text_trimmed_range(),
+            markup! {
+                "Prefer symbols names in camel case."
+            },
+        );
+
+        for reference in state.1.iter() {
+            let node = reference.node();
+            diag = diag.secondary(node.text_trimmed_range(), "Used here.")
+        }
+
+        Some(diag)
+    }
+
+    fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
+        let mut batch = ctx.root().begin();
+
+        // Avoid renaming conflicts
+        // First time use the name without suffix
+        for suffix in 1..999 {
+            let new_name = if suffix < 2 {
+                state.0.clone()
+            } else {
+                format!("{}{}", state.0, suffix)
+            };
+            if batch.rename_node_declaration(&ctx.model(), ctx.query().clone(), &new_name) {
+                return Some(JsRuleAction {
+                    category: ActionCategory::Refactor,
+                    applicability: Applicability::Always,
+                    message: markup! { "Rename this symbol to camel case" }.to_owned(),
+                    root: batch.commit(),
+                });
+            }
+        }
+
+        None
+    }
+}

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
@@ -35,7 +35,7 @@ declare_rule! {
     pub(crate) UseCamelCase {
         version: "0.8.0",
         name: "useCamelCase",
-        recommended: true
+        recommended: false
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
@@ -8,7 +8,6 @@ use rome_analyze::{
 };
 use rome_console::markup;
 use rome_diagnostics::Applicability;
-use rome_js_semantic::AllReferencesExtensions;
 use rome_js_syntax::{JsFormalParameter, JsIdentifierBinding, JsVariableDeclarator};
 use rome_rowan::{AstNode, BatchMutationExt};
 use std::{borrow::Cow, iter::once};
@@ -60,7 +59,7 @@ impl Rule for UseCamelCase {
             let name = binding.name_token().ok()?;
             let name = name.text_trimmed();
 
-            if name.starts_with("_") {
+            if name.starts_with('_') {
                 return None;
             }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
@@ -8,7 +8,7 @@ use rome_analyze::{
 };
 use rome_console::markup;
 use rome_diagnostics::Applicability;
-use rome_js_semantic::{AllReferencesExtensions, Reference};
+use rome_js_semantic::AllReferencesExtensions;
 use rome_js_syntax::{JsFormalParameter, JsIdentifierBinding, JsVariableDeclarator};
 use rome_rowan::{AstNode, BatchMutationExt};
 use std::{borrow::Cow, iter::once};
@@ -69,7 +69,7 @@ impl Rule for UseCamelCase {
         }
     }
 
-    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
         let binding = ctx.query();
 
         let mut diag = RuleDiagnostic::warning(
@@ -94,7 +94,7 @@ impl Rule for UseCamelCase {
 
         let candidates = (2..).map(|i| format!("{}{}", new_name, i).into());
         let candidates = once(Cow::from(new_name)).chain(candidates);
-        if batch.try_rename_node_declaration_until_success(model, ctx.query().clone(), candidates) {
+        if batch.rename_node_declaration_with_retry(model, ctx.query().clone(), candidates) {
             Some(JsRuleAction {
                 category: ActionCategory::Refactor,
                 applicability: Applicability::Always,

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -83,7 +83,7 @@ pub fn to_camel_case(input: &str) -> Cow<str> {
         //SAFETY: bytes were already inside a valid &str
         let mut output = unsafe { String::from_utf8_unchecked(output) };
 
-        while let Some((_, chr)) = chars.next() {
+        for (_, chr) in chars {
             if !chr.is_alphanumeric() {
                 force_next = Some(ForceNext::Uppercase);
                 continue;

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 pub mod rename;
 #[cfg(test)]
 pub mod tests;
@@ -32,4 +34,123 @@ impl<'a> Iterator for InterpretEscapedString<'a> {
 ///
 pub(crate) fn escape_string(s: &str) -> Result<String, EscapeError> {
     (InterpretEscapedString { s: s.chars() }).collect()
+}
+
+pub trait ToCamelCase {
+    fn to_camel_case(&self) -> Cow<str>;
+}
+
+impl ToCamelCase for str {
+    fn to_camel_case(&self) -> Cow<str> {
+        to_camel_case(self)
+    }
+}
+
+pub fn to_camel_case(input: &str) -> Cow<str> {
+    pub enum ForceNext {
+        Uppercase,
+        Lowercase,
+    }
+
+    let mut force_next = None;
+    let mut chars = input.char_indices();
+    let mut last_i = input.len() - 1;
+
+    while let Some((i, chr)) = chars.next() {
+        if i == 0 && chr.is_uppercase() {
+            chars = input.char_indices();
+            force_next = Some(ForceNext::Lowercase);
+            last_i = i;
+            break;
+        }
+
+        if !chr.is_alphanumeric() {
+            if i == 0 {
+                force_next = Some(ForceNext::Lowercase);
+            } else {
+                force_next = Some(ForceNext::Uppercase);
+            }
+            last_i = i;
+            break;
+        }
+    }
+
+    if last_i >= (input.len() - 1) {
+        Cow::Borrowed(input)
+    } else {
+        let mut output = Vec::with_capacity(input.len());
+        output.extend_from_slice(input[..last_i].as_bytes());
+        //SAFETY: bytes were already inside a valid &str
+        let mut output = unsafe { String::from_utf8_unchecked(output) };
+
+        while let Some((_, chr)) = chars.next() {
+            if !chr.is_alphanumeric() {
+                force_next = Some(ForceNext::Uppercase);
+                continue;
+            }
+
+            match force_next {
+                Some(ForceNext::Uppercase) => {
+                    output.extend(chr.to_uppercase());
+                }
+                Some(ForceNext::Lowercase) => {
+                    output.extend(chr.to_lowercase());
+                }
+                None => {
+                    output.push(chr);
+                }
+            }
+
+            force_next = None;
+        }
+
+        Cow::Owned(output)
+    }
+}
+
+#[test]
+fn ok_to_camel_case() {
+    assert_eq!(to_camel_case("camelCase"), Cow::Borrowed("camelCase"));
+    assert_eq!(
+        to_camel_case("longCamelCase"),
+        Cow::Borrowed("longCamelCase")
+    );
+
+    assert!(matches!(
+        to_camel_case("CamelCase"),
+        Cow::Owned(s) if s.as_str() == "camelCase"
+    ));
+    assert!(matches!(
+        to_camel_case("_camelCase"),
+        Cow::Owned(s) if s.as_str() == "camelCase"
+    ));
+    assert!(matches!(
+        to_camel_case("_camelCase_"),
+        Cow::Owned(s) if s.as_str() == "camelCase"
+    ));
+    assert!(matches!(
+        to_camel_case("_camel_Case_"),
+        Cow::Owned(s) if s.as_str() == "camelCase"
+    ));
+    assert!(matches!(
+        to_camel_case("_camel_case_"),
+        Cow::Owned(s) if s.as_str() == "camelCase"
+    ));
+    assert!(matches!(
+        to_camel_case("_camel_case"),
+        Cow::Owned(s) if s.as_str() == "camelCase"
+    ));
+    assert!(matches!(
+        to_camel_case("camel_case"),
+        Cow::Owned(s) if s.as_str() == "camelCase"
+    ));
+
+    assert!(matches!(
+        to_camel_case("LongCamelCase"),
+        Cow::Owned(s) if s.as_str() == "longCamelCase"
+    ));
+    assert!(matches!(
+        to_camel_case("long_camel_case"),
+        Cow::Owned(s) if s.as_str() == "longCamelCase"
+    ));
 }

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -37,6 +37,10 @@ pub(crate) fn escape_string(s: &str) -> Result<String, EscapeError> {
 }
 
 pub trait ToCamelCase {
+    /// Return the camel case form of the input parameter.
+    /// If it is already in camel case, nothing is done.
+    ///
+    /// This method do not address abbreviations and acronyms.
     fn to_camel_case(&self) -> Cow<str>;
 }
 
@@ -46,6 +50,10 @@ impl ToCamelCase for str {
     }
 }
 
+/// Return the camel case form of the input parameter.
+/// If it is already in camel case, nothing is done.
+///
+/// This method do not address abbreviations and acronyms.
 pub fn to_camel_case(input: &str) -> Cow<str> {
     pub enum ForceNext {
         Uppercase,

--- a/crates/rome_js_analyze/src/utils/rename.rs
+++ b/crates/rome_js_analyze/src/utils/rename.rs
@@ -88,8 +88,8 @@ pub trait RenameSymbolExtensions {
         new_name: &str,
     ) -> bool;
 
-    /// Succesively try to rename a symbol using an iterator
-    /// as source for candidate names.
+    /// Rename a symbol using the new name from the candidates iterator
+    /// until the first success.
     ///
     /// A usual usecase is to append a suffix to a variable name.
     ///
@@ -99,7 +99,7 @@ pub trait RenameSymbolExtensions {
     /// let candidates = once(Cow::from(new_name)).chain(candidates);
     /// batch.try_rename_node_declaration_until_success(model, node, candidates);
     /// ```
-    fn try_rename_node_declaration_until_success<S, I>(
+    fn rename_node_declaration_with_retry<S, I>(
         &mut self,
         model: &SemanticModel,
         node: impl RenamableNode + Clone,

--- a/crates/rome_js_analyze/src/utils/rename.rs
+++ b/crates/rome_js_analyze/src/utils/rename.rs
@@ -91,7 +91,7 @@ pub trait RenameSymbolExtensions {
     /// Rename a symbol using the new name from the candidates iterator
     /// until the first success.
     ///
-    /// A usual usecase is to append a suffix to a variable name.
+    /// A usual use case is to append a suffix to a variable name.
     ///
     /// ```ignore
     /// let new_name = "new_name";

--- a/crates/rome_js_analyze/src/utils/rename.rs
+++ b/crates/rome_js_analyze/src/utils/rename.rs
@@ -88,6 +88,36 @@ pub trait RenameSymbolExtensions {
         new_name: &str,
     ) -> bool;
 
+    /// Succesively try to rename a symbol using an iterator
+    /// as source for candidate names.
+    ///
+    /// A usual usecase is to append a suffix to a variable name.
+    ///
+    /// ```ignore
+    /// let new_name = "new_name";
+    /// let candidates = (2..).map(|i| format!("{}{}", new_name, i).into());
+    /// let candidates = once(Cow::from(new_name)).chain(candidates);
+    /// batch.try_rename_node_declaration_until_success(model, node, candidates);
+    /// ```
+    fn try_rename_node_declaration_until_success<S, I>(
+        &mut self,
+        model: &SemanticModel,
+        node: impl RenamableNode + Clone,
+        candidates: I,
+    ) -> bool
+    where
+        S: AsRef<str>,
+        I: Iterator<Item = S>,
+    {
+        for candidate in candidates {
+            if self.rename_node_declaration(model, node.clone(), candidate.as_ref()) {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Rename the binding and all its references to "new_name".
     fn rename_any_renamable_node(
         &mut self,

--- a/crates/rome_js_analyze/tests/specs/js/useCamelCase.js
+++ b/crates/rome_js_analyze/tests/specs/js/useCamelCase.js
@@ -1,0 +1,14 @@
+let snake_case
+snake_case = 1;
+let _snake_case
+console.log(_snake_case);
+
+function f(snake_case, PascalCase) {
+}
+
+class PascalCase {
+
+}
+
+let camelCase;
+let longCamelCase;

--- a/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
@@ -28,8 +28,6 @@ warning[js/useCamelCase]: Prefer symbols names in camel case.
   │
 1 │ let snake_case
   │     ----------
-2 │ snake_case = 1;
-  │ ---------- Used here.
 
 Safe fix: Rename this symbol to camel case
     | @@ -1,5 +1,5 @@
@@ -40,30 +38,6 @@ Safe fix: Rename this symbol to camel case
 2 2 |   let _snake_case
 3 3 |   console.log(_snake_case);
 4 4 |   
-
-
-```
-
-```
-warning[js/useCamelCase]: Prefer symbols names in camel case.
-  ┌─ useCamelCase.js:3:5
-  │
-3 │ let _snake_case
-  │     -----------
-4 │ console.log(_snake_case);
-  │             ----------- Used here.
-
-Safe fix: Rename this symbol to camel case
-    | @@ -1,7 +1,7 @@
-0 0 |   let snake_case
-1 1 |   snake_case = 1;
-2   | - let _snake_case
-3   | - console.log(_snake_case);
-  2 | + let snakeCase
-  3 | + console.log(snakeCase);
-4 4 |   
-5 5 |   function f(snake_case, PascalCase) {
-6 6 |   }
 
 
 ```

--- a/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
@@ -1,0 +1,113 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: useCamelCase.js
+---
+# Input
+```js
+let snake_case
+snake_case = 1;
+let _snake_case
+console.log(_snake_case);
+
+function f(snake_case, PascalCase) {
+}
+
+class PascalCase {
+
+}
+
+let camelCase;
+let longCamelCase;
+
+```
+
+# Diagnostics
+```
+warning[js/useCamelCase]: Prefer symbols names in camel case.
+  ┌─ useCamelCase.js:1:5
+  │
+1 │ let snake_case
+  │     ----------
+2 │ snake_case = 1;
+  │ ---------- Used here.
+
+Safe fix: Rename this symbol to camel case
+    | @@ -1,5 +1,5 @@
+0   | - let snake_case
+1   | - snake_case = 1;
+  0 | + let snakeCase
+  1 | + snakeCase = 1;
+2 2 |   let _snake_case
+3 3 |   console.log(_snake_case);
+4 4 |   
+
+
+```
+
+```
+warning[js/useCamelCase]: Prefer symbols names in camel case.
+  ┌─ useCamelCase.js:3:5
+  │
+3 │ let _snake_case
+  │     -----------
+4 │ console.log(_snake_case);
+  │             ----------- Used here.
+
+Safe fix: Rename this symbol to camel case
+    | @@ -1,7 +1,7 @@
+0 0 |   let snake_case
+1 1 |   snake_case = 1;
+2   | - let _snake_case
+3   | - console.log(_snake_case);
+  2 | + let snakeCase
+  3 | + console.log(snakeCase);
+4 4 |   
+5 5 |   function f(snake_case, PascalCase) {
+6 6 |   }
+
+
+```
+
+```
+warning[js/useCamelCase]: Prefer symbols names in camel case.
+  ┌─ useCamelCase.js:6:12
+  │
+6 │ function f(snake_case, PascalCase) {
+  │            ----------
+
+Safe fix: Rename this symbol to camel case
+    | @@ -3,7 +3,7 @@
+2 2 |   let _snake_case
+3 3 |   console.log(_snake_case);
+4 4 |   
+5   | - function f(snake_case, PascalCase) {
+  5 | + function f(snakeCase, PascalCase) {
+6 6 |   }
+7 7 |   
+8 8 |   class PascalCase {
+
+
+```
+
+```
+warning[js/useCamelCase]: Prefer symbols names in camel case.
+  ┌─ useCamelCase.js:6:24
+  │
+6 │ function f(snake_case, PascalCase) {
+  │                        ----------
+
+Safe fix: Rename this symbol to camel case
+    | @@ -3,7 +3,7 @@
+2 2 |   let _snake_case
+3 3 |   console.log(_snake_case);
+4 4 |   
+5   | - function f(snake_case, PascalCase) {
+  5 | + function f(snake_case, pascalCase) {
+6 6 |   }
+7 7 |   
+8 8 |   class PascalCase {
+
+
+```
+
+

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -161,6 +161,7 @@ JavaScript allows the omission of curly braces when a block contains only one st
 <h3 data-toc-exclude id="useCamelCase">
 	<a href="/docs/lint/rules/useCamelCase">useCamelCase (since v0.8.0)</a>
 	<a class="header-anchor" href="#useCamelCase"></a>
+	<span class="recommended">recommended</span>
 </h3>
 Enforce camel case naming convention.
 </div>

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -158,6 +158,13 @@ Requires following curly brace conventions.
 JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to never omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity.
 </div>
 <div class="rule">
+<h3 data-toc-exclude id="useCamelCase">
+	<a href="/docs/lint/rules/useCamelCase">useCamelCase (since v0.8.0)</a>
+	<a class="header-anchor" href="#useCamelCase"></a>
+</h3>
+Enforce camel case naming convention.
+</div>
+<div class="rule">
 <h3 data-toc-exclude id="useSimplifiedLogicExpression">
 	<a href="/docs/lint/rules/useSimplifiedLogicExpression">useSimplifiedLogicExpression (since v0.7.0)</a>
 	<a class="header-anchor" href="#useSimplifiedLogicExpression"></a>

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -161,7 +161,6 @@ JavaScript allows the omission of curly braces when a block contains only one st
 <h3 data-toc-exclude id="useCamelCase">
 	<a href="/docs/lint/rules/useCamelCase">useCamelCase (since v0.8.0)</a>
 	<a class="header-anchor" href="#useCamelCase"></a>
-	<span class="recommended">recommended</span>
 </h3>
 Enforce camel case naming convention.
 </div>

--- a/website/src/docs/lint/rules/useCamelCase.md
+++ b/website/src/docs/lint/rules/useCamelCase.md
@@ -1,0 +1,53 @@
+---
+title: Lint Rule useCamelCase
+layout: layouts/rule.liquid
+---
+
+# useCamelCase (since v0.8.0)
+
+Enforce camel case naming convention.
+
+## Examples
+
+### Invalid
+
+```jsx
+let snake_case;
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">js/useCamelCase</span><span style="color: Orange;">]</span><em>: </em><em>Prefer symbols names in camel case.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> js/useCamelCase.js:1:5
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> let snake_case;
+  <span style="color: rgb(38, 148, 255);">│</span>     <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Rename this symbol to camel case</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">let snake_case;</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">let snakeCase;</span>
+
+</code></pre>{% endraw %}
+
+```jsx
+let PascalCase;
+```
+
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">js/useCamelCase</span><span style="color: Orange;">]</span><em>: </em><em>Prefer symbols names in camel case.</em>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> js/useCamelCase.js:1:5
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> let PascalCase;
+  <span style="color: rgb(38, 148, 255);">│</span>     <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
+
+<span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Rename this symbol to camel case</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">let PascalCase;</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">let pascalCase;</span>
+
+</code></pre>{% endraw %}
+
+## Valid
+
+```jsx
+let camelCase;
+```
+

--- a/website/src/docs/lint/rules/useCamelCase.md
+++ b/website/src/docs/lint/rules/useCamelCase.md
@@ -15,7 +15,7 @@ Enforce camel case naming convention.
 let snake_case;
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">js/useCamelCase</span><span style="color: Orange;">]</span><em>: </em><em>Prefer symbols names in camel case.</em>
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;"><a href="https://rome.tools/docs/lint/rules/useCamelCase/">js/useCamelCase</a></span><span style="color: Orange;">]</span><em>: </em><em>Prefer symbols names in camel case.</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> js/useCamelCase.js:1:5
   <span style="color: rgb(38, 148, 255);">│</span>
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> let snake_case;
@@ -32,7 +32,7 @@ let snake_case;
 let PascalCase;
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;">js/useCamelCase</span><span style="color: Orange;">]</span><em>: </em><em>Prefer symbols names in camel case.</em>
+{% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;"><a href="https://rome.tools/docs/lint/rules/useCamelCase/">js/useCamelCase</a></span><span style="color: Orange;">]</span><em>: </em><em>Prefer symbols names in camel case.</em>
   <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> js/useCamelCase.js:1:5
   <span style="color: rgb(38, 148, 255);">│</span>
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> let PascalCase;

--- a/website/src/docs/lint/rules/useCamelCase.md
+++ b/website/src/docs/lint/rules/useCamelCase.md
@@ -5,8 +5,6 @@ layout: layouts/rule.liquid
 
 # useCamelCase (since v0.8.0)
 
-> This rule is recommended by Rome.
-
 Enforce camel case naming convention.
 
 ## Examples

--- a/website/src/docs/lint/rules/useCamelCase.md
+++ b/website/src/docs/lint/rules/useCamelCase.md
@@ -5,6 +5,8 @@ layout: layouts/rule.liquid
 
 # useCamelCase (since v0.8.0)
 
+> This rule is recommended by Rome.
+
 Enforce camel case naming convention.
 
 ## Examples


### PR DESCRIPTION
## Summary

Implements https://github.com/rome/tools/issues/2903.

## Test Plan

```
> cargo rome-cli check ./crates/rome_js_analyze/tests/specs/js/useCamelCase.js
```

### Camel Case

This PR implements only the happy path for camel case. It does not support nice camel case for abbreviations and acronyms.

### Renaming and conflicts

Given that we rename different bindings to possibly the same name, they can conflict. The renaming is correctly dealing with this. So if we have:

```js
let snake_case
snake_case = 1;
let _snake_case
console.log(_snake_case);
```

After renaming everything in one go, we have:

```js
let snakeCase
snakeCase = 1;
let snakeCase2
console.log(snakeCase2);
```

But this is not reflected in the diagnostic phase. Because there is no conflict there. This is something we may need to address in another PR.

```
warning[js/useCamelCase]: Prefer symbols names in camel case.
  ┌─ ./crates/rome_js_analyze/tests/specs/js/useCamelCase.js:1:5
  │
1 │ let snake_case;
  │     ----------
2 │ snake_case = 1;
  │ ---------- Used here.

Safe fix: Rename this symbol to camel case
    | @@ -1,5 +1,5 @@
0   | - let snake_case;
1   | - snake_case = 1;
  0 | + let snakeCase;
  1 | + snakeCase = 1;
2 2 |   let _snake_case;
3 3 |   console.log(_snake_case);
4 4 |   


warning[js/useCamelCase]: Prefer symbols names in camel case.
  ┌─ ./crates/rome_js_analyze/tests/specs/js/useCamelCase.js:3:5
  │
3 │ let _snake_case;
  │     -----------
4 │ console.log(_snake_case);
  │             ----------- Used here.

Safe fix: Rename this symbol to camel case
    | @@ -1,7 +1,7 @@
0 0 |   let snake_case;
1 1 |   snake_case = 1;
2   | - let _snake_case;
3   | - console.log(_snake_case);
  2 | + let snakeCase;
  3 | + console.log(snakeCase);
4 4 |   
5 5 |   function f(snake_case, PascalCase) {}
6 6 |  
```

### Performance

I compared this PR to https://github.com/SkylerLipthay/case. But focusing on being faster when everything is ok. Now we are only slower when we actually need to transform the string. We run fewer instructions, but unfortunately, we access the memory more times.

```
rome_all_lowercase
  Instructions:                 194 
  L1 Accesses:                  226
  L2 Accesses:                    4 
  RAM Accesses:                   7
  Estimated Cycles:             491

case_all_lowercase
  Instructions:                 613
  L1 Accesses:                  768
  L2 Accesses:                    5 
  RAM Accesses:                  12
  Estimated Cycles:            1213 

rome_already_camel_case
  Instructions:                 194 
  L1 Accesses:                  226 
  L2 Accesses:                    3 
  RAM Accesses:                   8 
  Estimated Cycles:             521 

case_already_camel_case
  Instructions:                 613 
  L1 Accesses:                  769 
  L2 Accesses:                    4 
  RAM Accesses:                  12 
  Estimated Cycles:            1209 

rome_pascal_case
  Instructions:                 574 
  L1 Accesses:                  767 
  L2 Accesses:                    7 
  RAM Accesses:                  25 
  Estimated Cycles:            1677 

case_pascal_case
  Instructions:                 613 
  L1 Accesses:                  771 
  L2 Accesses:                    3 
  RAM Accesses:                  11 
  Estimated Cycles:            1171 
```
