### PR TITLE
refactor(rome_js_formatter): Extract `JsAnyFunction` formatter into `FormatFunction`

### DIFF
--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -1,110 +1,17 @@
-use crate::prelude::*;
-use crate::utils::is_simple_expression;
-use rome_formatter::{format_args, write};
-use rome_js_syntax::{
-    JsAnyArrowFunctionParameters, JsAnyExpression, JsAnyFunction, JsAnyFunctionBody,
-};
+//! Generated file, do not edit by hand, see `xtask/codegen`
 
+use crate::prelude::*;
+use rome_js_syntax::JsAnyFunction;
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsAnyFunction;
-
 impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
     type Context = JsFormatContext;
-
     fn fmt(&self, node: &JsAnyFunction, f: &mut JsFormatter) -> FormatResult<()> {
-        if let Some(async_token) = node.async_token() {
-            write!(f, [async_token.format(), space()])?;
+        match node {
+            JsAnyFunction::JsFunctionExpression(node) => node.format().fmt(f),
+            JsAnyFunction::JsFunctionDeclaration(node) => node.format().fmt(f),
+            JsAnyFunction::JsArrowFunctionExpression(node) => node.format().fmt(f),
+            JsAnyFunction::JsFunctionExportDefaultDeclaration(node) => node.format().fmt(f),
         }
-
-        write!(
-            f,
-            [node.function_token().format(), node.star_token().format()]
-        )?;
-
-        if !matches!(node, JsAnyFunction::JsArrowFunctionExpression(_)) {
-            match node.id()? {
-                Some(id) => {
-                    write!(f, [space(), id.format()])?;
-                }
-                None => {
-                    write!(f, [space()])?;
-                }
-            }
-        }
-
-        write!(f, [node.type_parameters().format()])?;
-
-        match node.parameters()? {
-            JsAnyArrowFunctionParameters::JsAnyBinding(binding) => write!(
-                f,
-                [format_parenthesize(
-                    binding.syntax().first_token().as_ref(),
-                    &format_args![binding.format(), if_group_breaks(&text(",")),],
-                    binding.syntax().last_token().as_ref(),
-                )
-                .grouped_with_soft_block_indent()]
-            )?,
-            JsAnyArrowFunctionParameters::JsParameters(params) => write![f, [params.format()]]?,
-        }
-
-        write![f, [node.return_type_annotation().format(), space()]]?;
-
-        // We create a new group for everything after the parameters. That way if the parameters
-        // get broken, we don't line break the arrow and the body if they can fit on the same line.
-        // For instance:
-        //
-        //   (
-        //     a = [abcdefghijklmnopqrstuvwxyz123456789],
-        //     b = [abcdefghijklmnopqrstuvwxyz123456789],
-        //   ) =>
-        //     a + b
-        //
-        // The line break for `a + b` is not necessary
-        //
-        if let JsAnyFunction::JsArrowFunctionExpression(arrow) = node {
-            write![f, [arrow.fat_arrow_token().format(), space()]]?;
-        }
-
-        let body = node.body()?;
-        // With arrays, arrow functions and objects, they have a natural line breaking strategy:
-        // Arrays and objects become blocks:
-        //
-        //    [
-        //      100000,
-        //      200000,
-        //      300000
-        //    ]
-        //
-        // Arrow functions get line broken after the `=>`:
-        //
-        //  (foo) => (bar) =>
-        //     (foo + bar) * (foo + bar)
-        //
-        // Therefore if our body is an arrow function, array, or object, we
-        // do not have a soft line break after the arrow because the body is
-        // going to get broken anyways.
-        //
-        // TODO: Explore the concept of hierarchical line breaking
-        //   or vertical stacking for arrow functions
-        let body_has_soft_line_break = match body {
-            JsAnyFunctionBody::JsFunctionBody(_) => true,
-            JsAnyFunctionBody::JsAnyExpression(expr) => match expr {
-                JsAnyExpression::JsArrowFunctionExpression(_) => true,
-                JsAnyExpression::JsParenthesizedExpression(_) => true,
-                JsAnyExpression::JsxTagExpression(_) => true,
-                expr => is_simple_expression(&expr)?,
-            },
-        };
-
-        if body_has_soft_line_break {
-            write![f, [node.body().format()]]?;
-        } else {
-            write!(
-                f,
-                [group(&soft_line_indent_or_space(&node.body().format()))]
-            )?;
-        }
-
-        Ok(())
     }
 }

--- a/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
@@ -53,9 +53,7 @@ impl FormatFunction {
 
     fn id(&self) -> SyntaxResult<Option<JsAnyBinding>> {
         match self {
-            FormatFunction::JsFunctionDeclaration(declaration) => {
-                declaration.id().map(Some)
-            }
+            FormatFunction::JsFunctionDeclaration(declaration) => declaration.id().map(Some),
             FormatFunction::JsFunctionExpression(expression) => Ok(expression.id()),
             FormatFunction::JsFunctionExportDefaultDeclaration(declaration) => Ok(declaration.id()),
         }

--- a/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
@@ -1,13 +1,130 @@
 use crate::prelude::*;
 
-use rome_formatter::write;
-use rome_js_syntax::{JsAnyFunction, JsFunctionDeclaration};
+use crate::utils::is_simple_expression;
+use rome_formatter::{format_args, write};
+use rome_js_syntax::{
+    JsAnyArrowFunctionParameters, JsAnyExpression, JsAnyFunction, JsAnyFunctionBody,
+    JsFunctionDeclaration,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsFunctionDeclaration;
 
 impl FormatNodeRule<JsFunctionDeclaration> for FormatJsFunctionDeclaration {
     fn fmt_fields(&self, node: &JsFunctionDeclaration, f: &mut JsFormatter) -> FormatResult<()> {
-        write![f, [JsAnyFunction::from(node.clone()).format()]]
+        write![f, [FormatFunction::new(&JsAnyFunction::from(node.clone()))]]
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FormatFunction<'a>(&'a JsAnyFunction);
+
+impl<'a> FormatFunction<'a> {
+    pub fn new(function: &'a JsAnyFunction) -> Self {
+        Self(function)
+    }
+}
+
+impl Format<JsFormatContext> for FormatFunction<'_> {
+    fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
+        let function = self.0;
+
+        if let Some(async_token) = function.async_token() {
+            write!(f, [async_token.format(), space()])?;
+        }
+
+        write!(
+            f,
+            [
+                function.function_token().format(),
+                function.star_token().format()
+            ]
+        )?;
+
+        if !matches!(function, JsAnyFunction::JsArrowFunctionExpression(_)) {
+            match function.id()? {
+                Some(id) => {
+                    write!(f, [space(), id.format()])?;
+                }
+                None => {
+                    write!(f, [space()])?;
+                }
+            }
+        }
+
+        write!(f, [function.type_parameters().format()])?;
+
+        match function.parameters()? {
+            JsAnyArrowFunctionParameters::JsAnyBinding(binding) => write!(
+                f,
+                [format_parenthesize(
+                    binding.syntax().first_token().as_ref(),
+                    &format_args![binding.format(), if_group_breaks(&text(",")),],
+                    binding.syntax().last_token().as_ref(),
+                )
+                .grouped_with_soft_block_indent()]
+            )?,
+            JsAnyArrowFunctionParameters::JsParameters(params) => write![f, [params.format()]]?,
+        }
+
+        write![f, [function.return_type_annotation().format(), space()]]?;
+
+        // We create a new group for everything after the parameters. That way if the parameters
+        // get broken, we don't line break the arrow and the body if they can fit on the same line.
+        // For instance:
+        //
+        //   (
+        //     a = [abcdefghijklmnopqrstuvwxyz123456789],
+        //     b = [abcdefghijklmnopqrstuvwxyz123456789],
+        //   ) =>
+        //     a + b
+        //
+        // The line break for `a + b` is not necessary
+        //
+        if let JsAnyFunction::JsArrowFunctionExpression(arrow) = function {
+            write![f, [arrow.fat_arrow_token().format(), space()]]?;
+        }
+
+        let body = function.body()?;
+        // With arrays, arrow functions and objects, they have a natural line breaking strategy:
+        // Arrays and objects become blocks:
+        //
+        //    [
+        //      100000,
+        //      200000,
+        //      300000
+        //    ]
+        //
+        // Arrow functions get line broken after the `=>`:
+        //
+        //  (foo) => (bar) =>
+        //     (foo + bar) * (foo + bar)
+        //
+        // Therefore if our body is an arrow function, array, or object, we
+        // do not have a soft line break after the arrow because the body is
+        // going to get broken anyways.
+        //
+        // TODO: Explore the concept of hierarchical line breaking
+        //   or vertical stacking for arrow functions
+        let body_has_soft_line_break = match body {
+            JsAnyFunctionBody::JsFunctionBody(_) => true,
+            JsAnyFunctionBody::JsAnyExpression(expr) => match expr {
+                JsAnyExpression::JsArrowFunctionExpression(_) => true,
+                JsAnyExpression::JsParenthesizedExpression(_) => true,
+                JsAnyExpression::JsxTagExpression(_) => true,
+                expr => is_simple_expression(&expr)?,
+            },
+        };
+
+        if body_has_soft_line_break {
+            write![f, [function.body().format()]]?;
+        } else {
+            write!(
+                f,
+                [group(&soft_line_indent_or_space(&function.body().format()))]
+            )?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
@@ -54,7 +54,7 @@ impl FormatFunction {
     fn id(&self) -> SyntaxResult<Option<JsAnyBinding>> {
         match self {
             FormatFunction::JsFunctionDeclaration(declaration) => {
-                declaration.id().map(|binding| Some(binding))
+                declaration.id().map(Some)
             }
             FormatFunction::JsFunctionExpression(expression) => Ok(expression.id()),
             FormatFunction::JsFunctionExportDefaultDeclaration(declaration) => Ok(declaration.id()),

--- a/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use rome_formatter::write;
 
+use crate::js::declarations::function_declaration::FormatFunction;
 use rome_js_syntax::JsAnyFunction;
 use rome_js_syntax::JsFunctionExportDefaultDeclaration;
 
@@ -15,6 +16,6 @@ impl FormatNodeRule<JsFunctionExportDefaultDeclaration>
         node: &JsFunctionExportDefaultDeclaration,
         f: &mut JsFormatter,
     ) -> FormatResult<()> {
-        write![f, [JsAnyFunction::from(node.clone()).format()]]
+        write![f, [FormatFunction::new(&JsAnyFunction::from(node.clone()))]]
     }
 }

--- a/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 use rome_formatter::write;
 
 use crate::js::declarations::function_declaration::FormatFunction;
-use rome_js_syntax::JsAnyFunction;
 use rome_js_syntax::JsFunctionExportDefaultDeclaration;
 
 #[derive(Debug, Clone, Default)]
@@ -16,6 +15,6 @@ impl FormatNodeRule<JsFunctionExportDefaultDeclaration>
         node: &JsFunctionExportDefaultDeclaration,
         f: &mut JsFormatter,
     ) -> FormatResult<()> {
-        write![f, [FormatFunction::new(&JsAnyFunction::from(node.clone()))]]
+        write![f, [FormatFunction::from(node.clone())]]
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -86,7 +86,7 @@ impl FormatNodeRule<JsArrowFunctionExpression> for FormatJsArrowFunctionExpressi
                 | JsObjectExpression(_)
                 | JsxTagExpression(_) => true,
                 JsParenthesizedExpression(_) => true,
-                expr => is_simple_expression(&expr)?,
+                expr => is_simple_expression(expr)?,
             },
         };
 

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -1,8 +1,11 @@
 use crate::prelude::*;
-use rome_formatter::write;
+use rome_formatter::{format_args, write};
 
-use crate::js::declarations::function_declaration::FormatFunction;
-use rome_js_syntax::{JsAnyFunction, JsArrowFunctionExpression};
+use crate::utils::is_simple_expression;
+use rome_js_syntax::{
+    JsAnyArrowFunctionParameters, JsAnyExpression, JsAnyFunctionBody, JsArrowFunctionExpression,
+    JsArrowFunctionExpressionFields,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsArrowFunctionExpression;
@@ -13,6 +16,84 @@ impl FormatNodeRule<JsArrowFunctionExpression> for FormatJsArrowFunctionExpressi
         node: &JsArrowFunctionExpression,
         f: &mut JsFormatter,
     ) -> FormatResult<()> {
-        write![f, [FormatFunction::new(&JsAnyFunction::from(node.clone()))]]
+        use self::JsAnyExpression::*;
+        use JsAnyFunctionBody::*;
+
+        let JsArrowFunctionExpressionFields {
+            async_token,
+            type_parameters,
+            parameters,
+            return_type_annotation,
+            fat_arrow_token,
+            body,
+        } = node.as_fields();
+
+        if let Some(async_token) = async_token {
+            write!(f, [async_token.format(), space()])?;
+        }
+
+        write!(f, [type_parameters.format()])?;
+
+        match parameters? {
+            JsAnyArrowFunctionParameters::JsAnyBinding(binding) => write!(
+                f,
+                [format_parenthesize(
+                    binding.syntax().first_token().as_ref(),
+                    &format_args![binding.format(), if_group_breaks(&text(",")),],
+                    binding.syntax().last_token().as_ref(),
+                )
+                .grouped_with_soft_block_indent()]
+            )?,
+            JsAnyArrowFunctionParameters::JsParameters(params) => write![f, [params.format()]]?,
+        }
+
+        write![
+            f,
+            [
+                return_type_annotation.format(),
+                space(),
+                fat_arrow_token.format(),
+                space()
+            ]
+        ]?;
+
+        let body = body?;
+
+        // With arrays, arrow selfs and objects, they have a natural line breaking strategy:
+        // Arrays and objects become blocks:
+        //
+        //    [
+        //      100000,
+        //      200000,
+        //      300000
+        //    ]
+        //
+        // Arrow selfs get line broken after the `=>`:
+        //
+        //  (foo) => (bar) =>
+        //     (foo + bar) * (foo + bar)
+        //
+        // Therefore if our body is an arrow self, array, or object, we
+        // do not have a soft line break after the arrow because the body is
+        // going to get broken anyways.
+        // TODO: Explore the concept of hierarchical line breaking
+        //   or vertical stacking for arrow selfs
+        let body_has_soft_line_break = match &body {
+            JsFunctionBody(_) => true,
+            JsAnyExpression(expr) => match expr {
+                JsArrowFunctionExpression(_)
+                | JsArrayExpression(_)
+                | JsObjectExpression(_)
+                | JsxTagExpression(_) => true,
+                JsParenthesizedExpression(_) => true,
+                expr => is_simple_expression(&expr)?,
+            },
+        };
+
+        if body_has_soft_line_break {
+            write![f, [body.format()]]
+        } else {
+            write!(f, [group(&soft_line_indent_or_space(&body.format()))])
+        }
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use rome_formatter::write;
 
+use crate::js::declarations::function_declaration::FormatFunction;
 use rome_js_syntax::{JsAnyFunction, JsArrowFunctionExpression};
 
 #[derive(Debug, Clone, Default)]
@@ -12,6 +13,6 @@ impl FormatNodeRule<JsArrowFunctionExpression> for FormatJsArrowFunctionExpressi
         node: &JsArrowFunctionExpression,
         f: &mut JsFormatter,
     ) -> FormatResult<()> {
-        write![f, [JsAnyFunction::from(node.clone()).format()]]
+        write![f, [FormatFunction::new(&JsAnyFunction::from(node.clone()))]]
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/function_expression.rs
@@ -2,13 +2,13 @@ use crate::prelude::*;
 
 use crate::js::declarations::function_declaration::FormatFunction;
 use rome_formatter::write;
-use rome_js_syntax::{JsAnyFunction, JsFunctionExpression};
+use rome_js_syntax::JsFunctionExpression;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsFunctionExpression;
 
 impl FormatNodeRule<JsFunctionExpression> for FormatJsFunctionExpression {
     fn fmt_fields(&self, node: &JsFunctionExpression, f: &mut JsFormatter) -> FormatResult<()> {
-        write![f, [FormatFunction::new(&JsAnyFunction::from(node.clone()))]]
+        write![f, [FormatFunction::from(node.clone())]]
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/function_expression.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 
+use crate::js::declarations::function_declaration::FormatFunction;
 use rome_formatter::write;
 use rome_js_syntax::{JsAnyFunction, JsFunctionExpression};
 
@@ -8,6 +9,6 @@ pub struct FormatJsFunctionExpression;
 
 impl FormatNodeRule<JsFunctionExpression> for FormatJsFunctionExpression {
     fn fmt_fields(&self, node: &JsFunctionExpression, f: &mut JsFormatter) -> FormatResult<()> {
-        write![f, [JsAnyFunction::from(node.clone()).format()]]
+        write![f, [FormatFunction::new(&JsAnyFunction::from(node.clone()))]]
     }
 }

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -293,7 +293,7 @@ pub fn generate_formatter() {
 
         // Union nodes except for AnyFunction and AnyClass have a generated
         // implementation, the codegen will always overwrite any existing file
-        let allow_overwrite = matches!(kind, NodeKind::Union { .. }) && name != "JsAnyFunction";
+        let allow_overwrite = matches!(kind, NodeKind::Union { .. });
 
         if !allow_overwrite && path.exists() {
             continue;


### PR DESCRIPTION
Remove the exception for `FormatJsAnyFunction` in the code gen and instead move the shared logic for formatting a `JsAnyFunction` to `FormatFunction`

