### PR TITLE
feat(rome_js_semantic): semantic model "is_exported" query

### DIFF
--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -411,19 +411,19 @@ impl SemanticEventExtractor {
                             declaration_at.start() < reference.range().start();
                         let e = match (declaration_before_reference, &reference) {
                             (true, Reference::Read { range, .. }) => SemanticEvent::Read {
-                                range: range.clone(),
+                                range: *range,
                                 declared_at: *declaration_at,
                             },
                             (false, Reference::Read { range, .. }) => SemanticEvent::HoistedRead {
-                                range: range.clone(),
+                                range: *range,
                                 declared_at: *declaration_at,
                             },
                             (true, Reference::Write { range }) => SemanticEvent::Write {
-                                range: range.clone(),
+                                range: *range,
                                 declared_at: *declaration_at,
                             },
                             (false, Reference::Write { range }) => SemanticEvent::HoistedWrite {
-                                range: range.clone(),
+                                range: *range,
                                 declared_at: *declaration_at,
                             },
                         };

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -584,16 +584,14 @@ impl SemanticEventExtractor {
             return;
         }
 
-        if let Some(possible_export) = function_declaration.parent() {
-            let is_exported = matches!(
-                possible_export.kind(),
-                JS_EXPORT | JS_EXPORT_DEFAULT_DECLARATION_CLAUSE
-            );
-            if is_exported {
-                self.stash.push_back(SemanticEvent::Exported {
-                    range: binding.text_range(),
-                });
-            }
+        let is_exported = matches!(
+            function_declaration.parent().map(|p| p.kind()),
+            Some(JS_EXPORT | JS_EXPORT_DEFAULT_DECLARATION_CLAUSE)
+        );
+        if is_exported {
+            self.stash.push_back(SemanticEvent::Exported {
+                range: binding.text_range(),
+            });
         }
     }
 
@@ -614,17 +612,14 @@ impl SemanticEventExtractor {
             return;
         }
 
-        if let Some(possible_export) = class_declaration.parent() {
-            let is_exported = matches!(
-                possible_export.kind(),
-                JS_EXPORT | JS_EXPORT_DEFAULT_DECLARATION_CLAUSE
-            );
-
-            if is_exported {
-                self.stash.push_back(SemanticEvent::Exported {
-                    range: binding.text_range(),
-                });
-            }
+        let is_exported = matches!(
+            class_declaration.parent().map(|p| p.kind()),
+            Some(JS_EXPORT | JS_EXPORT_DEFAULT_DECLARATION_CLAUSE)
+        );
+        if is_exported {
+            self.stash.push_back(SemanticEvent::Exported {
+                range: binding.text_range(),
+            });
         }
     }
 

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -584,15 +584,16 @@ impl SemanticEventExtractor {
             return;
         }
 
-        let is_exported = matches!(
-            function_declaration.parent().unwrap().kind(),
-            JS_EXPORT | JS_EXPORT_DEFAULT_DECLARATION_CLAUSE
-        );
-
-        if is_exported {
-            self.stash.push_back(SemanticEvent::Exported {
-                range: binding.text_range(),
-            });
+        if let Some(possible_export) = function_declaration.parent() {
+            let is_exported = matches!(
+                possible_export.kind(),
+                JS_EXPORT | JS_EXPORT_DEFAULT_DECLARATION_CLAUSE
+            );
+            if is_exported {
+                self.stash.push_back(SemanticEvent::Exported {
+                    range: binding.text_range(),
+                });
+            }
         }
     }
 
@@ -613,15 +614,17 @@ impl SemanticEventExtractor {
             return;
         }
 
-        let is_exported = matches!(
-            class_declaration.parent().unwrap().kind(),
-            JS_EXPORT | JS_EXPORT_DEFAULT_DECLARATION_CLAUSE
-        );
+        if let Some(possible_export) = class_declaration.parent() {
+            let is_exported = matches!(
+                possible_export.kind(),
+                JS_EXPORT | JS_EXPORT_DEFAULT_DECLARATION_CLAUSE
+            );
 
-        if is_exported {
-            self.stash.push_back(SemanticEvent::Exported {
-                range: binding.text_range(),
-            });
+            if is_exported {
+                self.stash.push_back(SemanticEvent::Exported {
+                    range: binding.text_range(),
+                });
+            }
         }
     }
 

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -87,7 +87,7 @@ pub enum SemanticEvent {
     },
 
     /// Tracks where a symbol is exported.
-    /// The range points to the binding or the reference that
+    /// The range points to the binding that
     /// is being exported
     Exported { range: TextRange },
 }
@@ -161,14 +161,14 @@ struct Binding {
 
 #[derive(Debug)]
 enum Reference {
-    Read { range: TextRange },
+    Read { range: TextRange, is_exported: bool },
     Write { range: TextRange },
 }
 
 impl Reference {
     pub fn range(&self) -> &TextRange {
         match self {
-            Reference::Read { range } => range,
+            Reference::Read { range, .. } => range,
             Reference::Write { range } => range,
         }
     }
@@ -272,6 +272,8 @@ impl SemanticEventExtractor {
     }
 
     fn enter_js_identifier_binding(&mut self, node: &JsSyntaxNode) -> Option<()> {
+        debug_assert!(matches!(node.kind(), JsSyntaxKind::JS_IDENTIFIER_BINDING));
+
         let binding = node.clone().cast::<JsIdentifierBinding>()?;
         let name_token = binding.name_token().ok()?;
 
@@ -285,11 +287,16 @@ impl SemanticEventExtractor {
                 } else {
                     self.push_binding_into_scope(None, &name_token);
                 };
+                self.export_variable_declarator(node, &parent);
             }
             JS_FUNCTION_DECLARATION | JS_FUNCTION_EXPORT_DEFAULT_DECLARATION => {
                 let hoisted_scope_id = self.scope_index_to_hoist_declarations(1);
                 self.push_binding_into_scope(hoisted_scope_id, &name_token);
                 self.export_function_declaration(node, &parent);
+            }
+            JS_CLASS_DECLARATION | JS_CLASS_EXPORT_DEFAULT_DECLARATION => {
+                self.push_binding_into_scope(None, &name_token);
+                self.export_class_declaration(node, &parent);
             }
             _ => {
                 self.push_binding_into_scope(None, &name_token);
@@ -300,17 +307,19 @@ impl SemanticEventExtractor {
     }
 
     fn enter_js_reference_identifier(&mut self, node: &JsSyntaxNode) -> Option<()> {
+        debug_assert!(matches!(node.kind(), JsSyntaxKind::JS_REFERENCE_IDENTIFIER));
+
         let reference = node.clone().cast::<JsReferenceIdentifier>()?;
         let name_token = reference.value_token().ok()?;
         let name = name_token.token_text_trimmed();
 
+        let is_exported = self.is_reference_identifier_exported(node);
         let current_scope = self.current_scope_mut();
         let references = current_scope.references.entry(name).or_default();
         references.push(Reference::Read {
             range: node.text_range(),
+            is_exported,
         });
-
-        self.export_reference_identifier(node);
 
         Some(())
     }
@@ -400,25 +409,34 @@ impl SemanticEventExtractor {
                     for reference in references {
                         let declaration_before_reference =
                             declaration_at.start() < reference.range().start();
-                        let e = match (declaration_before_reference, reference) {
-                            (true, Reference::Read { range }) => SemanticEvent::Read {
-                                range,
+                        let e = match (declaration_before_reference, &reference) {
+                            (true, Reference::Read { range, .. }) => SemanticEvent::Read {
+                                range: range.clone(),
                                 declared_at: *declaration_at,
                             },
-                            (false, Reference::Read { range }) => SemanticEvent::HoistedRead {
-                                range,
+                            (false, Reference::Read { range, .. }) => SemanticEvent::HoistedRead {
+                                range: range.clone(),
                                 declared_at: *declaration_at,
                             },
                             (true, Reference::Write { range }) => SemanticEvent::Write {
-                                range,
+                                range: range.clone(),
                                 declared_at: *declaration_at,
                             },
                             (false, Reference::Write { range }) => SemanticEvent::HoistedWrite {
-                                range,
+                                range: range.clone(),
                                 declared_at: *declaration_at,
                             },
                         };
                         self.stash.push_back(e);
+
+                        match reference {
+                            Reference::Read { is_exported, .. } if is_exported => {
+                                self.stash.push_back(SemanticEvent::Exported {
+                                    range: *declaration_at,
+                                });
+                            }
+                            _ => {}
+                        }
                     }
                 } else if let Some(parent) = self.scopes.last_mut() {
                     // ... if not, promote these references to the parent scope ...
@@ -556,11 +574,15 @@ impl SemanticEventExtractor {
         function_declaration: &JsSyntaxNode,
     ) {
         use JsSyntaxKind::*;
-
         debug_assert!(matches!(
             function_declaration.kind(),
             JS_FUNCTION_DECLARATION | JS_FUNCTION_EXPORT_DEFAULT_DECLARATION
         ));
+
+        // scope[0] = global, scope[1] = the function itself
+        if self.scopes.len() != 2 {
+            return;
+        }
 
         let is_exported = matches!(
             function_declaration.parent().unwrap().kind(),
@@ -574,28 +596,86 @@ impl SemanticEventExtractor {
         }
     }
 
-    // Check if a function is exported and raise the [Exported] event.
-    fn export_reference_identifier(&mut self, reference: &JsSyntaxNode) {
+    // Check if a class is exported and raise the [Exported] event.
+    fn export_class_declaration(
+        &mut self,
+        binding: &JsSyntaxNode,
+        class_declaration: &JsSyntaxNode,
+    ) {
         use JsSyntaxKind::*;
+        debug_assert!(matches!(
+            class_declaration.kind(),
+            JS_CLASS_DECLARATION | JS_CLASS_EXPORT_DEFAULT_DECLARATION
+        ));
 
+        // export can only exist in the global scope
+        if self.scopes.len() > 1 {
+            return;
+        }
+
+        let is_exported = matches!(
+            class_declaration.parent().unwrap().kind(),
+            JS_EXPORT | JS_EXPORT_DEFAULT_DECLARATION_CLAUSE
+        );
+
+        if is_exported {
+            self.stash.push_back(SemanticEvent::Exported {
+                range: binding.text_range(),
+            });
+        }
+    }
+
+    // Check if a function is exported and raise the [Exported] event.
+    fn export_variable_declarator(
+        &mut self,
+        binding: &JsSyntaxNode,
+        variable_declarator: &JsSyntaxNode,
+    ) {
+        use JsSyntaxKind::*;
+        debug_assert!(matches!(variable_declarator.kind(), JS_VARIABLE_DECLARATOR));
+
+        // export can only exist in the global scope
+        if self.scopes.len() > 1 {
+            return;
+        }
+
+        let is_exported = matches!(
+            variable_declarator
+                .parent()
+                .and_then(|list| list.parent())
+                .and_then(|declaration| declaration.parent())
+                .and_then(|declaration_clause| declaration_clause.parent())
+                .map(|x| x.kind()),
+            Some(JS_EXPORT)
+        );
+
+        if is_exported {
+            self.stash.push_back(SemanticEvent::Exported {
+                range: binding.text_range(),
+            });
+        }
+    }
+
+    // Check if a reference is exported and raise the [Exported] event.
+    fn is_reference_identifier_exported(&mut self, reference: &JsSyntaxNode) -> bool {
+        use JsSyntaxKind::*;
         debug_assert!(matches!(reference.kind(), JS_REFERENCE_IDENTIFIER));
+
+        // export can only exist in the global scope
+        if self.scopes.len() > 1 {
+            return false;
+        }
 
         let reference_parent = reference.parent();
         let reference_greatparent = reference_parent.as_ref().and_then(|p| p.parent());
 
-        let is_exported = matches!(
+        matches!(
             reference_parent.map(|p| p.kind()),
             Some(JS_EXPORT_NAMED_SHORTHAND_SPECIFIER | JS_EXPORT_NAMED_SPECIFIER)
         ) | matches!(
             reference_greatparent.map(|p| p.kind()),
             Some(JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE)
-        );
-
-        if is_exported {
-            self.stash.push_back(SemanticEvent::Exported {
-                range: reference.text_range(),
-            });
-        }
+        )
     }
 }
 

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -1013,7 +1013,7 @@ mod test {
 
         match node.kind() {
             JsSyntaxKind::JS_IDENTIFIER_BINDING => {
-                let binding = JsIdentifierBinding::cast(node.clone()).unwrap();
+                let binding = JsIdentifierBinding::cast(node).unwrap();
                 // These do the same thing, but with different APIs
                 assert!(
                     is_exported == model.is_exported(binding.node()),
@@ -1027,7 +1027,7 @@ mod test {
                 );
             }
             JsSyntaxKind::JS_REFERENCE_IDENTIFIER => {
-                let reference = JsReferenceIdentifier::cast(node.clone()).unwrap();
+                let reference = JsReferenceIdentifier::cast(node).unwrap();
                 // These do the same thing, but with different APIs
                 assert!(
                     is_exported == model.is_exported(&reference).unwrap(),

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -85,7 +85,7 @@ struct SemanticModelData {
     declaration_all_reads: HashMap<TextRange, Vec<(ReferenceType, TextRange)>>,
     // Maps a declaration range to the range of its "writes"
     declaration_all_writes: HashMap<TextRange, Vec<(ReferenceType, TextRange)>>,
-    // All bindings and references that were exported
+    // All bindings that were exported
     exported: HashSet<TextRange>,
 }
 

--- a/crates/rome_js_semantic/src/tests/assertions.rs
+++ b/crates/rome_js_semantic/src/tests/assertions.rs
@@ -127,6 +127,7 @@ pub fn assert(code: &str, test_name: &str) {
             SemanticEvent::Write { range, .. } => range.start(),
             SemanticEvent::HoistedWrite { range, .. } => range.start(),
             SemanticEvent::UnresolvedReference { range } => range.start(),
+            SemanticEvent::Exported { range } => range.start(),
         };
 
         let v = events_by_pos.entry(pos).or_default();

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -128,3 +128,8 @@ assert_semantics! {
     ok_unmatched_reference, r#"a/*?*/"#,
     ok_function_expression_read,"let f/*#F*/ = function g/*#G*/(){}; g/*?*/();",
 }
+
+assert_semantics! {
+    ok_export_hoisted_variable,
+        "var a/*#A1*/ = 2; export {a/*READ A2*/}; var a/*#A2*/ = 1;",
+}

--- a/crates/rome_js_semantic/src/tests/scopes.rs
+++ b/crates/rome_js_semantic/src/tests/scopes.rs
@@ -19,6 +19,7 @@ assert_semantics! {
 // Functions
 assert_semantics! {
     ok_scope_function, ";function/*START A*/ f() {}/*END A*/",
+    ok_scope_function_with_export_default, ";export default function/*START A*/ f() {}/*END A*/",
     ok_scope_function_expression, ";var a = function/*START A*/ f() {}/*END A*/",
     ok_scope_arrow_function, ";(/*START A*/) => {}/*END A*/",
 }


### PR DESCRIPTION
## Summary

This PR implements the "is_exported" query in the SemanticModel.
It will be first used by the ```noUnusedVariables``` lint rule (https://github.com/rome/tools/issues/2979) to avoid false flags like 

```js
error[[js/noUnusedVariables](https://rome.tools/docs/lint/rules/noUnusedVariables/)]: This function is unused.
  ┌─ main.js:1:17
  │
1 │ export function f() {
```

## Test Plan

```
>  cargo test -p rome_js_semantic -- ok_semantic_model_is_exported
```
