### PR TITLE
refactor(rome_service): change how rules config is shaped

### DIFF
--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -36,16 +36,14 @@ pub const CONFIG_ALL_FIELDS: &str = r#"{
     "enabled": true,
     "rules": {
         "js": {
-            "rules": {
-                "noDeadCode": "off",
-                "useSimplifiedLogicExpression": "warn",
-                "noCatchAssign": "error",
-                "noLabelVar": {
-                    "level": "warn"
-                },
-                "useTemplate": {
-                    "level": "error"
-                }
+            "noDeadCode": "off",
+            "useSimplifiedLogicExpression": "warn",
+            "noCatchAssign": "error",
+            "noLabelVar": {
+                "level": "warn"
+            },
+            "useTemplate": {
+                "level": "error"
             }
         }
     }
@@ -75,14 +73,10 @@ pub const CONFIG_LINTER_WRONG_RULE: &str = r#"{
     "enabled": true,
     "rules": {
         "js": {
-            "rules": {
-                "foo_rule": "off"
-            }
+            "foo_rule": "off"
         },
         "jsx": {
-            "rules": {
-                "what_the_hell": "off"
-            }
+            "what_the_hell": "off"
         }
     }
   }
@@ -102,9 +96,7 @@ pub const CONFIG_LINTER_SUPPRESSED_RULE: &str = r#"{
     "rules": {
         "recommended": true,
         "js": {
-            "rules": {
-                "noDebugger": "off"
-            }
+            "noDebugger": "off"
         }
     }
   }
@@ -126,9 +118,8 @@ pub const CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC: &str = r#"{
     "rules": {
         "recommended": true,
         "js": {
-            "rules": {
-                "noDebugger": "warn"
-            }
+            "recommended": true,      
+            "noDebugger": "warn"
         }
     }
   }
@@ -139,9 +130,7 @@ pub const CONFIG_LINTER_UPGRADE_DIAGNOSTIC: &str = r#"{
     "rules": {
         "recommended": true,
         "js": {
-            "rules": {
-                "noDeadCode": "error"
-            }
+            "noDeadCode": "error"
         }
     }
   }

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -1120,7 +1120,7 @@ mod configuration {
             args: Arguments::from_vec(vec![OsString::from("format"), OsString::from("file.js")]),
         });
 
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "run_cli returned {result:?}");
     }
 
     #[test]
@@ -1137,7 +1137,8 @@ mod configuration {
             ),
             args: Arguments::from_vec(vec![OsString::from("format"), OsString::from("file.js")]),
         });
-        assert!(result.is_err());
+
+        assert!(result.is_err(), "run_cli returned {result:?}");
 
         match result {
             Err(error) => {
@@ -1164,6 +1165,8 @@ mod configuration {
             args: Arguments::from_vec(vec![OsString::from("check"), OsString::from("file.js")]),
         });
 
+        assert!(result.is_err(), "run_cli returned {result:?}");
+
         match result {
             Err(error) => {
                 assert!(error.to_string().contains("Invalid rule name `foo_rule`"),)
@@ -1187,7 +1190,7 @@ mod configuration {
             args: Arguments::from_vec(vec![OsString::from("check"), OsString::from("file.js")]),
         });
 
-        assert!(result.is_err());
+        assert!(result.is_err(), "run_cli returned {result:?}");
 
         match result {
             Err(error) => {
@@ -1214,6 +1217,6 @@ mod configuration {
             args: Arguments::from_vec(vec![OsString::from("check"), OsString::from("file.js")]),
         });
 
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "run_cli returned {result:?}");
     }
 }

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -201,7 +201,7 @@ impl Rules {
     }
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+#[serde(rename_all = "camelCase", default)]
 pub struct Js {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -209,7 +209,8 @@ pub struct Js {
     #[doc = r" List of rules for the current group"]
     #[serde(
         skip_serializing_if = "IndexMap::is_empty",
-        deserialize_with = "deserialize_js_rules"
+        deserialize_with = "deserialize_js_rules",
+        flatten
     )]
     pub rules: IndexMap<String, RuleConfiguration>,
 }
@@ -352,7 +353,7 @@ where
     Ok(value)
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+#[serde(rename_all = "camelCase", default)]
 pub struct Jsx {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -360,7 +361,8 @@ pub struct Jsx {
     #[doc = r" List of rules for the current group"]
     #[serde(
         skip_serializing_if = "IndexMap::is_empty",
-        deserialize_with = "deserialize_jsx_rules"
+        deserialize_with = "deserialize_jsx_rules",
+        flatten
     )]
     pub rules: IndexMap<String, RuleConfiguration>,
 }
@@ -429,7 +431,7 @@ where
     Ok(value)
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+#[serde(rename_all = "camelCase", default)]
 pub struct Regex {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -437,7 +439,8 @@ pub struct Regex {
     #[doc = r" List of rules for the current group"]
     #[serde(
         skip_serializing_if = "IndexMap::is_empty",
-        deserialize_with = "deserialize_regex_rules"
+        deserialize_with = "deserialize_regex_rules",
+        flatten
     )]
     pub rules: IndexMap<String, RuleConfiguration>,
 }
@@ -496,7 +499,7 @@ where
     Ok(value)
 }
 #[derive(Deserialize, Default, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+#[serde(rename_all = "camelCase", default)]
 pub struct Ts {
     #[doc = r" It enables the recommended rules for this group"]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -504,7 +507,8 @@ pub struct Ts {
     #[doc = r" List of rules for the current group"]
     #[serde(
         skip_serializing_if = "IndexMap::is_empty",
-        deserialize_with = "deserialize_ts_rules"
+        deserialize_with = "deserialize_ts_rules",
+        flatten
     )]
     pub rules: IndexMap<String, RuleConfiguration>,
 }

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -71,14 +71,14 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
 
         let group_struct = quote! {
             #[derive(Deserialize, Default, Serialize, Debug, Clone)]
-            #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+            #[serde(rename_all = "camelCase", default)]
             pub struct #group_struct_name {
                 /// It enables the recommended rules for this group
                 #[serde(skip_serializing_if = "Option::is_none")]
                 pub recommended: Option<bool>,
 
                 /// List of rules for the current group
-                #[serde(skip_serializing_if = "IndexMap::is_empty", deserialize_with = #deserialize_function_string)]
+                #[serde(skip_serializing_if = "IndexMap::is_empty", deserialize_with = #deserialize_function_string, flatten)]
                 pub rules: IndexMap<String, RuleConfiguration>,
             }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #3015 

The first attempt of the configuration of the rules tried to be too smart (using `IndexMap`) but it wasn't well designed and it couldn't be extended easily and as a consequence we have `rules.js.rules`, which was very redundant.

Fortunately `flatten` directive form `serde` seems to fit the bill here, and it works as expected.


## Future optimization

At the moment the enabled/disabled rules are always computed every time we get a diagnostic from a rule. Same for when we have to create an `AnalysisFilter`. This is not efficient. We should look into ways to cache this information, although this would require some work around lifetimes, because `RuleFilter` only works with references and caching them might only be possible if we use the lifetime coming `App`. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated the tests, and now it all passes! We will need to change the configuration once this lands.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
