### PR TITLE
feat(rome_analyze): improve the extensibility of the `declare_rule` macro

### DIFF
--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -19,9 +19,11 @@ pub use crate::categories::{ActionCategory, RuleCategories, RuleCategory};
 pub use crate::matcher::{QueryMatcher, RuleKey, SignalEntry};
 pub use crate::query::{Ast, QueryKey, QueryMatch, Queryable};
 pub use crate::registry::{
-    LanguageRoot, Phase, Phases, RuleMetadata, RuleRegistry, RuleSuppressions,
+    LanguageRoot, Phase, Phases, RegistryRuleMetadata, RuleRegistry, RuleSuppressions,
 };
-pub use crate::rule::{GroupLanguage, Rule, RuleAction, RuleDiagnostic, RuleGroup, RuleMeta};
+pub use crate::rule::{
+    GroupLanguage, Rule, RuleAction, RuleDiagnostic, RuleGroup, RuleMeta, RuleMetadata,
+};
 pub use crate::services::{CannotCreateServicesError, FromServices, ServiceBag};
 use crate::signals::DiagnosticSignal;
 pub use crate::signals::{AnalyzerAction, AnalyzerSignal};
@@ -521,7 +523,7 @@ impl RuleFilter<'_> {
     {
         match self {
             RuleFilter::Group(group) => group == G::NAME,
-            RuleFilter::Rule(group, rule) => group == G::NAME && rule == R::NAME,
+            RuleFilter::Rule(group, rule) => group == G::NAME && rule == R::METADATA.name,
         }
     }
 }

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -63,7 +63,7 @@ impl RuleKey {
     }
 
     pub fn rule<G: RuleGroup, R: Rule>() -> Self {
-        Self::new(G::NAME, R::NAME)
+        Self::new(G::NAME, R::METADATA.name)
     }
 }
 

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -130,8 +130,8 @@ where
         R::diagnostic(&ctx, &self.state).map(|diag| {
             diag.into_diagnostic(
                 self.file_id,
-                format!("{}/{}", G::NAME, R::NAME),
-                format!("https://rome.tools/docs/lint/rules/{}/", R::NAME),
+                format!("{}/{}", G::NAME, R::METADATA.name),
+                format!("https://rome.tools/docs/lint/rules/{}/", R::METADATA.name),
             )
         })
     }
@@ -141,7 +141,7 @@ where
 
         R::action(&ctx, &self.state).map(|action| AnalyzerAction {
             group_name: G::NAME,
-            rule_name: R::NAME,
+            rule_name: R::METADATA.name,
             file_id: self.file_id,
             category: action.category,
             applicability: action.applicability,

--- a/crates/rome_js_analyze/src/analyzers/js/no_async_promise_executor.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_async_promise_executor.rs
@@ -37,7 +37,7 @@ declare_rule! {
     pub(crate) NoAsyncPromiseExecutor {
         version: "0.7.0",
         name: "noAsyncPromiseExecutor",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_compare_neg_zero.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_compare_neg_zero.rs
@@ -36,7 +36,7 @@ declare_rule! {
     pub(crate) NoCompareNegZero {
         version: "0.7.0",
         name: "noCompareNegZero",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_dead_code.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_dead_code.rs
@@ -43,7 +43,7 @@ declare_rule! {
     pub(crate) NoDeadCode {
         version: "0.7.0",
         name: "noDeadCode",
-        recommended: false
+        recommended: false,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_debugger.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_debugger.rs
@@ -29,7 +29,7 @@ declare_rule! {
     pub(crate) NoDebugger {
         version: "0.7.0",
         name: "noDebugger",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_delete.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_delete.rs
@@ -39,7 +39,7 @@ declare_rule! {
     pub(crate) NoDelete {
         version: "0.7.0",
         name: "noDelete",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_double_equals.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_double_equals.rs
@@ -49,7 +49,7 @@ declare_rule! {
     pub(crate) NoDoubleEquals {
         version: "0.7.0",
         name: "noDoubleEquals",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_empty_pattern.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_empty_pattern.rs
@@ -35,7 +35,7 @@ declare_rule! {
     pub(crate) NoEmptyPattern {
         version: "0.7.0",
         name: "noEmptyPattern",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_negation_else.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_negation_else.rs
@@ -38,7 +38,7 @@ declare_rule! {
     pub(crate) NoNegationElse {
         version: "0.7.0",
         name: "noNegationElse",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_sparse_array.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_sparse_array.rs
@@ -22,7 +22,7 @@ declare_rule! {
     pub(crate) NoSparseArray {
         version: "0.7.0",
         name: "noSparseArray",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_unnecessary_continue.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_unnecessary_continue.rs
@@ -74,7 +74,7 @@ declare_rule! {
     pub(crate) NoUnnecessaryContinue {
         version: "0.7.0",
         name: "noUnnecessaryContinue",
-        recommended: true
+        recommended: true,
     }
 
 }

--- a/crates/rome_js_analyze/src/analyzers/js/no_unsafe_negation.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_unsafe_negation.rs
@@ -35,7 +35,7 @@ declare_rule! {
     pub(crate) NoUnsafeNegation {
         version: "0.7.0",
         name: "noUnsafeNegation",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/no_unused_template_literal.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/no_unused_template_literal.rs
@@ -39,7 +39,7 @@ declare_rule! {
     pub(crate) NoUnusedTemplateLiteral {
         version: "0.7.0",
         name: "noUnusedTemplateLiteral",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_block_statements.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_block_statements.rs
@@ -65,7 +65,7 @@ declare_rule! {
     pub(crate) UseBlockStatements {
         version: "0.7.0",
         name: "useBlockStatements",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_simplified_logic_expression.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_simplified_logic_expression.rs
@@ -52,7 +52,7 @@ declare_rule! {
     pub(crate) UseSimplifiedLogicExpression {
         version: "0.7.0",
         name: "useSimplifiedLogicExpression",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_single_case_statement.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_single_case_statement.rs
@@ -44,7 +44,7 @@ declare_rule! {
     pub(crate) UseSingleCaseStatement {
         version: "0.7.0",
         name: "useSingleCaseStatement",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_single_var_declarator.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_single_var_declarator.rs
@@ -33,7 +33,7 @@ declare_rule! {
     pub(crate) UseSingleVarDeclarator {
         version: "0.7.0",
         name: "useSingleVarDeclarator",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_template.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_template.rs
@@ -50,7 +50,7 @@ declare_rule! {
     pub(crate) UseTemplate {
         version: "0.7.0",
         name: "useTemplate",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_valid_typeof.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_valid_typeof.rs
@@ -73,7 +73,7 @@ declare_rule! {
     pub(crate) UseValidTypeof {
         version: "0.7.0",
         name: "useValidTypeof",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/js/use_while.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_while.rs
@@ -25,7 +25,7 @@ declare_rule! {
     pub(crate) UseWhile {
         version: "0.7.0",
         name: "useWhile",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/jsx/no_comment_text.rs
+++ b/crates/rome_js_analyze/src/analyzers/jsx/no_comment_text.rs
@@ -37,7 +37,7 @@ declare_rule! {
     pub(crate) NoCommentText {
         version: "0.7.0",
         name: "noCommentText",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/jsx/no_implicit_boolean.rs
+++ b/crates/rome_js_analyze/src/analyzers/jsx/no_implicit_boolean.rs
@@ -46,7 +46,7 @@ declare_rule! {
     pub(crate) NoImplicitBoolean {
         version: "0.7.0",
         name: "noImplicitBoolean",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/jsx/use_self_closing_elements.rs
+++ b/crates/rome_js_analyze/src/analyzers/jsx/use_self_closing_elements.rs
@@ -56,7 +56,7 @@ declare_rule! {
     pub(crate) UseSelfClosingElements {
         version: "0.7.0",
         name: "useSelfClosingElements",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/regex/no_multiple_spaces_in_regular_expression_literals.rs
+++ b/crates/rome_js_analyze/src/analyzers/regex/no_multiple_spaces_in_regular_expression_literals.rs
@@ -60,7 +60,7 @@ declare_rule! {
     pub(crate) NoMultipleSpacesInRegularExpressionLiterals {
         version: "0.7.0",
         name: "noMultipleSpacesInRegularExpressionLiterals",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/ts/use_shorthand_array_type.rs
+++ b/crates/rome_js_analyze/src/analyzers/ts/use_shorthand_array_type.rs
@@ -45,7 +45,7 @@ declare_rule! {
     pub(crate) UseShorthandArrayType  {
         version: "0.7.0",
         name: "useShorthandArrayType",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/assists/js/flip_bin_exp.rs
+++ b/crates/rome_js_analyze/src/assists/js/flip_bin_exp.rs
@@ -20,7 +20,7 @@ declare_rule! {
     pub(crate) FlipBinExp {
         version: "0.7.0",
         name: "flipBinExp",
-        recommended: false
+        recommended: false,
     }
 }
 

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -1,7 +1,7 @@
 use control_flow::make_visitor;
 use rome_analyze::{
     AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerSignal, ControlFlow, LanguageRoot, Phases,
-    RuleAction, RuleMetadata, ServiceBag, SyntaxVisitor,
+    RegistryRuleMetadata, RuleAction, ServiceBag, SyntaxVisitor,
 };
 use rome_diagnostics::file::FileId;
 use rome_js_syntax::{
@@ -23,7 +23,7 @@ pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
 
 /// Return an iterator over the name and documentation of all the rules
 /// implemented by the JS analyzer
-pub fn metadata(filter: AnalysisFilter) -> impl Iterator<Item = RuleMetadata> {
+pub fn metadata(filter: AnalysisFilter) -> impl Iterator<Item = RegistryRuleMetadata> {
     build_registry(&filter).metadata()
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_arguments.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_arguments.rs
@@ -28,7 +28,7 @@ declare_rule! {
     pub(crate) NoArguments {
         version: "0.7.0",
         name: "noArguments",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_catch_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_catch_assign.rs
@@ -33,7 +33,7 @@ declare_rule! {
     pub(crate) NoCatchAssign {
         version: "0.7.0",
         name: "noCatchAssign",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_function_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_function_assign.rs
@@ -96,7 +96,7 @@ declare_rule! {
     pub(crate) NoFunctionAssign {
         version: "0.7.0",
         name: "noFunctionAssign",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_label_var.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_label_var.rs
@@ -25,7 +25,7 @@ declare_rule! {
     pub(crate) NoLabelVar {
         version: "0.7.0",
         name: "noLabelVar",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
@@ -26,7 +26,7 @@ declare_rule! {
     pub(crate) NoShoutyConstants {
         version: "0.7.0",
         name: "noShoutyConstants",
-        recommended: true
+        recommended: true,
     }
 }
 

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -21,7 +21,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
         groups
             .entry(meta.group)
             .or_insert_with(BTreeMap::new)
-            .insert(meta.name, meta.recommended);
+            .insert(meta.rule.name, meta.rule.recommended);
     }
 
     let mut struct_groups = Vec::new();

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> Result<()> {
         groups
             .entry(meta.group)
             .or_insert_with(BTreeMap::new)
-            .insert(meta.name, meta);
+            .insert(meta.rule.name, meta.rule);
     }
 
     for (group, rules) in groups {


### PR DESCRIPTION
## Summary

This PR modifies the `RuleMeta` trait and how it's implemented in the `declare_rule`: instead of having individual constants for each metadata field, the trait now uses a single const-constructible `RuleMetadata` struct. This struct takes all the required fields as arguments on its constructor, then allows optional fields to have a non-default value set through builder methods. This allows the `declare_rule` to only explicitly match on the require fields, then expand all additional rule properties into builder method calls on the metadata object. While implementing this I also made the trailing comma on rule properties mandatory, it should make future changes on rule metadata easier to read

## Test Plan

This is a syntax level change with all the new code contained in constant expressions, so everything is checked at compile time
