### PR TITLE
fix(rome_js_syntax): Don't panic on unclosed block comment

### DIFF
--- a/crates/rome_js_syntax/src/suppression.rs
+++ b/crates/rome_js_syntax/src/suppression.rs
@@ -166,6 +166,32 @@ mod tests {
             }],
         );
     }
+    #[test]
+    fn parse_unclosed_block_comment_suppressions() {
+        assert_eq!(
+            parse_suppression_comment("/* rome-ignore format: explanation").collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("format", None)],
+                reason: "explanation"
+            }],
+        );
+
+        assert_eq!(
+            parse_suppression_comment("/* rome-ignore format: explanation *").collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("format", None)],
+                reason: "explanation"
+            }],
+        );
+
+        assert_eq!(
+            parse_suppression_comment("/* rome-ignore format: explanation /").collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("format", None)],
+                reason: "explanation"
+            }],
+        );
+    }
 
     #[test]
     fn parse_multiple_suppression() {

--- a/crates/rome_js_syntax/src/suppression.rs
+++ b/crates/rome_js_syntax/src/suppression.rs
@@ -29,7 +29,8 @@ pub fn parse_suppression_comment(comment: &str) -> impl Iterator<Item = Suppress
         "/*" => {
             comment = comment
                 .strip_suffix("*/")
-                .expect("block comment with no closing token");
+                .or_else(|| comment.strip_suffix(&['*', '/']))
+                .unwrap_or(comment);
             true
         }
         token => panic!("comment with unknown opening token {token:?}"),


### PR DESCRIPTION
This fixes an issue where Rome panicked when parsing suppression comments from a block comment without the closing `*/`.

This PR gracefully handles the case where a block comment has no closing `*/` by trying to remove a trailing `*` or `/` at the end of the comment and otherwise take the comment as is.

## Tests

I verified that running rome over rome classic no longer panics and added a unit test to the suppression comment parsing.