### PR TITLE
feat(rome_formatter): `Dedent` IR

### DIFF
--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -691,10 +691,14 @@ impl<Context> std::fmt::Debug for Indent<'_, Context> {
 ///             text("Indented, not aligned")
 ///         ]))
 ///     ]),
+///     dedent(&format_args![
+///         hard_line_break(),
+///         text("Dedent on root level is a no-op.")
+///     ])
 /// ]).unwrap();
 ///
 /// assert_eq!(
-///     "root\n  aligned\nnot aligned\n\tIndented, not aligned",
+///     "root\n  aligned\nnot aligned\n\tIndented, not aligned\nDedent on root level is a no-op.",
 ///     block.print().as_code()
 /// );
 /// ```

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -665,6 +665,75 @@ impl<Context> std::fmt::Debug for Indent<'_, Context> {
     }
 }
 
+/// It reduces the indention for the given content depending on the closest [indent] or [align] parent element.
+/// * [align] Undoes the spaces added by [align]
+/// * [indent] Reduces the indention level by one
+///
+/// This is a No-op if the indention level is zero.
+///
+/// # Examples
+///
+/// ```
+/// use rome_formatter::{format, format_args};
+/// use rome_formatter::prelude::*;
+///
+/// let block = format!(SimpleFormatContext::default(), [
+///     text("root"),
+///     align(2, &format_args![
+///         hard_line_break(),
+///         text("aligned"),
+///         dedent(&format_args![
+///             hard_line_break(),
+///             text("not aligned"),
+///         ]),
+///         dedent(&indent(&format_args![
+///             hard_line_break(),
+///             text("Indented, not aligned")
+///         ]))
+///     ]),
+/// ]).unwrap();
+///
+/// assert_eq!(
+///     "root\n  aligned\nnot aligned\n\tIndented, not aligned",
+///     block.print().as_code()
+/// );
+/// ```
+#[inline]
+pub fn dedent<Content, Context>(content: &Content) -> Dedent<Context>
+where
+    Content: Format<Context>,
+{
+    Dedent {
+        content: Argument::new(content),
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Dedent<'a, Context> {
+    content: Argument<'a, Context>,
+}
+
+impl<Context> Format<Context> for Dedent<'_, Context> {
+    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
+        let mut buffer = VecBuffer::new(f.state_mut());
+
+        buffer.write_fmt(Arguments::from(&self.content))?;
+
+        if buffer.is_empty() {
+            return Ok(());
+        }
+
+        let content = buffer.into_vec();
+        f.write_element(FormatElement::Dedent(content.into_boxed_slice()))
+    }
+}
+
+impl<Context> std::fmt::Debug for Dedent<'_, Context> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Dedent").field(&"{{content}}").finish()
+    }
+}
+
 /// Aligns its content by indenting the content by `count` spaces.
 ///
 /// [align] is a variant of `[indent]` that indents its content by a specified number of spaces rather than

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -561,7 +561,7 @@ impl PrintElementArgs {
     }
 
     pub fn decrement_indent(mut self) -> Self {
-        self.indent = self.indent.decrement_indent();
+        self.indent = self.indent.decrement();
         self
     }
 
@@ -636,7 +636,7 @@ impl Indention {
     /// * Removing the `align` if this is [Indent::Align]
     ///
     /// No-op if the level is already zero.
-    fn decrement_indent(self) -> Self {
+    fn decrement(self) -> Self {
         match self {
             Indention::Level(level) => Indention::Level(level.saturating_sub(1)),
             Indention::Align { level, .. } => Indention::Level(level),


### PR DESCRIPTION
## Summary

This PR adds a new IR that allows to reduce the indention for some content nested inside of an `align` or `indent`.

The behaviour of the element depends on whether the closest ancestor is an `align` or `indent`

* `align`: Removes the `align` spaces
* `indent`: Reduces the indention level by one *EXCEPT* if the level is 0, in which case this is a no-op

This is necessary for the formatting of nested conditional expressions where the `consequent` gets wrapped in an `align` but any nested consequent should be indented by one level (and not an indent). That's why the formatter uses `dedent(indent(...))` to undo the `align` but enforce an `indent`.



## Test Plan

I added a new builder test showing the behaviour of the `dedent` element.
