### PR TITLE
fix(rome_js_analyze): improve trivia handling in useSingleVarDeclarator

### DIFF
--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -26,20 +26,10 @@ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 "#;
 
 const FIX_BEFORE: &str = "
-var a, b, c;
-var d, e, f;
-var g, h, i;
+if(a != -0) {}
 ";
 const FIX_AFTER: &str = "
-var a;
-var b;
-var c;
-var d;
-var e;
-var f;
-var g;
-var h;
-var i;
+if(a != 0) {}
 ";
 
 const CUSTOM_FORMAT_BEFORE: &str = r#"

--- a/crates/rome_css_factory/src/generated/node_factory.rs
+++ b/crates/rome_css_factory/src/generated/node_factory.rs
@@ -701,22 +701,25 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn css_at_media_query_list<I>(items: I) -> CssAtMediaQueryList
+pub fn css_at_media_query_list<I, S>(items: I, separators: S) -> CssAtMediaQueryList
 where
-    I: IntoIterator<Item = (CssAtMediaQuery, Option<CssSyntaxToken>)>,
+    I: IntoIterator<Item = CssAtMediaQuery>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = CssSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     CssAtMediaQueryList::unwrap_cast(SyntaxNode::new_detached(
         CssSyntaxKind::CSS_AT_MEDIA_QUERY_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn css_attribute_list<I>(items: I) -> CssAttributeList
@@ -743,22 +746,25 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn css_keyframes_selector_list<I>(items: I) -> CssKeyframesSelectorList
+pub fn css_keyframes_selector_list<I, S>(items: I, separators: S) -> CssKeyframesSelectorList
 where
-    I: IntoIterator<Item = (CssKeyframesSelector, Option<CssSyntaxToken>)>,
+    I: IntoIterator<Item = CssKeyframesSelector>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = CssSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     CssKeyframesSelectorList::unwrap_cast(SyntaxNode::new_detached(
         CssSyntaxKind::CSS_KEYFRAMES_SELECTOR_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn css_parameter_list<I>(items: I) -> CssParameterList
@@ -785,21 +791,24 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn css_selector_list<I>(items: I) -> CssSelectorList
+pub fn css_selector_list<I, S>(items: I, separators: S) -> CssSelectorList
 where
-    I: IntoIterator<Item = (CssSelector, Option<CssSyntaxToken>)>,
+    I: IntoIterator<Item = CssSelector>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = CssSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     CssSelectorList::unwrap_cast(SyntaxNode::new_detached(
         CssSyntaxKind::CSS_SELECTOR_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }

--- a/crates/rome_js_analyze/src/analyzers/js/use_single_var_declarator.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_single_var_declarator.rs
@@ -8,9 +8,10 @@ use rome_diagnostics::Applicability;
 use rome_js_factory::make;
 use rome_js_syntax::{
     JsModuleItemList, JsStatementList, JsSyntaxToken, JsVariableDeclarationFields,
-    JsVariableDeclaratorList, JsVariableStatement, JsVariableStatementFields,
+    JsVariableDeclaratorList, JsVariableStatement, JsVariableStatementFields, TextSize,
+    TriviaPieceKind, T,
 };
-use rome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
+use rome_rowan::{AstNode, AstNodeExt, AstSeparatedList, BatchMutationExt, TriviaPiece};
 
 use crate::JsRuleAction;
 
@@ -78,54 +79,150 @@ impl Rule for UseSingleVarDeclarator {
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
         let node = ctx.query();
-        let mut mutation = ctx.root().begin();
-
-        let (kind, declarators, semicolon_token) = state;
-
         let prev_parent = node.syntax().parent()?;
+
         if !JsStatementList::can_cast(prev_parent.kind())
             && !JsModuleItemList::can_cast(prev_parent.kind())
         {
             return None;
         }
 
+        let (kind, declarators, semicolon_token) = state;
+
         let index = prev_parent
             .children()
             .position(|slot| &slot == node.syntax())?;
 
-        let mut is_first = true;
+        // Extract the indentation part from the leading trivia of the kind
+        // token, defined as all whitespace and newline trivia pieces starting
+        // from the token going backwards up to the first newline (included).
+        // If the leading trivia for the token is empty a single newline trivia
+        // piece is created.  For efficiency, the trivia pieces are stored in
+        // reverse order (the vector is then reversed again on iteration)
+        let mut has_newline = false;
+        let leading_trivia: Vec<_> = kind
+            .leading_trivia()
+            .pieces()
+            .rev()
+            .take_while(|piece| {
+                let has_previous_newline = has_newline;
+                has_newline |= piece.is_newline();
+                !has_previous_newline
+            })
+            .filter_map(|piece| {
+                if piece.is_whitespace() || piece.is_newline() {
+                    Some((piece.kind(), piece.text().to_string()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let kind_indent = if !leading_trivia.is_empty() {
+            leading_trivia
+        } else {
+            vec![(TriviaPieceKind::Newline, String::from("\n"))]
+        };
+
+        let last_semicolon_token = semicolon_token.as_ref();
+        let remaining_semicolor_token = semicolon_token.clone().map(|_| make::token(T![;]));
+
+        let declarators_len = declarators.len();
+
         let next_parent = prev_parent.clone().splice_slots(
             index..=index,
-            declarators.iter().filter_map(|declarator| {
-                let declarator = declarator.ok()?;
+            declarators
+                .iter()
+                .enumerate()
+                .filter_map(|(index, declarator)| {
+                    let mut declarator = declarator.ok()?;
 
-                // Clone the entire leading trivia for the first statement, but
-                // trim it to the first newline for the following lines
-                let kind = if is_first {
-                    is_first = false;
-                    kind.clone()
-                } else {
-                    make::clone_token_up_to_first_newline(kind)
-                };
+                    // Remove the leading trivia for the declarators
+                    let first_token = declarator.syntax().first_token()?;
+                    let first_token_leading_trivia = first_token.leading_trivia();
 
-                let mut builder = make::js_variable_statement(make::js_variable_declaration(
-                    kind,
-                    make::js_variable_declarator_list(iter::once((declarator, None))),
-                ));
+                    declarator = declarator
+                        .replace_token_discard_trivia(
+                            first_token.clone(),
+                            first_token.with_leading_trivia(iter::empty()),
+                        )
+                        // SAFETY: first_token is a known child of declarator
+                        .unwrap();
 
-                if let Some(semicolon_token) = semicolon_token {
-                    builder = builder.with_semicolon_token(semicolon_token.clone());
-                }
+                    let kind = if index == 0 {
+                        // Clone the kind token with its entire leading trivia
+                        // for the first statement
+                        kind.clone()
+                    } else {
+                        // For the remaining statements, clone the kind token
+                        // with the leading trivia pieces previously removed
+                        // from the first token of the declarator node, with
+                        // the indentation fixed up to match the original kind
+                        // token
+                        let indent: &[(TriviaPieceKind, String)] = &kind_indent;
+                        let mut trivia_pieces = Vec::new();
+                        let mut token_text = String::new();
 
-                Some(Some(builder.build().into_syntax().into()))
-            }),
+                        for piece in first_token_leading_trivia.pieces() {
+                            if !piece.is_comments() {
+                                continue;
+                            }
+
+                            for (kind, text) in indent.iter().rev() {
+                                trivia_pieces.push(TriviaPiece::new(*kind, TextSize::of(text)));
+                                token_text.push_str(text);
+                            }
+
+                            trivia_pieces.push(TriviaPiece::new(piece.kind(), piece.text_len()));
+                            token_text.push_str(piece.text());
+                        }
+
+                        for (kind, text) in indent.iter().rev() {
+                            trivia_pieces.push(TriviaPiece::new(*kind, TextSize::of(text)));
+                            token_text.push_str(text);
+                        }
+
+                        token_text.push_str(kind.text_trimmed());
+
+                        for piece in kind.trailing_trivia().pieces() {
+                            token_text.push_str(piece.text());
+                        }
+
+                        JsSyntaxToken::new_detached(
+                            kind.kind(),
+                            &token_text,
+                            trivia_pieces,
+                            kind.trailing_trivia().pieces().map(|piece| {
+                                TriviaPiece::new(piece.kind(), TextSize::of(piece.text()))
+                            }),
+                        )
+                    };
+
+                    let mut builder = make::js_variable_statement(make::js_variable_declaration(
+                        kind,
+                        make::js_variable_declarator_list(iter::once(declarator), iter::empty()),
+                    ));
+
+                    let semicolon_token = if index + 1 == declarators_len {
+                        last_semicolon_token
+                    } else {
+                        remaining_semicolor_token.as_ref()
+                    };
+
+                    if let Some(semicolon_token) = semicolon_token {
+                        builder = builder.with_semicolon_token(semicolon_token.clone());
+                    }
+
+                    Some(Some(builder.build().into_syntax().into()))
+                }),
         );
 
+        let mut mutation = ctx.root().begin();
         mutation.replace_element(prev_parent.into(), next_parent.into());
 
         Some(JsRuleAction {
             category: ActionCategory::QuickFix,
-            applicability: Applicability::Always,
+            applicability: Applicability::MaybeIncorrect,
             message: markup! { "Break out into multiple declarations" }.to_owned(),
             mutation,
         })

--- a/crates/rome_js_analyze/src/analyzers/js/use_single_var_declarator.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_single_var_declarator.rs
@@ -96,7 +96,7 @@ impl Rule for UseSingleVarDeclarator {
         // Extract the indentation part from the leading trivia of the kind
         // token, defined as all whitespace and newline trivia pieces starting
         // from the token going backwards up to the first newline (included).
-        // If the leading trivia for the token is empty a single newline trivia
+        // If the leading trivia for the token is empty, a single newline trivia
         // piece is created.  For efficiency, the trivia pieces are stored in
         // reverse order (the vector is then reversed again on iteration)
         let mut has_newline = false;
@@ -125,7 +125,7 @@ impl Rule for UseSingleVarDeclarator {
         };
 
         let last_semicolon_token = semicolon_token.as_ref();
-        let remaining_semicolor_token = semicolon_token.clone().map(|_| make::token(T![;]));
+        let remaining_semicolon_token = semicolon_token.clone().map(|_| make::token(T![;]));
 
         let declarators_len = declarators.len();
 
@@ -206,7 +206,7 @@ impl Rule for UseSingleVarDeclarator {
                     let semicolon_token = if index + 1 == declarators_len {
                         last_semicolon_token
                     } else {
-                        remaining_semicolor_token.as_ref()
+                        remaining_semicolon_token.as_ref()
                     };
 
                     if let Some(semicolon_token) = semicolon_token {

--- a/crates/rome_js_analyze/src/analyzers/ts/use_shorthand_array_type.rs
+++ b/crates/rome_js_analyze/src/analyzers/ts/use_shorthand_array_type.rs
@@ -141,21 +141,17 @@ fn convert_to_array_type(type_arguments: TsTypeArguments) -> Option<TsType> {
             }
             length => {
                 let ts_union_type_builder = make::ts_union_type(make::ts_union_type_variant_list(
-                    types_array.into_iter().enumerate().map(|(i, item)| {
-                        (
-                            item,
-                            (i != length - 1).then(|| {
-                                make::token(T![|])
-                                    .with_leading_trivia(std::iter::once((
-                                        TriviaPieceKind::Whitespace,
-                                        " ",
-                                    )))
-                                    .with_trailing_trivia(std::iter::once((
-                                        TriviaPieceKind::Whitespace,
-                                        " ",
-                                    )))
-                            }),
-                        )
+                    types_array.into_iter(),
+                    (0..length - 1).map(|_| {
+                        make::token(T![|])
+                            .with_leading_trivia(std::iter::once((
+                                TriviaPieceKind::Whitespace,
+                                " ",
+                            )))
+                            .with_trailing_trivia(std::iter::once((
+                                TriviaPieceKind::Whitespace,
+                                " ",
+                            )))
                     }),
                 ));
                 return Some(TsType::TsUnionType(ts_union_type_builder.build()));

--- a/crates/rome_js_analyze/tests/specs/js/useSingleVarDeclarator.js
+++ b/crates/rome_js_analyze/tests/specs/js/useSingleVarDeclarator.js
@@ -1,4 +1,10 @@
+var x, y
+
 function test() {
 	// Comment
 	let foo, bar;
 }
+
+var x = 1,
+	// comment
+    y = 2

--- a/crates/rome_js_analyze/tests/specs/js/useSingleVarDeclarator.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/useSingleVarDeclarator.js.snap
@@ -4,29 +4,81 @@ expression: useSingleVarDeclarator.js
 ---
 # Input
 ```js
+var x, y
+
 function test() {
 	// Comment
 	let foo, bar;
 }
+
+var x = 1,
+	// comment
+    y = 2
 
 ```
 
 # Diagnostics
 ```
 warning[js/useSingleVarDeclarator]: Declare variables separately
-  ┌─ useSingleVarDeclarator.js:3:2
+  ┌─ useSingleVarDeclarator.js:1:1
   │
-3 │     let foo, bar;
+1 │ var x, y
+  │ --------
+
+Suggested fix: Break out into multiple declarations
+    | @@ -1,4 +1,5 @@
+0   | - var x, y
+  0 | + var x
+  1 | + var y
+1 2 |   
+2 3 |   function test() {
+3 4 |   	// Comment
+
+
+```
+
+```
+warning[js/useSingleVarDeclarator]: Declare variables separately
+  ┌─ useSingleVarDeclarator.js:5:2
+  │
+5 │     let foo, bar;
   │     -------------
 
-Safe fix: Break out into multiple declarations
-    | @@ -1,4 +1,5 @@
-0 0 |   function test() {
-1 1 |   	// Comment
-2   | - 	let foo, bar;
-  2 | + 	let foo;
-  3 | + 	let bar;
-3 4 |   }
+Suggested fix: Break out into multiple declarations
+    | @@ -2,7 +2,8 @@
+1 1 |   
+2 2 |   function test() {
+3 3 |   	// Comment
+4   | - 	let foo, bar;
+  4 | + 	let foo;
+  5 | + 	let bar;
+5 6 |   }
+6 7 |   
+7 8 |   var x = 1,
+
+
+```
+
+```
+warning[js/useSingleVarDeclarator]: Declare variables separately
+   ┌─ useSingleVarDeclarator.js:8:1
+   │  
+ 8 │ ┌ var x = 1,
+ 9 │ │     // comment
+10 │ │     y = 2
+   │ └─────────'
+
+Suggested fix: Break out into multiple declarations
+    | @@ -5,6 +5,6 @@
+4 4 |   	let foo, bar;
+5 5 |   }
+6 6 |   
+7   | - var x = 1,
+8   | - 	// comment
+9   | -     y = 2
+  7 | + var x = 1
+  8 | + // comment
+  9 | + var y = 2
 
 
 ```

--- a/crates/rome_js_factory/src/generated/node_factory.rs
+++ b/crates/rome_js_factory/src/generated/node_factory.rs
@@ -6144,76 +6144,94 @@ pub fn ts_void_type(void_token: SyntaxToken) -> TsVoidType {
         [Some(SyntaxElement::Token(void_token))],
     ))
 }
-pub fn js_array_assignment_pattern_element_list<I>(items: I) -> JsArrayAssignmentPatternElementList
+pub fn js_array_assignment_pattern_element_list<I, S>(
+    items: I,
+    separators: S,
+) -> JsArrayAssignmentPatternElementList
 where
-    I: IntoIterator<Item = (JsAnyArrayAssignmentPatternElement, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyArrayAssignmentPatternElement>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsArrayAssignmentPatternElementList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn js_array_binding_pattern_element_list<I>(items: I) -> JsArrayBindingPatternElementList
+pub fn js_array_binding_pattern_element_list<I, S>(
+    items: I,
+    separators: S,
+) -> JsArrayBindingPatternElementList
 where
-    I: IntoIterator<Item = (JsAnyArrayBindingPatternElement, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyArrayBindingPatternElement>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsArrayBindingPatternElementList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn js_array_element_list<I>(items: I) -> JsArrayElementList
+pub fn js_array_element_list<I, S>(items: I, separators: S) -> JsArrayElementList
 where
-    I: IntoIterator<Item = (JsAnyArrayElement, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyArrayElement>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsArrayElementList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_ARRAY_ELEMENT_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn js_call_argument_list<I>(items: I) -> JsCallArgumentList
+pub fn js_call_argument_list<I, S>(items: I, separators: S) -> JsCallArgumentList
 where
-    I: IntoIterator<Item = (JsAnyCallArgument, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyCallArgument>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsCallArgumentList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_CALL_ARGUMENT_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn js_class_member_list<I>(items: I) -> JsClassMemberList
@@ -6240,22 +6258,25 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn js_constructor_parameter_list<I>(items: I) -> JsConstructorParameterList
+pub fn js_constructor_parameter_list<I, S>(items: I, separators: S) -> JsConstructorParameterList
 where
-    I: IntoIterator<Item = (JsAnyConstructorParameter, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyConstructorParameter>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsConstructorParameterList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_CONSTRUCTOR_PARAMETER_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn js_directive_list<I>(items: I) -> JsDirectiveList
@@ -6270,58 +6291,70 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn js_export_named_from_specifier_list<I>(items: I) -> JsExportNamedFromSpecifierList
+pub fn js_export_named_from_specifier_list<I, S>(
+    items: I,
+    separators: S,
+) -> JsExportNamedFromSpecifierList
 where
-    I: IntoIterator<Item = (JsExportNamedFromSpecifier, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsExportNamedFromSpecifier>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsExportNamedFromSpecifierList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_EXPORT_NAMED_FROM_SPECIFIER_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn js_export_named_specifier_list<I>(items: I) -> JsExportNamedSpecifierList
+pub fn js_export_named_specifier_list<I, S>(items: I, separators: S) -> JsExportNamedSpecifierList
 where
-    I: IntoIterator<Item = (JsAnyExportNamedSpecifier, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyExportNamedSpecifier>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsExportNamedSpecifierList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_EXPORT_NAMED_SPECIFIER_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn js_import_assertion_entry_list<I>(items: I) -> JsImportAssertionEntryList
+pub fn js_import_assertion_entry_list<I, S>(items: I, separators: S) -> JsImportAssertionEntryList
 where
-    I: IntoIterator<Item = (JsAnyImportAssertionEntry, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyImportAssertionEntry>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsImportAssertionEntryList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_IMPORT_ASSERTION_ENTRY_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn js_method_modifier_list<I>(items: I) -> JsMethodModifierList
@@ -6348,96 +6381,115 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn js_named_import_specifier_list<I>(items: I) -> JsNamedImportSpecifierList
+pub fn js_named_import_specifier_list<I, S>(items: I, separators: S) -> JsNamedImportSpecifierList
 where
-    I: IntoIterator<Item = (JsAnyNamedImportSpecifier, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyNamedImportSpecifier>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsNamedImportSpecifierList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIER_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn js_object_assignment_pattern_property_list<I>(
+pub fn js_object_assignment_pattern_property_list<I, S>(
     items: I,
+    separators: S,
 ) -> JsObjectAssignmentPatternPropertyList
 where
-    I: IntoIterator<Item = (JsAnyObjectAssignmentPatternMember, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyObjectAssignmentPatternMember>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsObjectAssignmentPatternPropertyList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn js_object_binding_pattern_property_list<I>(items: I) -> JsObjectBindingPatternPropertyList
+pub fn js_object_binding_pattern_property_list<I, S>(
+    items: I,
+    separators: S,
+) -> JsObjectBindingPatternPropertyList
 where
-    I: IntoIterator<Item = (JsAnyObjectBindingPatternMember, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyObjectBindingPatternMember>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsObjectBindingPatternPropertyList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn js_object_member_list<I>(items: I) -> JsObjectMemberList
+pub fn js_object_member_list<I, S>(items: I, separators: S) -> JsObjectMemberList
 where
-    I: IntoIterator<Item = (JsAnyObjectMember, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyObjectMember>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsObjectMemberList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_OBJECT_MEMBER_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn js_parameter_list<I>(items: I) -> JsParameterList
+pub fn js_parameter_list<I, S>(items: I, separators: S) -> JsParameterList
 where
-    I: IntoIterator<Item = (JsAnyParameter, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsAnyParameter>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsParameterList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_PARAMETER_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn js_property_modifier_list<I>(items: I) -> JsPropertyModifierList
@@ -6488,22 +6540,25 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn js_variable_declarator_list<I>(items: I) -> JsVariableDeclaratorList
+pub fn js_variable_declarator_list<I, S>(items: I, separators: S) -> JsVariableDeclaratorList
 where
-    I: IntoIterator<Item = (JsVariableDeclarator, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = JsVariableDeclarator>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsVariableDeclaratorList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_VARIABLE_DECLARATOR_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn jsx_attribute_list<I>(items: I) -> JsxAttributeList
@@ -6530,22 +6585,25 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn ts_enum_member_list<I>(items: I) -> TsEnumMemberList
+pub fn ts_enum_member_list<I, S>(items: I, separators: S) -> TsEnumMemberList
 where
-    I: IntoIterator<Item = (TsEnumMember, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = TsEnumMember>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     TsEnumMemberList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::TS_ENUM_MEMBER_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn ts_index_signature_modifier_list<I>(items: I) -> TsIndexSignatureModifierList
@@ -6560,22 +6618,28 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn ts_intersection_type_element_list<I>(items: I) -> TsIntersectionTypeElementList
+pub fn ts_intersection_type_element_list<I, S>(
+    items: I,
+    separators: S,
+) -> TsIntersectionTypeElementList
 where
-    I: IntoIterator<Item = (TsType, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = TsType>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     TsIntersectionTypeElementList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::TS_INTERSECTION_TYPE_ELEMENT_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn ts_method_signature_modifier_list<I>(items: I) -> TsMethodSignatureModifierList
@@ -6626,58 +6690,67 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn ts_tuple_type_element_list<I>(items: I) -> TsTupleTypeElementList
+pub fn ts_tuple_type_element_list<I, S>(items: I, separators: S) -> TsTupleTypeElementList
 where
-    I: IntoIterator<Item = (TsAnyTupleTypeElement, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = TsAnyTupleTypeElement>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     TsTupleTypeElementList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::TS_TUPLE_TYPE_ELEMENT_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn ts_type_argument_list<I>(items: I) -> TsTypeArgumentList
+pub fn ts_type_argument_list<I, S>(items: I, separators: S) -> TsTypeArgumentList
 where
-    I: IntoIterator<Item = (TsType, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = TsType>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     TsTypeArgumentList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::TS_TYPE_ARGUMENT_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn ts_type_list<I>(items: I) -> TsTypeList
+pub fn ts_type_list<I, S>(items: I, separators: S) -> TsTypeList
 where
-    I: IntoIterator<Item = (TsNameWithTypeArguments, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = TsNameWithTypeArguments>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     TsTypeList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::TS_TYPE_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn ts_type_member_list<I>(items: I) -> TsTypeMemberList
@@ -6692,39 +6765,45 @@ where
             .map(|item| Some(item.into_syntax().into())),
     ))
 }
-pub fn ts_type_parameter_list<I>(items: I) -> TsTypeParameterList
+pub fn ts_type_parameter_list<I, S>(items: I, separators: S) -> TsTypeParameterList
 where
-    I: IntoIterator<Item = (TsTypeParameter, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = TsTypeParameter>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     TsTypeParameterList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::TS_TYPE_PARAMETER_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn ts_union_type_variant_list<I>(items: I) -> TsUnionTypeVariantList
+pub fn ts_union_type_variant_list<I, S>(items: I, separators: S) -> TsUnionTypeVariantList
 where
-    I: IntoIterator<Item = (TsType, Option<JsSyntaxToken>)>,
+    I: IntoIterator<Item = TsType>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     TsUnionTypeVariantList::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::TS_UNION_TYPE_VARIANT_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }

--- a/crates/rome_js_factory/src/make.rs
+++ b/crates/rome_js_factory/src/make.rs
@@ -1,4 +1,4 @@
-use rome_js_syntax::{JsSyntaxKind, JsSyntaxToken, TextSize, TriviaPieceKind};
+use rome_js_syntax::{JsSyntaxKind, JsSyntaxToken, TriviaPieceKind};
 use rome_rowan::TriviaPiece;
 
 pub use crate::generated::node_factory::*;
@@ -40,66 +40,4 @@ pub fn token_decorated_with_space(kind: JsSyntaxKind) -> JsSyntaxToken {
     } else {
         panic!("token kind {kind:?} cannot be transformed to text")
     }
-}
-
-/// Returns a clone of `token` with the leading trivia trimmed at the first
-/// newline piece (included), starting from the token itself and iterating backward
-///
-/// # Example
-/// ```
-/// # use rome_rowan::TriviaPiece;
-/// # use rome_js_syntax::{JsSyntaxToken, T};
-/// # use rome_js_factory::make::clone_token_up_to_first_newline;
-/// let input = JsSyntaxToken::new_detached(
-///     T![let],
-///     "\n  // Comment\n  let ",
-///     [TriviaPiece::newline(1), TriviaPiece::whitespace(2), TriviaPiece::single_line_comment(10), TriviaPiece::newline(1), TriviaPiece::whitespace(2)],
-///     [TriviaPiece::whitespace(1)],
-/// );
-///
-/// let output = clone_token_up_to_first_newline(&input);
-///
-/// let expected = JsSyntaxToken::new_detached(
-///     T![let],
-///     "\n  let ",
-///     [TriviaPiece::newline(1), TriviaPiece::whitespace(2)],
-///     [TriviaPiece::whitespace(1)],
-/// );
-///
-/// assert_eq!(output.text(), expected.text());
-/// ```
-pub fn clone_token_up_to_first_newline(token: &JsSyntaxToken) -> JsSyntaxToken {
-    let leading_trivia = token.leading_trivia().pieces();
-    let num_pieces = leading_trivia.len();
-    let skip_count = leading_trivia
-        .rev()
-        .position(|piece| piece.is_newline())
-        .and_then(|index| num_pieces.checked_sub(index + 1))
-        .unwrap_or(0);
-
-    let mut text = String::new();
-
-    for piece in token.leading_trivia().pieces().skip(skip_count) {
-        text.push_str(piece.text());
-    }
-
-    text.push_str(token.text_trimmed());
-
-    for piece in token.trailing_trivia().pieces() {
-        text.push_str(piece.text());
-    }
-
-    JsSyntaxToken::new_detached(
-        token.kind(),
-        &text,
-        token
-            .leading_trivia()
-            .pieces()
-            .skip(skip_count)
-            .map(|piece| TriviaPiece::new(piece.kind(), TextSize::of(piece.text()))),
-        token
-            .trailing_trivia()
-            .pieces()
-            .map(|piece| TriviaPiece::new(piece.kind(), TextSize::of(piece.text()))),
-    )
 }

--- a/crates/rome_json_factory/src/generated/node_factory.rs
+++ b/crates/rome_json_factory/src/generated/node_factory.rs
@@ -108,39 +108,45 @@ pub fn json_string(json_string_literal_token: SyntaxToken) -> JsonString {
         [Some(SyntaxElement::Token(json_string_literal_token))],
     ))
 }
-pub fn json_array_element_list<I>(items: I) -> JsonArrayElementList
+pub fn json_array_element_list<I, S>(items: I, separators: S) -> JsonArrayElementList
 where
-    I: IntoIterator<Item = (JsonValue, Option<JsonSyntaxToken>)>,
+    I: IntoIterator<Item = JsonValue>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsonSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsonArrayElementList::unwrap_cast(SyntaxNode::new_detached(
         JsonSyntaxKind::JSON_ARRAY_ELEMENT_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
-pub fn json_member_list<I>(items: I) -> JsonMemberList
+pub fn json_member_list<I, S>(items: I, separators: S) -> JsonMemberList
 where
-    I: IntoIterator<Item = (JsonMember, Option<JsonSyntaxToken>)>,
+    I: IntoIterator<Item = JsonMember>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = JsonSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
-    let items = items.into_iter();
-    let length = items.len() * 2;
-    let mut iter = items.flat_map(|(item, separator)| {
-        [
-            Some(item.into_syntax().into()),
-            separator.map(|token| token.into()),
-        ]
-    });
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     JsonMemberList::unwrap_cast(SyntaxNode::new_detached(
         JsonSyntaxKind::JSON_MEMBER_LIST,
-        (0..length).map(|_| iter.next().unwrap()),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }

--- a/website/src/docs/lint/rules/useSingleVarDeclarator.md
+++ b/website/src/docs/lint/rules/useSingleVarDeclarator.md
@@ -23,10 +23,11 @@ let foo, bar;
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> let foo, bar;
   <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
 
-<span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Break out into multiple declarations</span>
-    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
+<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Break out into multiple declarations</span>
+    | <span style="color: rgb(38, 148, 255);">@@ -1 +1,2 @@</span>
 0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">let foo, bar;</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">let foo;let bar;</span>
+  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">let foo;</span>
+  1 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">let bar;</span>
 
 </code></pre>{% endraw %}
 


### PR DESCRIPTION
## Summary

This PR fixes #2945 by improving how trivia is handled as tokens are moved in the syntax tree mutation. Since that rule isn't really safe to apply I've downgraded its applicability to `MaybeIncorrect`, and modified the CLI tests that were relying on this

I also fixed the issue of separated lists created with the node factory API having an empty slot at the end of the list if the trailing separator was `None` by having the factory function take two iterators (one for the list elements and one for the separators) instead of a single iterator of pairs of list element + an optional separator token. The content of the two iterators are interleaved while building the list, and the separator iterator can simply be one item shorter than the elements iterator in order to omit the last separator without creating an empty slot

## Test Plan

I've added the problematic cases from #2945 to the tests for the `useSingleVarDeclarator` rule, the code actions being emitted for these are now correct
