### PR TITLE
feat(rome_js_formatter): Format `throw` and `return` argument

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::utils::{is_simple_expression, FormatPrecedence};
+use crate::utils::{
+    binary_argument_needs_parens, is_simple_expression, FormatPrecedence,
+    JsAnyBinaryLikeLeftExpression,
+};
 use rome_formatter::write;
 
 use crate::utils::JsAnyBinaryLikeExpression;
@@ -36,7 +39,7 @@ impl FormatNodeRule<JsParenthesizedExpression> for FormatJsParenthesizedExpressi
                 write![f, [l_paren_token.format()]]?;
             };
 
-            write![f, [expression.format(),]]?;
+            write![f, [expression.format()]]?;
 
             if parenthesis_can_be_omitted {
                 write!(f, [format_removed(&r_paren_token?)])?;
@@ -49,7 +52,7 @@ impl FormatNodeRule<JsParenthesizedExpression> for FormatJsParenthesizedExpressi
                 f,
                 [
                     format_removed(&l_paren_token?),
-                    group(&expression.format()),
+                    expression.format(),
                     format_removed(&r_paren_token?),
                 ]
             ]?;
@@ -132,6 +135,19 @@ fn parenthesis_can_be_omitted(node: &JsParenthesizedExpression) -> SyntaxResult<
     let expression = node.expression()?;
     let parent = node.syntax().parent();
 
+    if let Some(parent) = &parent {
+        match parent.kind() {
+            // The formatting of the return or throw argument takes care of adding parens if necessary
+            JsSyntaxKind::JS_RETURN_STATEMENT | JsSyntaxKind::JS_THROW_STATEMENT => {
+                return Ok(true)
+            }
+            JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION => return Ok(true),
+            _ => {
+                // fall through
+            }
+        }
+    }
+
     // if expression is a StringLiteralExpression, we need to check it before precedence comparison, here is an example:
     // ```js
     // a[("test")]
@@ -156,34 +172,27 @@ fn parenthesis_can_be_omitted(node: &JsParenthesizedExpression) -> SyntaxResult<
             Some(JsSyntaxKind::JS_EXPRESSION_STATEMENT)
         ));
     }
+
     let parent_precedence = FormatPrecedence::with_precedence_for_parenthesis(parent.as_ref());
     let node_precedence = FormatPrecedence::with_precedence_for_parenthesis(Some(node.syntax()));
 
     if parent_precedence > node_precedence {
         return Ok(false);
     }
-    // Here we handle cases where we have binary/logical expressions.
-    // We want to remove the parenthesis only in cases where `left` and `right` are not other
-    // binary/logical expressions.
-    //
-    // From another point of view, logical/binary expressions with the same operator can stay without
-    // parenthesis.
-    match expression {
-        JsAnyExpression::JsBinaryExpression(expression) => {
-            let left = expression.left()?;
-            let right = expression.right()?;
 
-            Ok(!JsAnyBinaryLikeExpression::can_cast(left.syntax().kind())
-                && !JsAnyBinaryLikeExpression::can_cast(right.syntax().kind()))
+    if let Some(parent) = &parent {
+        if JsAnyBinaryLikeExpression::can_cast(parent.kind()) {
+            let binary_like = JsAnyBinaryLikeExpression::unwrap_cast(parent.clone());
+            let operator = binary_like.operator()?;
+
+            if !binary_argument_needs_parens(
+                operator,
+                &JsAnyBinaryLikeLeftExpression::from(expression),
+            )? {
+                return Ok(true);
+            }
         }
-
-        JsAnyExpression::JsLogicalExpression(expression) => {
-            let left = expression.left()?;
-            let right = expression.right()?;
-
-            Ok(!JsAnyBinaryLikeExpression::can_cast(left.syntax().kind())
-                && !JsAnyBinaryLikeExpression::can_cast(right.syntax().kind()))
-        }
-        _ => Ok(false),
     }
+
+    Ok(false)
 }

--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -137,7 +137,7 @@ fn parenthesis_can_be_omitted(node: &JsParenthesizedExpression) -> SyntaxResult<
 
     if let Some(parent) = &parent {
         match parent.kind() {
-            // The formatting of the return or throw argument takes care of adding parens if necessary
+            // The formatting of the return or throw argument takes care of adding parentheses if necessary
             JsSyntaxKind::JS_RETURN_STATEMENT | JsSyntaxKind::JS_THROW_STATEMENT => {
                 return Ok(true)
             }
@@ -180,9 +180,8 @@ fn parenthesis_can_be_omitted(node: &JsParenthesizedExpression) -> SyntaxResult<
         return Ok(false);
     }
 
-    if let Some(parent) = &parent {
-        if JsAnyBinaryLikeExpression::can_cast(parent.kind()) {
-            let binary_like = JsAnyBinaryLikeExpression::unwrap_cast(parent.clone());
+    if let Some(parent) = parent {
+        if let Some(binary_like) = JsAnyBinaryLikeExpression::cast(parent) {
             let operator = binary_like.operator()?;
 
             if !binary_argument_needs_parens(

--- a/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -19,6 +19,7 @@ impl FormatNodeRule<JsSequenceExpression> for FormatJsSequenceExpression {
         let mut is_nested = false;
         let mut first_non_sequence_or_paren_parent = None;
 
+        // Skip 1 because ancestor starts with the current node but we're interested in the parent
         for parent in node.syntax().ancestors().skip(1) {
             if parent.kind() == JS_SEQUENCE_EXPRESSION {
                 is_nested = true;

--- a/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 use rome_formatter::write;
-use rome_js_syntax::JsSyntaxKind::JS_SEQUENCE_EXPRESSION;
+use rome_js_syntax::JsSyntaxKind::{JS_PARENTHESIZED_EXPRESSION, JS_SEQUENCE_EXPRESSION};
 use rome_js_syntax::{JsSequenceExpression, JsSequenceExpressionFields, JsSyntaxKind};
 use rome_rowan::AstNode;
 
@@ -10,61 +10,58 @@ pub struct FormatJsSequenceExpression;
 
 impl FormatNodeRule<JsSequenceExpression> for FormatJsSequenceExpression {
     fn fmt_fields(&self, node: &JsSequenceExpression, f: &mut JsFormatter) -> FormatResult<()> {
-        let first_non_sequence_parent = node
-            .syntax()
-            .ancestors()
-            .find(|p| p.kind() != JS_SEQUENCE_EXPRESSION);
-
-        let is_nested = first_non_sequence_parent != node.syntax().parent();
-
-        let has_already_indentation = first_non_sequence_parent.map_or(false, |parent| {
-            match parent.kind() {
-                // Return statement already does the indentation for us
-                // Arrow function body can't have a sequence expression unless it's parenthesized, otherwise
-                // would be a syntax error
-                JsSyntaxKind::JS_RETURN_STATEMENT => true,
-                JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION => {
-                    // In case we are inside a sequence expression, we have to go up a level and see the great parent.
-                    // Arrow function body and return statements applying indentation for us, so we signal the
-                    // sequence expression to not add other indentation levels
-                    let great_parent = parent.parent().map(|gp| gp.kind());
-
-                    matches!(
-                        great_parent,
-                        Some(
-                            JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION
-                                | JsSyntaxKind::JS_RETURN_STATEMENT
-                                | JsSyntaxKind::JS_PROPERTY_OBJECT_MEMBER
-                        )
-                    )
-                }
-                _ => false,
-            }
-        });
-
         let JsSequenceExpressionFields {
             left,
             comma_token,
             right,
         } = node.as_fields();
 
-        let format_content = format_with(|f| {
-            write!(f, [left.format(), comma_token.format()])?;
+        let mut is_nested = false;
+        let mut first_non_sequence_or_paren_parent = None;
 
-            let format_right =
-                format_with(|f| write!(f, [soft_line_break_or_space(), right.format()]));
-
-            if has_already_indentation {
-                write!(f, [format_right])
-            } else {
-                write!(f, [indent(&format_right)])
+        for parent in node.syntax().ancestors().skip(1) {
+            if parent.kind() == JS_SEQUENCE_EXPRESSION {
+                is_nested = true;
+            } else if parent.kind() != JS_PARENTHESIZED_EXPRESSION {
+                first_non_sequence_or_paren_parent = Some(parent);
+                break;
             }
+        }
+
+        let format_inner = format_with(|f| {
+            if let Some(parent) = &first_non_sequence_or_paren_parent {
+                if matches!(
+                    parent.kind(),
+                    JsSyntaxKind::JS_EXPRESSION_STATEMENT | JsSyntaxKind::JS_FOR_STATEMENT
+                ) {
+                    return write!(
+                        f,
+                        [
+                            left.format(),
+                            comma_token.format(),
+                            line_suffix_boundary(),
+                            soft_line_indent_or_space(&right.format())
+                        ]
+                    );
+                }
+            }
+
+            write!(
+                f,
+                [
+                    left.format(),
+                    comma_token.format(),
+                    line_suffix_boundary(),
+                    soft_line_break_or_space(),
+                    right.format()
+                ]
+            )
         });
 
         if is_nested {
-            write!(f, [format_content])
+            write!(f, [format_inner])
         } else {
-            write!(f, [group(&format_content)])
+            write!(f, [group(&format_inner)])
         }
     }
 }

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -1,8 +1,12 @@
 use crate::prelude::*;
-use crate::utils::FormatWithSemicolon;
+use crate::utils::{FormatWithSemicolon, JsAnyBinaryLikeExpression};
 
-use rome_formatter::write;
-use rome_js_syntax::{JsAnyExpression, JsReturnStatement, JsReturnStatementFields};
+use rome_formatter::{format_args, write};
+
+use rome_js_syntax::{
+    JsAnyExpression, JsReturnStatement, JsReturnStatementFields, JsSequenceExpression,
+};
+use rome_rowan::SyntaxResult;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsReturnStatement;
@@ -15,32 +19,94 @@ impl FormatNodeRule<JsReturnStatement> for FormatJsReturnStatement {
             semicolon_token,
         } = node.as_fields();
 
+        let format_inner = format_with(|f| {
+            write!(f, [return_token.format()])?;
+
+            if let Some(argument) = &argument {
+                write!(f, [space(), FormatReturnOrThrowArgument(argument)])?;
+            }
+
+            Ok(())
+        });
+
         write!(
             f,
             [FormatWithSemicolon::new(
-                &format_with(|f| {
-                    write!(f, [return_token.format()])?;
-
-                    if let Some(argument) = &argument {
-                        write!(f, [space()])?;
-
-                        if let JsAnyExpression::JsSequenceExpression(_expression) = argument {
-                            format_parenthesize(
-                                argument.syntax().first_token().as_ref(),
-                                &argument.format(),
-                                argument.syntax().last_token().as_ref(),
-                            )
-                            .grouped_with_soft_block_indent()
-                            .fmt(f)?;
-                        } else {
-                            write![f, [argument.format()]]?;
-                        }
-                    }
-
-                    Ok(())
-                }),
+                &format_inner,
                 semicolon_token.as_ref()
             )]
         )
+    }
+}
+
+pub(super) struct FormatReturnOrThrowArgument<'a>(&'a JsAnyExpression);
+
+impl<'a> FormatReturnOrThrowArgument<'a> {
+    pub fn new(argument: &'a JsAnyExpression) -> Self {
+        Self(argument)
+    }
+}
+
+impl Format<JsFormatContext> for FormatReturnOrThrowArgument<'_> {
+    fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
+        let argument = self.0;
+
+        if has_argument_leading_comments(argument)? {
+            let syntax = argument.syntax();
+            let first_token = syntax.first_token();
+            let last_token = syntax.last_token();
+            write!(
+                f,
+                [format_parenthesize(
+                    first_token.as_ref(),
+                    &block_indent(&argument.format()),
+                    last_token.as_ref()
+                )]
+            )
+        } else if is_binary_or_sequence_argument(argument)? {
+            write!(
+                f,
+                [group(&format_args![
+                    if_group_breaks(&text("(")),
+                    soft_block_indent(&argument.format()),
+                    if_group_breaks(&text(")"))
+                ])]
+            )
+        } else {
+            write!(f, [argument.format()])
+        }
+    }
+}
+
+fn has_argument_leading_comments(argument: &JsAnyExpression) -> SyntaxResult<bool> {
+    if matches!(argument, JsAnyExpression::JsxTagExpression(_)) {
+        // JSX formatting takes care of adding parens
+        return Ok(false);
+    }
+
+    if argument.syntax().has_leading_comments() {
+        return Ok(true);
+    }
+
+    let result = match argument {
+        JsAnyExpression::JsParenthesizedExpression(inner) => {
+            inner.syntax().has_leading_comments()
+                || has_argument_leading_comments(&inner.expression()?)?
+        }
+        _ => false,
+    };
+
+    Ok(result)
+}
+
+fn is_binary_or_sequence_argument(argument: &JsAnyExpression) -> SyntaxResult<bool> {
+    if JsSequenceExpression::can_cast(argument.syntax().kind())
+        || JsAnyBinaryLikeExpression::can_cast(argument.syntax().kind())
+    {
+        Ok(true)
+    } else if let JsAnyExpression::JsParenthesizedExpression(inner) = argument {
+        is_binary_or_sequence_argument(&inner.expression()?)
+    } else {
+        Ok(false)
     }
 }

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -78,6 +78,9 @@ impl Format<JsFormatContext> for FormatReturnOrThrowArgument<'_> {
     }
 }
 
+/// Tests if the passed in argument has any leading comments. This is the case if
+/// * the argument's first token has a leading comment
+/// * the argument is a parenthesized expression and the inner expression has a leading comment.
 fn has_argument_leading_comments(argument: &JsAnyExpression) -> SyntaxResult<bool> {
     if matches!(argument, JsAnyExpression::JsxTagExpression(_)) {
         // JSX formatting takes care of adding parens
@@ -90,8 +93,7 @@ fn has_argument_leading_comments(argument: &JsAnyExpression) -> SyntaxResult<boo
 
     let result = match argument {
         JsAnyExpression::JsParenthesizedExpression(inner) => {
-            inner.syntax().has_leading_comments()
-                || has_argument_leading_comments(&inner.expression()?)?
+            has_argument_leading_comments(&inner.expression()?)?
         }
         _ => false,
     };

--- a/crates/rome_js_formatter/src/js/statements/throw_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/throw_statement.rs
@@ -3,6 +3,7 @@ use rome_formatter::{format_args, write};
 
 use crate::utils::FormatWithSemicolon;
 
+use crate::js::statements::return_statement::FormatReturnOrThrowArgument;
 use rome_js_syntax::JsThrowStatement;
 use rome_js_syntax::JsThrowStatementFields;
 
@@ -17,13 +18,14 @@ impl FormatNodeRule<JsThrowStatement> for FormatJsThrowStatement {
             semicolon_token,
         } = node.as_fields();
 
-        let throw_token = throw_token.format();
-        let exception = argument.format();
-
         write!(
             f,
             [FormatWithSemicolon::new(
-                &format_args!(throw_token, space(), exception),
+                &format_args![
+                    throw_token.format(),
+                    space(),
+                    FormatReturnOrThrowArgument::new(&argument?)
+                ],
                 semicolon_token.as_ref()
             )]
         )

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -17,7 +17,10 @@ mod typescript;
 
 use crate::prelude::*;
 pub(crate) use assignment_like::{should_break_after_operator, JsAnyAssignmentLike};
-pub(crate) use binary_like_expression::{format_binary_like_expression, JsAnyBinaryLikeExpression};
+pub(crate) use binary_like_expression::{
+    binary_argument_needs_parens, format_binary_like_expression, JsAnyBinaryLikeExpression,
+    JsAnyBinaryLikeLeftExpression,
+};
 pub(crate) use format_conditional::{format_conditional, Conditional};
 pub(crate) use member_chain::format_call_expression;
 pub(crate) use object_like::JsObjectLike;

--- a/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
@@ -12,5 +12,5 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 -----
-export default 1 - 43;
+export default (1 - 43);
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -188,13 +188,15 @@ while (
 (something && elsewhere && happy && thoughts);
 
 function a() {
-	return something &&
-	elsewhere &&
-	happy &&
-	thoughts &&
-	somethingsomethingsomethingsomething &&
-	thoughts &&
-	somethingsomethingsomethingsomething;
+	return (
+		something &&
+		elsewhere &&
+		happy &&
+		thoughts &&
+		somethingsomethingsomethingsomething &&
+		thoughts &&
+		somethingsomethingsomethingsomething
+	);
 }
 
 const a = () => aa && bb && something && somethingsomethingsomethingsomething;
@@ -244,7 +246,9 @@ undefined === function () {
 };
 
 const b = `${
-	veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar
+	(
+		veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar
+	)
 }`;
 
 const a =
@@ -323,5 +327,5 @@ a in
 
 ## Lines exceeding width of 80 characters
 
-  121: 	veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar
+  124: 		veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -23,6 +23,6 @@ function f1() {
 }
 
 function f2() {
-	return (1, 3, 4);
+	return 1, 3, 4;
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
@@ -163,24 +163,16 @@ const obj = {
  
  this.steps = (steps && checkStep) || [
    {
-@@ -61,11 +65,12 @@
+@@ -61,7 +65,8 @@
    const result = doSomething();
    return (
      shouldReturn &&
 -    result.ok && {
--      status: "ok",
--      createdAt: result.createdAt,
--      updatedAt: result.updatedAt,
--    }
-+      result.ok &&
-+      {
-+        status: "ok",
-+        createdAt: result.createdAt,
-+        updatedAt: result.updatedAt,
-+      }
-   );
- };
- 
++    result.ok &&
++    {
+       status: "ok",
+       createdAt: result.createdAt,
+       updatedAt: result.updatedAt,
 @@ -82,7 +87,8 @@
  
  const obj = {
@@ -263,12 +255,12 @@ const create = () => {
   const result = doSomething();
   return (
     shouldReturn &&
-      result.ok &&
-      {
-        status: "ok",
-        createdAt: result.createdAt,
-        updatedAt: result.updatedAt,
-      }
+    result.ok &&
+    {
+      status: "ok",
+      createdAt: result.createdAt,
+      updatedAt: result.updatedAt,
+    }
   );
 };
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/return.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/return.js.snap
@@ -28,14 +28,14 @@ function foo3() {
 ```diff
 --- Prettier
 +++ Rome
-@@ -1,20 +1,15 @@
+@@ -1,20 +1,17 @@
  function foo() {
--  return (
+   return (
 -    this.hasPlugin("dynamicImports") &&
 -    this.lookahead().type === tt.parenLeft.right
--  );
-+  return this.hasPlugin("dynamicImports") && this.lookahead().type === tt
-+    .parenLeft.right;
++    this.hasPlugin("dynamicImports") && this.lookahead().type === tt.parenLeft
++      .right
+   );
  }
  
  function foo2() {
@@ -62,8 +62,10 @@ function foo3() {
 
 ```js
 function foo() {
-  return this.hasPlugin("dynamicImports") && this.lookahead().type === tt
-    .parenLeft.right;
+  return (
+    this.hasPlugin("dynamicImports") && this.lookahead().type === tt.parenLeft
+      .right
+  );
 }
 
 function foo2() {

--- a/crates/rome_js_formatter/tests/specs/prettier/js/bind-expressions/await.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/bind-expressions/await.js.snap
@@ -21,7 +21,7 @@ const doBothThings = async () => {
  const doBothThings = async () => {
    const request = doAsyncThing();
 -  return (await request)::doSyncThing();
-+  return (await request);
++  return await request;
 +  ::doSyncThing()
  };
 ```
@@ -31,7 +31,7 @@ const doBothThings = async () => {
 ```js
 const doBothThings = async () => {
   const request = doAsyncThing();
-  return (await request);
+  return await request;
   ::doSyncThing()
 };
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/closure-compiler-type-cast.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/closure-compiler-type-cast.js.snap
@@ -73,7 +73,7 @@ const style2 =/**
 ```diff
 --- Prettier
 +++ Rome
-@@ -1,18 +1,21 @@
+@@ -1,21 +1,24 @@
  // test to make sure comments are attached correctly
 -let inlineComment = /* some comment */ someReallyLongFunctionCall(
 -  withLots,
@@ -99,32 +99,23 @@ const style2 =/**
 +);
  
  function returnValue() {
-   return /** @type {!Array.<string>} */ (["hello", "you"]);
-@@ -20,19 +23,19 @@
+-  return /** @type {!Array.<string>} */ (["hello", "you"]);
++  return /** @type {!Array.<string>} */ ["hello", "you"];
+ }
  
  // Only numberOrString is typecast
- var newArray = /** @type {array} */ (numberOrString).map((x) => x);
--var newArray = /** @type {array} */ (numberOrString).map((x) => x);
-+var newArray = /** @type {array} */ ((numberOrString)).map((x) => x);
- var newArray = test(/** @type {array} */ (numberOrString).map((x) => x));
--var newArray = test(/** @type {array} */ (numberOrString).map((x) => x));
-+var newArray = test(/** @type {array} */ ((numberOrString)).map((x) => x));
+@@ -26,9 +29,9 @@
  
  // The numberOrString.map CallExpression is typecast
--var newArray = /** @type {array} */ (numberOrString.map((x) => x));
  var newArray = /** @type {array} */ (numberOrString.map((x) => x));
+-var newArray = /** @type {array} */ (numberOrString.map((x) => x));
+-var newArray = test(/** @type {array} */ (numberOrString.map((x) => x)));
 +var newArray = /** @type {array} */ ((numberOrString).map((x) => x));
  var newArray = test(/** @type {array} */ (numberOrString.map((x) => x)));
--var newArray = test(/** @type {array} */ (numberOrString.map((x) => x)));
 +var newArray = test(/** @type {array} */ ((numberOrString).map((x) => x)));
  
  test(/** @type {number} */ (num) + 1);
  test(/** @type {!Array} */ (arrOrString).length + 1);
--test(/** @type {!Array} */ (arrOrString).length + 1);
-+test(/** @type {!Array} */ ((arrOrString)).length + 1);
- 
- const data = functionCall(
-   arg1,
 @@ -57,6 +60,6 @@
   * @type {{
   *   width: number,
@@ -158,14 +149,14 @@ functionCall(
 );
 
 function returnValue() {
-  return /** @type {!Array.<string>} */ (["hello", "you"]);
+  return /** @type {!Array.<string>} */ ["hello", "you"];
 }
 
 // Only numberOrString is typecast
 var newArray = /** @type {array} */ (numberOrString).map((x) => x);
-var newArray = /** @type {array} */ ((numberOrString)).map((x) => x);
+var newArray = /** @type {array} */ (numberOrString).map((x) => x);
 var newArray = test(/** @type {array} */ (numberOrString).map((x) => x));
-var newArray = test(/** @type {array} */ ((numberOrString)).map((x) => x));
+var newArray = test(/** @type {array} */ (numberOrString).map((x) => x));
 
 // The numberOrString.map CallExpression is typecast
 var newArray = /** @type {array} */ (numberOrString.map((x) => x));
@@ -175,7 +166,7 @@ var newArray = test(/** @type {array} */ ((numberOrString).map((x) => x)));
 
 test(/** @type {number} */ (num) + 1);
 test(/** @type {!Array} */ (arrOrString).length + 1);
-test(/** @type {!Array} */ ((arrOrString)).length + 1);
+test(/** @type {!Array} */ (arrOrString).length + 1);
 
 const data = functionCall(
   arg1,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/comment-in-the-middle.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/comment-in-the-middle.js.snap
@@ -40,8 +40,7 @@ console.log(a.foo());
 +* bla bla bla
 + */
    //2
--  (window["s"]).toString();
-+  ((window["s"])).toString();
+   (window["s"]).toString();
  console.log(a.foo());
 ```
 
@@ -57,7 +56,7 @@ var a =
 * bla bla bla
  */
   //2
-  ((window["s"])).toString();
+  (window["s"]).toString();
 console.log(a.foo());
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-4124.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-4124.js.snap
@@ -32,7 +32,7 @@ const test = /** @type (function (*): ?|undefined) */ (foo);
 @@ -1,11 +1,11 @@
  /** @type {Object} */ (myObject.property).someProp = true;
 -/** @type {Object} */ (myObject.property).someProp = true;
-+(/** @type {Object} */ (myObject.property)).someProp = true;
++(/** @type {Object} */ myObject.property).someProp = true;
  
  const prop = /** @type {Object} */ (myObject.property).someProp;
  
@@ -51,7 +51,7 @@ const test = /** @type (function (*): ?|undefined) */ (foo);
 
 ```js
 /** @type {Object} */ (myObject.property).someProp = true;
-(/** @type {Object} */ (myObject.property)).someProp = true;
+(/** @type {Object} */ myObject.property).someProp = true;
 
 const prop = /** @type {Object} */ (myObject.property).someProp;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-8045.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-8045.js.snap
@@ -34,16 +34,17 @@ function jsdocCastInReturn() {
 ```diff
 --- Prettier
 +++ Rome
-@@ -1,5 +1,5 @@
+@@ -1,30 +1,20 @@
 -const myLongVariableName =
 -  /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (fooBarBaz);
 +const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
 +  (fooBarBaz);
  
  function jsdocCastInReturn() {
-   return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
-@@ -7,8 +7,7 @@
-   );
+-  return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
+-    fooBarBaz
+-  );
++  return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ fooBarBaz;
  }
  
 -const myLongVariableName =
@@ -52,8 +53,11 @@ function jsdocCastInReturn() {
    (fooBarBaz);
  
  function jsdocCastInReturn() {
-@@ -18,8 +17,7 @@
-   );
+-  return (
+-    /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+-    (fooBarBaz)
+-  );
++  return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ fooBarBaz;
  }
  
 -const myLongVariableName =
@@ -62,6 +66,12 @@ function jsdocCastInReturn() {
    (fooBarBaz);
  
  function jsdocCastInReturn() {
+-  return (
+-    /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+-    (fooBarBaz)
+-  );
++  return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ fooBarBaz;
+ }
 ```
 
 # Output
@@ -71,29 +81,21 @@ const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWr
   (fooBarBaz);
 
 function jsdocCastInReturn() {
-  return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ (
-    fooBarBaz
-  );
+  return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ fooBarBaz;
 }
 
 const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
   (fooBarBaz);
 
 function jsdocCastInReturn() {
-  return (
-    /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
-    (fooBarBaz)
-  );
+  return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ fooBarBaz;
 }
 
 const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
   (fooBarBaz);
 
 function jsdocCastInReturn() {
-  return (
-    /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
-    (fooBarBaz)
-  );
+  return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ fooBarBaz;
 }
 ```
 
@@ -101,7 +103,10 @@ function jsdocCastInReturn() {
 # Lines exceeding max width of 80 characters
 ```
     1: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
-   10: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
-   20: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+    5:   return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ fooBarBaz;
+    8: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+   12:   return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ fooBarBaz;
+   15: const myLongVariableName = /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+   19:   return /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */ fooBarBaz;
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-9358.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/issue-9358.js.snap
@@ -16,17 +16,8 @@ const fooooba3 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems ||
 ```diff
 --- Prettier
 +++ Rome
-@@ -1,11 +1,7 @@
--const fooooba1 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (
--  fooobaarbazzItems || foo
--);
--const fooooba2 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (
--  fooobaarbazzItems + foo
--);
-+const fooooba1 = /** @type {Array.<fooo.barr.baaaaaaz>} */
-+  fooobaarbazzItems || foo;
-+const fooooba2 = /** @type {Array.<fooo.barr.baaaaaaz>} */
-+  fooobaarbazzItems + foo;
+@@ -6,6 +6,4 @@
+ );
  const fooooba3 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (
    fooobaarbazzItems || foo
 -)
@@ -38,10 +29,12 @@ const fooooba3 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems ||
 # Output
 
 ```js
-const fooooba1 = /** @type {Array.<fooo.barr.baaaaaaz>} */
-  fooobaarbazzItems || foo;
-const fooooba2 = /** @type {Array.<fooo.barr.baaaaaaz>} */
-  fooobaarbazzItems + foo;
+const fooooba1 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (
+  fooobaarbazzItems || foo
+);
+const fooooba2 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (
+  fooobaarbazzItems + foo
+);
 const fooooba3 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (
   fooobaarbazzItems || foo
 ) ? foo : bar;

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/nested.js.snap
@@ -30,9 +30,9 @@ const BarImpl = /** @type {BarConstructor} */ (
 -      throw new Error("Internal error: Illegal constructor");
 -    }
 -  )
-+  (function Bar() {
++  function Bar() {
 +    throw new Error("Internal error: Illegal constructor");
-+  })
++  }
  );
 ```
 
@@ -43,9 +43,9 @@ foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar);
 
 const BarImpl = /** @type {BarConstructor} */ (
   /** @type {unknown} */
-  (function Bar() {
+  function Bar() {
     throw new Error("Internal error: Illegal constructor");
-  })
+  }
 );
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/non-casts.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/non-casts.js.snap
@@ -31,27 +31,23 @@ const w1 = /** @typefoo Foo */ (value);
 ```diff
 --- Prettier
 +++ Rome
-@@ -1,18 +1,18 @@
+@@ -1,12 +1,12 @@
  /* @type { } */
  z((x) => {
 -  foo(bar(2 + 3));
--  return 1;
 +  (foo)((bar)(2 + (3)));
-+  return (1);
+   return 1;
  });
  
  /** @type { } */
  z((x) => {
 -  foo(bar(2 + 3));
--  return 1;
 +  (foo)((bar)(2 + (3)));
-+  return (1);
+   return 1;
  });
  
- /** @type {number} */
- let q = z((x) => {
--  return 1;
-+  return (1);
+@@ -15,4 +15,4 @@
+   return 1;
  });
  
 -const w1 = /** @typefoo Foo */ value;
@@ -64,18 +60,18 @@ const w1 = /** @typefoo Foo */ (value);
 /* @type { } */
 z((x) => {
   (foo)((bar)(2 + (3)));
-  return (1);
+  return 1;
 });
 
 /** @type { } */
 z((x) => {
   (foo)((bar)(2 + (3)));
-  return (1);
+  return 1;
 });
 
 /** @type {number} */
 let q = z((x) => {
-  return (1);
+  return 1;
 });
 
 const w1 = /** @typefoo Foo */ (value);

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/return-statement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/return-statement.js.snap
@@ -134,44 +134,52 @@ function inlineComment() {
 ```diff
 --- Prettier
 +++ Rome
-@@ -19,77 +19,83 @@
+@@ -18,78 +18,92 @@
+ 
  function logical() {
    return (
-     // Reason for 42
+-    // Reason for 42
 -    42 && 84
--  );
-+    42
-+  ) && 84;
++    (
++      // Reason for 42
++      42
++    ) && 84
+   );
  }
  
  function binary() {
    return (
-     // Reason for 42
+-    // Reason for 42
 -    42 * 84
--  );
-+    42
-+  ) * 84;
++    (
++      // Reason for 42
++      42
++    ) * 84
+   );
  }
  
  function binaryInBinaryLeft() {
    return (
 -    // Reason for 42
 -    42 * 84 + 2
--  );
 +    (
-+      // Reason for 42
-+      42
-+    ) * 84
-+  ) + 2;
++      (
++        // Reason for 42
++        42
++      ) * 84
++    ) + 2
+   );
  }
  
  function binaryInBinaryRight() {
    return (
-     // Reason for 42
+-    // Reason for 42
 -    42 + 84 * 2
--  );
-+    42
-+  ) + (84 * 2);
++    (
++      // Reason for 42
++      42
++    ) + (84 * 2)
+   );
  }
  
  function conditional() {
@@ -242,7 +250,17 @@ function inlineComment() {
    );
  }
  
-@@ -111,10 +117,12 @@
+@@ -103,18 +117,22 @@
+ 
+ function sequenceExpressionInside() {
+   return (
+-    // Reason for a
+-    a, b
++    a, // Reason for a
++    b
+   );
+ }
+ 
  function taggedTemplate() {
    return (
      // Reason for a
@@ -255,8 +273,10 @@ function inlineComment() {
  function inlineComment() {
 -  return /* hi */ 42 || 42;
 +  return (
-+    /* hi */ 42
-+  ) || 42;
++    (
++      /* hi */ 42
++    ) || 42
++  );
  }
 ```
 
@@ -283,32 +303,40 @@ function numericLiteralNoParen() {
 
 function logical() {
   return (
-    // Reason for 42
-    42
-  ) && 84;
+    (
+      // Reason for 42
+      42
+    ) && 84
+  );
 }
 
 function binary() {
-  return (
-    // Reason for 42
-    42
-  ) * 84;
-}
-
-function binaryInBinaryLeft() {
   return (
     (
       // Reason for 42
       42
     ) * 84
-  ) + 2;
+  );
+}
+
+function binaryInBinaryLeft() {
+  return (
+    (
+      (
+        // Reason for 42
+        42
+      ) * 84
+    ) + 2
+  );
 }
 
 function binaryInBinaryRight() {
   return (
-    // Reason for 42
-    42
-  ) + (84 * 2);
+    (
+      // Reason for 42
+      42
+    ) + (84 * 2)
+  );
 }
 
 function conditional() {
@@ -374,8 +402,8 @@ function excessiveEverything() {
 
 function sequenceExpressionInside() {
   return (
-    // Reason for a
-    a, b
+    a, // Reason for a
+    b
   );
 }
 
@@ -388,8 +416,10 @@ function taggedTemplate() {
 
 function inlineComment() {
   return (
-    /* hi */ 42
-  ) || 42;
+    (
+      /* hi */ 42
+    ) || 42
+  );
 }
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/return/binaryish.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/return/binaryish.js.snap
@@ -36,21 +36,18 @@ function f() {
 ```diff
 --- Prettier
 +++ Rome
-@@ -1,23 +1,24 @@
- function f() {
+@@ -2,22 +2,25 @@
    return (
      property.isIdentifier() &&
--    FUNCTIONS[property.node.name] &&
+     FUNCTIONS[property.node.name] &&
 -    (object.isIdentifier(JEST_GLOBAL) ||
 -      (callee.isMemberExpression() && shouldHoistExpression(object))) &&
--    FUNCTIONS[property.node.name](expr.get("arguments"))
-+      FUNCTIONS[property.node.name] &&
-+      (
-+        object.isIdentifier(JEST_GLOBAL) || (
-+          callee.isMemberExpression() && shouldHoistExpression(object)
-+        )
-+      ) &&
-+      FUNCTIONS[property.node.name](expr.get("arguments"))
++    (
++      object.isIdentifier(JEST_GLOBAL) || (
++        callee.isMemberExpression() && shouldHoistExpression(object)
++      )
++    ) &&
+     FUNCTIONS[property.node.name](expr.get("arguments"))
    );
  
    return (
@@ -66,11 +63,12 @@ function f() {
      )
    );
  
--  return (
+   return (
 -    !filePath.includes(coverageDirectory) &&
 -    !filePath.endsWith(`.${SNAPSHOT_EXTENSION}`)
-+  return !filePath.includes(coverageDirectory) && !filePath.endsWith(
-+    `.${SNAPSHOT_EXTENSION}`,
++    !filePath.includes(coverageDirectory) && !filePath.endsWith(
++      `.${SNAPSHOT_EXTENSION}`,
++    )
    );
  }
 ```
@@ -81,13 +79,13 @@ function f() {
 function f() {
   return (
     property.isIdentifier() &&
-      FUNCTIONS[property.node.name] &&
-      (
-        object.isIdentifier(JEST_GLOBAL) || (
-          callee.isMemberExpression() && shouldHoistExpression(object)
-        )
-      ) &&
-      FUNCTIONS[property.node.name](expr.get("arguments"))
+    FUNCTIONS[property.node.name] &&
+    (
+      object.isIdentifier(JEST_GLOBAL) || (
+        callee.isMemberExpression() && shouldHoistExpression(object)
+      )
+    ) &&
+    FUNCTIONS[property.node.name](expr.get("arguments"))
   );
 
   return (
@@ -98,8 +96,10 @@ function f() {
     )
   );
 
-  return !filePath.includes(coverageDirectory) && !filePath.endsWith(
-    `.${SNAPSHOT_EXTENSION}`,
+  return (
+    !filePath.includes(coverageDirectory) && !filePath.endsWith(
+      `.${SNAPSHOT_EXTENSION}`,
+    )
   );
 }
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/return/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/return/comment.js.snap
@@ -54,7 +54,7 @@ fn(function f() {
 ```diff
 --- Prettier
 +++ Rome
-@@ -12,30 +12,29 @@
+@@ -12,30 +12,25 @@
  }
  
  function f() {
@@ -76,23 +76,25 @@ fn(function f() {
  }
  
  function f() {
-   return (
-     foo
+-  return (
+-    foo
 -      // comment
 -      .bar()
-+    // comment
-+    .bar()
-   );
+-  );
++  return foo
++  // comment
++  .bar();
  }
  
  fn(function f() {
-   return (
-     foo
+-  return (
+-    foo
 -      // comment
 -      .bar()
-+    // comment
-+    .bar()
-   );
+-  );
++  return foo
++  // comment
++  .bar();
  });
 ```
 
@@ -125,19 +127,15 @@ function x() {
 }
 
 function f() {
-  return (
-    foo
-    // comment
-    .bar()
-  );
+  return foo
+  // comment
+  .bar();
 }
 
 fn(function f() {
-  return (
-    foo
-    // comment
-    .bar()
-  );
+  return foo
+  // comment
+  .bar();
 });
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/throw_statement/binaryish.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/throw_statement/binaryish.js.snap
@@ -36,41 +36,39 @@ function f() {
 ```diff
 --- Prettier
 +++ Rome
-@@ -1,23 +1,22 @@
- function f() {
+@@ -2,22 +2,25 @@
    throw (
      property.isIdentifier() &&
--    FUNCTIONS[property.node.name] &&
+     FUNCTIONS[property.node.name] &&
 -    (object.isIdentifier(JEST_GLOBAL) ||
 -      (callee.isMemberExpression() && shouldHoistExpression(object))) &&
--    FUNCTIONS[property.node.name](expr.get("arguments"))
-+      FUNCTIONS[property.node.name] &&
-+      (
-+        object.isIdentifier(JEST_GLOBAL) || (
-+          callee.isMemberExpression() && shouldHoistExpression(object)
-+        )
-+      ) &&
-+      FUNCTIONS[property.node.name](expr.get("arguments"))
++    (
++      object.isIdentifier(JEST_GLOBAL) || (
++        callee.isMemberExpression() && shouldHoistExpression(object)
++      )
++    ) &&
+     FUNCTIONS[property.node.name](expr.get("arguments"))
    );
  
--  throw (
+   throw (
 -    chalk.bold("No tests found related to files changed since last commit.\n") +
 -    chalk.dim(
 -      patternInfo.watch
 -        ? "Press `a` to run all tests, or run Jest with `--watchAll`."
 -        : "Run Jest without `-o` to run all tests.",
--    )
-+  throw chalk.bold(
-+    "No tests found related to files changed since last commit.\n",
-+  ) + chalk.dim(
-+    patternInfo.watch ? "Press `a` to run all tests, or run Jest with `--watchAll`." : "Run Jest without `-o` to run all tests.",
++    chalk.bold(
++      "No tests found related to files changed since last commit.\n",
++    ) + chalk.dim(
++      patternInfo.watch ? "Press `a` to run all tests, or run Jest with `--watchAll`." : "Run Jest without `-o` to run all tests.",
+     )
    );
  
--  throw (
+   throw (
 -    !filePath.includes(coverageDirectory) &&
 -    !filePath.endsWith(`.${SNAPSHOT_EXTENSION}`)
-+  throw !filePath.includes(coverageDirectory) && !filePath.endsWith(
-+    `.${SNAPSHOT_EXTENSION}`,
++    !filePath.includes(coverageDirectory) && !filePath.endsWith(
++      `.${SNAPSHOT_EXTENSION}`,
++    )
    );
  }
 ```
@@ -81,23 +79,27 @@ function f() {
 function f() {
   throw (
     property.isIdentifier() &&
-      FUNCTIONS[property.node.name] &&
-      (
-        object.isIdentifier(JEST_GLOBAL) || (
-          callee.isMemberExpression() && shouldHoistExpression(object)
-        )
-      ) &&
-      FUNCTIONS[property.node.name](expr.get("arguments"))
+    FUNCTIONS[property.node.name] &&
+    (
+      object.isIdentifier(JEST_GLOBAL) || (
+        callee.isMemberExpression() && shouldHoistExpression(object)
+      )
+    ) &&
+    FUNCTIONS[property.node.name](expr.get("arguments"))
   );
 
-  throw chalk.bold(
-    "No tests found related to files changed since last commit.\n",
-  ) + chalk.dim(
-    patternInfo.watch ? "Press `a` to run all tests, or run Jest with `--watchAll`." : "Run Jest without `-o` to run all tests.",
+  throw (
+    chalk.bold(
+      "No tests found related to files changed since last commit.\n",
+    ) + chalk.dim(
+      patternInfo.watch ? "Press `a` to run all tests, or run Jest with `--watchAll`." : "Run Jest without `-o` to run all tests.",
+    )
   );
 
-  throw !filePath.includes(coverageDirectory) && !filePath.endsWith(
-    `.${SNAPSHOT_EXTENSION}`,
+  throw (
+    !filePath.includes(coverageDirectory) && !filePath.endsWith(
+      `.${SNAPSHOT_EXTENSION}`,
+    )
   );
 }
 ```
@@ -105,6 +107,6 @@ function f() {
 
 # Lines exceeding max width of 80 characters
 ```
-   16:     patternInfo.watch ? "Press `a` to run all tests, or run Jest with `--watchAll`." : "Run Jest without `-o` to run all tests.",
+   17:       patternInfo.watch ? "Press `a` to run all tests, or run Jest with `--watchAll`." : "Run Jest without `-o` to run all tests.",
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/throw_statement/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/throw_statement/comment.js.snap
@@ -34,7 +34,7 @@ fn(function f() {
 ```diff
 --- Prettier
 +++ Rome
-@@ -1,23 +1,21 @@
+@@ -1,23 +1,17 @@
  function x() {
 -  throw (
 -    func2
@@ -47,23 +47,25 @@ fn(function f() {
  }
  
  function f() {
-   throw (
-     foo
+-  throw (
+-    foo
 -      // comment
 -      .bar()
-+    // comment
-+    .bar()
-   );
+-  );
++  throw foo
++  // comment
++  .bar();
  }
  
  fn(function f() {
-   throw (
-     foo
+-  throw (
+-    foo
 -      // comment
 -      .bar()
-+    // comment
-+    .bar()
-   );
+-  );
++  throw foo
++  // comment
++  .bar();
  });
 ```
 
@@ -77,19 +79,15 @@ function x() {
 }
 
 function f() {
-  throw (
-    foo
-    // comment
-    .bar()
-  );
+  throw foo
+  // comment
+  .bar();
 }
 
 fn(function f() {
-  throw (
-    foo
-    // comment
-    .bar()
-  );
+  throw foo
+  // comment
+  .bar();
 });
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
@@ -59,10 +59,11 @@ const iter2 = createIterator(self.controller, child, self.tag as SyncFunctionCom
 -(originalError
 -  ? wrappedError(errMsg, originalError)
 -  : Error(errMsg)) as InjectionError;
+-"current" in (props.pagination as Object);
 +(
 +  originalError ? wrappedError(errMsg, originalError) : Error(errMsg)
 +) as InjectionError;
- "current" in (props.pagination as Object);
++"current" in props.pagination as Object;
  ("current" in props.pagination) as Object;
  start + (yearSelectTotal as number);
  (start + yearSelectTotal) as number;
@@ -122,7 +123,7 @@ this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 (
   originalError ? wrappedError(errMsg, originalError) : Error(errMsg)
 ) as InjectionError;
-"current" in (props.pagination as Object);
+"current" in props.pagination as Object;
 ("current" in props.pagination) as Object;
 start + (yearSelectTotal as number);
 (start + yearSelectTotal) as number;

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/private-fields-in-in/basic.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/private-fields-in-in/basic.ts.snap
@@ -28,19 +28,15 @@ class Person {
 ```diff
 --- Prettier
 +++ Rome
-@@ -7,9 +7,9 @@
-   equals(other: unknown) {
+@@ -8,7 +8,7 @@
      return (
        other &&
--      typeof other === "object" &&
+       typeof other === "object" &&
 -      #name in other && // <- this is new!
--      this.#name === other.#name
-+        typeof other === "object" &&
-+        (#name in other) && // <- this is new!
-+        this.#name === other.#name
++      (#name in other) && // <- this is new!
+       this.#name === other.#name
      );
    }
- }
 ```
 
 # Output
@@ -55,9 +51,9 @@ class Person {
   equals(other: unknown) {
     return (
       other &&
-        typeof other === "object" &&
-        (#name in other) && // <- this is new!
-        this.#name === other.#name
+      typeof other === "object" &&
+      (#name in other) && // <- this is new!
+      this.#name === other.#name
     );
   }
 }


### PR DESCRIPTION
This PR ensures that `throw` and `return` add parentheses around the argument for binary like expressions, sequence expressions and if the argument has any leading comments.

## Testing

 I manually reviewed all snapshot cases. The differences to prettier are around

 * formatting of binary like expressions -> separate PR
 * when to add or omit parentheses -> not part of this PR
 * comments -> requires the comments refactoring.

File Based Average Prettier Similarity: 77.98% -> 78.02%
Line Based Average Prettier Similarity: 73.23% -> 73.20%

The main reason why line based regresses is that the parenthesized / comments issues tend to spawn over multiple lines. However, these must be addressed as part of their own PR as they require significant architectural changes.
