### PR TITLE
refactor(playground): refactor the playground to use the WASM bindings for the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,16 +1651,10 @@ name = "rome_playground"
 version = "0.0.0"
 dependencies = [
  "js-sys",
- "rome_analyze",
  "rome_console",
  "rome_diagnostics",
- "rome_formatter",
- "rome_js_analyze",
- "rome_js_formatter",
- "rome_js_parser",
- "rome_js_syntax",
+ "rome_service",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2407,6 +2401,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/crates/rome_lsp/src/requests/syntax_tree.rs
+++ b/crates/rome_lsp/src/requests/syntax_tree.rs
@@ -16,7 +16,8 @@ pub struct SyntaxTreePayload {
 pub(crate) fn syntax_tree(session: &Session, url: &Url) -> Result<String> {
     info!("Showing syntax tree");
     let rome_path = session.file_path(url);
-    Ok(session
+    let syntax_tree = session
         .workspace
-        .get_syntax_tree(GetSyntaxTreeParams { path: rome_path })?)
+        .get_syntax_tree(GetSyntaxTreeParams { path: rome_path })?;
+    Ok(syntax_tree.ast)
 }

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -1,22 +1,24 @@
-use rome_analyze::{AnalysisFilter, ControlFlow, Never, RuleCategories, RuleFilter};
+use rome_analyze::{AnalysisFilter, ControlFlow, Never, QueryMatch, RuleCategories, RuleFilter};
 use rome_diagnostics::{Applicability, CodeSuggestion, Diagnostic};
 use rome_formatter::{FormatError, Printed};
 use rome_fs::RomePath;
 use rome_js_analyze::utils::rename::RenameError;
-use rome_js_analyze::{analyze, RuleError};
+use rome_js_analyze::{analyze, analyze_with_inspect_matcher, RuleError};
 use rome_js_formatter::context::QuoteStyle;
 use rome_js_formatter::{context::JsFormatContext, format_node};
 use rome_js_parser::Parse;
 use rome_js_semantic::semantic_model;
-use rome_js_syntax::{JsAnyRoot, JsLanguage, SourceType, TextRange, TextSize, TokenAtOffset};
+use rome_js_syntax::{
+    JsAnyRoot, JsLanguage, JsSyntaxNode, SourceType, TextRange, TextSize, TokenAtOffset,
+};
 use rome_rowan::{AstNode, BatchMutationExt, Direction};
 
-use crate::workspace::{
-    CodeAction, FixAction, FixFileMode, FixFileResult, PullActionsResult, RenameResult,
-};
 use crate::{
     settings::{FormatSettings, Language, LanguageSettings, LanguagesSettings, SettingsHandle},
-    workspace::server::AnyParse,
+    workspace::{
+        server::AnyParse, CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult,
+        PullActionsResult, RenameResult,
+    },
     RomeError, Rules,
 };
 
@@ -73,7 +75,9 @@ impl ExtensionHandler for JsFileHandler {
     fn capabilities(&self) -> super::Capabilities {
         super::Capabilities {
             parse: Some(parse),
-            debug_print: Some(debug_print),
+            debug_syntax_tree: Some(debug_syntax_tree),
+            debug_control_flow: Some(debug_control_flow),
+            debug_formatter_ir: Some(debug_formatter_ir),
             lint: Some(lint),
             format: Some(format),
             code_actions: Some(code_actions),
@@ -124,9 +128,67 @@ where
     }
 }
 
-fn debug_print(_rome_path: &RomePath, parse: AnyParse) -> String {
+fn debug_syntax_tree(_rome_path: &RomePath, parse: AnyParse) -> GetSyntaxTreeResult {
+    let syntax: JsSyntaxNode = parse.syntax();
     let tree: JsAnyRoot = parse.tree();
-    format!("{tree:#?}")
+    GetSyntaxTreeResult {
+        cst: format!("{syntax:#?}"),
+        ast: format!("{tree:#?}"),
+    }
+}
+
+fn debug_control_flow(rome_path: &RomePath, parse: AnyParse, cursor: TextSize) -> String {
+    let mut control_flow_graph = None;
+
+    let filter = AnalysisFilter {
+        categories: RuleCategories::LINT,
+        enabled_rules: Some(&[RuleFilter::Rule("js", "noDeadCode")]),
+        ..AnalysisFilter::default()
+    };
+
+    analyze_with_inspect_matcher(
+        rome_path.file_id(),
+        &parse.tree(),
+        filter,
+        |match_params| {
+            let (cfg, range) = match &match_params.query {
+                QueryMatch::ControlFlowGraph(cfg, node) => (cfg, node),
+                _ => return,
+            };
+
+            if !range.contains(cursor) {
+                return;
+            }
+
+            match &control_flow_graph {
+                None => {
+                    control_flow_graph = Some((cfg.to_string(), *range));
+                }
+                Some((_, prev_range)) => {
+                    if range.len() < prev_range.len() {
+                        control_flow_graph = Some((cfg.to_string(), *range));
+                    }
+                }
+            }
+        },
+        |_| ControlFlow::<Never>::Continue(()),
+    );
+
+    control_flow_graph.map(|(cfg, _)| cfg).unwrap_or_default()
+}
+
+fn debug_formatter_ir(
+    rome_path: &RomePath,
+    parse: AnyParse,
+    settings: SettingsHandle,
+) -> Result<String, RomeError> {
+    let context = settings.format_context::<JsLanguage>(rome_path);
+
+    let tree = parse.syntax();
+    let formatted = format_node(context, &tree)?;
+
+    let root_element = formatted.into_format_element();
+    Ok(root_element.to_string())
 }
 
 fn lint(

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -22,7 +22,10 @@ use crate::{
     RomeError, Rules,
 };
 
-use super::{ExtensionHandler, Mime};
+use super::{
+    AnalyzerCapabilities, DebugCapabilities, ExtensionHandler, FormatterCapabilities, Mime,
+    ParserCapabilities,
+};
 use crate::file_handlers::FixAllParams;
 use indexmap::IndexSet;
 use rome_console::codespan::Severity;
@@ -74,17 +77,23 @@ pub(crate) struct JsFileHandler;
 impl ExtensionHandler for JsFileHandler {
     fn capabilities(&self) -> super::Capabilities {
         super::Capabilities {
-            parse: Some(parse),
-            debug_syntax_tree: Some(debug_syntax_tree),
-            debug_control_flow: Some(debug_control_flow),
-            debug_formatter_ir: Some(debug_formatter_ir),
-            lint: Some(lint),
-            format: Some(format),
-            code_actions: Some(code_actions),
-            fix_all: Some(fix_all),
-            format_range: Some(format_range),
-            format_on_type: Some(format_on_type),
-            rename: Some(rename),
+            parser: ParserCapabilities { parse: Some(parse) },
+            debug: DebugCapabilities {
+                debug_syntax_tree: Some(debug_syntax_tree),
+                debug_control_flow: Some(debug_control_flow),
+                debug_formatter_ir: Some(debug_formatter_ir),
+            },
+            analyzer: AnalyzerCapabilities {
+                lint: Some(lint),
+                code_actions: Some(code_actions),
+                fix_all: Some(fix_all),
+                rename: Some(rename),
+            },
+            formatter: FormatterCapabilities {
+                format: Some(format),
+                format_range: Some(format_range),
+                format_on_type: Some(format_on_type),
+            },
         }
     }
 

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -3,22 +3,6 @@ use super::{ExtensionHandler, Mime};
 pub(crate) struct JsonFileHandler;
 
 impl ExtensionHandler for JsonFileHandler {
-    fn capabilities(&self) -> super::Capabilities {
-        super::Capabilities {
-            parse: None,
-            debug_syntax_tree: None,
-            debug_control_flow: None,
-            debug_formatter_ir: None,
-            format: None,
-            lint: None,
-            code_actions: None,
-            fix_all: None,
-            format_range: None,
-            format_on_type: None,
-            rename: None,
-        }
-    }
-
     fn language(&self) -> super::Language {
         super::Language::Json
     }

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -6,7 +6,9 @@ impl ExtensionHandler for JsonFileHandler {
     fn capabilities(&self) -> super::Capabilities {
         super::Capabilities {
             parse: None,
-            debug_print: None,
+            debug_syntax_tree: None,
+            debug_control_flow: None,
+            debug_formatter_ir: None,
             format: None,
             lint: None,
             code_actions: None,

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -7,7 +7,9 @@ use std::ffi::OsStr;
 
 use crate::{
     settings::SettingsHandle,
-    workspace::{server::AnyParse, FixFileResult, PullActionsResult, RenameResult},
+    workspace::{
+        server::AnyParse, FixFileResult, GetSyntaxTreeResult, PullActionsResult, RenameResult,
+    },
     RomeError, Rules,
 };
 
@@ -79,7 +81,9 @@ pub struct FixAllParams<'a> {
 }
 
 type Parse = fn(&RomePath, &str) -> AnyParse;
-type DebugPrint = fn(&RomePath, AnyParse) -> String;
+type DebugSyntaxTree = fn(&RomePath, AnyParse) -> GetSyntaxTreeResult;
+type DebugControlFlow = fn(&RomePath, AnyParse, TextSize) -> String;
+type DebugFormatterIR = fn(&RomePath, AnyParse, SettingsHandle) -> Result<String, RomeError>;
 type Lint = fn(&RomePath, AnyParse, AnalysisFilter, Option<&Rules>) -> Vec<Diagnostic>;
 type CodeActions = fn(&RomePath, AnyParse, TextRange, Option<&Rules>) -> PullActionsResult;
 type FixAll = fn(FixAllParams) -> Result<FixFileResult, RomeError>;
@@ -93,7 +97,9 @@ pub(crate) struct Capabilities {
     /// Parse a file
     pub(crate) parse: Option<Parse>,
     /// Prints the tree
-    pub(crate) debug_print: Option<DebugPrint>,
+    pub(crate) debug_syntax_tree: Option<DebugSyntaxTree>,
+    pub(crate) debug_control_flow: Option<DebugControlFlow>,
+    pub(crate) debug_formatter_ir: Option<DebugFormatterIR>,
     /// It lints a file
     pub(crate) lint: Option<Lint>,
     /// It extracts code actions for a file
@@ -128,7 +134,9 @@ pub(crate) trait ExtensionHandler {
     fn capabilities(&self) -> Capabilities {
         Capabilities {
             parse: None,
-            debug_print: None,
+            debug_syntax_tree: None,
+            debug_control_flow: None,
+            debug_formatter_ir: None,
             format: None,
             lint: None,
             code_actions: None,

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -80,40 +80,66 @@ pub struct FixAllParams<'a> {
     pub(crate) fix_file_mode: FixFileMode,
 }
 
+#[derive(Default)]
+/// The list of capabilities that are available for a language
+pub(crate) struct Capabilities {
+    pub(crate) parser: ParserCapabilities,
+    pub(crate) debug: DebugCapabilities,
+    pub(crate) analyzer: AnalyzerCapabilities,
+    pub(crate) formatter: FormatterCapabilities,
+}
+
 type Parse = fn(&RomePath, &str) -> AnyParse;
+
+#[derive(Default)]
+pub(crate) struct ParserCapabilities {
+    /// Parse a file
+    pub(crate) parse: Option<Parse>,
+}
+
 type DebugSyntaxTree = fn(&RomePath, AnyParse) -> GetSyntaxTreeResult;
 type DebugControlFlow = fn(&RomePath, AnyParse, TextSize) -> String;
 type DebugFormatterIR = fn(&RomePath, AnyParse, SettingsHandle) -> Result<String, RomeError>;
+
+#[derive(Default)]
+pub(crate) struct DebugCapabilities {
+    /// Prints the syntax tree
+    pub(crate) debug_syntax_tree: Option<DebugSyntaxTree>,
+    /// Prints the control flow graph
+    pub(crate) debug_control_flow: Option<DebugControlFlow>,
+    /// Prints the formatter IR
+    pub(crate) debug_formatter_ir: Option<DebugFormatterIR>,
+}
+
 type Lint = fn(&RomePath, AnyParse, AnalysisFilter, Option<&Rules>) -> Vec<Diagnostic>;
 type CodeActions = fn(&RomePath, AnyParse, TextRange, Option<&Rules>) -> PullActionsResult;
 type FixAll = fn(FixAllParams) -> Result<FixFileResult, RomeError>;
-type Format = fn(&RomePath, AnyParse, SettingsHandle) -> Result<Printed, RomeError>;
-type FormatRange = fn(&RomePath, AnyParse, SettingsHandle, TextRange) -> Result<Printed, RomeError>;
-type FormatOnType = fn(&RomePath, AnyParse, SettingsHandle, TextSize) -> Result<Printed, RomeError>;
 type Rename = fn(&RomePath, AnyParse, TextSize, String) -> Result<RenameResult, RomeError>;
 
-/// The list of capabilities that are available for a language
-pub(crate) struct Capabilities {
-    /// Parse a file
-    pub(crate) parse: Option<Parse>,
-    /// Prints the tree
-    pub(crate) debug_syntax_tree: Option<DebugSyntaxTree>,
-    pub(crate) debug_control_flow: Option<DebugControlFlow>,
-    pub(crate) debug_formatter_ir: Option<DebugFormatterIR>,
+#[derive(Default)]
+pub(crate) struct AnalyzerCapabilities {
     /// It lints a file
     pub(crate) lint: Option<Lint>,
     /// It extracts code actions for a file
     pub(crate) code_actions: Option<CodeActions>,
     /// Applies fixes to a file
     pub(crate) fix_all: Option<FixAll>,
+    /// It renames a binding inside a file
+    pub(crate) rename: Option<Rename>,
+}
+
+type Format = fn(&RomePath, AnyParse, SettingsHandle) -> Result<Printed, RomeError>;
+type FormatRange = fn(&RomePath, AnyParse, SettingsHandle, TextRange) -> Result<Printed, RomeError>;
+type FormatOnType = fn(&RomePath, AnyParse, SettingsHandle, TextSize) -> Result<Printed, RomeError>;
+
+#[derive(Default)]
+pub(crate) struct FormatterCapabilities {
     /// It formats a file
     pub(crate) format: Option<Format>,
     /// It formats a portion of text of a file
     pub(crate) format_range: Option<FormatRange>,
     /// It formats a file while typing
     pub(crate) format_on_type: Option<FormatOnType>,
-    /// It renames a binding inside a file
-    pub(crate) rename: Option<Rename>,
 }
 
 /// Main trait to use to add a new language to Rome
@@ -132,19 +158,7 @@ pub(crate) trait ExtensionHandler {
 
     /// Capabilities that can applied to a file
     fn capabilities(&self) -> Capabilities {
-        Capabilities {
-            parse: None,
-            debug_syntax_tree: None,
-            debug_control_flow: None,
-            debug_formatter_ir: None,
-            format: None,
-            lint: None,
-            code_actions: None,
-            fix_all: None,
-            format_range: None,
-            format_on_type: None,
-            rename: None,
-        }
+        Capabilities::default()
     }
 
     /// How a file should be treated. Usually an asset doesn't posses a parser.

--- a/crates/rome_service/src/file_handlers/unknown.rs
+++ b/crates/rome_service/src/file_handlers/unknown.rs
@@ -4,22 +4,6 @@ use super::ExtensionHandler;
 pub(crate) struct UnknownFileHandler {}
 
 impl ExtensionHandler for UnknownFileHandler {
-    fn capabilities(&self) -> super::Capabilities {
-        super::Capabilities {
-            parse: None,
-            debug_syntax_tree: None,
-            debug_control_flow: None,
-            debug_formatter_ir: None,
-            format: None,
-            lint: None,
-            code_actions: None,
-            fix_all: None,
-            format_range: None,
-            format_on_type: None,
-            rename: None,
-        }
-    }
-
     fn language(&self) -> super::Language {
         super::Language::Unknown
     }

--- a/crates/rome_service/src/file_handlers/unknown.rs
+++ b/crates/rome_service/src/file_handlers/unknown.rs
@@ -7,7 +7,9 @@ impl ExtensionHandler for UnknownFileHandler {
     fn capabilities(&self) -> super::Capabilities {
         super::Capabilities {
             parse: None,
-            debug_print: None,
+            debug_syntax_tree: None,
+            debug_control_flow: None,
+            debug_formatter_ir: None,
             format: None,
             lint: None,
             code_actions: None,

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -14,10 +14,13 @@ use std::sync::{RwLock, RwLockReadGuard};
 )]
 pub struct WorkspaceSettings {
     /// Formatter settings applied to all files in the workspaces
+    #[cfg_attr(feature = "serde_workspace", serde(default))]
     pub format: FormatSettings,
     /// Linter settings applied to all files in the workspace
+    #[cfg_attr(feature = "serde_workspace", serde(default))]
     pub linter: LinterSettings,
     /// Language specific settings
+    #[cfg_attr(feature = "serde_workspace", serde(default))]
     pub languages: LanguagesSettings,
 }
 
@@ -119,6 +122,7 @@ impl Default for LinterSettings {
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct LanguagesSettings {
+    #[cfg_attr(feature = "serde_workspace", serde(default))]
     pub javascript: LanguageSettings<JsLanguage>,
 }
 
@@ -151,15 +155,18 @@ pub trait Language: rome_rowan::Language {
 )]
 pub struct LanguageSettings<L: Language> {
     /// Formatter settings for this language
+    #[cfg_attr(feature = "serde_workspace", serde(default))]
     pub format: L::FormatSettings,
 
     /// Linter settings for this language
+    #[cfg_attr(feature = "serde_workspace", serde(default))]
     pub linter: L::LinterSettings,
 
     /// Globals variables/bindings that can be found in a file
     #[cfg_attr(
         feature = "serde_workspace",
         serde(
+            default,
             deserialize_with = "crate::configuration::deserialize_globals",
             serialize_with = "crate::configuration::serialize_globals"
         )

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -112,6 +112,32 @@ pub struct GetSyntaxTreeParams {
     feature = "serde_workspace",
     derive(serde::Serialize, serde::Deserialize)
 )]
+pub struct GetSyntaxTreeResult {
+    pub cst: String,
+    pub ast: String,
+}
+
+#[cfg_attr(
+    feature = "serde_workspace",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct GetControlFlowGraphParams {
+    pub path: RomePath,
+    pub cursor: TextSize,
+}
+
+#[cfg_attr(
+    feature = "serde_workspace",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct GetFormatterIRParams {
+    pub path: RomePath,
+}
+
+#[cfg_attr(
+    feature = "serde_workspace",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct ChangeFileParams {
     pub path: RomePath,
     pub content: String,
@@ -279,7 +305,19 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     fn open_file(&self, params: OpenFileParams) -> Result<(), RomeError>;
 
     // Return a textual, debug representation of the syntax tree for a given document
-    fn get_syntax_tree(&self, params: GetSyntaxTreeParams) -> Result<String, RomeError>;
+    fn get_syntax_tree(
+        &self,
+        params: GetSyntaxTreeParams,
+    ) -> Result<GetSyntaxTreeResult, RomeError>;
+
+    // Return a textual, debug representation of the control flow graph at a given position in the document
+    fn get_control_flow_graph(
+        &self,
+        params: GetControlFlowGraphParams,
+    ) -> Result<String, RomeError>;
+
+    // Return a textual, debug representation of the formatter IR for a given document
+    fn get_formatter_ir(&self, params: GetFormatterIRParams) -> Result<String, RomeError>;
 
     /// Change the content of an open file
     fn change_file(&self, params: ChangeFileParams) -> Result<(), RomeError>;
@@ -335,7 +373,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         Ok(Self { workspace, path })
     }
 
-    pub fn get_syntax_tree(&self) -> Result<String, RomeError> {
+    pub fn get_syntax_tree(&self) -> Result<GetSyntaxTreeResult, RomeError> {
         self.workspace.get_syntax_tree(GetSyntaxTreeParams {
             path: self.path.clone(),
         })

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -123,6 +123,7 @@ impl WorkspaceServer {
 
                 let capabilities = self.features.get_capabilities(rome_path);
                 let parser = capabilities
+                    .parser
                     .parse
                     .ok_or_else(|| RomeError::SourceFileNotSupported(rome_path.clone()))?;
 
@@ -139,8 +140,10 @@ impl Workspace for WorkspaceServer {
         let capabilities = self.features.get_capabilities(&params.path);
         let settings = self.settings.read().unwrap();
         match params.feature {
-            FeatureName::Format => capabilities.format.is_some() && settings.format.enabled,
-            FeatureName::Lint => capabilities.lint.is_some() && settings.linter.enabled,
+            FeatureName::Format => {
+                capabilities.formatter.format.is_some() && settings.format.enabled
+            }
+            FeatureName::Lint => capabilities.analyzer.lint.is_some() && settings.linter.enabled,
         }
     }
 
@@ -174,6 +177,7 @@ impl Workspace for WorkspaceServer {
     ) -> Result<GetSyntaxTreeResult, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let printer = capabilities
+            .debug
             .debug_syntax_tree
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
@@ -189,6 +193,7 @@ impl Workspace for WorkspaceServer {
     ) -> Result<String, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let printer = capabilities
+            .debug
             .debug_control_flow
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
@@ -201,6 +206,7 @@ impl Workspace for WorkspaceServer {
     fn get_formatter_ir(&self, params: GetFormatterIRParams) -> Result<String, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let printer = capabilities
+            .debug
             .debug_formatter_ir
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
@@ -246,6 +252,7 @@ impl Workspace for WorkspaceServer {
     ) -> Result<PullDiagnosticsResult, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let linter = capabilities
+            .analyzer
             .lint
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
@@ -275,6 +282,7 @@ impl Workspace for WorkspaceServer {
     fn pull_actions(&self, params: PullActionsParams) -> Result<PullActionsResult, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let code_actions = capabilities
+            .analyzer
             .code_actions
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
@@ -291,6 +299,7 @@ impl Workspace for WorkspaceServer {
     fn format_file(&self, params: FormatFileParams) -> Result<Printed, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let formatter = capabilities
+            .formatter
             .format
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
@@ -307,6 +316,7 @@ impl Workspace for WorkspaceServer {
     fn format_range(&self, params: FormatRangeParams) -> Result<Printed, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let formatter = capabilities
+            .formatter
             .format_range
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
@@ -323,6 +333,7 @@ impl Workspace for WorkspaceServer {
     fn format_on_type(&self, params: FormatOnTypeParams) -> Result<Printed, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let formatter = capabilities
+            .formatter
             .format_on_type
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
@@ -339,6 +350,7 @@ impl Workspace for WorkspaceServer {
     fn fix_file(&self, params: super::FixFileParams) -> Result<FixFileResult, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let fix_all = capabilities
+            .analyzer
             .fix_all
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 
@@ -356,6 +368,7 @@ impl Workspace for WorkspaceServer {
     fn rename(&self, params: super::RenameParams) -> Result<RenameResult, RomeError> {
         let capabilities = self.features.get_capabilities(&params.path);
         let rename = capabilities
+            .analyzer
             .rename
             .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
 

--- a/website/playground/Cargo.toml
+++ b/website/playground/Cargo.toml
@@ -10,14 +10,8 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasm-bindgen = "0.2.79"
+wasm-bindgen = { version = "0.2.79", features = ["serde-serialize"] }
 js-sys = "0.3.58"
-web-sys = "0.3.58"
-rome_js_formatter = { path = "../../crates/rome_js_formatter" }
-rome_formatter = { path = "../../crates/rome_formatter" }
-rome_js_parser = { path = "../../crates/rome_js_parser", features = ["serde"] }
-rome_js_syntax = { path = "../../crates/rome_js_syntax" }
-rome_diagnostics = { path = "../../crates/rome_diagnostics" }
-rome_analyze = { path = "../../crates/rome_analyze" }
-rome_js_analyze = { path = "../../crates/rome_js_analyze" }
+rome_service = { path = "../../crates/rome_service", features = ["serde_workspace"] }
 rome_console = { path = "../../crates/rome_console" }
+rome_diagnostics = { path = "../../crates/rome_diagnostics" }

--- a/website/playground/src/lib.rs
+++ b/website/playground/src/lib.rs
@@ -260,7 +260,6 @@ interface GetControlFlowGraphParams {
 
 interface GetFormatterIRParams {
     path: RomePath;
-    indent_style: IndentStyle;
 }
 
 interface ChangeFileParams {
@@ -310,17 +309,13 @@ interface CodeAction {
     suggestion: CodeSuggestion;
 }
 
-type IndentStyle = "Tab" | { "Space": number };
-
 interface FormatFileParams {
     path: RomePath;
-    indent_style: IndentStyle;
 }
 
 interface FormatRangeParams {
     path: RomePath;
     range: TextRange;
-    indent_style: IndentStyle;
 }
 
 type TextSize = number;
@@ -328,7 +323,6 @@ type TextSize = number;
 interface FormatOnTypeParams {
     path: RomePath;
     offset: TextSize;
-    indent_style: IndentStyle;
 }
 
 interface FixFileParams {

--- a/website/playground/src/romeWorker.ts
+++ b/website/playground/src/romeWorker.ts
@@ -1,4 +1,8 @@
-import init, { DiagnosticPrinter, RomePath, Workspace } from "../pkg/rome_playground";
+import init, {
+	DiagnosticPrinter,
+	RomePath,
+	Workspace,
+} from "../pkg/rome_playground";
 import {
 	SourceType,
 	LoadingState,
@@ -83,6 +87,8 @@ self.addEventListener("message", async (e) => {
 						enabled: true,
 						format_with_errors: true,
 						line_width: lineWidth,
+						indent_style:
+							indentStyle === IndentStyle.Tab ? "Tab" : { Space: indentWidth },
 					},
 					linter: {
 						enabled: true,
@@ -90,8 +96,9 @@ self.addEventListener("message", async (e) => {
 					languages: {
 						javascript: {
 							format: {
-								quote_style: quoteStyle === QuoteStyle.Double ? "Double" : "Single",
-							}
+								quote_style:
+									quoteStyle === QuoteStyle.Double ? "Double" : "Single",
+							},
 						},
 					},
 				},
@@ -132,8 +139,6 @@ self.addEventListener("message", async (e) => {
 			});
 			const formatter_ir = workspace.get_formatter_ir({
 				path,
-				indent_style:
-					indentStyle === IndentStyle.Tab ? "Tab" : { Space: indentWidth },
 			});
 
 			const diagnostics = workspace.pull_diagnostics({
@@ -148,8 +153,6 @@ self.addEventListener("message", async (e) => {
 
 			const printed = workspace.format_file({
 				path,
-				indent_style:
-					indentStyle === IndentStyle.Tab ? "Tab" : { Space: indentWidth },
 			});
 
 			const romeOutput: RomeOutput = {

--- a/website/playground/src/romeWorker.ts
+++ b/website/playground/src/romeWorker.ts
@@ -1,13 +1,57 @@
-import init, { PlaygroundFormatOptions, run } from "../pkg/rome_playground";
-import { IndentStyle, LoadingState } from "./types";
+import init, { DiagnosticPrinter, RomePath, Workspace } from "../pkg/rome_playground";
+import {
+	SourceType,
+	LoadingState,
+	PlaygroundState,
+	IndentStyle,
+	RomeOutput,
+	QuoteStyle,
+} from "./types";
+
+let workspace: Workspace | null = null;
+
+const PATH_SCRIPT = {
+	path: "main.js",
+	id: 0,
+};
+
+const PATHS_MODULE = [
+	{ path: "main.mjs", id: 1 },
+	{ path: "main.jsx", id: 2 },
+	{ path: "main.ts", id: 3 },
+	{ path: "main.tsx", id: 4 },
+];
+
+function getPathForType(
+	sourceType: SourceType,
+	isTypeScript: boolean,
+	isJsx: boolean,
+): RomePath {
+	if (sourceType === SourceType.Script) {
+		return PATH_SCRIPT;
+	}
+
+	return PATHS_MODULE[(Number(isTypeScript) * 2) + Number(isJsx)];
+}
+
+type CurrentFile = {
+	path: RomePath;
+	version: number;
+};
+
+let currentFile: CurrentFile | null = null;
 
 self.addEventListener("message", async (e) => {
 	switch (e.data.type) {
 		case "init": {
 			try {
 				await init();
+
+				workspace = new Workspace();
+
 				self.postMessage({ type: "init", loadingState: LoadingState.Success });
-			} catch {
+			} catch (err) {
+				console.error(err);
 				self.postMessage({ type: "init", loadingState: LoadingState.Error });
 			}
 
@@ -15,6 +59,12 @@ self.addEventListener("message", async (e) => {
 		}
 
 		case "format": {
+			if (!workspace) {
+				console.error("Workspace was not initialized");
+				break;
+			}
+
+			const playgroundState: PlaygroundState = e.data.playgroundState;
 			const {
 				code,
 				lineWidth,
@@ -25,31 +75,96 @@ self.addEventListener("message", async (e) => {
 				isJsx,
 				sourceType,
 				cursorPosition,
-			} = e.data.playgroundState;
-			const romeOutput = run(
-				code,
-				new PlaygroundFormatOptions(
-					lineWidth,
-					indentStyle === IndentStyle.Space ? indentWidth : undefined,
-					quoteStyle,
-				),
-				isTypeScript,
-				isJsx,
-				sourceType,
-				cursorPosition,
-			);
-			self.postMessage({
-				type: "formatted",
-				romeOutput: {
-					ast: romeOutput.ast,
-					cst: romeOutput.cst,
-					errors: romeOutput.errors,
-					formatted_code: romeOutput.formatted_code,
-					formatter_ir: romeOutput.formatter_ir,
-					control_flow_graph: romeOutput.control_flow_graph,
+			} = playgroundState;
+
+			workspace.update_settings({
+				settings: {
+					format: {
+						enabled: true,
+						format_with_errors: true,
+						line_width: lineWidth,
+					},
+					linter: {
+						enabled: true,
+					},
+					languages: {
+						javascript: {
+							format: {
+								quote_style: quoteStyle === QuoteStyle.Double ? "Double" : "Single",
+							}
+						},
+					},
 				},
 			});
 
+			const path = getPathForType(sourceType, isTypeScript, isJsx);
+			if (currentFile?.path === path) {
+				workspace.change_file({
+					path,
+					version: currentFile.version++,
+					content: code,
+				});
+			} else {
+				if (currentFile) {
+					workspace.close_file({
+						path: currentFile.path,
+					});
+				}
+
+				currentFile = {
+					path,
+					version: 0,
+				};
+
+				workspace.open_file({
+					path,
+					version: currentFile.version++,
+					content: code,
+				});
+			}
+
+			const syntax_tree = workspace.get_syntax_tree({
+				path,
+			});
+			const control_flow_graph = workspace.get_control_flow_graph({
+				path,
+				cursor: cursorPosition,
+			});
+			const formatter_ir = workspace.get_formatter_ir({
+				path,
+				indent_style:
+					indentStyle === IndentStyle.Tab ? "Tab" : { Space: indentWidth },
+			});
+
+			const diagnostics = workspace.pull_diagnostics({
+				path,
+				categories: ["Syntax", "Lint"],
+			});
+
+			const printer = new DiagnosticPrinter(path.path, code);
+			for (const diag of diagnostics.diagnostics) {
+				printer.print(diag);
+			}
+
+			const printed = workspace.format_file({
+				path,
+				indent_style:
+					indentStyle === IndentStyle.Tab ? "Tab" : { Space: indentWidth },
+			});
+
+			const romeOutput: RomeOutput = {
+				ast: syntax_tree.ast,
+				cst: syntax_tree.cst,
+				errors: printer.finish(),
+				formatted_code: printed.code,
+				formatter_ir,
+				control_flow_graph,
+			};
+
+			self.postMessage({
+				type: "formatted",
+				romeOutput,
+			});
 			break;
 		}
 


### PR DESCRIPTION
## Summary

Fixes #3012 

This PR refactors the Playground to use the WASM bindings to the Workspace API. These bindings currently live in the playground crate itself along with a few utilities, but I plan on eventually moving this code out into its own crate in a later refactor (as part of the Node API umbrella).

The core of the change is relatively simple, and only requires adding a few methods to the workspace in order to access the internal debug representations rendered by the playground (like the formatter IR or the control flow graph). The WASM binding glue is implemented over the existing serde implementations for all the Workspace-related types, using the `serde-serialize` feature of `wasm-bindgen`. Unfortunately since these types go through serialization they are represented as untyped `any` values in the generated TypeScript definitions for the bindings (#3031 will add auto-generated definitions for these)

## Test Plan

Many of the changes are statically checked or execute at compile time, but unfortunately the playground doesn't really any testing infrastructure in place so that will have to be manually tested in the PR deployment
