### PR TITLE
refactor(rome_rowan): change mutation methods to return detached nodes

### DIFF
--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -176,6 +176,18 @@ where
         self.push_change(prev_element, Some(next_element))
     }
 
+    /// Push a change to replace the "prev_node" with "next_node".
+    ///
+    /// Changes to take effect must be commited.
+    pub fn replace_node_discard_trivia<T>(&mut self, prev_node: T, next_node: T)
+    where
+        T: AstNode<Language = L>,
+    {
+        self.replace_element_discard_trivia(
+            prev_node.into_syntax().into(),
+            next_node.into_syntax().into(),
+        )
+    }
     /// Push a change to replace the "prev_element" with "next_element".
     ///
     /// Changes to take effect must be commited.

--- a/crates/rome_rowan/src/ast/mutation.rs
+++ b/crates/rome_rowan/src/ast/mutation.rs
@@ -50,6 +50,8 @@ pub trait AstNodeExt: AstNode {
     ) -> Option<Self>
     where
         Self: Sized;
+
+    fn detach(self) -> Self;
 }
 
 impl<T> AstNodeExt for T
@@ -145,6 +147,10 @@ where
                         .map(|piece| (piece.kind(), piece.text())),
                 ),
         )
+    }
+
+    fn detach(self) -> Self {
+        Self::unwrap_cast(self.into_syntax().detach())
     }
 }
 

--- a/crates/rome_rowan/src/cursor/element.rs
+++ b/crates/rome_rowan/src/cursor/element.rs
@@ -1,5 +1,5 @@
 use crate::cursor::{SyntaxNode, SyntaxToken};
-use crate::green::GreenElementRef;
+use crate::green::{GreenElement, GreenElementRef};
 use crate::{NodeOrToken, RawSyntaxKind, TokenAtOffset};
 use std::iter;
 use text_size::{TextRange, TextSize};
@@ -103,6 +103,13 @@ impl SyntaxElement {
         match self {
             NodeOrToken::Node(it) => Self::Node(it.detach()),
             NodeOrToken::Token(it) => Self::Token(it.detach()),
+        }
+    }
+
+    pub(crate) fn into_green(self) -> GreenElement {
+        match self {
+            NodeOrToken::Node(it) => it.ptr.into_green(),
+            NodeOrToken::Token(it) => it.into_green(),
         }
     }
 }

--- a/crates/rome_rowan/src/cursor/node.rs
+++ b/crates/rome_rowan/src/cursor/node.rs
@@ -422,6 +422,13 @@ impl SyntaxNode {
             ),
         }
     }
+
+    #[must_use = "syntax elements are immutable, the result of update methods must be propagated to have any effect"]
+    pub fn replace_child(self, prev_elem: SyntaxElement, next_elem: SyntaxElement) -> Option<Self> {
+        Some(Self {
+            ptr: self.ptr.replace_child(prev_elem, next_elem)?,
+        })
+    }
 }
 
 // Identity semantics for hash & eq

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -9,7 +9,7 @@ use crate::{
 use serde::Serialize;
 use std::any::TypeId;
 use std::fmt::{Debug, Formatter};
-use std::iter::{self, FusedIterator};
+use std::iter::FusedIterator;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::{fmt, ops};
@@ -441,28 +441,10 @@ impl<L: Language> SyntaxNode<L> {
         prev_elem: SyntaxElement<L>,
         next_elem: SyntaxElement<L>,
     ) -> Option<Self> {
-        let (depth, prev_parent, index) = match prev_elem {
-            NodeOrToken::Node(prev_node) => (
-                prev_node
-                    .ancestors()
-                    .position(move |node| node == self)?
-                    .checked_sub(1)?,
-                prev_node.parent()?,
-                prev_node.index(),
-            ),
-            NodeOrToken::Token(prev_token) => (
-                prev_token.ancestors().position(move |node| node == self)?,
-                prev_token.parent()?,
-                prev_token.index(),
-            ),
-        };
-
-        let next_parent = prev_parent.splice_slots(index..=index, iter::once(Some(next_elem)));
-
-        match depth {
-            0 => Some(next_parent),
-            index => next_parent.ancestors().nth(index),
-        }
+        Some(Self {
+            raw: self.raw.replace_child(prev_elem.into(), next_elem.into())?,
+            _p: PhantomData,
+        })
     }
 
     pub fn into_list(self) -> SyntaxList<L> {


### PR DESCRIPTION
## Summary

The `splice_slots` and `replace_child` methods in `rome_rowan` were initially implemented to rebuild the entire tree above the mutated node, but no code was actually relying on this outside of the implementation of `replace_child` itself. I've modified `splice_slots` and moved `replace_child` into the `cursor` API to return a new detached node instead of respining the entire tree, this greatly simplifies the algorithm since it doesn't need to rebuild the green tree above the current node and doesn't need to rebuild the red tree at all.

## Test Plan

This change is internal to rowan, while it does change the semantics of `splice_slots` and `replace_child` no code relies on this specific behavior and all the tests for the analyzer should continue to pass
