### PR TITLE
refactor(rome_service): remove `root` field from configuration

### DIFF
--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -4,13 +4,13 @@ use crate::{
     CliSession, Termination,
 };
 use rome_diagnostics::MAXIMUM_DISPLAYABLE_DIAGNOSTICS;
+use rome_service::load_config;
 use rome_service::settings::WorkspaceSettings;
 use rome_service::workspace::UpdateSettingsParams;
-use rome_service::{load_config, ConfigurationType};
 
 /// Handler for the "check" command of the Rome CLI
 pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
-    let configuration = load_config(&session.app.fs, ConfigurationType::Root)?;
+    let configuration = load_config(&session.app.fs)?;
     let mut workspace_settings = WorkspaceSettings::default();
 
     let max_diagnostics: Option<u8> = session

--- a/crates/rome_cli/src/commands/ci.rs
+++ b/crates/rome_cli/src/commands/ci.rs
@@ -2,15 +2,15 @@ use crate::{
     traversal::{traverse, TraversalMode},
     CliSession, Termination,
 };
+use rome_service::load_config;
 use rome_service::settings::WorkspaceSettings;
 use rome_service::workspace::UpdateSettingsParams;
-use rome_service::{load_config, ConfigurationType};
 
 use super::format::apply_format_settings_from_cli;
 
 /// Handler for the "ci" command of the Rome CLI
 pub(crate) fn ci(mut session: CliSession) -> Result<(), Termination> {
-    let configuration = load_config(&session.app.fs, ConfigurationType::Root)?;
+    let configuration = load_config(&session.app.fs)?;
     let mut workspace_settings = WorkspaceSettings::default();
 
     if let Some(configuration) = configuration {

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -1,7 +1,5 @@
 use rome_formatter::IndentStyle;
-use rome_service::{
-    load_config, settings::WorkspaceSettings, workspace::UpdateSettingsParams, ConfigurationType,
-};
+use rome_service::{load_config, settings::WorkspaceSettings, workspace::UpdateSettingsParams};
 
 use crate::{
     traversal::{traverse, TraversalMode},
@@ -10,7 +8,7 @@ use crate::{
 
 /// Handler for the "format" command of the Rome CLI
 pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
-    let configuration = load_config(&session.app.fs, ConfigurationType::Root)?;
+    let configuration = load_config(&session.app.fs)?;
     let mut workspace_settings = WorkspaceSettings::default();
 
     if let Some(configuration) = &configuration {

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -1,5 +1,4 @@
 pub const CONFIG_FORMAT: &str = r#"{
-  "root": true,
   "formatter": {
     "enabled": true,
     "lineWidth": 160,
@@ -10,27 +9,19 @@ pub const CONFIG_FORMAT: &str = r#"{
 "#;
 
 pub const CONFIG_INIT_DEFAULT: &str = r#"{
-  "root": true,
   "linter": {
     "enabled": true
   }
 }"#;
 
 pub const CONFIG_DISABLED_FORMATTER: &str = r#"{
-  "root": true,
   "formatter": {
     "enabled": false
   }
 }
 "#;
 
-pub const CONFIG_ROOT_FALSE: &str = r#"{
-    "root": false
-}
-"#;
-
 pub const CONFIG_ALL_FIELDS: &str = r#"{
-  "root": true,
   "formatter": {
     "enabled": true,
     "formatWithErrors": true,
@@ -63,21 +54,18 @@ pub const CONFIG_ALL_FIELDS: &str = r#"{
 }"#;
 
 pub const CONFIG_BAD_LINE_WIDTH: &str = r#"{
-  "root": true,
   "formatter": {
     "lineWidth": 500
   }
 }"#;
 
 pub const CONFIG_LINTER_DISABLED: &str = r#"{
-  "root": true,
   "linter": {
     "enabled": false
   }
 }"#;
 
 pub const CONFIG_LINTER_WRONG_RULE: &str = r#"{
-  "root": true,
   "linter": {
     "enabled": true,
     "rules": {
@@ -92,7 +80,6 @@ pub const CONFIG_LINTER_WRONG_RULE: &str = r#"{
 }"#;
 
 pub const CONFIG_INCORRECT_GLOBALS: &str = r#"{
-  "root": true,
   "linter": {
     "enabled": false
   },

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -858,7 +858,7 @@ mod init {
 mod configuration {
     use crate::configs::{
         CONFIG_ALL_FIELDS, CONFIG_BAD_LINE_WIDTH, CONFIG_INCORRECT_GLOBALS,
-        CONFIG_LINTER_WRONG_RULE, CONFIG_ROOT_FALSE,
+        CONFIG_LINTER_WRONG_RULE,
     };
     use pico_args::Arguments;
     use rome_cli::{run_cli, CliSession};
@@ -867,33 +867,6 @@ mod configuration {
     use rome_service::{App, DynRef};
     use std::ffi::OsString;
     use std::path::Path;
-
-    #[test]
-    fn incorrect_root() {
-        let mut fs = MemoryFileSystem::default();
-        let file_path = Path::new("rome.json");
-        fs.insert(file_path.into(), CONFIG_ROOT_FALSE.as_bytes());
-
-        let result = run_cli(CliSession {
-            app: App::with_filesystem_and_console(
-                DynRef::Borrowed(&mut fs),
-                DynRef::Owned(Box::new(BufferConsole::default())),
-            ),
-            args: Arguments::from_vec(vec![OsString::from("format"), OsString::from("file.js")]),
-        });
-
-        assert!(result.is_err());
-
-        match result {
-            Err(error) => {
-                assert_eq!(
-                    error.to_string(),
-                    "the main configuration file, rome.json, must have the field 'root' set to `true`"
-                )
-            }
-            _ => panic!("expected an error, but found none"),
-        }
-    }
 
     #[test]
     fn correct_root() {

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -3,7 +3,7 @@ use crate::requests::syntax_tree::{SyntaxTreePayload, SYNTAX_TREE_REQUEST};
 use crate::session::Session;
 use crate::utils::into_lsp_error;
 use crate::{handlers, requests};
-use rome_service::{load_config, ConfigurationType};
+use rome_service::load_config;
 use serde_json::Value;
 use tokio::io::{Stdin, Stdout};
 use tower_lsp::jsonrpc::Result as LspResult;
@@ -61,7 +61,7 @@ impl LanguageServer for LSPServer {
     async fn initialized(&self, _: InitializedParams) {
         info!("Attempting to load the configuration from 'rome.json' file");
 
-        match load_config(&self.session.fs, ConfigurationType::Root) {
+        match load_config(&self.session.fs) {
             Ok(Some(configuration)) => {
                 info!("Configuration found, and it is valid!");
                 self.session.configuration.write().replace(configuration);

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -13,8 +13,7 @@ pub mod settings;
 pub mod workspace;
 
 pub use crate::configuration::{
-    create_config, load_config, Configuration, ConfigurationError, ConfigurationType,
-    RuleConfiguration, Rules,
+    create_config, load_config, Configuration, ConfigurationError, RuleConfiguration, Rules,
 };
 pub use crate::file_handlers::JsFormatSettings;
 pub use crate::workspace::Workspace;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR removes `root` from the configuration file.

I completely misinterpreted the meaning of that field from Rome classic. That fields was used in case of nested projects, which is something we don't have at the moment.


## Test Plan

Removed test cases around `root`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
