### PR TITLE
fix(rome_js_analyze): fix the removal of nodes from syntax lists in batch mutations

### DIFF
--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -13,7 +13,6 @@ rome_control_flow = { path = "../rome_control_flow" }
 rome_rowan = { path = "../rome_rowan" }
 rome_js_semantic = { path = "../rome_js_semantic" }
 rome_js_syntax = { path = "../rome_js_syntax" }
-rome_js_parser = { path = "../rome_js_parser" }
 rome_js_factory = { path = "../rome_js_factory" }
 rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
@@ -24,6 +23,7 @@ iai = "0.1.1"
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }
 rome_text_edit = { path = "../rome_text_edit" }
+rome_js_parser = { path = "../rome_js_parser", features = ["tests"] }
 insta = { version = "1.10.0", features = ["glob"] }
 countme = { version = "3.0.0", features = ["enable"] }
 case = "1.0.0"

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -1,3 +1,6 @@
+use rome_js_factory::make;
+use rome_js_syntax::{JsAnyRoot, JsAnyStatement, JsLanguage, JsModuleItemList, JsStatementList, T};
+use rome_rowan::{AstNode, BatchMutation};
 use std::borrow::Cow;
 
 pub mod rename;
@@ -114,6 +117,28 @@ pub fn to_camel_case(input: &str) -> Cow<str> {
 
         Cow::Owned(output)
     }
+}
+
+pub(crate) fn remove_statement<N>(
+    mutation: &mut BatchMutation<JsLanguage, JsAnyRoot>,
+    node: &N,
+) -> Option<()>
+where
+    N: AstNode<Language = JsLanguage>,
+    JsAnyStatement: From<N>,
+{
+    let parent = node.syntax().parent()?;
+
+    if JsStatementList::can_cast(parent.kind()) || JsModuleItemList::can_cast(parent.kind()) {
+        mutation.remove_node(node.clone());
+    } else {
+        mutation.replace_node(
+            JsAnyStatement::from(node.clone()),
+            JsAnyStatement::JsEmptyStatement(make::js_empty_statement(make::token(T![;]))),
+        );
+    }
+
+    Some(())
 }
 
 #[test]

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -119,13 +119,15 @@ pub fn to_camel_case(input: &str) -> Cow<str> {
     }
 }
 
+/// Utility function to remove a statement node from a syntax tree, by either
+/// removing the node from its parent if said parent is a statement list or
+/// module item list, or by replacing the statement node with an empty statement
 pub(crate) fn remove_statement<N>(
     mutation: &mut BatchMutation<JsLanguage, JsAnyRoot>,
     node: &N,
 ) -> Option<()>
 where
-    N: AstNode<Language = JsLanguage>,
-    JsAnyStatement: From<N>,
+    N: AstNode<Language = JsLanguage> + Into<JsAnyStatement>,
 {
     let parent = node.syntax().parent()?;
 
@@ -133,7 +135,7 @@ where
         mutation.remove_node(node.clone());
     } else {
         mutation.replace_node(
-            JsAnyStatement::from(node.clone()),
+            node.clone().into(),
             JsAnyStatement::JsEmptyStatement(make::js_empty_statement(make::token(T![;]))),
         );
     }

--- a/crates/rome_js_analyze/tests/specs/js/noDelete.js
+++ b/crates/rome_js_analyze/tests/specs/js/noDelete.js
@@ -1,5 +1,12 @@
-delete a;
 delete a.b;
 delete a?.b;
 delete a["b"];
 delete a?.["b"];
+delete a.b.c;
+delete a.b?.c;
+delete a.b["c"];
+delete a.b?.["c"];
+delete a?.b.c;
+delete a?.b?.c;
+delete a?.b["c"];
+delete a?.b?.["c"];

--- a/crates/rome_js_analyze/tests/specs/js/noDelete.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noDelete.js.snap
@@ -4,30 +4,36 @@ expression: noDelete.js
 ---
 # Input
 ```js
-delete a;
 delete a.b;
 delete a?.b;
 delete a["b"];
 delete a?.["b"];
+delete a.b.c;
+delete a.b?.c;
+delete a.b["c"];
+delete a.b?.["c"];
+delete a?.b.c;
+delete a?.b?.c;
+delete a?.b["c"];
+delete a?.b?.["c"];
 
 ```
 
 # Diagnostics
 ```
 warning[js/noDelete]: This is an unexpected use of the delete operator.
-  ┌─ noDelete.js:2:1
+  ┌─ noDelete.js:1:1
   │
-2 │ delete a.b;
+1 │ delete a.b;
   │ ----------
 
 Suggested fix: Replace with undefined assignment
-    | @@ -1,5 +1,5 @@
-0 0 |   delete a;
-1   | - delete a.b;
-  1 | + a.b = undefined;
-2 2 |   delete a?.b;
-3 3 |   delete a["b"];
-4 4 |   delete a?.["b"];
+    | @@ -1,4 +1,4 @@
+0   | - delete a.b;
+  0 | + a.b = undefined;
+1 1 |   delete a?.b;
+2 2 |   delete a["b"];
+3 3 |   delete a?.["b"];
 
 
 ```
@@ -36,36 +42,60 @@ Suggested fix: Replace with undefined assignment
 warning[js/noDelete]: This is an unexpected use of the delete operator.
   ┌─ noDelete.js:3:1
   │
-3 │ delete a?.b;
-  │ -----------
+3 │ delete a["b"];
+  │ -------------
 
 Suggested fix: Replace with undefined assignment
-    | @@ -1,5 +1,5 @@
-0 0 |   delete a;
-1 1 |   delete a.b;
-2   | - delete a?.b;
-  2 | + a?.b = undefined;
-3 3 |   delete a["b"];
-4 4 |   delete a?.["b"];
+    | @@ -1,6 +1,6 @@
+0 0 |   delete a.b;
+1 1 |   delete a?.b;
+2   | - delete a["b"];
+  2 | + a["b"] = undefined;
+3 3 |   delete a?.["b"];
+4 4 |   delete a.b.c;
+5 5 |   delete a.b?.c;
 
 
 ```
 
 ```
 warning[js/noDelete]: This is an unexpected use of the delete operator.
-  ┌─ noDelete.js:4:1
+  ┌─ noDelete.js:5:1
   │
-4 │ delete a["b"];
-  │ -------------
+5 │ delete a.b.c;
+  │ ------------
 
 Suggested fix: Replace with undefined assignment
-    | @@ -1,5 +1,5 @@
-0 0 |   delete a;
-1 1 |   delete a.b;
-2 2 |   delete a?.b;
-3   | - delete a["b"];
-  3 | + a["b"] = undefined;
-4 4 |   delete a?.["b"];
+    | @@ -2,7 +2,7 @@
+1 1 |   delete a?.b;
+2 2 |   delete a["b"];
+3 3 |   delete a?.["b"];
+4   | - delete a.b.c;
+  4 | + a.b.c = undefined;
+5 5 |   delete a.b?.c;
+6 6 |   delete a.b["c"];
+7 7 |   delete a.b?.["c"];
+
+
+```
+
+```
+warning[js/noDelete]: This is an unexpected use of the delete operator.
+  ┌─ noDelete.js:7:1
+  │
+7 │ delete a.b["c"];
+  │ ---------------
+
+Suggested fix: Replace with undefined assignment
+    | @@ -4,7 +4,7 @@
+3 3 |   delete a?.["b"];
+4 4 |   delete a.b.c;
+5 5 |   delete a.b?.c;
+6   | - delete a.b["c"];
+  6 | + a.b["c"] = undefined;
+7 7 |   delete a.b?.["c"];
+8 8 |   delete a?.b.c;
+9 9 |   delete a?.b?.c;
 
 
 ```

--- a/crates/rome_js_analyze/tests/specs/js/noUnnecessaryContinue.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noUnnecessaryContinue.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 95
 expression: noUnnecessaryContinue.js
 ---
 # Input
@@ -193,7 +194,7 @@ Suggested fix: Delete the unnecessary continue statement
 22 22 |   }
 23 23 |   
 24    | - test: for (let i = 0; i < 9; i++) continue test;
-   24 | + test: for (let i = 0; i < 9; i++)
+   24 | + test: for (let i = 0; i < 9; i++) ;
 25 25 |   
 26 26 |   test2: do {
 27 27 |   	continue test2;

--- a/crates/rome_js_analyze/tests/specs/js/useBlockStatements.js
+++ b/crates/rome_js_analyze/tests/specs/js/useBlockStatements.js
@@ -12,4 +12,3 @@ for (x of xs);
 do;
 while (x);
 while (x);
-with (x);

--- a/crates/rome_js_analyze/tests/specs/js/useBlockStatements.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/useBlockStatements.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 95
 expression: useBlockStatements.js
 ---
 # Input
@@ -18,7 +19,7 @@ for (x of xs);
 do;
 while (x);
 while (x);
-with (x);
+
 ```
 
 # Diagnostics
@@ -157,7 +158,7 @@ warning[js/useBlockStatements]: Block statements are preferred in this position.
    │ └──────────'
 
 Suggested fix: Wrap the statement with a `JsBlockStatement`
-      | @@ -9,7 +9,7 @@
+      | @@ -9,6 +9,6 @@
  8  8 |   for (;;);
  9  9 |   for (p in obj);
 10 10 |   for (x of xs);
@@ -165,7 +166,6 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
    11 | + do {}
 12 12 |   while (x);
 13 13 |   while (x);
-14 14 |   with (x);
 
 
 ```
@@ -178,13 +178,12 @@ warning[js/useBlockStatements]: Block statements are preferred in this position.
    │ ----------
 
 Suggested fix: Wrap the statement with a `JsBlockStatement`
-      | @@ -11,5 +11,5 @@
+      | @@ -11,4 +11,4 @@
 10 10 |   for (x of xs);
 11 11 |   do;
 12 12 |   while (x);
 13    | - while (x);
    13 | + while (x) {}
-14 14 |   with (x);
 
 
 ```

--- a/crates/rome_js_parser/Cargo.toml
+++ b/crates/rome_js_parser/Cargo.toml
@@ -27,3 +27,4 @@ quickcheck_macros = "1.0.0"
 
 [features]
 serde = ["rome_js_syntax/serde"]
+tests = []

--- a/crates/rome_js_parser/src/lib.rs
+++ b/crates/rome_js_parser/src/lib.rs
@@ -310,6 +310,8 @@ mod lossless_tree_sink;
 mod parse;
 mod state;
 
+#[cfg(any(test, feature = "tests"))]
+pub mod test_utils;
 #[cfg(test)]
 mod tests;
 

--- a/crates/rome_js_parser/src/test_utils.rs
+++ b/crates/rome_js_parser/src/test_utils.rs
@@ -6,9 +6,9 @@ use rome_rowan::{AstNode, SyntaxKind, SyntaxSlot};
 
 use crate::Parse;
 
-// This check is used in the parser test to ensure it doesn't emit
-// unknown nodes without diagnostics, and in the analyzer tests to
-// check the syntax trees resulting from code actions are correct
+/// This check is used in the parser test to ensure it doesn't emit
+/// unknown nodes without diagnostics, and in the analyzer tests to
+/// check the syntax trees resulting from code actions are correct
 pub fn has_unknown_nodes_or_empty_slots(node: &JsSyntaxNode) -> bool {
     node.descendants().any(|descendant| {
         let kind = descendant.kind();
@@ -26,6 +26,9 @@ pub fn has_unknown_nodes_or_empty_slots(node: &JsSyntaxNode) -> bool {
     })
 }
 
+/// This function analyzes the parsing result of a file and panic with a
+/// detailed message if it contains any error-level diagnostic, unknown nodes,
+/// empty list slots or missing required children
 pub fn assert_errors_are_absent<T>(program: &Parse<T>, path: &Path)
 where
     T: AstNode<Language = JsLanguage> + Debug,

--- a/crates/rome_js_parser/src/test_utils.rs
+++ b/crates/rome_js_parser/src/test_utils.rs
@@ -1,0 +1,55 @@
+use std::{fmt::Debug, path::Path};
+
+use rome_diagnostics::{file::SimpleFile, termcolor::Buffer, Emitter};
+use rome_js_syntax::{JsLanguage, JsSyntaxNode};
+use rome_rowan::{AstNode, SyntaxKind, SyntaxSlot};
+
+use crate::Parse;
+
+// This check is used in the parser test to ensure it doesn't emit
+// unknown nodes without diagnostics, and in the analyzer tests to
+// check the syntax trees resulting from code actions are correct
+pub fn has_unknown_nodes_or_empty_slots(node: &JsSyntaxNode) -> bool {
+    node.descendants().any(|descendant| {
+        let kind = descendant.kind();
+        if kind.is_unknown() {
+            return true;
+        }
+
+        if kind.is_list() {
+            return descendant
+                .slots()
+                .any(|slot| matches!(slot, SyntaxSlot::Empty));
+        }
+
+        false
+    })
+}
+
+pub fn assert_errors_are_absent<T>(program: &Parse<T>, path: &Path)
+where
+    T: AstNode<Language = JsLanguage> + Debug,
+{
+    let syntax = program.syntax();
+    let debug_tree = format!("{:?}", program.tree());
+    let has_missing_children = debug_tree.contains("missing (required)");
+
+    if !program.has_errors() && !has_unknown_nodes_or_empty_slots(&syntax) && !has_missing_children
+    {
+        return;
+    }
+
+    let file = SimpleFile::new(path.to_str().unwrap().to_string(), syntax.to_string());
+    let mut emitter = Emitter::new(&file);
+    let mut buffer = Buffer::no_color();
+
+    for diagnostic in program.diagnostics() {
+        emitter.emit_with_writer(diagnostic, &mut buffer).unwrap();
+    }
+
+    panic!("There should be no errors in the file {:?} but the following errors where present:\n{}\n\nParsed tree:\n{:#?}",
+        path.display(),
+        std::str::from_utf8(buffer.as_slice()).unwrap(),
+        &syntax
+	);
+}

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -131,7 +131,7 @@ pub struct Js {
 }
 impl Js {
     const GROUP_NAME: &'static str = "js";
-    pub(crate) const GROUP_RULES: [&'static str; 24] = [
+    pub(crate) const GROUP_RULES: [&'static str; 25] = [
         "noArguments",
         "noAsyncPromiseExecutor",
         "noCatchAssign",
@@ -150,6 +150,7 @@ impl Js {
         "noUnsafeNegation",
         "noUnusedTemplateLiteral",
         "useBlockStatements",
+        "useCamelCase",
         "useSimplifiedLogicExpression",
         "useSingleCaseStatement",
         "useSingleVarDeclarator",
@@ -175,12 +176,12 @@ impl Js {
         RuleFilter::Rule("js", Self::GROUP_RULES[15]),
         RuleFilter::Rule("js", Self::GROUP_RULES[16]),
         RuleFilter::Rule("js", Self::GROUP_RULES[17]),
-        RuleFilter::Rule("js", Self::GROUP_RULES[18]),
         RuleFilter::Rule("js", Self::GROUP_RULES[19]),
         RuleFilter::Rule("js", Self::GROUP_RULES[20]),
         RuleFilter::Rule("js", Self::GROUP_RULES[21]),
         RuleFilter::Rule("js", Self::GROUP_RULES[22]),
         RuleFilter::Rule("js", Self::GROUP_RULES[23]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[24]),
     ];
     pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {


### PR DESCRIPTION
## Summary

This PR fixes #2966 by changing the behavior of the `remove_node` batch mutation method in syntax lists, making it actually remove the corresponding slot from the list instead of replacing the previous node with an empty slot.

In order to make this work the batch mutation now has to track the number of removed slots in a node to adjust the indices of other modifications being applied to the same node, in turn this means I had to change the ordering semantics of mutation changes slightly so that modifications that apply to the same node are sorted in increasing order by the index of the slot they are modifying.

## Test Plan

To test this change and protect from future regressions I modified the analyzer tests to perform additional checks on the syntax tree emitted by code actions. These checks include:
- verifying that applying the text edits returned by `as_text_edits` and printing the syntax tree returned by `commit` result in the same source code
- verifying the resulting syntax tree has no unknown nodes, empty slots or missing required children
- verifying that re-parsing the returned source code does not yield any syntax errors

Incidentally these new checks required changes in a few existing tests that had syntax errors in the input file