### PR TITLE
feat(rome_formatter): `align > indent` nesting with `IndentStyle::Space`

### DIFF
--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -747,6 +747,9 @@ impl<Context> std::fmt::Debug for Dedent<'_, Context> {
 /// Using [indent] is preferred in all other situations as it respects the users preferred indent character.
 ///
 /// # Examples
+///
+/// ## Tab indention
+///
 /// ```
 /// use std::num::NonZeroU8;
 /// use rome_formatter::{format, format_args};
@@ -779,9 +782,52 @@ impl<Context> std::fmt::Debug for Dedent<'_, Context> {
 /// );
 /// ```
 ///
-/// You can see that the printer indents the function's `}` by two spaces as specified by the IR and not with a tab.
-/// You can further see that alignments behave the same as an `indent` if you nest `indent` inside an align.
+/// You can see that:
 ///
+/// * the printer indents the function's `}` by two spaces as specified by the IR and not with a tab.
+/// * that `align` acts the same as an `indent` if you nest `indent` inside an align.
+///
+/// ## Spaces indention
+///
+/// ```
+/// use std::num::NonZeroU8;
+/// use rome_formatter::{format, format_args, IndentStyle};
+/// use rome_formatter::prelude::*;
+///
+/// let context = SimpleFormatContext {
+///     indent_style: IndentStyle::Space(4),
+///     ..SimpleFormatContext::default()
+/// };
+///
+/// let block = format!(context, [
+///     text("a"),
+///     hard_line_break(),
+///     text("?"),
+///     space(),
+///     align(2, &format_args![
+///         text("function () {"),
+///         hard_line_break(),
+///         text("}"),
+///     ]),
+///     hard_line_break(),
+///     text(":"),
+///     space(),
+///     align(2, &format_args![
+///         text("function () {"),
+///         block_indent(&text("console.log('test');")),
+///         text("}"),
+///     ]),
+///     text(";")
+/// ]).unwrap();
+///
+/// assert_eq!(
+///     "a\n? function () {\n  }\n: function () {\n      console.log('test');\n  };",
+///     block.print().as_code()
+/// );
+/// ```
+///
+/// Nesting an `indent` inside of an `align` has a different semantic when using spaces over tabs as indent sequence.
+/// With spaces, the outer `align` doesn't get converted into an `indent` and is, instead, kept as is.
 pub fn align<Content, Context>(count: u8, content: &Content) -> Align<Context>
 where
     Content: Format<Context>,

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -784,8 +784,11 @@ impl<Context> std::fmt::Debug for Dedent<'_, Context> {
 ///
 /// You can see that:
 ///
-/// * the printer indents the function's `}` by two spaces as specified by the IR and not with a tab.
-/// * that `align` acts the same as an `indent` if you nest `indent` inside an align.
+/// * the printer indents the function's `}` by two spaces because it is inside of an `align`.
+/// * the block `console.log` gets indented by two tabs.
+///   This is because `align` increases the indention level by one (same as `indent`)
+///   if you nest an `indent` inside an `align`.
+///   Meaning that, `align > ... > indent` results in the same indention as `indent > ... > indent`.
 ///
 /// ## Spaces indention
 ///
@@ -826,8 +829,11 @@ impl<Context> std::fmt::Debug for Dedent<'_, Context> {
 /// );
 /// ```
 ///
-/// Nesting an `indent` inside of an `align` has a different semantic when using spaces over tabs as indent sequence.
-/// With spaces, the outer `align` doesn't get converted into an `indent` and is, instead, kept as is.
+/// The printing of `align` differs if using spaces as indention sequence *and* it contains an `indent`.
+/// You can see the difference when comparing the indention of the `console.log(...)` expression to the previous example:
+///
+/// * tab indention: Printer indents the expression with two tabs because the `align` increases the indention level.
+/// * space indention: Printer indents the expression by 4 spaces (one indention level) **and** 2 spaces for the align.
 pub fn align<Content, Context>(count: u8, content: &Content) -> Align<Context>
 where
     Content: Format<Context>,

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -396,6 +396,10 @@ impl std::fmt::Debug for BestFitting {
 pub struct Interned(Rc<FormatElement>);
 
 impl Interned {
+    pub(crate) fn new(element: FormatElement) -> Self {
+        Self(Rc::new(element))
+    }
+
     pub(crate) fn try_unwrap(this: Interned) -> Result<FormatElement, Interned> {
         Rc::try_unwrap(this.0).map_err(Interned)
     }
@@ -697,16 +701,6 @@ impl FormatElement {
             _ => Some(self),
         }
     }
-
-    /// Interns a format element.
-    ///
-    /// Returns `self` for an already interned element.
-    pub fn intern(self) -> Interned {
-        match self {
-            FormatElement::Interned(interned) => interned,
-            element => Interned(Rc::new(element)),
-        }
-    }
 }
 
 impl From<Text> for FormatElement {
@@ -772,7 +766,7 @@ impl FormatContext for IrFormatContext {
             tab_width: 2,
             print_width: self.line_width(),
             line_ending: LineEnding::LineFeed,
-            indent_string: "  ".to_string(),
+            indent_style: IndentStyle::Space(2),
         }
     }
 }

--- a/crates/rome_formatter/src/format_extensions.rs
+++ b/crates/rome_formatter/src/format_extensions.rs
@@ -142,7 +142,7 @@ impl<T, Context> MemoizeFormat<Context> for T where T: Format<Context> {}
 #[derive(Debug)]
 pub struct Memoized<F, Context> {
     inner: F,
-    memory: RefCell<Option<FormatResult<Interned>>>,
+    memory: RefCell<Option<FormatResult<FormatElement>>>,
     options: PhantomData<Context>,
 }
 
@@ -218,7 +218,8 @@ where
             .get_or_insert_with(|| f.intern(&self.inner));
 
         match result.as_ref() {
-            Ok(content) => Ok(content.deref()),
+            Ok(FormatElement::Interned(interned)) => Ok(interned.deref()),
+            Ok(other) => Ok(other),
             Err(error) => Err(*error),
         }
     }
@@ -234,7 +235,7 @@ where
 
         match result {
             Ok(elements) => {
-                f.write_element(FormatElement::Interned(elements.clone()))?;
+                f.write_element(elements.clone())?;
 
                 Ok(())
             }

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -68,7 +68,7 @@ use std::num::ParseIntError;
 use std::rc::Rc;
 use std::str::FromStr;
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum IndentStyle {
     /// Tab
@@ -79,6 +79,16 @@ pub enum IndentStyle {
 
 impl IndentStyle {
     pub const DEFAULT_SPACES: u8 = 2;
+
+    /// Returns `true` if this is an [IndentStyle::Tab].
+    pub const fn is_tab(&self) -> bool {
+        matches!(self, IndentStyle::Tab)
+    }
+
+    /// Returns `true` if this is an [IndentStyle::Space].
+    pub const fn is_space(&self) -> bool {
+        matches!(self, IndentStyle::Space(_))
+    }
 }
 
 impl Default for IndentStyle {

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -639,7 +639,7 @@ impl Indention {
 
     /// Increments the level by one.
     ///
-    /// The behaviour if this is an [Indent::Align] depends on the indent character used by the printer:
+    /// The behaviour depends on the [`indent_style`][IndentStyle] if this is an [Indent::Align]:
     /// * **Tabs**: `align` is converted into an indent. This results in `level` increasing by two: once for the align, once for the level increment
     /// * **Spaces**: Increments the `level` by one and keeps the `align` unchanged.
     /// Keeps any  the current value is [Indent::Align] and increments the level by one.

--- a/crates/rome_formatter/src/printer/printer_options/mod.rs
+++ b/crates/rome_formatter/src/printer/printer_options/mod.rs
@@ -12,12 +12,8 @@ pub struct PrinterOptions {
     /// The type of line ending to apply to the printed input
     pub line_ending: LineEnding,
 
-    /// The never ending question whatever to use spaces or tabs, and if spaces, how many spaces
-    /// to indent code.
-    ///
-    /// * Tab: Value is '\t'
-    /// * Spaces: String containing the number of spaces per indention level, e.g. "  " for using two spaces
-    pub indent_string: String,
+    /// Whether the printer should use tabs or spaces to indent code and if spaces, by how many.
+    pub indent_style: IndentStyle,
 }
 
 impl PrinterOptions {
@@ -27,18 +23,21 @@ impl PrinterOptions {
     }
 
     pub fn with_indent(mut self, style: IndentStyle) -> Self {
-        match style {
-            IndentStyle::Tab => {
-                self.indent_string = String::from("\t");
-                self.tab_width = 2;
-            }
-            IndentStyle::Space(quantity) => {
-                self.indent_string = " ".repeat(quantity as usize);
-                self.tab_width = quantity;
-            }
-        }
+        self.indent_style = style;
 
         self
+    }
+
+    pub(crate) fn indent_style(&self) -> IndentStyle {
+        self.indent_style
+    }
+
+    /// Width of an indent in characters.
+    pub(super) const fn indent_width(&self) -> u8 {
+        match self.indent_style {
+            IndentStyle::Tab => self.tab_width,
+            IndentStyle::Space(count) => count,
+        }
     }
 }
 
@@ -71,7 +70,7 @@ impl Default for PrinterOptions {
         PrinterOptions {
             tab_width: 2,
             print_width: LineWidth::default(),
-            indent_string: String::from("\t"),
+            indent_style: Default::default(),
             line_ending: LineEnding::LineFeed,
         }
     }

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 256
 expression: call.js
 ---
 # Input
@@ -74,7 +73,8 @@ expect(() => asyncRequest({ url: "/test-endpoint-but-with-a-long-url" }));
 // .toThrowError(/Required parameter/);
 
 expect(
-	() => asyncRequest({ url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url" }),
+	() =>
+		asyncRequest({ url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url" }),
 );
 // .toThrowError(/Required parameter/);
 
@@ -82,7 +82,8 @@ expect(() => asyncRequest({ type: "foo", url: "/test-endpoint" })).not
 	.toThrowError();
 
 expect(
-	() => asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" }),
+	() =>
+		asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" }),
 ).not.toThrowError();
 
 const a = Observable.fromPromise(axiosInstance.post("/carts/mine")).map(

--- a/crates/rome_js_formatter/tests/specs/jsx/element.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/element.jsx.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 256
 expression: element.jsx
 ---
 # Input
@@ -184,7 +183,9 @@ function Tabs() {
 				<Tab selectedClassName="bg-slate-300">AST</Tab>
 				<Tab selectedClassName="bg-slate-300">Rome IR</Tab>
 				<Tab selectedClassName="bg-slate-300">Prettier IR</Tab>
-				<Tab disabled={errors === ""} selectedClassName="bg-slate-300">Errors</Tab>
+				<Tab disabled={errors === ""} selectedClassName="bg-slate-300">
+					Errors
+				</Tab>
 			</TabList>
 			<TabPanel>
 				<CodeEditor
@@ -350,9 +351,9 @@ let a = <a>{/* comment */ " "}</a>;
 ## Lines exceeding width of 80 characters
 
     5: 		The films of Wong Kar-Wai exemplify the synthesis of French New Wave cinema—specifically the unrelenting experimental technique and fascination with American/western culture—with more conventional melodramatic, romantic narratives.
-   39: 							"ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
-   60: 							"ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
-   73: 							"ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
-   99: 					className="h-screen overflow-y-scroll whitespace-pre-wrap text-red-500 text-xs"
-  155: 					the quick brown fox jumps over the lazy dog and then jumps over the lazy cat and then over the lazy fish.
+   41: 							"ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
+   62: 							"ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
+   75: 							"ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
+  101: 					className="h-screen overflow-y-scroll whitespace-pre-wrap text-red-500 text-xs"
+  157: 					the quick brown fox jumps over the lazy dog and then jumps over the lazy cat and then over the lazy fish.
 


### PR DESCRIPTION
## Summary

This changes the behaviour of the printer if an `indent` is nested inside an `align`.
The existing behaviour was to convert the `align` to an `indent`.

This PR changes the behaviour to keep the spaces as is, so that an `align(2) > indent` results in a `______` sequence with `IndentStyle::Space(4)`

This PR further improves `Memoized` so that it avoids creating an `Interned` element on the heap if it has no content.
## Test Plan

I expanded the doc test on `align` to show how the IR behaves differently depending on the `IndentStyle`

There are two snapshots that changed because of a fix in `fits` in combination with the indent width ([see this comment](https://github.com/rome/tools/pull/3021#discussion_r939568614))
