### PR TITLE
fix(rome_js_parser): Syntax error when using optional binding on .d.ts

### DIFF
--- a/crates/rome_js_parser/src/syntax/function.rs
+++ b/crates/rome_js_parser/src/syntax/function.rs
@@ -918,11 +918,6 @@ impl ParameterContext {
         self == &ParameterContext::Setter
     }
 
-    // Comment for now, maybe it would be used in the future
-    // pub fn is_implementation(&self) -> bool {
-    //     self == &ParameterContext::Implementation
-    // }
-
     pub fn is_parameter_property(&self) -> bool {
         self == &ParameterContext::ParameterProperty
     }

--- a/crates/rome_js_parser/src/syntax/function.rs
+++ b/crates/rome_js_parser/src/syntax/function.rs
@@ -918,9 +918,10 @@ impl ParameterContext {
         self == &ParameterContext::Setter
     }
 
-    pub fn is_implementation(&self) -> bool {
-        self == &ParameterContext::Implementation
-    }
+    // Comment for now, maybe it would be used in the future
+    // pub fn is_implementation(&self) -> bool {
+    //     self == &ParameterContext::Implementation
+    // }
 
     pub fn is_parameter_property(&self) -> bool {
         self == &ParameterContext::ParameterProperty
@@ -978,29 +979,24 @@ pub(crate) fn parse_formal_parameter(
             false
         };
 
+        // test ts ts_parameter_option_binding_pattern
+        // declare namespace A {
+        //   export class Ajv {
+        //     errorsText(errors?: string[] | null | undefined, { separator, dataVar }?: ErrorsTextOptions): string;
+        //   }
+        // }
         if valid
             && matches!(
                 binding_kind,
                 JS_OBJECT_BINDING_PATTERN | JS_ARRAY_BINDING_PATTERN
             )
+            && parameter_context.is_parameter_property()
         {
-            if parameter_context.is_parameter_property() {
-                valid = false;
-                p.error(
-                    p.err_builder(
-                        "A parameter property may not be declared using a binding pattern.",
-                    )
+            valid = false;
+            p.error(
+                p.err_builder("A parameter property may not be declared using a binding pattern.")
                     .primary(binding_range, ""),
-                );
-            } else if parameter_context.is_implementation() && is_optional {
-                valid = false;
-                p.error(
-					p.err_builder(
-						"A binding pattern parameter cannot be optional in an implementation signature.",
-					)
-						.primary(binding_range, ""),
-				);
-            }
+            );
         }
 
         TypeScript

--- a/crates/rome_js_parser/test_data/inline/ok/ts_parameter_option_binding_pattern.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_parameter_option_binding_pattern.rast
@@ -1,0 +1,213 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsDeclareStatement {
+            declare_token: DECLARE_KW@0..8 "declare" [] [Whitespace(" ")],
+            declaration: TsModuleDeclaration {
+                module_or_namespace: NAMESPACE_KW@8..18 "namespace" [] [Whitespace(" ")],
+                name: TsIdentifierBinding {
+                    name_token: IDENT@18..20 "A" [] [Whitespace(" ")],
+                },
+                body: TsModuleBlock {
+                    l_curly_token: L_CURLY@20..21 "{" [] [],
+                    items: JsModuleItemList [
+                        JsExport {
+                            export_token: EXPORT_KW@21..31 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                            export_clause: JsClassDeclaration {
+                                abstract_token: missing (optional),
+                                class_token: CLASS_KW@31..37 "class" [] [Whitespace(" ")],
+                                id: JsIdentifierBinding {
+                                    name_token: IDENT@37..41 "Ajv" [] [Whitespace(" ")],
+                                },
+                                type_parameters: missing (optional),
+                                extends_clause: missing (optional),
+                                implements_clause: missing (optional),
+                                l_curly_token: L_CURLY@41..42 "{" [] [],
+                                members: JsClassMemberList [
+                                    TsMethodSignatureClassMember {
+                                        modifiers: TsMethodSignatureModifierList [],
+                                        async_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@42..57 "errorsText" [Newline("\n"), Whitespace("    ")] [],
+                                        },
+                                        question_mark_token: missing (optional),
+                                        type_parameters: missing (optional),
+                                        parameters: JsParameters {
+                                            l_paren_token: L_PAREN@57..58 "(" [] [],
+                                            items: JsParameterList [
+                                                JsFormalParameter {
+                                                    binding: JsIdentifierBinding {
+                                                        name_token: IDENT@58..64 "errors" [] [],
+                                                    },
+                                                    question_mark_token: QUESTION@64..65 "?" [] [],
+                                                    type_annotation: TsTypeAnnotation {
+                                                        colon_token: COLON@65..67 ":" [] [Whitespace(" ")],
+                                                        ty: TsUnionType {
+                                                            leading_separator_token: missing (optional),
+                                                            types: TsUnionTypeVariantList [
+                                                                TsArrayType {
+                                                                    element_type: TsStringType {
+                                                                        string_token: STRING_KW@67..73 "string" [] [],
+                                                                    },
+                                                                    l_brack_token: L_BRACK@73..74 "[" [] [],
+                                                                    r_brack_token: R_BRACK@74..76 "]" [] [Whitespace(" ")],
+                                                                },
+                                                                PIPE@76..78 "|" [] [Whitespace(" ")],
+                                                                TsNullLiteralType {
+                                                                    literal_token: NULL_KW@78..83 "null" [] [Whitespace(" ")],
+                                                                },
+                                                                PIPE@83..85 "|" [] [Whitespace(" ")],
+                                                                TsUndefinedType {
+                                                                    undefined_token: UNDEFINED_KW@85..94 "undefined" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    },
+                                                    initializer: missing (optional),
+                                                },
+                                                COMMA@94..96 "," [] [Whitespace(" ")],
+                                                JsFormalParameter {
+                                                    binding: JsObjectBindingPattern {
+                                                        l_curly_token: L_CURLY@96..98 "{" [] [Whitespace(" ")],
+                                                        properties: JsObjectBindingPatternPropertyList [
+                                                            JsObjectBindingPatternShorthandProperty {
+                                                                identifier: JsIdentifierBinding {
+                                                                    name_token: IDENT@98..107 "separator" [] [],
+                                                                },
+                                                                init: missing (optional),
+                                                            },
+                                                            COMMA@107..109 "," [] [Whitespace(" ")],
+                                                            JsObjectBindingPatternShorthandProperty {
+                                                                identifier: JsIdentifierBinding {
+                                                                    name_token: IDENT@109..117 "dataVar" [] [Whitespace(" ")],
+                                                                },
+                                                                init: missing (optional),
+                                                            },
+                                                        ],
+                                                        r_curly_token: R_CURLY@117..118 "}" [] [],
+                                                    },
+                                                    question_mark_token: QUESTION@118..119 "?" [] [],
+                                                    type_annotation: TsTypeAnnotation {
+                                                        colon_token: COLON@119..121 ":" [] [Whitespace(" ")],
+                                                        ty: TsReferenceType {
+                                                            name: JsReferenceIdentifier {
+                                                                value_token: IDENT@121..138 "ErrorsTextOptions" [] [],
+                                                            },
+                                                            type_arguments: missing (optional),
+                                                        },
+                                                    },
+                                                    initializer: missing (optional),
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@138..139 ")" [] [],
+                                        },
+                                        return_type_annotation: TsReturnTypeAnnotation {
+                                            colon_token: COLON@139..141 ":" [] [Whitespace(" ")],
+                                            ty: TsStringType {
+                                                string_token: STRING_KW@141..147 "string" [] [],
+                                            },
+                                        },
+                                        semicolon_token: SEMICOLON@147..148 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@148..152 "}" [Newline("\n"), Whitespace("  ")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@152..154 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@154..155 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..155
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..154
+    0: TS_DECLARE_STATEMENT@0..154
+      0: DECLARE_KW@0..8 "declare" [] [Whitespace(" ")]
+      1: TS_MODULE_DECLARATION@8..154
+        0: NAMESPACE_KW@8..18 "namespace" [] [Whitespace(" ")]
+        1: TS_IDENTIFIER_BINDING@18..20
+          0: IDENT@18..20 "A" [] [Whitespace(" ")]
+        2: TS_MODULE_BLOCK@20..154
+          0: L_CURLY@20..21 "{" [] []
+          1: JS_MODULE_ITEM_LIST@21..152
+            0: JS_EXPORT@21..152
+              0: EXPORT_KW@21..31 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+              1: JS_CLASS_DECLARATION@31..152
+                0: (empty)
+                1: CLASS_KW@31..37 "class" [] [Whitespace(" ")]
+                2: JS_IDENTIFIER_BINDING@37..41
+                  0: IDENT@37..41 "Ajv" [] [Whitespace(" ")]
+                3: (empty)
+                4: (empty)
+                5: (empty)
+                6: L_CURLY@41..42 "{" [] []
+                7: JS_CLASS_MEMBER_LIST@42..148
+                  0: TS_METHOD_SIGNATURE_CLASS_MEMBER@42..148
+                    0: TS_METHOD_SIGNATURE_MODIFIER_LIST@42..42
+                    1: (empty)
+                    2: JS_LITERAL_MEMBER_NAME@42..57
+                      0: IDENT@42..57 "errorsText" [Newline("\n"), Whitespace("    ")] []
+                    3: (empty)
+                    4: (empty)
+                    5: JS_PARAMETERS@57..139
+                      0: L_PAREN@57..58 "(" [] []
+                      1: JS_PARAMETER_LIST@58..138
+                        0: JS_FORMAL_PARAMETER@58..94
+                          0: JS_IDENTIFIER_BINDING@58..64
+                            0: IDENT@58..64 "errors" [] []
+                          1: QUESTION@64..65 "?" [] []
+                          2: TS_TYPE_ANNOTATION@65..94
+                            0: COLON@65..67 ":" [] [Whitespace(" ")]
+                            1: TS_UNION_TYPE@67..94
+                              0: (empty)
+                              1: TS_UNION_TYPE_VARIANT_LIST@67..94
+                                0: TS_ARRAY_TYPE@67..76
+                                  0: TS_STRING_TYPE@67..73
+                                    0: STRING_KW@67..73 "string" [] []
+                                  1: L_BRACK@73..74 "[" [] []
+                                  2: R_BRACK@74..76 "]" [] [Whitespace(" ")]
+                                1: PIPE@76..78 "|" [] [Whitespace(" ")]
+                                2: TS_NULL_LITERAL_TYPE@78..83
+                                  0: NULL_KW@78..83 "null" [] [Whitespace(" ")]
+                                3: PIPE@83..85 "|" [] [Whitespace(" ")]
+                                4: TS_UNDEFINED_TYPE@85..94
+                                  0: UNDEFINED_KW@85..94 "undefined" [] []
+                          3: (empty)
+                        1: COMMA@94..96 "," [] [Whitespace(" ")]
+                        2: JS_FORMAL_PARAMETER@96..138
+                          0: JS_OBJECT_BINDING_PATTERN@96..118
+                            0: L_CURLY@96..98 "{" [] [Whitespace(" ")]
+                            1: JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST@98..117
+                              0: JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY@98..107
+                                0: JS_IDENTIFIER_BINDING@98..107
+                                  0: IDENT@98..107 "separator" [] []
+                                1: (empty)
+                              1: COMMA@107..109 "," [] [Whitespace(" ")]
+                              2: JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY@109..117
+                                0: JS_IDENTIFIER_BINDING@109..117
+                                  0: IDENT@109..117 "dataVar" [] [Whitespace(" ")]
+                                1: (empty)
+                            2: R_CURLY@117..118 "}" [] []
+                          1: QUESTION@118..119 "?" [] []
+                          2: TS_TYPE_ANNOTATION@119..138
+                            0: COLON@119..121 ":" [] [Whitespace(" ")]
+                            1: TS_REFERENCE_TYPE@121..138
+                              0: JS_REFERENCE_IDENTIFIER@121..138
+                                0: IDENT@121..138 "ErrorsTextOptions" [] []
+                              1: (empty)
+                          3: (empty)
+                      2: R_PAREN@138..139 ")" [] []
+                    6: TS_RETURN_TYPE_ANNOTATION@139..147
+                      0: COLON@139..141 ":" [] [Whitespace(" ")]
+                      1: TS_STRING_TYPE@141..147
+                        0: STRING_KW@141..147 "string" [] []
+                    7: SEMICOLON@147..148 ";" [] []
+                8: R_CURLY@148..152 "}" [Newline("\n"), Whitespace("  ")] []
+          2: R_CURLY@152..154 "}" [Newline("\n")] []
+  3: EOF@154..155 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/ts_parameter_option_binding_pattern.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_parameter_option_binding_pattern.ts
@@ -1,0 +1,5 @@
+declare namespace A {
+  export class Ajv {
+    errorsText(errors?: string[] | null | undefined, { separator, dataVar }?: ErrorsTextOptions): string;
+  }
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
1. Part of #2310
2. Fix syntax error when using Optional binding on `.d.ts` or `.ts`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. Checkout the new snapshot
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
