### PR TITLE
refactor(rome_service): refactor the caching system of the workspace server to use salsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +60,12 @@ name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+
+[[package]]
+name = "arc-swap"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "ascii_table"
@@ -92,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -675,12 +692,24 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown 0.11.2",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -690,6 +719,15 @@ checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
 dependencies = [
  "byteorder",
  "num-traits",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -881,10 +919,11 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -1048,9 +1087,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1664,6 +1703,7 @@ dependencies = [
  "rome_js_syntax",
  "rome_rowan",
  "rome_text_edit",
+ "salsa",
  "serde",
  "serde_json",
 ]
@@ -1723,6 +1763,36 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "salsa"
+version = "0.17.0-pre.2"
+source = "git+https://github.com/salsa-rs/salsa?rev=754eea8#754eea8b5f8a31b1100ba313d59e41260b494225"
+dependencies = [
+ "arc-swap",
+ "crossbeam-utils",
+ "dashmap 4.0.2",
+ "hashlink",
+ "indexmap",
+ "lock_api",
+ "log",
+ "oorandom",
+ "parking_lot",
+ "rustc-hash",
+ "salsa-macros",
+ "smallvec",
+]
+
+[[package]]
+name = "salsa-macros"
+version = "0.17.0-pre.2"
+source = "git+https://github.com/salsa-rs/salsa?rev=754eea8#754eea8b5f8a31b1100ba313d59e41260b494225"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "same-file"

--- a/crates/rome_diagnostics/src/diagnostic.rs
+++ b/crates/rome_diagnostics/src/diagnostic.rs
@@ -9,7 +9,7 @@ use rome_text_edit::*;
 
 /// A diagnostic message that can give information
 /// like errors or warnings.
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Diagnostic {
     pub file_id: FileId,
@@ -445,7 +445,7 @@ impl Diagnostic {
 
 /// Everything that can be added to a diagnostic, like
 /// a suggestion that will be displayed under the actual error.
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubDiagnostic {
     pub severity: Severity,
@@ -454,7 +454,7 @@ pub struct SubDiagnostic {
 }
 
 /// A note or help that is displayed under the diagnostic.
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Footer {
     pub msg: MarkupBuf,

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -68,7 +68,7 @@ use std::num::ParseIntError;
 use std::rc::Rc;
 use std::str::FromStr;
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum IndentStyle {
     /// Tab
@@ -379,7 +379,7 @@ impl Printed {
 /// Public return type of the formatter
 pub type FormatResult<F> = Result<F, FormatError>;
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 /// Series of errors encountered during formatting
 pub enum FormatError {
     /// In case a node can't be formatted because it either misses a require child element or

--- a/crates/rome_js_analyze/src/utils/rename.rs
+++ b/crates/rome_js_analyze/src/utils/rename.rs
@@ -49,6 +49,7 @@ impl RenamableNode for JsAnyRenamableDeclaration {
     }
 }
 
+#[derive(Clone, PartialEq, Eq)]
 pub enum RenameError {
     CannotFindDeclaration,
     CannotBeRenamed {

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -581,7 +581,7 @@ impl<L: Language> From<cursor::SyntaxNode> for SyntaxNode<L> {
 
 /// Language-agnostic representation of the root node of a syntax tree, can be
 /// sent or shared between threads
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SendNode {
     language: TypeId,
     green: GreenNode,

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -24,6 +24,7 @@ rome_js_semantic = { path = "../rome_js_semantic" }
 rome_rowan = { path = "../rome_rowan" }
 rome_text_edit = { path = "../rome_text_edit" }
 indexmap = { version = "1.9.1", features = ["serde"] }
+salsa = { git = "https://github.com/salsa-rs/salsa", rev = "754eea8" }
 
 [features]
 serde_workspace = [

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -131,7 +131,7 @@ pub struct Js {
 }
 impl Js {
     const GROUP_NAME: &'static str = "js";
-    pub(crate) const GROUP_RULES: [&'static str; 26] = [
+    pub(crate) const GROUP_RULES: [&'static str; 27] = [
         "noArguments",
         "noAsyncPromiseExecutor",
         "noCatchAssign",
@@ -160,7 +160,7 @@ impl Js {
         "useValidTypeof",
         "useWhile",
     ];
-    const RECOMMENDED_RULES: [RuleFilter<'static>; 24] = [
+    const RECOMMENDED_RULES: [RuleFilter<'static>; 25] = [
         RuleFilter::Rule("js", Self::GROUP_RULES[0]),
         RuleFilter::Rule("js", Self::GROUP_RULES[1]),
         RuleFilter::Rule("js", Self::GROUP_RULES[2]),
@@ -179,12 +179,13 @@ impl Js {
         RuleFilter::Rule("js", Self::GROUP_RULES[16]),
         RuleFilter::Rule("js", Self::GROUP_RULES[17]),
         RuleFilter::Rule("js", Self::GROUP_RULES[18]),
-        RuleFilter::Rule("js", Self::GROUP_RULES[20]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[19]),
         RuleFilter::Rule("js", Self::GROUP_RULES[21]),
         RuleFilter::Rule("js", Self::GROUP_RULES[22]),
         RuleFilter::Rule("js", Self::GROUP_RULES[23]),
         RuleFilter::Rule("js", Self::GROUP_RULES[24]),
         RuleFilter::Rule("js", Self::GROUP_RULES[25]),
+        RuleFilter::Rule("js", Self::GROUP_RULES[26]),
     ];
     pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -61,6 +61,7 @@ impl Configuration {
     }
 }
 
+#[derive(Clone, PartialEq, Eq)]
 /// Series of errors that can be thrown while computing the configuration
 pub enum ConfigurationError {
     /// Thrown when the program can't serialize the configuration, while saving it

--- a/crates/rome_service/src/database.rs
+++ b/crates/rome_service/src/database.rs
@@ -1,0 +1,63 @@
+use rome_fs::RomePath;
+use salsa::{database, query_group, Durability, ParallelDatabase, Snapshot, Storage};
+
+mod analyzer;
+mod formatter;
+mod parser;
+
+use crate::{
+    database::{analyzer::AnalyzerStorage, formatter::FormatterStorage, parser::ParserStorage},
+    file_handlers::Features,
+    settings::WorkspaceSettings,
+};
+
+pub(crate) use self::{
+    analyzer::Analyzer,
+    formatter::Formatter,
+    parser::{AnyParse, Parser},
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Document {
+    pub(crate) content: String,
+    pub(crate) version: i32,
+}
+
+#[query_group(InputsStorage)]
+pub(crate) trait Inputs {
+    #[salsa::input]
+    fn document(&self, name: RomePath) -> Document;
+
+    #[salsa::input]
+    fn language_features(&self, key: ()) -> Features;
+
+    #[salsa::input]
+    fn settings(&self, key: ()) -> WorkspaceSettings;
+}
+
+#[database(InputsStorage, ParserStorage, AnalyzerStorage, FormatterStorage)]
+pub(crate) struct WorkspaceDatabase {
+    storage: Storage<Self>,
+}
+
+impl Default for WorkspaceDatabase {
+    fn default() -> Self {
+        let mut db = Self {
+            storage: Storage::default(),
+        };
+
+        db.set_language_features_with_durability((), Features::new(), Durability::HIGH);
+        db.set_settings_with_durability((), WorkspaceSettings::default(), Durability::MEDIUM);
+        db
+    }
+}
+
+impl salsa::Database for WorkspaceDatabase {}
+
+impl ParallelDatabase for WorkspaceDatabase {
+    fn snapshot(&self) -> Snapshot<Self> {
+        Snapshot::new(WorkspaceDatabase {
+            storage: self.storage.snapshot(),
+        })
+    }
+}

--- a/crates/rome_service/src/database/analyzer.rs
+++ b/crates/rome_service/src/database/analyzer.rs
@@ -1,0 +1,118 @@
+use indexmap::IndexSet;
+use rome_analyze::{AnalysisFilter, RuleCategories, RuleFilter};
+use rome_fs::RomePath;
+use rome_js_syntax::{TextRange, TextSize};
+use salsa::query_group;
+
+use crate::{
+    database::Parser,
+    workspace::{FixFileResult, PullActionsResult, PullDiagnosticsResult, RenameResult},
+    RomeError,
+};
+
+#[query_group(AnalyzerStorage)]
+pub(crate) trait Analyzer: Parser {
+    fn lint(
+        &self,
+        name: RomePath,
+        categories: RuleCategories,
+    ) -> Result<PullDiagnosticsResult, RomeError>;
+    fn code_actions(
+        &self,
+        name: RomePath,
+        range: TextRange,
+    ) -> Result<PullActionsResult, RomeError>;
+    fn fix_all(&self, name: RomePath) -> Result<FixFileResult, RomeError>;
+    fn rename(
+        &self,
+        name: RomePath,
+        symbol_at: TextSize,
+        new_name: String,
+    ) -> Result<RenameResult, RomeError>;
+}
+
+fn lint(
+    db: &dyn Analyzer,
+    name: RomePath,
+    categories: RuleCategories,
+) -> Result<PullDiagnosticsResult, RomeError> {
+    let settings = db.settings(());
+    let features = db.language_features(());
+
+    let capabilities = features.get_capabilities(&name);
+    let linter = capabilities
+        .lint
+        .ok_or_else(|| RomeError::SourceFileNotSupported(name.clone()))?;
+
+    let parse = db.syntax(name.clone())?;
+
+    let rules = settings.linter.rules.as_ref();
+    let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
+        let enabled: IndexSet<RuleFilter> = rules.as_enabled_rules();
+        Some(enabled.into_iter().collect())
+    } else {
+        None
+    };
+
+    let mut filter = match &enabled_rules {
+        Some(rules) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
+        _ => AnalysisFilter::default(),
+    };
+
+    filter.categories = categories;
+
+    let mut diagnostics = db.diagnostics(name.clone())?;
+    diagnostics.extend(linter(&name, parse, filter));
+
+    Ok(PullDiagnosticsResult { diagnostics })
+}
+
+fn code_actions(
+    db: &dyn Analyzer,
+    name: RomePath,
+    range: TextRange,
+) -> Result<PullActionsResult, RomeError> {
+    let features = db.language_features(());
+    let settings = db.settings(());
+
+    let capabilities = features.get_capabilities(&name);
+    let code_actions = capabilities
+        .code_actions
+        .ok_or_else(|| RomeError::SourceFileNotSupported(name.clone()))?;
+
+    let parse = db.syntax(name.clone())?;
+    let rules = settings.linter.rules.as_ref();
+
+    Ok(code_actions(&name, parse, range, rules))
+}
+
+fn fix_all(db: &dyn Analyzer, name: RomePath) -> Result<FixFileResult, RomeError> {
+    let features = db.language_features(());
+    let settings = db.settings(());
+
+    let capabilities = features.get_capabilities(&name);
+    let fix_all = capabilities
+        .fix_all
+        .ok_or_else(|| RomeError::SourceFileNotSupported(name.clone()))?;
+
+    let parse = db.syntax(name.clone())?;
+    let rules = settings.linter.rules.as_ref();
+    Ok(fix_all(&name, parse, rules))
+}
+
+fn rename(
+    db: &dyn Analyzer,
+    name: RomePath,
+    symbol_at: TextSize,
+    new_name: String,
+) -> Result<RenameResult, RomeError> {
+    let features = db.language_features(());
+
+    let capabilities = features.get_capabilities(&name);
+    let rename = capabilities
+        .rename
+        .ok_or_else(|| RomeError::SourceFileNotSupported(name.clone()))?;
+
+    let parse = db.syntax(name.clone())?;
+    rename(&name, parse, symbol_at, new_name)
+}

--- a/crates/rome_service/src/database/formatter.rs
+++ b/crates/rome_service/src/database/formatter.rs
@@ -1,0 +1,91 @@
+use rome_formatter::{IndentStyle, Printed};
+use rome_fs::RomePath;
+use rome_js_syntax::{TextRange, TextSize};
+use salsa::query_group;
+
+use crate::{database::Parser, settings::SettingsHandle, RomeError};
+
+#[query_group(FormatterStorage)]
+pub(crate) trait Formatter: Parser {
+    fn format(&self, name: RomePath, indent_style: IndentStyle) -> Result<Printed, RomeError>;
+    fn format_range(
+        &self,
+        name: RomePath,
+        indent_style: IndentStyle,
+        range: TextRange,
+    ) -> Result<Printed, RomeError>;
+    fn format_on_type(
+        &self,
+        name: RomePath,
+        indent_style: IndentStyle,
+        offset: TextSize,
+    ) -> Result<Printed, RomeError>;
+}
+
+fn format(
+    db: &dyn Formatter,
+    name: RomePath,
+    indent_style: IndentStyle,
+) -> Result<Printed, RomeError> {
+    let features = db.language_features(());
+    let settings = db.settings(());
+
+    let capabilities = features.get_capabilities(&name);
+    let formatter = capabilities
+        .format
+        .ok_or_else(|| RomeError::SourceFileNotSupported(name.clone()))?;
+
+    let parse = db.syntax(name.clone())?;
+    if !settings.format.format_with_errors && db.has_errors(name.clone()) {
+        return Err(RomeError::FormatWithErrorsDisabled);
+    }
+
+    let settings = SettingsHandle::new(db, indent_style);
+    formatter(&name, parse, settings)
+}
+
+fn format_range(
+    db: &dyn Formatter,
+    name: RomePath,
+    indent_style: IndentStyle,
+    range: TextRange,
+) -> Result<Printed, RomeError> {
+    let features = db.language_features(());
+    let settings = db.settings(());
+
+    let capabilities = features.get_capabilities(&name);
+    let formatter = capabilities
+        .format_range
+        .ok_or_else(|| RomeError::SourceFileNotSupported(name.clone()))?;
+
+    let parse = db.syntax(name.clone())?;
+    if !settings.format.format_with_errors && db.has_errors(name.clone()) {
+        return Err(RomeError::FormatWithErrorsDisabled);
+    }
+
+    let settings = SettingsHandle::new(db, indent_style);
+    formatter(&name, parse, settings, range)
+}
+
+fn format_on_type(
+    db: &dyn Formatter,
+    name: RomePath,
+    indent_style: IndentStyle,
+    offset: TextSize,
+) -> Result<Printed, RomeError> {
+    let features = db.language_features(());
+    let settings = db.settings(());
+
+    let capabilities = features.get_capabilities(&name);
+    let format_on_type = capabilities
+        .format_on_type
+        .ok_or_else(|| RomeError::SourceFileNotSupported(name.clone()))?;
+
+    let parse = db.syntax(name.clone())?;
+    if !settings.format.format_with_errors && db.has_errors(name.clone()) {
+        return Err(RomeError::FormatWithErrorsDisabled);
+    }
+
+    let settings = SettingsHandle::new(db, indent_style);
+    format_on_type(&name, parse, settings, offset)
+}

--- a/crates/rome_service/src/database/parser.rs
+++ b/crates/rome_service/src/database/parser.rs
@@ -1,0 +1,108 @@
+use std::any::type_name;
+
+use rome_diagnostics::{Diagnostic, Severity};
+use rome_fs::RomePath;
+use rome_rowan::{AstNode, Language as RowanLanguage, SendNode, SyntaxNode};
+use salsa::query_group;
+
+use crate::{database::Inputs, RomeError};
+
+/// Language-independent cache entry for a parsed file
+///
+/// This struct holds a handle to the root node of the parsed syntax tree,
+/// along with the list of diagnostics emitted by the parser while generating
+/// this entry.
+///
+/// It can be dynamically downcast into a concrete [SyntaxNode] or [AstNode] of
+/// the corresponding language, generally through a language-specific capability
+#[derive(Clone, Debug)]
+pub(crate) struct AnyParse {
+    root: SendNode,
+}
+
+impl AnyParse {
+    pub(crate) fn new(root: SendNode) -> Self {
+        Self { root }
+    }
+
+    pub(crate) fn syntax<L>(&self) -> SyntaxNode<L>
+    where
+        L: RowanLanguage + 'static,
+    {
+        self.root.clone().into_node().unwrap_or_else(|| {
+            panic!(
+                "could not downcast root node to language {}",
+                type_name::<L>()
+            )
+        })
+    }
+
+    pub(crate) fn tree<N>(&self) -> N
+    where
+        N: AstNode,
+        N::Language: 'static,
+    {
+        N::unwrap_cast(self.syntax::<N::Language>())
+    }
+}
+
+impl PartialEq for AnyParse {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root
+    }
+}
+
+impl Eq for AnyParse {}
+
+#[query_group(ParserStorage)]
+pub(crate) trait Parser: Inputs {
+    fn parse(&self, name: RomePath) -> Result<(AnyParse, Vec<Diagnostic>), RomeError>;
+    fn debug_print(&self, name: RomePath) -> Result<String, RomeError>;
+
+    fn syntax(&self, name: RomePath) -> Result<AnyParse, RomeError>;
+    fn diagnostics(&self, name: RomePath) -> Result<Vec<Diagnostic>, RomeError>;
+    fn has_errors(&self, name: RomePath) -> bool;
+}
+
+fn parse(db: &dyn Parser, name: RomePath) -> Result<(AnyParse, Vec<Diagnostic>), RomeError> {
+    let features = db.language_features(());
+    let document = db.document(name.clone());
+
+    let capabilities = features.get_capabilities(&name);
+    let parser = capabilities
+        .parse
+        .ok_or_else(|| RomeError::SourceFileNotSupported(name.clone()))?;
+
+    Ok(parser(&name, &document.content))
+}
+
+fn debug_print(db: &dyn Parser, name: RomePath) -> Result<String, RomeError> {
+    let features = db.language_features(());
+    let parse = db.syntax(name.clone())?;
+
+    let capabilities = features.get_capabilities(&name);
+    let printer = capabilities
+        .debug_print
+        .ok_or_else(|| RomeError::SourceFileNotSupported(name.clone()))?;
+
+    Ok(printer(&name, parse))
+}
+
+fn syntax(db: &dyn Parser, name: RomePath) -> Result<AnyParse, RomeError> {
+    let (syntax, _) = db.parse(name)?;
+    Ok(syntax)
+}
+
+fn diagnostics(db: &dyn Parser, name: RomePath) -> Result<Vec<Diagnostic>, RomeError> {
+    let (_, diagnostics) = db.parse(name)?;
+    Ok(diagnostics)
+}
+
+fn has_errors(db: &dyn Parser, name: RomePath) -> bool {
+    match db.diagnostics(name) {
+        Ok(diagnostics) => diagnostics
+            .iter()
+            .any(|diag| diag.severity >= Severity::Error),
+        Err(_) => true,
+    }
+}

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -1,5 +1,5 @@
 use super::{ExtensionHandler, Mime};
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct JsonFileHandler;
 
 impl ExtensionHandler for JsonFileHandler {

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -6,8 +6,10 @@ use rome_js_syntax::{TextRange, TextSize};
 use std::ffi::OsStr;
 
 use crate::{
+    database::AnyParse,
     settings::SettingsHandle,
-    workspace::{server::AnyParse, FixFileResult, PullActionsResult, RenameResult},
+    workspace::FixFileResult,
+    workspace::{PullActionsResult, RenameResult},
     RomeError, Rules,
 };
 
@@ -70,7 +72,7 @@ impl std::fmt::Display for Mime {
     }
 }
 
-type Parse = fn(&RomePath, &str) -> AnyParse;
+type Parse = fn(&RomePath, &str) -> (AnyParse, Vec<Diagnostic>);
 type DebugPrint = fn(&RomePath, AnyParse) -> String;
 type Lint = fn(&RomePath, AnyParse, AnalysisFilter) -> Vec<Diagnostic>;
 type CodeActions = fn(&RomePath, AnyParse, TextRange, Option<&Rules>) -> PullActionsResult;
@@ -132,6 +134,7 @@ pub(crate) trait ExtensionHandler {
 }
 
 /// Features available for each language
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct Features {
     js: JsFileHandler,
     json: JsonFileHandler,

--- a/crates/rome_service/src/file_handlers/unknown.rs
+++ b/crates/rome_service/src/file_handlers/unknown.rs
@@ -1,6 +1,6 @@
 use super::ExtensionHandler;
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct UnknownFileHandler {}
 
 impl ExtensionHandler for UnknownFileHandler {

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -8,6 +8,7 @@ use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 
 pub mod configuration;
+mod database;
 mod file_handlers;
 pub mod settings;
 pub mod workspace;
@@ -29,6 +30,7 @@ pub struct App<'app> {
     pub console: DynRef<'app, dyn Console>,
 }
 
+#[derive(Clone, PartialEq, Eq)]
 /// Generic errors thrown during rome operations
 pub enum RomeError {
     /// The project contains uncommitted changes

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -135,6 +135,7 @@ pub struct PullDiagnosticsParams {
     pub categories: RuleCategories,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_workspace",
     derive(serde::Serialize, serde::Deserialize)
@@ -152,6 +153,7 @@ pub struct PullActionsParams {
     pub range: TextRange,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_workspace",
     derive(serde::Serialize, serde::Deserialize)
@@ -160,6 +162,7 @@ pub struct PullActionsResult {
     pub actions: Vec<CodeAction>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_workspace",
     derive(serde::Serialize, serde::Deserialize)
@@ -207,6 +210,7 @@ pub struct FixFileParams {
     pub path: RomePath,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_workspace",
     derive(serde::Serialize, serde::Deserialize)
@@ -218,6 +222,7 @@ pub struct FixFileResult {
     pub actions: Vec<FixAction>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_workspace",
     derive(serde::Serialize, serde::Deserialize)
@@ -239,6 +244,7 @@ pub struct RenameParams {
     pub new_name: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_workspace",
     derive(serde::Serialize, serde::Deserialize)
@@ -301,7 +307,7 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
 
 /// Convenience function for constructing a server instance of [Workspace]
 pub fn server() -> Box<dyn Workspace> {
-    Box::new(server::WorkspaceServer::new())
+    Box::new(server::WorkspaceServer::default())
 }
 
 /// [RAII](https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization)

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -1,16 +1,10 @@
-use std::{any::type_name, panic::RefUnwindSafe, sync::RwLock};
+use std::sync::Mutex;
 
-use dashmap::{mapref::entry::Entry, DashMap};
-use indexmap::IndexSet;
-use rome_analyze::{AnalysisFilter, RuleFilter};
-use rome_diagnostics::{Diagnostic, Severity};
 use rome_formatter::Printed;
-use rome_fs::RomePath;
-use rome_rowan::{AstNode, Language as RowanLanguage, SendNode, SyntaxNode};
+use salsa::{Durability, ParallelDatabase, Snapshot};
 
 use crate::{
-    file_handlers::Features,
-    settings::{SettingsHandle, WorkspaceSettings},
+    database::{Analyzer, Document, Formatter, Inputs, Parser, WorkspaceDatabase},
     RomeError, Workspace,
 };
 
@@ -21,124 +15,26 @@ use super::{
     SupportsFeatureParams, UpdateSettingsParams,
 };
 
+#[derive(Default)]
 pub(super) struct WorkspaceServer {
-    /// features available throughout the application
-    features: Features,
-    /// global settings object for this workspace
-    settings: RwLock<WorkspaceSettings>,
-    /// Stores the document (text content + version number) associated with a URL
-    documents: DashMap<RomePath, Document>,
-    /// Stores the result of the parser (syntax tree + diagnostics) for a given URL
-    syntax: DashMap<RomePath, AnyParse>,
-}
-
-/// The `Workspace` object is long lived, so we want it to be able to cross
-/// unwind boundaries.
-/// In return we have to make sure operations on the workspace either do not
-/// panic, of that panicking will not result in any broken invariant (it would
-/// not result in any undefined behavior as catching an unwind is safe, but it
-/// could lead to hard to debug issues)
-impl RefUnwindSafe for WorkspaceServer {}
-
-#[derive(Clone, Debug)]
-pub(crate) struct Document {
-    pub(crate) content: String,
-    pub(crate) version: i32,
-}
-
-/// Language-independent cache entry for a parsed file
-///
-/// This struct holds a handle to the root node of the parsed syntax tree,
-/// along with the list of diagnostics emitted by the parser while generating
-/// this entry.
-///
-/// It can be dynamically downcast into a concrete [SyntaxNode] or [AstNode] of
-/// the corresponding language, generally through a language-specific capability
-#[derive(Clone)]
-pub(crate) struct AnyParse {
-    pub(crate) root: SendNode,
-    pub(crate) diagnostics: Vec<Diagnostic>,
-}
-
-impl AnyParse {
-    pub(crate) fn syntax<L>(&self) -> SyntaxNode<L>
-    where
-        L: RowanLanguage + 'static,
-    {
-        self.root.clone().into_node().unwrap_or_else(|| {
-            panic!(
-                "could not downcast root node to language {}",
-                type_name::<L>()
-            )
-        })
-    }
-
-    pub(crate) fn tree<N>(&self) -> N
-    where
-        N: AstNode,
-        N::Language: 'static,
-    {
-        N::unwrap_cast(self.syntax::<N::Language>())
-    }
-
-    pub(crate) fn into_diagnostics(self) -> Vec<Diagnostic> {
-        self.diagnostics
-    }
-
-    fn has_errors(&self) -> bool {
-        self.diagnostics
-            .iter()
-            .any(|diag| diag.severity >= Severity::Error)
-    }
+    /// Salsa database holding most of the state for the workspace
+    database: Mutex<WorkspaceDatabase>,
 }
 
 impl WorkspaceServer {
-    /// Create a new [Workspace]
-    ///
-    /// This is implemented as a crate-private method instead of using
-    /// [Default] to disallow instances of [Workspace] from being created
-    /// outside of a [crate::App]
-    pub(crate) fn new() -> Self {
-        Self {
-            features: Features::new(),
-            settings: RwLock::default(),
-            documents: DashMap::default(),
-            syntax: DashMap::default(),
-        }
-    }
-
-    fn settings<E>(&self, editor: E) -> SettingsHandle<E> {
-        SettingsHandle::new(&self.settings, editor)
-    }
-
-    /// Get the parser result for a given file
-    ///
-    /// Returns and error if no file exists in the workspace with this path or
-    /// if the language associated with the file has no parser capability
-    fn get_parse(&self, rome_path: RomePath) -> Result<AnyParse, RomeError> {
-        match self.syntax.entry(rome_path) {
-            Entry::Occupied(entry) => Ok(entry.get().clone()),
-            Entry::Vacant(entry) => {
-                let rome_path = entry.key();
-                let document = self.documents.get(rome_path).ok_or(RomeError::NotFound)?;
-
-                let capabilities = self.features.get_capabilities(rome_path);
-                let parser = capabilities
-                    .parse
-                    .ok_or_else(|| RomeError::SourceFileNotSupported(rome_path.clone()))?;
-
-                let parsed = parser(rome_path, &document.content);
-
-                Ok(entry.insert(parsed).clone())
-            }
-        }
+    /// Returns a thread-local handle to the database
+    fn database(&self) -> Snapshot<WorkspaceDatabase> {
+        self.database.lock().unwrap().snapshot()
     }
 }
 
 impl Workspace for WorkspaceServer {
     fn supports_feature(&self, params: SupportsFeatureParams) -> bool {
-        let capabilities = self.features.get_capabilities(&params.path);
-        let settings = self.settings.read().unwrap();
+        let database = self.database();
+        let features = database.language_features(());
+        let settings = database.settings(());
+
+        let capabilities = features.get_capabilities(&params.path);
         match params.feature {
             FeatureName::Format => capabilities.format.is_some() && settings.format.enabled,
             FeatureName::Lint => capabilities.lint.is_some() && settings.linter.enabled,
@@ -151,59 +47,53 @@ impl Workspace for WorkspaceServer {
     /// This function may panic if the internal settings mutex has been poisoned
     /// by another thread having previously panicked while holding the lock
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), RomeError> {
-        let mut settings = self.settings.write().unwrap();
-        *settings = params.settings;
+        let mut database = self.database.lock().unwrap();
+        database.set_settings_with_durability((), params.settings, Durability::MEDIUM);
         Ok(())
     }
 
     /// Add a new file to the workspace
     fn open_file(&self, params: OpenFileParams) -> Result<(), RomeError> {
-        self.syntax.remove(&params.path);
-        self.documents.insert(
+        let mut database = self.database.lock().unwrap();
+
+        database.set_document(
             params.path,
             Document {
                 content: params.content,
                 version: params.version,
             },
         );
+
         Ok(())
-    }
-
-    fn get_syntax_tree(&self, params: GetSyntaxTreeParams) -> Result<String, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
-        let printer = capabilities
-            .debug_print
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
-
-        let parse = self.get_parse(params.path.clone())?;
-        let printed = printer(&params.path, parse);
-
-        Ok(printed)
     }
 
     /// Change the content of an open file
     fn change_file(&self, params: ChangeFileParams) -> Result<(), RomeError> {
-        let mut document = self
-            .documents
-            .get_mut(&params.path)
-            .ok_or(RomeError::NotFound)?;
+        let mut database = self.database.lock().unwrap();
 
+        let document = database.remove_document(params.path.clone());
         debug_assert!(params.version > document.version);
-        document.version = params.version;
-        document.content = params.content;
 
-        self.syntax.remove(&params.path);
+        database.set_document(
+            params.path,
+            Document {
+                content: params.content,
+                version: params.version,
+            },
+        );
+
         Ok(())
     }
 
     /// Remove a file from the workspace
     fn close_file(&self, params: CloseFileParams) -> Result<(), RomeError> {
-        self.documents
-            .remove(&params.path)
-            .ok_or(RomeError::NotFound)?;
-
-        self.syntax.remove(&params.path);
+        let mut database = self.database.lock().unwrap();
+        database.remove_document(params.path);
         Ok(())
+    }
+
+    fn get_syntax_tree(&self, params: GetSyntaxTreeParams) -> Result<String, RomeError> {
+        self.database().debug_print(params.path)
     }
 
     /// Retrieves the list of diagnostics associated with a file
@@ -211,119 +101,37 @@ impl Workspace for WorkspaceServer {
         &self,
         params: PullDiagnosticsParams,
     ) -> Result<PullDiagnosticsResult, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
-        let linter = capabilities
-            .lint
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
-
-        let parse = self.get_parse(params.path.clone())?;
-        let settings = self.settings.read().unwrap();
-        let rules = settings.linter.rules.as_ref();
-        let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
-            let enabled: IndexSet<RuleFilter> = rules.as_enabled_rules();
-            Some(enabled.into_iter().collect())
-        } else {
-            None
-        };
-
-        let mut filter = match &enabled_rules {
-            Some(rules) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
-            _ => AnalysisFilter::default(),
-        };
-
-        filter.categories = params.categories;
-        let diagnostics = linter(&params.path, parse, filter);
-
-        Ok(PullDiagnosticsResult { diagnostics })
+        self.database().lint(params.path, params.categories)
     }
 
     /// Retrieves the list of code actions available for a given cursor
     /// position within a file
     fn pull_actions(&self, params: PullActionsParams) -> Result<PullActionsResult, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
-        let code_actions = capabilities
-            .code_actions
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
-
-        let parse = self.get_parse(params.path.clone())?;
-
-        let settings = self.settings.read().unwrap();
-        let rules = settings.linter.rules.as_ref();
-
-        Ok(code_actions(&params.path, parse, params.range, rules))
+        self.database().code_actions(params.path, params.range)
     }
 
     /// Runs the given file through the formatter using the provided options
     /// and returns the resulting source code
     fn format_file(&self, params: FormatFileParams) -> Result<Printed, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
-        let formatter = capabilities
-            .format
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
-
-        let parse = self.get_parse(params.path.clone())?;
-        let settings = self.settings(params.indent_style);
-
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
-            return Err(RomeError::FormatWithErrorsDisabled);
-        }
-
-        formatter(&params.path, parse, settings)
+        self.database().format(params.path, params.indent_style)
     }
 
     fn format_range(&self, params: FormatRangeParams) -> Result<Printed, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
-        let formatter = capabilities
-            .format_range
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
-
-        let parse = self.get_parse(params.path.clone())?;
-        let settings = self.settings(params.indent_style);
-
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
-            return Err(RomeError::FormatWithErrorsDisabled);
-        }
-
-        formatter(&params.path, parse, settings, params.range)
+        self.database()
+            .format_range(params.path, params.indent_style, params.range)
     }
 
     fn format_on_type(&self, params: FormatOnTypeParams) -> Result<Printed, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
-        let formatter = capabilities
-            .format_on_type
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
-
-        let parse = self.get_parse(params.path.clone())?;
-        let settings = self.settings(params.indent_style);
-
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
-            return Err(RomeError::FormatWithErrorsDisabled);
-        }
-
-        formatter(&params.path, parse, settings, params.offset)
+        self.database()
+            .format_on_type(params.path, params.indent_style, params.offset)
     }
 
     fn fix_file(&self, params: super::FixFileParams) -> Result<FixFileResult, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
-        let fix_all = capabilities
-            .fix_all
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
-
-        let parse = self.get_parse(params.path.clone())?;
-        let settings = self.settings.read().unwrap();
-        let rules = settings.linter.rules.as_ref();
-        Ok(fix_all(&params.path, parse, rules))
+        self.database().fix_all(params.path)
     }
 
     fn rename(&self, params: super::RenameParams) -> Result<RenameResult, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
-        let rename = capabilities
-            .rename
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
-
-        let parse = self.get_parse(params.path.clone())?;
-        let result = rename(&params.path, parse, params.symbol_at, params.new_name)?;
-
-        Ok(result)
+        self.database()
+            .rename(params.path, params.symbol_at, params.new_name)
     }
 }


### PR DESCRIPTION
## Summary

This PR replaces the ad-hoc caching system used in the Workspace server with the `salsa` library. This is only intended as a prototype / proof of concept and I don't plan on merging this in for now since it depends on a recent revision of salsa (pulled from GitHub) to support closing documents, and the salsa library itself is undergoing a rework named "Salsa 2022" that may incur large changes in the public API of the library (but also make some queries less awkward, for instance by allowing diagnostics to be emitted as a "side-effect" of the parser query)

## Test Plan

Caching is intended as an internal change that's not visible to the external consumers of the Workspace API, in this case the CLI and Language Server whose test suite should continue to pass with no modification
