### PR TITLE
fix(rome_js_analyze): improve the handling of trivia in `useBlockStatements`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/js/use_block_statements.rs
+++ b/crates/rome_js_analyze/src/analyzers/js/use_block_statements.rs
@@ -7,9 +7,13 @@ use rome_analyze::{
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
-use rome_js_syntax::{JsAnyStatement, JsElseClauseFields, JsIfStatementFields, TriviaPieceKind, T};
+use rome_js_syntax::{
+    JsAnyStatement, JsDoWhileStatement, JsElseClause, JsForInStatement, JsForOfStatement,
+    JsForStatement, JsIfStatement, JsLanguage, JsSyntaxTrivia, JsWhileStatement, JsWithStatement,
+    TriviaPieceKind, T,
+};
 
-use rome_rowan::{AstNode, BatchMutationExt};
+use rome_rowan::{declare_node_union, AstNode, BatchMutationExt, SyntaxTriviaPiece};
 
 use crate::JsRuleAction;
 use crate::{use_block_statements_diagnostic, use_block_statements_replace_body};
@@ -69,66 +73,55 @@ declare_rule! {
     }
 }
 
+declare_node_union! {
+    pub(crate) JsAnyBlockStatement = JsIfStatement | JsElseClause | JsDoWhileStatement | JsForInStatement | JsForOfStatement | JsForStatement | JsWhileStatement | JsWithStatement
+}
+
 impl Rule for UseBlockStatements {
     const CATEGORY: RuleCategory = RuleCategory::Lint;
 
-    type Query = Ast<JsAnyStatement>;
+    type Query = Ast<JsAnyBlockStatement>;
     type State = UseBlockStatementsOperationType;
     type Signals = Option<Self::State>;
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
         match node {
-            JsAnyStatement::JsIfStatement(stmt) => {
-                let JsIfStatementFields {
-                    if_token: _,
-                    l_paren_token: _,
-                    test: _,
-                    r_paren_token: _,
-                    consequent,
-                    else_clause,
-                } = stmt.as_fields();
-                let consequent = consequent.ok()?;
-                // if `IfStatement` has not consequent then it must has no else clause,
-                // so this `?` operation here is safe
-                if !matches!(&consequent, JsAnyStatement::JsBlockStatement(_)) {
-                    return Some(UseBlockStatementsOperationType::Wrap(consequent));
+            JsAnyBlockStatement::JsIfStatement(stmt) => {
+                use_block_statements_diagnostic!(stmt, consequent)
+            }
+            JsAnyBlockStatement::JsDoWhileStatement(stmt) => {
+                use_block_statements_diagnostic!(stmt)
+            }
+            JsAnyBlockStatement::JsForInStatement(stmt) => {
+                use_block_statements_diagnostic!(stmt)
+            }
+            JsAnyBlockStatement::JsForOfStatement(stmt) => {
+                use_block_statements_diagnostic!(stmt)
+            }
+            JsAnyBlockStatement::JsForStatement(stmt) => {
+                use_block_statements_diagnostic!(stmt)
+            }
+            JsAnyBlockStatement::JsWhileStatement(stmt) => {
+                use_block_statements_diagnostic!(stmt)
+            }
+            JsAnyBlockStatement::JsWithStatement(stmt) => {
+                use_block_statements_diagnostic!(stmt)
+            }
+            JsAnyBlockStatement::JsElseClause(stmt) => {
+                let body = stmt.alternate().ok()?;
+                if matches!(body, JsAnyStatement::JsEmptyStatement(_)) {
+                    return Some(UseBlockStatementsOperationType::ReplaceBody);
                 }
-                if let Some(else_clause) = else_clause {
-                    // SAFETY: because we know the variant of `else_clause` is `Some(_)`
-                    let JsElseClauseFields {
-                        else_token: _,
-                        alternate,
-                    } = else_clause.as_fields();
-                    let alternate = alternate.ok()?;
-                    if !matches!(
-                        alternate,
-                        JsAnyStatement::JsBlockStatement(_) | JsAnyStatement::JsIfStatement(_)
-                    ) {
-                        return Some(UseBlockStatementsOperationType::Wrap(alternate));
-                    }
+                let is_block = matches!(
+                    body,
+                    JsAnyStatement::JsBlockStatement(_) | JsAnyStatement::JsIfStatement(_)
+                );
+                if !is_block {
+                    return Some(UseBlockStatementsOperationType::Wrap(body));
                 }
                 None
             }
-            JsAnyStatement::JsDoWhileStatement(stmt) => {
-                use_block_statements_diagnostic!(stmt)
-            }
-            JsAnyStatement::JsForInStatement(stmt) => {
-                use_block_statements_diagnostic!(stmt)
-            }
-            JsAnyStatement::JsForOfStatement(stmt) => {
-                use_block_statements_diagnostic!(stmt)
-            }
-            JsAnyStatement::JsForStatement(stmt) => {
-                use_block_statements_diagnostic!(stmt)
-            }
-            JsAnyStatement::JsWhileStatement(stmt) => {
-                use_block_statements_diagnostic!(stmt)
-            }
-            JsAnyStatement::JsWithStatement(stmt) => {
-                use_block_statements_diagnostic!(stmt)
-            }
-            _ => None,
         }
     }
 
@@ -150,36 +143,129 @@ impl Rule for UseBlockStatements {
         let mut mutation = ctx.root().begin();
 
         match nodes_need_to_replaced {
-            UseBlockStatementsOperationType::Wrap(stmt) => mutation.replace_node(
-                stmt.clone(),
-                JsAnyStatement::JsBlockStatement(make::js_block_statement(
-                    make::token(T!['{'])
-                        .with_trailing_trivia(iter::once((TriviaPieceKind::Whitespace, " "))),
-                    make::js_statement_list(iter::once(stmt.clone())),
-                    make::token(T!['}'])
-                        .with_leading_trivia(iter::once((TriviaPieceKind::Whitespace, " "))),
-                )),
-            ),
+            UseBlockStatementsOperationType::Wrap(stmt) => {
+                let mut l_curly_token = make::token(T!['{']);
+                let r_curly_token = make::token(T!['}']);
+
+                // Ensure the opening curly token is separated from the previous token by at least one space
+                let has_previous_space = stmt
+                    .syntax()
+                    .first_token()
+                    .and_then(|token| token.prev_token())
+                    .map(|token| {
+                        token
+                            .trailing_trivia()
+                            .pieces()
+                            .rev()
+                            .take_while(|piece| !piece.is_newline())
+                            .any(|piece| piece.is_whitespace())
+                    })
+                    .unwrap_or(false);
+
+                if !has_previous_space {
+                    l_curly_token = l_curly_token
+                        .with_leading_trivia(iter::once((TriviaPieceKind::Whitespace, " ")));
+                }
+
+                // Clone the leading trivia of the single statement as the
+                // leading trivia of the closing curly token
+                let mut leading_trivia = stmt
+                    .syntax()
+                    .first_leading_trivia()
+                    .map(collect_to_first_newline)
+                    .unwrap_or_else(Vec::new);
+
+                // If the statement has no leading trivia, add a space after
+                // the opening curly token
+                if leading_trivia.is_empty() {
+                    l_curly_token = l_curly_token
+                        .with_trailing_trivia(iter::once((TriviaPieceKind::Whitespace, " ")));
+                }
+
+                // If the leading trivia for the statement contains any newline,
+                // then the indentation is probably one level too deep for the
+                // closing curly token, clone the leading trivia from the
+                // parent node instead
+                if leading_trivia.iter().any(|piece| piece.is_newline()) {
+                    // Find the parent block statement node, skipping over
+                    // else-clause nodes if this statement is part of an
+                    // else-if chain
+                    let mut node = node.clone();
+                    while let Some(parent) = node.parent::<JsAnyBlockStatement>() {
+                        if !matches!(parent, JsAnyBlockStatement::JsElseClause(_)) {
+                            break;
+                        }
+
+                        node = parent;
+                    }
+
+                    leading_trivia = node
+                        .syntax()
+                        .first_leading_trivia()
+                        .map(collect_to_first_newline)
+                        .unwrap_or_else(Vec::new);
+                }
+
+                // Apply the cloned trivia to the closing curly token, or
+                // fallback to a single space if it's still empty
+                let r_curly_token = if !leading_trivia.is_empty() {
+                    let leading_trivia = leading_trivia
+                        .iter()
+                        .rev()
+                        .map(|piece| (piece.kind(), piece.text()));
+
+                    r_curly_token.with_leading_trivia(leading_trivia)
+                } else {
+                    r_curly_token
+                        .with_leading_trivia(iter::once((TriviaPieceKind::Whitespace, " ")))
+                };
+
+                mutation.replace_node_discard_trivia(
+                    stmt.clone(),
+                    JsAnyStatement::JsBlockStatement(make::js_block_statement(
+                        l_curly_token,
+                        make::js_statement_list(iter::once(stmt.clone())),
+                        r_curly_token,
+                    )),
+                );
+            }
             UseBlockStatementsOperationType::ReplaceBody => match node {
-                JsAnyStatement::JsDoWhileStatement(stmt) => {
+                JsAnyBlockStatement::JsIfStatement(stmt) => {
+                    use_block_statements_replace_body!(
+                        JsIfStatement,
+                        with_consequent,
+                        mutation,
+                        node,
+                        stmt
+                    )
+                }
+                JsAnyBlockStatement::JsElseClause(stmt) => {
+                    use_block_statements_replace_body!(
+                        JsElseClause,
+                        with_alternate,
+                        mutation,
+                        node,
+                        stmt
+                    )
+                }
+                JsAnyBlockStatement::JsDoWhileStatement(stmt) => {
                     use_block_statements_replace_body!(JsDoWhileStatement, mutation, node, stmt)
                 }
-                JsAnyStatement::JsForInStatement(stmt) => {
+                JsAnyBlockStatement::JsForInStatement(stmt) => {
                     use_block_statements_replace_body!(JsForInStatement, mutation, node, stmt)
                 }
-                JsAnyStatement::JsForOfStatement(stmt) => {
+                JsAnyBlockStatement::JsForOfStatement(stmt) => {
                     use_block_statements_replace_body!(JsForOfStatement, mutation, node, stmt)
                 }
-                JsAnyStatement::JsForStatement(stmt) => {
+                JsAnyBlockStatement::JsForStatement(stmt) => {
                     use_block_statements_replace_body!(JsForStatement, mutation, node, stmt)
                 }
-                JsAnyStatement::JsWhileStatement(stmt) => {
+                JsAnyBlockStatement::JsWhileStatement(stmt) => {
                     use_block_statements_replace_body!(JsWhileStatement, mutation, node, stmt)
                 }
-                JsAnyStatement::JsWithStatement(stmt) => {
+                JsAnyBlockStatement::JsWithStatement(stmt) => {
                     use_block_statements_replace_body!(JsWithStatement, mutation, node, stmt)
                 }
-                _ => return None,
             },
         };
         Some(RuleAction {
@@ -191,6 +277,21 @@ impl Rule for UseBlockStatements {
     }
 }
 
+/// Collect newline and comment trivia pieces in reverse order up to the first newline included
+fn collect_to_first_newline(trivia: JsSyntaxTrivia) -> Vec<SyntaxTriviaPiece<JsLanguage>> {
+    let mut has_newline = false;
+    trivia
+        .pieces()
+        .rev()
+        .filter(|piece| piece.is_newline() || piece.is_whitespace())
+        .take_while(|piece| {
+            let had_newline = has_newline;
+            has_newline |= piece.is_newline();
+            !had_newline
+        })
+        .collect()
+}
+
 pub enum UseBlockStatementsOperationType {
     Wrap(JsAnyStatement),
     ReplaceBody,
@@ -198,33 +299,40 @@ pub enum UseBlockStatementsOperationType {
 
 #[macro_export]
 macro_rules! use_block_statements_diagnostic {
-    ($id:ident) => {{
-        let body = $id.body().ok()?;
+    ($id:ident, $field:ident) => {{
+        let body = $id.$field().ok()?;
         if matches!(body, JsAnyStatement::JsEmptyStatement(_)) {
-            return Some(UseBlockStatementsOperationType::ReplaceBody);
+            Some(UseBlockStatementsOperationType::ReplaceBody)
+        } else if !matches!(body, JsAnyStatement::JsBlockStatement(_)) {
+            Some(UseBlockStatementsOperationType::Wrap(body))
+        } else {
+            None
         }
-        if !matches!(body, JsAnyStatement::JsBlockStatement(_)) {
-            return Some(UseBlockStatementsOperationType::Wrap(body.clone()));
-        }
-        None
     }};
+    ($id:ident) => {
+        use_block_statements_diagnostic!($id, body)
+    };
 }
 
 #[macro_export]
 macro_rules! use_block_statements_replace_body {
-    ($stmt_type:ident, $mutation:ident, $node:ident, $stmt:ident) => {{
+    ($stmt_type:ident, $builder_method:ident, $mutation:ident, $node:ident, $stmt:ident) => {
         $mutation.replace_node(
             $node.clone(),
-            JsAnyStatement::$stmt_type(
-                $stmt.clone().with_body(JsAnyStatement::JsBlockStatement(
-                    make::js_block_statement(
+            JsAnyBlockStatement::$stmt_type(
+                $stmt
+                    .clone()
+                    .$builder_method(JsAnyStatement::JsBlockStatement(make::js_block_statement(
                         make::token(T!['{'])
                             .with_leading_trivia(iter::once((TriviaPieceKind::Whitespace, " "))),
                         make::js_statement_list([]),
                         make::token(T!['}']),
-                    ),
-                )),
+                    ))),
             ),
         )
-    }};
+    };
+
+    ($stmt_type:ident, $mutation:ident, $node:ident, $stmt:ident) => {
+        use_block_statements_replace_body!($stmt_type, with_body, $mutation, $node, $stmt)
+    };
 }

--- a/crates/rome_js_analyze/tests/specs/js/useBlockStatements.js
+++ b/crates/rome_js_analyze/tests/specs/js/useBlockStatements.js
@@ -12,3 +12,29 @@ for (x of xs);
 do;
 while (x);
 while (x);
+
+if (x);
+
+if (test);
+else if (test);
+else;
+
+while (test)
+  bar
+
+  while (test)
+    bar
+
+if (test)
+  bar
+else if(test)
+  bar
+else
+  bar
+
+  if (test)
+    bar
+  else if(test)
+    bar
+  else
+    bar

--- a/crates/rome_js_analyze/tests/specs/js/useBlockStatements.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/useBlockStatements.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 95
 expression: useBlockStatements.js
 ---
 # Input
@@ -19,6 +18,32 @@ for (x of xs);
 do;
 while (x);
 while (x);
+
+if (x);
+
+if (test);
+else if (test);
+else;
+
+while (test)
+  bar
+
+  while (test)
+    bar
+
+if (test)
+  bar
+else if(test)
+  bar
+else
+  bar
+
+  if (test)
+    bar
+  else if(test)
+    bar
+  else
+    bar
 
 ```
 
@@ -44,12 +69,10 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 
 ```
 warning[js/useBlockStatements]: Block statements are preferred in this position.
-  ┌─ useBlockStatements.js:3:1
-  │  
-3 │ ┌ if (x) {
-4 │ │   x;
-5 │ │ } else y;
-  │ └─────────'
+  ┌─ useBlockStatements.js:5:3
+  │
+5 │ } else y;
+  │   -------
 
 Suggested fix: Wrap the statement with a `JsBlockStatement`
     | @@ -2,7 +2,7 @@
@@ -158,7 +181,7 @@ warning[js/useBlockStatements]: Block statements are preferred in this position.
    │ └──────────'
 
 Suggested fix: Wrap the statement with a `JsBlockStatement`
-      | @@ -9,6 +9,6 @@
+      | @@ -9,7 +9,7 @@
  8  8 |   for (;;);
  9  9 |   for (p in obj);
 10 10 |   for (x of xs);
@@ -166,6 +189,7 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
    11 | + do {}
 12 12 |   while (x);
 13 13 |   while (x);
+14 14 |   
 
 
 ```
@@ -178,12 +202,305 @@ warning[js/useBlockStatements]: Block statements are preferred in this position.
    │ ----------
 
 Suggested fix: Wrap the statement with a `JsBlockStatement`
-      | @@ -11,4 +11,4 @@
+      | @@ -11,7 +11,7 @@
 10 10 |   for (x of xs);
 11 11 |   do;
 12 12 |   while (x);
 13    | - while (x);
    13 | + while (x) {}
+14 14 |   
+15 15 |   if (x);
+16 16 |   
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:16:1
+   │
+16 │ if (x);
+   │ -------
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -13,7 +13,7 @@
+12 12 |   while (x);
+13 13 |   while (x);
+14 14 |   
+15    | - if (x);
+   15 | + if (x) {}
+16 16 |   
+17 17 |   if (test);
+18 18 |   else if (test);
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:18:1
+   │  
+18 │ ┌ if (test);
+19 │ │ else if (test);
+20 │ │ else;
+   │ └─────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -15,7 +15,7 @@
+14 14 |   
+15 15 |   if (x);
+16 16 |   
+17    | - if (test);
+   17 | + if (test) {}
+18 18 |   else if (test);
+19 19 |   else;
+20 20 |   
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:19:6
+   │  
+19 │   else if (test);
+   │ ┌──────'
+20 │ │ else;
+   │ └─────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -16,7 +16,7 @@
+15 15 |   if (x);
+16 16 |   
+17 17 |   if (test);
+18    | - else if (test);
+   18 | + else if (test) {}
+19 19 |   else;
+20 20 |   
+21 21 |   while (test)
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:20:1
+   │
+20 │ else;
+   │ -----
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -17,7 +17,7 @@
+16 16 |   
+17 17 |   if (test);
+18 18 |   else if (test);
+19    | - else;
+   19 | + else {}
+20 20 |   
+21 21 |   while (test)
+22 22 |     bar
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:22:1
+   │  
+22 │ ┌ while (test)
+23 │ │   bar
+   │ └─────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -19,8 +19,9 @@
+18 18 |   else if (test);
+19 19 |   else;
+20 20 |   
+21    | - while (test)
+   21 | + while (test) {
+22 22 |     bar
+   23 | + }
+23 24 |   
+24 25 |     while (test)
+25 26 |       bar
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:25:3
+   │  
+25 │ ┌   while (test)
+26 │ │     bar
+   │ └───────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -22,8 +22,9 @@
+21 21 |   while (test)
+22 22 |     bar
+23 23 |   
+24    | -   while (test)
+   24 | +   while (test) {
+25 25 |       bar
+   26 | +   }
+26 27 |   
+27 28 |   if (test)
+28 29 |     bar
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:28:1
+   │  
+28 │ ┌ if (test)
+29 │ │   bar
+30 │ │ else if(test)
+31 │ │   bar
+32 │ │ else
+33 │ │   bar
+   │ └─────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -25,8 +25,9 @@
+24 24 |     while (test)
+25 25 |       bar
+26 26 |   
+27    | - if (test)
+   27 | + if (test) {
+28 28 |     bar
+   29 | + }
+29 30 |   else if(test)
+30 31 |     bar
+31 32 |   else
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:30:6
+   │  
+30 │   else if(test)
+   │ ┌──────'
+31 │ │   bar
+32 │ │ else
+33 │ │   bar
+   │ └─────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -27,8 +27,9 @@
+26 26 |   
+27 27 |   if (test)
+28 28 |     bar
+29    | - else if(test)
+   29 | + else if(test) {
+30 30 |     bar
+   31 | + }
+31 32 |   else
+32 33 |     bar
+33 34 |   
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:32:1
+   │  
+32 │ ┌ else
+33 │ │   bar
+   │ └─────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -29,8 +29,9 @@
+28 28 |     bar
+29 29 |   else if(test)
+30 30 |     bar
+31    | - else
+   31 | + else {
+32 32 |     bar
+   33 | + }
+33 34 |   
+34 35 |     if (test)
+35 36 |       bar
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:35:3
+   │  
+35 │ ┌   if (test)
+36 │ │     bar
+37 │ │   else if(test)
+38 │ │     bar
+39 │ │   else
+40 │ │     bar
+   │ └───────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -32,8 +32,9 @@
+31 31 |   else
+32 32 |     bar
+33 33 |   
+34    | -   if (test)
+   34 | +   if (test) {
+35 35 |       bar
+   36 | +   }
+36 37 |     else if(test)
+37 38 |       bar
+38 39 |     else
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:37:8
+   │  
+37 │     else if(test)
+   │ ┌────────'
+38 │ │     bar
+39 │ │   else
+40 │ │     bar
+   │ └───────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -34,7 +34,8 @@
+33 33 |   
+34 34 |     if (test)
+35 35 |       bar
+36    | -   else if(test)
+   36 | +   else if(test) {
+37 37 |       bar
+   38 | +   }
+38 39 |     else
+39 40 |       bar
+
+
+```
+
+```
+warning[js/useBlockStatements]: Block statements are preferred in this position.
+   ┌─ useBlockStatements.js:39:3
+   │  
+39 │ ┌   else
+40 │ │     bar
+   │ └───────'
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+      | @@ -36,5 +36,6 @@
+35 35 |       bar
+36 36 |     else if(test)
+37 37 |       bar
+38    | -   else
+   38 | +   else {
+39 39 |       bar
+   40 | +   }
 
 
 ```

--- a/website/src/docs/lint/rules/useBlockStatements.md
+++ b/website/src/docs/lint/rules/useBlockStatements.md
@@ -38,12 +38,10 @@ JavaScript allows the omission of curly braces when a block contains only one st
 ```
 
 {% raw %}<pre class="language-text"><code class="language-text"><span style="color: Orange;">warning</span><span style="color: Orange;">[</span><span style="color: Orange;"><a href="https://rome.tools/docs/lint/rules/useBlockStatements/">js/useBlockStatements</a></span><span style="color: Orange;">]</span><em>: </em><em>Block statements are preferred in this position.</em>
-  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> js/useBlockStatements.js:1:2
-  <span style="color: rgb(38, 148, 255);">│</span>  
-<span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">┌</span>  if (x) {
-<span style="color: rgb(38, 148, 255);">2</span> <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">│</span>    x;
-<span style="color: rgb(38, 148, 255);">3</span> <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">│</span>  } else y;
-  <span style="color: rgb(38, 148, 255);">│</span> <span style="color: rgb(38, 148, 255);">└</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">─</span><span style="color: rgb(38, 148, 255);">'</span>
+  <span style="color: rgb(38, 148, 255);">┌</span><span style="color: rgb(38, 148, 255);">─</span> js/useBlockStatements.js:3:4
+  <span style="color: rgb(38, 148, 255);">│</span>
+<span style="color: rgb(38, 148, 255);">3</span> <span style="color: rgb(38, 148, 255);">│</span>  } else y;
+  <span style="color: rgb(38, 148, 255);">│</span>    <span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span><span style="color: rgb(38, 148, 255);">-</span>
 
 <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Wrap the statement with a `JsBlockStatement`</span>
     | <span style="color: rgb(38, 148, 255);">@@ -1,3 +1,3 @@</span>


### PR DESCRIPTION
## Summary

This PR fixes #2943 by introducing additional logic in the code generating the auto-fix for the rule to inspect the tokens and nodes being modified, and move or add trivia pieces accordingly.

I also fixed the query used by the rule to ensure it would trigger separately for if statements and else clauses, ensuring both the consequent and alternate statements would have a diagnostic and code action emitted, and not only the first one visited by the rule.

## Test Plan

I added a number of additional test cases in the snapshot tests for the rule to verify the handling of empty statements in if-else chains and indentation
