### PR TITLE
chore(git): mark additional generated files in the gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,13 @@ crates/rome_js_parser/src/lexer/tables.rs linguist-generated=true text=auto eol=
 **/generated/* linguist-generated=true text=auto eol=lf
 crates/rome_js_analyze/src/analyzers.rs linguist-generated=true text=auto eol=lf
 crates/rome_js_analyze/src/assists.rs linguist-generated=true text=auto eol=lf
+crates/rome_js_analyze/src/semantic_analyzers.rs linguist-generated=true text=auto eol=lf
+crates/rome_js_analyze/src/analyzers/*.rs linguist-generated=true text=auto eol=lf
+crates/rome_js_analyze/src/assists/*.rs linguist-generated=true text=auto eol=lf
+crates/rome_js_analyze/src/semantic_analyzers/*.rs linguist-generated=true text=auto eol=lf
 crates/rome_js_analyze/src/registry.rs linguist-generated=true text=auto eol=lf
+crates/rome_service/src/configuration/linter/rules.rs linguist-generated=true text=auto eol=lf
+website/src/docs/lint/rules/**/*.md linguist-generated=true text=auto eol=lf
 
 
 crates/rome_js_formatter/tests/**/*.ts.prettier-snap linguist-language=TypeScript

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -119,6 +119,11 @@ jobs:
         with:
           command: codegen
           args: analyzer
+      - name: Run the configuration codegen
+        uses: actions-rs/cargo@v1
+        with:
+          command: codegen
+          args: configuration
       - name: Run the website codegen
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
## Summary

This adds additional entries to the `.gitattributes` configuration to mark the following files as auto-generated:
- The rule group modules in `rome_js_analyze`, eg. `crates/rome_js_analyze/src/analyzers/ts.rs` or `crates/rome_js_analyze/src/semantic_analyzers/js.rs`
- The configuration structure generated for the analyzer rules in `crates/rome_service/src/configuration/linter/rules.rs`
- All the generated rule documentation pages for the website in `website/src/docs/lint/rules`

Additionally I also added the `cargo codegen configuration` command to the list of codegen commands being run on CI

## Test Plan

The diffs for these files should not be hidden by default for future PRs, I don't think it will update the currently open ones though
