### PR TITLE
feat(rome_js_analyze): add an `inlineVariable` code action

### DIFF
--- a/crates/rome_js_analyze/src/assists/js.rs
+++ b/crates/rome_js_analyze/src/assists/js.rs
@@ -2,4 +2,5 @@
 
 use rome_analyze::declare_group;
 mod flip_bin_exp;
-declare_group! { pub (crate) Js { name : "js" , rules : [self :: flip_bin_exp :: FlipBinExp ,] } }
+mod inline_variable;
+declare_group! { pub (crate) Js { name : "js" , rules : [self :: flip_bin_exp :: FlipBinExp , self :: inline_variable :: InlineVariable ,] } }

--- a/crates/rome_js_analyze/src/assists/js/inline_variable.rs
+++ b/crates/rome_js_analyze/src/assists/js/inline_variable.rs
@@ -1,0 +1,90 @@
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory};
+use rome_console::markup;
+use rome_diagnostics::Applicability;
+use rome_js_semantic::{AllReferencesExtensions, Reference};
+use rome_js_syntax::{
+    JsAnyBinding, JsAnyBindingPattern, JsAnyExpression, JsIdentifierExpression,
+    JsVariableDeclarator,
+};
+use rome_rowan::{BatchMutationExt, SyntaxNodeCast};
+
+use crate::{semantic_services::Semantic, utils::remove_declarator, JsRuleAction};
+
+declare_rule! {
+    /// Provides a refactor to inline variables
+    ///
+    /// ## Examples
+    ///
+    /// ```js
+    /// let variable = expression();
+    /// statement(variable);
+    /// ```
+    pub(crate) InlineVariable {
+        version: "0.8.0",
+        name: "inlineVariable",
+        recommended: false,
+    }
+}
+
+impl Rule for InlineVariable {
+    const CATEGORY: RuleCategory = RuleCategory::Action;
+
+    type Query = Semantic<JsVariableDeclarator>;
+    type State = (Vec<Reference>, JsAnyExpression);
+    type Signals = Option<Self::State>;
+
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        let semantic_model = ctx.model();
+        let declarator = ctx.query();
+
+        let id = declarator.id().ok()?;
+        let binding = match id {
+            JsAnyBindingPattern::JsAnyBinding(JsAnyBinding::JsIdentifierBinding(binding)) => {
+                binding
+            }
+            JsAnyBindingPattern::JsAnyBinding(JsAnyBinding::JsUnknownBinding(_))
+            | JsAnyBindingPattern::JsArrayBindingPattern(_)
+            | JsAnyBindingPattern::JsObjectBindingPattern(_) => return None,
+        };
+
+        let mut references = Vec::new();
+        for reference in binding.all_references(semantic_model) {
+            if reference.is_write() {
+                return None;
+            }
+
+            references.push(reference);
+        }
+
+        let initializer = declarator.initializer()?;
+        let expression = initializer.expression().ok()?;
+        Some((references, expression))
+    }
+
+    fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
+        let node = ctx.query();
+        let mut mutation = ctx.root().begin();
+        let (references, expression) = state;
+
+        remove_declarator(&mut mutation, node);
+
+        for reference in references {
+            let node = reference
+                .node()
+                .parent()?
+                .cast::<JsIdentifierExpression>()?;
+
+            mutation.replace_node(
+                JsAnyExpression::JsIdentifierExpression(node),
+                expression.clone(),
+            );
+        }
+
+        Some(JsRuleAction {
+            category: ActionCategory::Refactor,
+            applicability: Applicability::Always,
+            message: markup! { "Inline variable" }.to_owned(),
+            mutation,
+        })
+    }
+}

--- a/crates/rome_js_analyze/src/assists/js/inline_variable.rs
+++ b/crates/rome_js_analyze/src/assists/js/inline_variable.rs
@@ -20,7 +20,7 @@ declare_rule! {
     /// statement(variable);
     /// ```
     pub(crate) InlineVariable {
-        version: "0.8.0",
+        version: "0.9.0",
         name: "inlineVariable",
         recommended: false,
     }

--- a/crates/rome_js_analyze/tests/specs/js/inlineVariable.js
+++ b/crates/rome_js_analyze/tests/specs/js/inlineVariable.js
@@ -1,0 +1,8 @@
+let inlinable = "value1";
+let notInlinable = "value2";
+
+if (inlinable) {
+    notInlinable = inlinable;
+}
+
+statement(notInlinable);

--- a/crates/rome_js_analyze/tests/specs/js/inlineVariable.js
+++ b/crates/rome_js_analyze/tests/specs/js/inlineVariable.js
@@ -6,3 +6,15 @@ if (inlinable) {
 }
 
 statement(notInlinable);
+
+let multipleDeclaratorsInlinable = "value3",
+    multipleDeclaratorsNotInlinable = "value4";
+
+if (multipleDeclaratorsInlinable) {
+    multipleDeclaratorsNotInlinable.memberWrite = multipleDeclaratorsInlinable;
+}
+
+statement(multipleDeclaratorsNotInlinable);
+
+let variable = expression();
+statement(variable);

--- a/crates/rome_js_analyze/tests/specs/js/inlineVariable.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/inlineVariable.js.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: inlineVariable.js
+---
+# Input
+```js
+let inlinable = "value1";
+let notInlinable = "value2";
+
+if (inlinable) {
+    notInlinable = inlinable;
+}
+
+statement(notInlinable);
+
+```
+
+# Actions
+```
+    | @@ -1,8 +1,8 @@
+0   | - let inlinable = "value1";
+  0 | + 
+1 1 |   let notInlinable = "value2";
+2 2 |   
+3   | - if (inlinable) {
+4   | -     notInlinable = inlinable;
+  3 | + if ("value1") {
+  4 | +     notInlinable = "value1";
+5 5 |   }
+6 6 |   
+7 7 |   statement(notInlinable);
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/js/inlineVariable.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/inlineVariable.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 95
 expression: inlineVariable.js
 ---
 # Input
@@ -12,6 +13,18 @@ if (inlinable) {
 }
 
 statement(notInlinable);
+
+let multipleDeclaratorsInlinable = "value3",
+    multipleDeclaratorsNotInlinable = "value4";
+
+if (multipleDeclaratorsInlinable) {
+    multipleDeclaratorsNotInlinable.memberWrite = multipleDeclaratorsInlinable;
+}
+
+statement(multipleDeclaratorsNotInlinable);
+
+let variable = expression();
+statement(variable);
 
 ```
 
@@ -29,6 +42,59 @@ statement(notInlinable);
 5 5 |   }
 6 6 |   
 7 7 |   statement(notInlinable);
+
+```
+
+```
+      | @@ -7,11 +7,11 @@
+ 6  6 |   
+ 7  7 |   statement(notInlinable);
+ 8  8 |   
+ 9    | - let multipleDeclaratorsInlinable = "value3",
+    9 | + let
+10 10 |       multipleDeclaratorsNotInlinable = "value4";
+11 11 |   
+12    | - if (multipleDeclaratorsInlinable) {
+13    | -     multipleDeclaratorsNotInlinable.memberWrite = multipleDeclaratorsInlinable;
+   12 | + if ("value3") {
+   13 | +     multipleDeclaratorsNotInlinable.memberWrite = "value3";
+14 14 |   }
+15 15 |   
+16 16 |   statement(multipleDeclaratorsNotInlinable);
+
+```
+
+```
+      | @@ -7,14 +7,13 @@
+ 6  6 |   
+ 7  7 |   statement(notInlinable);
+ 8  8 |   
+ 9    | - let multipleDeclaratorsInlinable = "value3",
+10    | -     multipleDeclaratorsNotInlinable = "value4";
+    9 | + let multipleDeclaratorsInlinable = "value3";
+11 10 |   
+12 11 |   if (multipleDeclaratorsInlinable) {
+13    | -     multipleDeclaratorsNotInlinable.memberWrite = multipleDeclaratorsInlinable;
+   12 | +     "value4".memberWrite = multipleDeclaratorsInlinable;
+14 13 |   }
+15 14 |   
+16    | - statement(multipleDeclaratorsNotInlinable);
+   15 | + statement("value4");
+17 16 |   
+18 17 |   let variable = expression();
+19 18 |   statement(variable);
+
+```
+
+```
+      | @@ -15,6 +15,4 @@
+14 14 |   }
+15 15 |   
+16 16 |   statement(multipleDeclaratorsNotInlinable);
+17    | - 
+18    | - let variable = expression();
+19    | - statement(variable);
+   17 | + statement(expression());
 
 ```
 

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -23,6 +23,8 @@ use tower_lsp::jsonrpc;
 use tower_lsp::jsonrpc::Response;
 use tower_lsp::lsp_types::ClientCapabilities;
 use tower_lsp::lsp_types::CodeActionContext;
+use tower_lsp::lsp_types::CodeActionKind;
+use tower_lsp::lsp_types::CodeActionOrCommand;
 use tower_lsp::lsp_types::CodeActionParams;
 use tower_lsp::lsp_types::CodeActionResponse;
 use tower_lsp::lsp_types::DidCloseTextDocumentParams;
@@ -272,7 +274,7 @@ async fn document_lifecycle() -> Result<()> {
 }
 
 #[tokio::test]
-async fn pull_code_actions() -> Result<()> {
+async fn pull_quick_fixes() -> Result<()> {
     let factory = ServerFactory::default();
     let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
@@ -283,7 +285,7 @@ async fn pull_code_actions() -> Result<()> {
     server.initialize().await?;
     server.initialized().await?;
 
-    server.open_document("for(;a == b;);").await?;
+    server.open_document("if(a == b) {}").await?;
 
     let res: CodeActionResponse = server
         .request(
@@ -296,16 +298,16 @@ async fn pull_code_actions() -> Result<()> {
                 range: Range {
                     start: Position {
                         line: 0,
-                        character: 8,
+                        character: 6,
                     },
                     end: Position {
                         line: 0,
-                        character: 8,
+                        character: 6,
                     },
                 },
                 context: CodeActionContext {
                     diagnostics: vec![],
-                    only: None,
+                    only: Some(vec![CodeActionKind::QUICKFIX]),
                 },
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
@@ -318,7 +320,82 @@ async fn pull_code_actions() -> Result<()> {
         .await?
         .context("codeAction returned None")?;
 
-    assert!(!res.is_empty());
+    let code_actions: Vec<_> = res
+        .iter()
+        .map(|action| match action {
+            CodeActionOrCommand::Command(_) => panic!("unexpected command"),
+            CodeActionOrCommand::CodeAction(action) => &action.title,
+        })
+        .collect();
+
+    assert_eq!(code_actions.as_slice(), &["Use ==="]);
+
+    server.close_document().await?;
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pull_refactors() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let reader = tokio::spawn(client_handler(stream, sink));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server
+        .open_document("let variable = \"value\"; func(variable);")
+        .await?;
+
+    let res: CodeActionResponse = server
+        .request(
+            "textDocument/codeAction",
+            "pull_code_actions",
+            CodeActionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: Url::parse("test://workspace/document.js")?,
+                },
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 7,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 7,
+                    },
+                },
+                context: CodeActionContext {
+                    diagnostics: vec![],
+                    only: Some(vec![CodeActionKind::REFACTOR]),
+                },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+        )
+        .await?
+        .context("codeAction returned None")?;
+
+    let code_actions: Vec<_> = res
+        .iter()
+        .map(|action| match action {
+            CodeActionOrCommand::Command(_) => panic!("unexpected command"),
+            CodeActionOrCommand::CodeAction(action) => &action.title,
+        })
+        .collect();
+
+    assert_eq!(code_actions.as_slice(), &["Inline variable"]);
 
     server.close_document().await?;
 


### PR DESCRIPTION
## Summary

This PR introduces a simple `inlineVariable` code assist, available on all variable declarations that only have have read-only references. The rule inlines the initializer expression for that variable into all the places it's used and removes the original variable declaration node, using logic that's largely shared with the existing `noShoutyConstants` rule

## Test Plan

I've added a test file for the rule verifying that "read-only variables" can be inlined while writable variables are not
