### PR TITLE
fix(playground): rome ast codemirror grammar

### DIFF
--- a/website/playground/package.json
+++ b/website/playground/package.json
@@ -15,7 +15,7 @@
 	},
 	"dependencies": {
 		"@codemirror/lang-javascript": "^6.0.1",
-		"codemirror-lang-rome-ast": "0.0.3",
+		"codemirror-lang-rome-ast": "0.0.4",
 		"@uiw/react-codemirror": "^4.11.4",
 		"@codemirror/view": "6.1.0",
 		"@codemirror/state": "6.1.0",

--- a/website/playground/pnpm-lock.yaml
+++ b/website/playground/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   '@uiw/react-codemirror': ^4.11.4
   '@vitejs/plugin-react': ^1.0.7
   autoprefixer: ^10.4.2
-  codemirror-lang-rome-ast: 0.0.3
+  codemirror-lang-rome-ast: 0.0.4
   postcss: ^8.4.6
   prettier: ^2.7.0
   react: ^17.0.2
@@ -30,7 +30,7 @@ dependencies:
   '@codemirror/state': 6.1.0
   '@codemirror/view': 6.1.0
   '@uiw/react-codemirror': 4.11.4_j45qn7k5iyiiecf3ysrf6hvqzq
-  codemirror-lang-rome-ast: 0.0.3
+  codemirror-lang-rome-ast: 0.0.4
   prettier: 2.7.0
   react: 17.0.2
   react-dom: 17.0.2_react@17.0.2
@@ -890,8 +890,8 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /codemirror-lang-rome-ast/0.0.3:
-    resolution: {integrity: sha512-0qKNS3u7kcK8OD7GZgyTBJ4VXD4memVnxP/MwYT1FMtimEnHgTMFcfH3apAmTLjZOfLRutJJs/+HCiXVQ1YtxA==}
+  /codemirror-lang-rome-ast/0.0.4:
+    resolution: {integrity: sha512-fX6ahzHRhN2dNU6YcMDelT74qL4S3w+mu9PqE8xQA0UvBR/auGJsMFuKM6AJTK9ktZQ2y3cwZAa3hOevSZy01g==}
     dependencies:
       '@codemirror/autocomplete': 6.0.4
       '@codemirror/language': 6.2.0


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
1. Fixing wrong Rome ast codemirror grammar
2. Screenshot:
**Main**
![image](https://user-images.githubusercontent.com/17974631/181906728-538c25d8-07a3-4354-b4e6-a4f258e98750.png)
**Current Branch**
![image](https://user-images.githubusercontent.com/17974631/181906742-3e494892-fc83-4ad1-8a0e-4b5749ba49af.png)
3. For more details, you could see patch pr https://github.com/IWANABETHATGUY/lang-rome-ast/commit/8134a49cb672290c930a8e6993c599833086ac37
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. Running the playground locally or see my screenshot.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
