### PR TITLE
chore(cargo): always enable LTO in release mode

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,3 +24,6 @@ bench_analyzer = "run -p xtask_bench --release -- --feature analyzer"
 coverage = "run -p xtask_coverage --profile=release-with-debug --"
 rome-cli = "run -p rome_cli --release --"
 rome-cli-dev = "run -p rome_cli --"
+
+[profile.release]
+lto = true

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -118,8 +118,6 @@ jobs:
         run: cargo build -p rome_cli --release --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          # Perform full Link-Time Optimizations
-          CARGO_PROFILE_RELEASE_LTO: "true"
           # Strip all debug symbols from the resulting binaries
           RUSTFLAGS: "-C strip=symbols"
           # Inline the version of the npm package in the CLI binary

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -105,8 +105,6 @@ jobs:
         run: cargo build -p rome_lsp --release --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          # Perform full Link-Time Optimizations
-          CARGO_PROFILE_RELEASE_LTO: "true"
           # Strip all debug symbols from the resulting binaries
           RUSTFLAGS: "-C strip=symbols"
 


### PR DESCRIPTION
## Summary

Link-Time Optimization was previously enabled only in production builds (running on CI) since it makes the compilation times longer, but release builds take a long time anyway so the difference seems marginal while enabling whole-project optimization brings in important improvements to performance (for instance the various functions making up the control flow graph visitor can be almost entirely inlined)

Measured cold compilation times for the CLI in release mode:
Without LTO: `105.1s (1m 45.1s)`
With LTO: `113.2s (1m 53.2s)`

## Test Plan

This is a change to the optimization options of the compiler, it shouldn't have any observable side effects (besides improving performances)
