### PR TITLE
fix(rome_js_parser): 🐛TsModuleDeclaration name should allow builtin types

### DIFF
--- a/crates/rome_js_parser/src/syntax/typescript.rs
+++ b/crates/rome_js_parser/src/syntax/typescript.rs
@@ -23,15 +23,19 @@ use super::expr::is_nth_at_identifier;
 use super::js_parse_error::expected_identifier;
 use super::stmt::optional_semi;
 
-fn parse_ts_identifier_binding(p: &mut Parser) -> ParsedSyntax {
+fn parse_ts_identifier_binding(p: &mut Parser, is_module: bool) -> ParsedSyntax {
     parse_identifier(p, TS_IDENTIFIER_BINDING).map(|mut ident| {
         if ident.kind().is_unknown() {
             return ident;
         }
 
         let name = p.source(ident.range(p));
-
-        if is_reserved_type_name(name) {
+        let is_reserved_word_this_context = if is_module {
+            is_reserved_module_name(name)
+        } else {
+            is_reserved_type_name(name)
+        };
+        if is_reserved_word_this_context {
             let error = p
                 .err_builder(&format!("Type alias cannot be {}", name))
                 .primary(ident.range(p), "");

--- a/crates/rome_js_parser/src/syntax/typescript/statement.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/statement.rs
@@ -207,7 +207,7 @@ pub(crate) fn parse_ts_type_alias_declaration(p: &mut Parser) -> ParsedSyntax {
     let start = p.cur_range().start();
     let m = p.start();
     p.expect(T![type]);
-    parse_ts_identifier_binding(p).or_add_diagnostic(p, expected_identifier);
+    parse_ts_identifier_binding(p, false).or_add_diagnostic(p, expected_identifier);
     parse_ts_type_parameters(p).ok();
     p.expect(T![=]);
     parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
@@ -297,7 +297,7 @@ pub(crate) fn parse_ts_interface_declaration(p: &mut Parser) -> ParsedSyntax {
 
     let m = p.start();
     p.expect(T![interface]);
-    parse_ts_identifier_binding(p).or_add_diagnostic(p, expected_identifier);
+    parse_ts_identifier_binding(p, false).or_add_diagnostic(p, expected_identifier);
     parse_ts_type_parameters(p).ok();
     eat_interface_heritage_clause(p);
     p.expect(T!['{']);
@@ -464,8 +464,13 @@ fn parse_ts_namespace_or_module_declaration_clause(
     Present(m.complete(p, TS_MODULE_DECLARATION))
 }
 
+// test ts built_in_module_name
+// // https://github.com/rome/tools/issues/2959
+// module number {}
+// module string {}
+// declare module never {}
 fn parse_ts_module_name(p: &mut Parser) -> ParsedSyntax {
-    let mut left = parse_ts_identifier_binding(p);
+    let mut left = parse_ts_identifier_binding(p, true);
 
     while p.at(T![.]) {
         let m = left.precede_or_add_diagnostic(p, expected_identifier);

--- a/crates/rome_js_parser/src/syntax/typescript/statement.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/statement.rs
@@ -207,7 +207,8 @@ pub(crate) fn parse_ts_type_alias_declaration(p: &mut Parser) -> ParsedSyntax {
     let start = p.cur_range().start();
     let m = p.start();
     p.expect(T![type]);
-    parse_ts_identifier_binding(p, false).or_add_diagnostic(p, expected_identifier);
+    parse_ts_identifier_binding(p, super::TsIdentifierContext::Type)
+        .or_add_diagnostic(p, expected_identifier);
     parse_ts_type_parameters(p).ok();
     p.expect(T![=]);
     parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
@@ -297,7 +298,8 @@ pub(crate) fn parse_ts_interface_declaration(p: &mut Parser) -> ParsedSyntax {
 
     let m = p.start();
     p.expect(T![interface]);
-    parse_ts_identifier_binding(p, false).or_add_diagnostic(p, expected_identifier);
+    parse_ts_identifier_binding(p, super::TsIdentifierContext::Type)
+        .or_add_diagnostic(p, expected_identifier);
     parse_ts_type_parameters(p).ok();
     eat_interface_heritage_clause(p);
     p.expect(T!['{']);
@@ -470,7 +472,7 @@ fn parse_ts_namespace_or_module_declaration_clause(
 // module string {}
 // declare module never {}
 fn parse_ts_module_name(p: &mut Parser) -> ParsedSyntax {
-    let mut left = parse_ts_identifier_binding(p, true);
+    let mut left = parse_ts_identifier_binding(p, super::TsIdentifierContext::Module);
 
     while p.at(T![.]) {
         let m = left.precede_or_add_diagnostic(p, expected_identifier);

--- a/crates/rome_js_parser/src/syntax/typescript/types.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/types.rs
@@ -34,24 +34,26 @@ use rome_js_syntax::{JsSyntaxKind::*, *};
 use super::{expect_ts_index_signature_member, is_at_ts_index_signature_member, MemberParent};
 
 pub(crate) fn is_reserved_type_name(name: &str) -> bool {
-    matches!(
-        name,
-        "string"
-            | "null"
-            | "number"
-            | "object"
-            | "any"
-            | "unknown"
-            | "boolean"
-            | "bigint"
-            | "symbol"
-            | "void"
-            | "never"
-    )
+    name.len() <= 6
+        && name.len() >= 3
+        && matches!(
+            name,
+            "string"
+                | "null"
+                | "number"
+                | "object"
+                | "any"
+                | "unknown"
+                | "boolean"
+                | "bigint"
+                | "symbol"
+                | "void"
+                | "never"
+        )
 }
 
 pub(crate) fn is_reserved_module_name(name: &str) -> bool {
-    matches!(name, "void" | "null")
+    name.len() == 4 && matches!(name, "void" | "null")
 }
 
 pub(crate) fn parse_ts_type_annotation(p: &mut Parser) -> ParsedSyntax {

--- a/crates/rome_js_parser/src/syntax/typescript/types.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/types.rs
@@ -34,20 +34,26 @@ use rome_js_syntax::{JsSyntaxKind::*, *};
 use super::{expect_ts_index_signature_member, is_at_ts_index_signature_member, MemberParent};
 
 pub(crate) fn is_reserved_type_name(name: &str) -> bool {
-    matches!(
-        name,
-        "string"
-            | "null"
-            | "number"
-            | "object"
-            | "any"
-            | "unknown"
-            | "boolean"
-            | "bigint"
-            | "symbol"
-            | "void"
-            | "never"
-    )
+    name.len() >= 3
+        && name.len() <= 6
+        && matches!(
+            name,
+            "string"
+                | "null"
+                | "number"
+                | "object"
+                | "any"
+                | "unknown"
+                | "boolean"
+                | "bigint"
+                | "symbol"
+                | "void"
+                | "never"
+        )
+}
+
+pub(crate) fn is_reserved_module_name(name: &str) -> bool {
+    name.len() == 4 && matches!(name, "void" | "null")
 }
 
 pub(crate) fn parse_ts_type_annotation(p: &mut Parser) -> ParsedSyntax {

--- a/crates/rome_js_parser/src/syntax/typescript/types.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/types.rs
@@ -34,26 +34,24 @@ use rome_js_syntax::{JsSyntaxKind::*, *};
 use super::{expect_ts_index_signature_member, is_at_ts_index_signature_member, MemberParent};
 
 pub(crate) fn is_reserved_type_name(name: &str) -> bool {
-    name.len() >= 3
-        && name.len() <= 6
-        && matches!(
-            name,
-            "string"
-                | "null"
-                | "number"
-                | "object"
-                | "any"
-                | "unknown"
-                | "boolean"
-                | "bigint"
-                | "symbol"
-                | "void"
-                | "never"
-        )
+    matches!(
+        name,
+        "string"
+            | "null"
+            | "number"
+            | "object"
+            | "any"
+            | "unknown"
+            | "boolean"
+            | "bigint"
+            | "symbol"
+            | "void"
+            | "never"
+    )
 }
 
 pub(crate) fn is_reserved_module_name(name: &str) -> bool {
-    name.len() == 4 && matches!(name, "void" | "null")
+    matches!(name, "void" | "null")
 }
 
 pub(crate) fn parse_ts_type_annotation(p: &mut Parser) -> ParsedSyntax {

--- a/crates/rome_js_parser/test_data/inline/ok/built_in_module_name.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/built_in_module_name.rast
@@ -1,0 +1,75 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsModuleDeclaration {
+            module_or_namespace: MODULE_KW@0..52 "module" [Comments("// https://github.com ..."), Newline("\n")] [Whitespace(" ")],
+            name: TsIdentifierBinding {
+                name_token: IDENT@52..59 "number" [] [Whitespace(" ")],
+            },
+            body: TsModuleBlock {
+                l_curly_token: L_CURLY@59..60 "{" [] [],
+                items: JsModuleItemList [],
+                r_curly_token: R_CURLY@60..61 "}" [] [],
+            },
+        },
+        TsModuleDeclaration {
+            module_or_namespace: MODULE_KW@61..69 "module" [Newline("\n")] [Whitespace(" ")],
+            name: TsIdentifierBinding {
+                name_token: IDENT@69..76 "string" [] [Whitespace(" ")],
+            },
+            body: TsModuleBlock {
+                l_curly_token: L_CURLY@76..77 "{" [] [],
+                items: JsModuleItemList [],
+                r_curly_token: R_CURLY@77..78 "}" [] [],
+            },
+        },
+        TsDeclareStatement {
+            declare_token: DECLARE_KW@78..87 "declare" [Newline("\n")] [Whitespace(" ")],
+            declaration: TsModuleDeclaration {
+                module_or_namespace: MODULE_KW@87..94 "module" [] [Whitespace(" ")],
+                name: TsIdentifierBinding {
+                    name_token: IDENT@94..100 "never" [] [Whitespace(" ")],
+                },
+                body: TsModuleBlock {
+                    l_curly_token: L_CURLY@100..101 "{" [] [],
+                    items: JsModuleItemList [],
+                    r_curly_token: R_CURLY@101..102 "}" [] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@102..103 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..103
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..102
+    0: TS_MODULE_DECLARATION@0..61
+      0: MODULE_KW@0..52 "module" [Comments("// https://github.com ..."), Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@52..59
+        0: IDENT@52..59 "number" [] [Whitespace(" ")]
+      2: TS_MODULE_BLOCK@59..61
+        0: L_CURLY@59..60 "{" [] []
+        1: JS_MODULE_ITEM_LIST@60..60
+        2: R_CURLY@60..61 "}" [] []
+    1: TS_MODULE_DECLARATION@61..78
+      0: MODULE_KW@61..69 "module" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@69..76
+        0: IDENT@69..76 "string" [] [Whitespace(" ")]
+      2: TS_MODULE_BLOCK@76..78
+        0: L_CURLY@76..77 "{" [] []
+        1: JS_MODULE_ITEM_LIST@77..77
+        2: R_CURLY@77..78 "}" [] []
+    2: TS_DECLARE_STATEMENT@78..102
+      0: DECLARE_KW@78..87 "declare" [Newline("\n")] [Whitespace(" ")]
+      1: TS_MODULE_DECLARATION@87..102
+        0: MODULE_KW@87..94 "module" [] [Whitespace(" ")]
+        1: TS_IDENTIFIER_BINDING@94..100
+          0: IDENT@94..100 "never" [] [Whitespace(" ")]
+        2: TS_MODULE_BLOCK@100..102
+          0: L_CURLY@100..101 "{" [] []
+          1: JS_MODULE_ITEM_LIST@101..101
+          2: R_CURLY@101..102 "}" [] []
+  3: EOF@102..103 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/built_in_module_name.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/built_in_module_name.ts
@@ -1,0 +1,4 @@
+// https://github.com/rome/tools/issues/2959
+module number {}
+module string {}
+declare module never {}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
1. Fixed #2959 
2. Some of `is_reserved_type_name` is allowed in `TsModuleDeclaration` but not in `interface` and `type` alias, you could see more details here https://github.com/rome/tools/issues/2959#issuecomment-1198930538 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. Should pass all  testcases newly added.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
