### PR TITLE
refactor(vscode): remove beta formatter options

### DIFF
--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0.133", features = ["derive"] }
 anyhow = "1.0.52"
 indexmap = "1.8.0"
 rome_fs = {  path = "../rome_fs" }
-rome_service = { path = "../rome_service", features = ["serde_workspace"] }
+rome_service = { path = "../rome_service" }
 rome_js_formatter = { path = "../rome_js_formatter" }
 rome_formatter = { path = "../rome_formatter" }
 rome_analyze = { path = "../rome_analyze" }

--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0.133", features = ["derive"] }
 anyhow = "1.0.52"
 indexmap = "1.8.0"
 rome_fs = {  path = "../rome_fs" }
-rome_service = { path = "../rome_service" }
+rome_service = { path = "../rome_service", features = ["serde_workspace"] }
 rome_js_formatter = { path = "../rome_js_formatter" }
 rome_formatter = { path = "../rome_formatter" }
 rome_analyze = { path = "../rome_analyze" }

--- a/crates/rome_lsp/src/config.rs
+++ b/crates/rome_lsp/src/config.rs
@@ -1,51 +1,15 @@
-use rome_formatter::{IndentStyle, LineWidth};
-use rome_js_formatter::context::QuoteStyle;
 use rome_service::configuration::Configuration;
 use rome_service::settings;
 use serde::{Deserialize, Serialize};
 use serde_json::{Error, Value};
-use tracing::{info, trace};
+use tracing::trace;
 
 pub const CONFIGURATION_SECTION: &str = "rome";
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-/// Specific settings for Rome formatter
-pub struct FormatterWorkspaceSettings {
-    /// Allows to format code that might contain syntax errors
-    pub format_with_syntax_errors: bool,
-    /// The width of a single line, specified by the user
-    pub line_width: u16,
-    /// The indent style, specified by the user
-    pub indent_style: String,
-    /// The quote style, specified by the user
-    pub quote_style: String,
-    /// The number of spaces, specified by the user and applied only when using Spaces
-    pub space_quantity: u8,
-}
-
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-/// Settings for Rome Analysis
-pub struct AnalysisWorkspaceSettings {
-    /// Allows rome to compute and publish diagnostics
-    pub enable_diagnostics: bool,
-    /// Allows rome to compute and provide code actions
-    pub enable_code_actions: bool,
-}
-
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
 /// The settings applied to the workspace by the LSP
 pub struct WorkspaceSettings {
-    /// Formatter settings
-    #[serde(default)]
-    pub formatter: FormatterWorkspaceSettings,
-
-    /// Analysis settings
-    #[serde(default)]
-    pub analysis: AnalysisWorkspaceSettings,
-
     /// Unstable features enabled
     #[serde(default)]
     pub unstable: bool,
@@ -61,10 +25,6 @@ impl Config {
         Self {
             settings: WorkspaceSettings::default(),
         }
-    }
-
-    pub fn get_workspace_settings(&self) -> WorkspaceSettings {
-        self.settings.clone()
     }
 
     pub fn set_workspace_settings(&mut self, value: Value) -> Result<(), Error> {
@@ -87,66 +47,9 @@ impl Config {
     ) -> settings::WorkspaceSettings {
         let mut settings = settings::WorkspaceSettings::default();
 
-        // second, we apply the settings coming from the client
-        settings.format.format_with_errors = self.settings.formatter.format_with_syntax_errors;
-
         if let Some(configuration) = configuration {
             trace!("Applying configuration coming from the configuration file");
             settings.merge_with_configuration(configuration);
-        } else {
-            trace!("Applying configuration coming from the client");
-            let custom_ident_style: IndentStyle = self
-                .settings
-                .formatter
-                .indent_style
-                .parse()
-                .unwrap_or_default();
-
-            if custom_ident_style != IndentStyle::default() {
-                // merge settings with the ones provided by the editor
-                match custom_ident_style {
-                    IndentStyle::Space(_) => {
-                        settings.format.indent_style =
-                            Some(IndentStyle::Space(self.settings.formatter.space_quantity));
-                    }
-                    IndentStyle::Tab => {
-                        settings.format.indent_style = Some(custom_ident_style);
-                    }
-                }
-
-                info!(
-                    "Using user setting indent style: {:?}",
-                    settings.format.indent_style
-                );
-            }
-
-            let custom_quote_style: QuoteStyle = self
-                .settings
-                .formatter
-                .quote_style
-                .parse()
-                .unwrap_or_default();
-
-            if custom_quote_style != QuoteStyle::default() {
-                settings.languages.javascript.format.quote_style = Some(custom_quote_style);
-                info!("Using user setting quote style: {}", custom_quote_style);
-            }
-
-            // apply the new line width only if they are different
-            let custom_line_width: LineWidth = self
-                .settings
-                .formatter
-                .line_width
-                .try_into()
-                .unwrap_or_default();
-
-            if custom_line_width != LineWidth::default() {
-                settings.format.line_width = Some(custom_line_width);
-                info!(
-                    "Using user settings line width: {}",
-                    custom_line_width.value()
-                );
-            }
         }
 
         settings

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -78,10 +78,6 @@ impl LanguageServer for LSPServer {
 
         self.session.fetch_client_configuration().await;
 
-        if self.session.config.read().get_workspace_settings().unstable {
-            rome_flags::set_unstable_flags(rome_flags::FeatureFlags::ALL);
-        }
-
         let msg = format!("Server initialized with PID: {}", std::process::id());
         self.session
             .client
@@ -140,14 +136,7 @@ impl LanguageServer for LSPServer {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
         let _ = params;
-
-        let diags_enabled_prev = self.session.diagnostics_enabled();
-
         self.session.fetch_client_configuration().await;
-
-        if diags_enabled_prev != self.session.diagnostics_enabled() {
-            self.session.update_all_diagnostics().await;
-        }
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -6,7 +6,6 @@ use futures::Sink;
 use futures::SinkExt;
 use futures::Stream;
 use futures::StreamExt;
-use rome_lsp::config::AnalysisWorkspaceSettings;
 use rome_lsp::config::WorkspaceSettings;
 use rome_lsp::server::build_server;
 use rome_lsp::server::LSPServer;
@@ -211,10 +210,6 @@ where
         let res = match req.method() {
             "workspace/configuration" => {
                 let settings = WorkspaceSettings {
-                    analysis: AnalysisWorkspaceSettings {
-                        enable_diagnostics: true,
-                        enable_code_actions: true,
-                    },
                     ..WorkspaceSettings::default()
                 };
 

--- a/crates/rome_service/src/configuration/formatter.rs
+++ b/crates/rome_service/src/configuration/formatter.rs
@@ -10,7 +10,6 @@ pub struct FormatterConfiguration {
 
     /// Stores whether formatting should be allowed to proceed if a given file
     /// has syntax errors
-    #[serde(skip_serializing)]
     pub format_with_errors: bool,
 
     /// The indent style.
@@ -49,7 +48,7 @@ impl From<FormatterConfiguration> for FormatSettings {
             enabled: conf.enabled,
             indent_style: Some(indent_style),
             line_width: Some(conf.line_width),
-            format_with_errors: false,
+            format_with_errors: conf.format_with_errors,
         }
     }
 }

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -40,7 +40,6 @@ pub struct Configuration {
 
 impl Default for Configuration {
     fn default() -> Self {
-        // TODO: enable recommendation settings https://github.com/rome/tools/issues/2912
         Self {
             linter: Some(LinterConfiguration {
                 enabled: true,

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -60,21 +60,21 @@
 			"type": "object",
 			"properties": {
 				"rome_lsp.trace.server": {
-          "type": "string",
-          "scope": "window",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "enumDescriptions": [
-            "No traces",
-            "Error only",
-            "Full log"
-          ],
-          "default": "off",
-          "description": "Traces the communication between VS Code and the language server."
-        },
+					"type": "string",
+					"scope": "window",
+					"enum": [
+						"off",
+						"messages",
+						"verbose"
+					],
+					"enumDescriptions": [
+						"No traces",
+						"Error only",
+						"Full log"
+					],
+					"default": "off",
+					"description": "Traces the communication between VS Code and the language server."
+				},
 				"rome.lspBin": {
 					"type": [
 						"string",
@@ -82,68 +82,6 @@
 					],
 					"default": null,
 					"markdownDescription": "The rome lsp server executable."
-				},
-				"rome.formatter.formatWithSyntaxErrors": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "**BETA**: allows the formatter to format code that contains syntax errors",
-					"examples": [
-						true,
-						false
-					]
-				},
-				"rome.formatter.lineWidth": {
-					"type": "number",
-					"default": 80,
-					"markdownDescription": "**BETA**: the max width of a single line, the code will have to fit in it",
-					"minimum": 40,
-					"maximum": 320
-				},
-				"rome.formatter.indentStyle": {
-					"type": "string",
-					"enum": [
-						"Tabs",
-						"Spaces"
-					],
-					"default": "Tabs",
-					"markdownEnumDescriptions": [
-						"**BETA**: applies **tabs** while formatting",
-						"**BETA**: applies **spaces** while formatting"
-					]
-				},
-				"rome.formatter.spaceQuantity": {
-					"type": "number",
-					"default": 2,
-					"markdownDescription": "**BETA**: applied **only** when choosing **Spaces**, it's the number of spaces applied when printing.",
-					"minimum": 1,
-					"maximum": 12
-				},
-				"rome.formatter.quoteStyle": {
-					"type": "string",
-					"enum": [
-						"Double",
-						"Single"
-					],
-					"default": "Double",
-					"markdownEnumDescriptions": [
-						"**BETA**: applies **double** quotes while formatting",
-						"**BETA**: applies **single** quotes while formatting"
-					]
-				},
-				"rome.analysis.enableDiagnostics": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "Allows rome to compute and publish diagnostics"
-				},
-				"rome.analysis.enableCodeActions": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "Allows rome to compute and provide code actions"
-				},
-				"rome.unstable": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "**BETA**: enables unstable features"
 				}
 			}
 		}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #2938 .

Now that we have a configuration file, users should use that as source to change Rome's defaults. The options in the VSCode were always a beta, with the idea that they were going to be removed once the configuration file was available.

Now it's the time to remove them.

I enabled the serialization of `format_with_errors` and assigned its value to the `WorkspaceSettings`. This field it hasn't been used yet in the CLI. I will make a further PR to enable it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current tests should pass. I manually built the VSCode extension and verified that the options don't exist anymore.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
