### PR TITLE
fix(rome_rowan): Slots iterator `last` and `size_hint`

### DIFF
--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -255,7 +255,7 @@ impl<L: Language, N: AstNode<Language = L>> Iterator for AstNodeListIterator<L, 
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.inner.len(), Some(self.inner.len()))
+        self.inner.size_hint()
     }
 
     fn last(self) -> Option<Self::Item>

--- a/crates/rome_rowan/src/green/node.rs
+++ b/crates/rome_rowan/src/green/node.rs
@@ -155,7 +155,7 @@ impl GreenNodeData {
     }
 
     #[inline]
-    fn slice(&self) -> &[Slot] {
+    pub(crate) fn slice(&self) -> &[Slot] {
         self.data.slice()
     }
 

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -59,6 +59,7 @@ impl<L: Language> SyntaxNode<L> {
     ///
     /// ## Panics
     /// If the slot index is out of bounds
+    #[inline]
     pub fn element_in_slot(&self, slot: u32) -> Option<SyntaxElement<L>> {
         self.raw.element_in_slot(slot).map(SyntaxElement::from)
     }
@@ -759,14 +760,17 @@ pub struct SyntaxSlots<L> {
 impl<L: Language> Iterator for SyntaxSlots<L> {
     type Item = SyntaxSlot<L>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.raw.next().map(SyntaxSlot::from)
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.raw.size_hint()
     }
 
+    #[inline]
     fn last(self) -> Option<Self::Item>
     where
         Self: Sized,
@@ -774,6 +778,7 @@ impl<L: Language> Iterator for SyntaxSlots<L> {
         self.raw.last().map(SyntaxSlot::from)
     }
 
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         self.raw.nth(n).map(SyntaxSlot::from)
     }
@@ -782,16 +787,19 @@ impl<L: Language> Iterator for SyntaxSlots<L> {
 impl<L: Language> FusedIterator for SyntaxSlots<L> {}
 
 impl<L: Language> ExactSizeIterator for SyntaxSlots<L> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.raw.len()
     }
 }
 
 impl<L: Language> DoubleEndedIterator for SyntaxSlots<L> {
+    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.raw.next_back().map(SyntaxSlot::from)
     }
 
+    #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         self.raw.nth_back(n).map(SyntaxSlot::from)
     }


### PR DESCRIPTION
Fix the `last` and `size_hint` implementations of the `SyntaxSlots` iterator.

* `size_hint` should return the count of the remaining items in the iterator and not the total count of the underlying list.
* `last` should return the last element remaining in the iterator, ignoring previously returned elements from calling `next_back`

## Tests

I added new tests that verified the incorrect behaviour and then fixed the implementation
