### PR TITLE
refactor(rome_rowan): Remove `AstNode` constraint from `BatchMutation`

### DIFF
--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -1,9 +1,7 @@
 use crate::categories::{ActionCategory, RuleCategory};
 use crate::context::RuleContext;
 use crate::registry::{RuleLanguage, RuleSuppressions};
-use crate::{
-    AnalysisFilter, AnalyzerDiagnostic, LanguageRoot, Phase, Phases, Queryable, RuleRegistry,
-};
+use crate::{AnalysisFilter, AnalyzerDiagnostic, Phase, Phases, Queryable, RuleRegistry};
 use rome_console::fmt::Display;
 use rome_console::{markup, MarkupBuf};
 use rome_diagnostics::{file::FileId, Applicability, Severity};
@@ -447,5 +445,5 @@ pub struct RuleAction<L: Language> {
     pub category: ActionCategory,
     pub applicability: Applicability,
     pub message: MarkupBuf,
-    pub mutation: BatchMutation<L, LanguageRoot<L>>,
+    pub mutation: BatchMutation<L>,
 }

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -1,7 +1,7 @@
 use crate::{
     categories::ActionCategory,
     context::RuleContext,
-    registry::{LanguageRoot, RuleLanguage, RuleRoot},
+    registry::{RuleLanguage, RuleRoot},
     rule::Rule,
     AnalyzerDiagnostic, Queryable, RuleGroup, ServiceBag,
 };
@@ -61,7 +61,7 @@ pub struct AnalyzerAction<L: Language> {
     pub category: ActionCategory,
     pub applicability: Applicability,
     pub message: MarkupBuf,
-    pub mutation: BatchMutation<L, LanguageRoot<L>>,
+    pub mutation: BatchMutation<L>,
 }
 
 impl<L> From<AnalyzerAction<L>> for CodeSuggestion

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -138,7 +138,7 @@ mod tests {
 /// Series of errors encountered when running rules on a file
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum RuleError {
-    /// The rule with the specified name replaced the root of the file with a node that is not a [JsAnyRoot].
+    /// The rule with the specified name replaced the root of the file with a node that is not a valid root for that language.
     ReplacedRootWithNonRootError { rule_name: &'static str },
 }
 

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -8,6 +8,7 @@ use rome_js_syntax::{
     suppression::{parse_suppression_comment, SuppressionCategory},
     JsLanguage,
 };
+use std::error::Error;
 
 mod analyzers;
 mod assists;
@@ -133,3 +134,25 @@ mod tests {
         );
     }
 }
+
+/// Series of errors encountered when running rules on a file
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum RuleError {
+    /// The rule with the specified name replaced the root of the file with a node that is not a [JsAnyRoot].
+    ReplacedRootWithNonRootError { rule_name: &'static str },
+}
+
+impl std::fmt::Display for RuleError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RuleError::ReplacedRootWithNonRootError { rule_name } => {
+                std::write!(
+                    fmt,
+                    "the rule '{rule_name}' replaced the root of the file with a non-root node."
+                )
+            }
+        }
+    }
+}
+
+impl Error for RuleError {}

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -1,5 +1,5 @@
 use rome_js_factory::make;
-use rome_js_syntax::{JsAnyRoot, JsAnyStatement, JsLanguage, JsModuleItemList, JsStatementList, T};
+use rome_js_syntax::{JsAnyStatement, JsLanguage, JsModuleItemList, JsStatementList, T};
 use rome_rowan::{AstNode, BatchMutation};
 use std::borrow::Cow;
 
@@ -34,7 +34,7 @@ impl<'a> Iterator for InterpretEscapedString<'a> {
     }
 }
 
-/// unescape   
+/// unescape
 ///
 pub(crate) fn escape_string(s: &str) -> Result<String, EscapeError> {
     (InterpretEscapedString { s: s.chars() }).collect()
@@ -123,10 +123,7 @@ pub fn to_camel_case(input: &str) -> Cow<str> {
 /// Utility function to remove a statement node from a syntax tree, by either
 /// removing the node from its parent if said parent is a statement list or
 /// module item list, or by replacing the statement node with an empty statement
-pub(crate) fn remove_statement<N>(
-    mutation: &mut BatchMutation<JsLanguage, JsAnyRoot>,
-    node: &N,
-) -> Option<()>
+pub(crate) fn remove_statement<N>(mutation: &mut BatchMutation<JsLanguage>, node: &N) -> Option<()>
 where
     N: AstNode<Language = JsLanguage> + Into<JsAnyStatement>,
 {

--- a/crates/rome_js_analyze/src/utils/batch.rs
+++ b/crates/rome_js_analyze/src/utils/batch.rs
@@ -1,7 +1,6 @@
 use rome_js_syntax::{
-    JsAnyFormalParameter, JsAnyParameter, JsAnyRoot, JsFormalParameter, JsLanguage,
-    JsParameterList, JsVariableDeclaration, JsVariableDeclarator, JsVariableDeclaratorList,
-    JsVariableStatement,
+    JsAnyFormalParameter, JsAnyParameter, JsFormalParameter, JsLanguage, JsParameterList,
+    JsVariableDeclaration, JsVariableDeclarator, JsVariableDeclaratorList, JsVariableStatement,
 };
 use rome_rowan::{AstNode, AstSeparatedList, BatchMutation};
 
@@ -16,7 +15,7 @@ pub trait JsBatchMutation {
     fn remove_js_formal_parameter(&mut self, parameter: &JsFormalParameter);
 }
 
-impl JsBatchMutation for BatchMutation<JsLanguage, JsAnyRoot> {
+impl JsBatchMutation for BatchMutation<JsLanguage> {
     fn remove_js_variable_declarator(&mut self, declarator: &JsVariableDeclarator) {
         declarator
             .parent::<JsVariableDeclaratorList>()

--- a/crates/rome_js_analyze/src/utils/rename.rs
+++ b/crates/rome_js_analyze/src/utils/rename.rs
@@ -151,7 +151,7 @@ fn token_with_new_text(token: &JsSyntaxToken, new_text: &str) -> JsSyntaxToken {
     JsSyntaxToken::new_detached(JsSyntaxKind::IDENT, new_text.as_str(), leading, trailing)
 }
 
-impl<N: AstNode<Language = JsLanguage>> RenameSymbolExtensions for BatchMutation<JsLanguage, N> {
+impl RenameSymbolExtensions for BatchMutation<JsLanguage> {
     /// Rename the binding and all its references to "new_name".
     /// If we can´t rename the binding, the [BatchMutation] is never changes and it is left
     /// intact.

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -15,7 +15,6 @@ use rome_js_parser::{
     test_utils::{assert_errors_are_absent, has_unknown_nodes_or_empty_slots},
 };
 use rome_js_syntax::{JsLanguage, SourceType};
-use rome_rowan::AstNode;
 use rome_text_edit::apply_indels;
 
 tests_macros::gen_tests! {"tests/specs/**/*.{cjs,js,jsx,tsx,ts}", crate::run_test, "module"}
@@ -155,7 +154,7 @@ fn check_code_action(
     // returns the same code as printing the modified syntax tree
     assert_eq!(new_tree.to_string(), output);
 
-    if has_unknown_nodes_or_empty_slots(new_tree.syntax()) {
+    if has_unknown_nodes_or_empty_slots(&new_tree) {
         panic!("modified tree has unknown nodes or empty slots:\n{new_tree:#?}")
     }
 

--- a/crates/rome_rowan/benches/mutation.rs
+++ b/crates/rome_rowan/benches/mutation.rs
@@ -63,7 +63,7 @@ fn mutation_batch() -> usize {
     batch.replace_node(a, b);
     let root = batch.commit();
 
-    root.syntax().descendants().count()
+    root.descendants().count()
 }
 
 iai::main!(mutation_replace_node, mutation_batch);

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -262,7 +262,7 @@ where
     /// [None] if the mutation is empty
     pub fn as_text_edits(&self) -> Option<(TextRange, Vec<Indel>)> {
         let iter = self.changes.iter().filter_map(|change| {
-            let parent = change.parent.as_ref().unwrap_or_else(|| &self.root);
+            let parent = change.parent.as_ref().unwrap_or(&self.root);
             let delete = match parent.slots().nth(change.new_node_slot) {
                 Some(SyntaxSlot::Node(node)) => node.text_range(),
                 Some(SyntaxSlot::Token(token)) => token.text_range(),

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -2,8 +2,8 @@ use rome_analyze::{AnalysisFilter, ControlFlow, Never, RuleCategories, RuleFilte
 use rome_diagnostics::{Applicability, CodeSuggestion, Diagnostic};
 use rome_formatter::{FormatError, Printed};
 use rome_fs::RomePath;
-use rome_js_analyze::analyze;
 use rome_js_analyze::utils::rename::RenameError;
+use rome_js_analyze::{analyze, RuleError};
 use rome_js_formatter::context::QuoteStyle;
 use rome_js_formatter::{context::JsFormatContext, format_node};
 use rome_js_parser::Parse;
@@ -262,7 +262,16 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, RomeError> {
         match action {
             Some(action) => {
                 if let Some((range, _)) = action.mutation.as_text_edits() {
-                    tree = JsAnyRoot::unwrap_cast(action.mutation.commit());
+                    tree = match JsAnyRoot::cast(action.mutation.commit()) {
+                        Some(tree) => tree,
+                        None => {
+                            return Err(RomeError::RuleError(
+                                RuleError::ReplacedRootWithNonRootError {
+                                    rule_name: action.rule_name,
+                                },
+                            ))
+                        }
+                    };
                     actions.push(FixAction {
                         rule_name: Cow::Borrowed(action.rule_name),
                         range,

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -262,7 +262,7 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, RomeError> {
         match action {
             Some(action) => {
                 if let Some((range, _)) = action.mutation.as_text_edits() {
-                    tree = action.mutation.commit();
+                    tree = JsAnyRoot::unwrap_cast(action.mutation.commit());
                     actions.push(FixAction {
                         rule_name: Cow::Borrowed(action.rule_name),
                         range,

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -2,6 +2,7 @@ use rome_console::{Console, EnvConsole};
 use rome_formatter::FormatError;
 use rome_fs::{FileSystem, OsFileSystem, RomePath};
 use rome_js_analyze::utils::rename::RenameError;
+use rome_js_analyze::RuleError;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::{Deref, DerefMut};
@@ -42,6 +43,8 @@ pub enum RomeError {
     FormatError(FormatError),
     /// The file could not be formatted since it has syntax errors and `format_with_errors` is disabled
     FormatWithErrorsDisabled,
+    /// The file could not be analyzed because a rule caused an error.
+    RuleError(RuleError),
     /// Thrown when Rome can't read a generic directory
     CantReadDirectory(PathBuf),
     /// Thrown when Rome can't read a generic file
@@ -54,17 +57,7 @@ pub enum RomeError {
 
 impl Debug for RomeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RomeError::NotFound => std::fmt::Display::fmt(self, f),
-            RomeError::SourceFileNotSupported(_) => std::fmt::Display::fmt(self, f),
-            RomeError::FormatError(_) => std::fmt::Display::fmt(self, f),
-            RomeError::FormatWithErrorsDisabled => std::fmt::Display::fmt(self, f),
-            RomeError::CantReadDirectory(_) => std::fmt::Display::fmt(self, f),
-            RomeError::CantReadFile(_) => std::fmt::Display::fmt(self, f),
-            RomeError::Configuration(_) => std::fmt::Display::fmt(self, f),
-            RomeError::DirtyWorkspace => std::fmt::Display::fmt(self, f),
-            RomeError::RenameError(_) => std::fmt::Display::fmt(self, f),
-        }
+        std::fmt::Display::fmt(self, f)
     }
 }
 
@@ -129,6 +122,12 @@ impl Display for RomeError {
                     )
                 }
             },
+            RomeError::RuleError(cause) => {
+                write!(
+                    f,
+                    "the linter encountered an error while analyzing the file: {cause}",
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR removes the `N: AstNode<Language=L>` constraint from the `BatchMutation` and changes the `root` to a `SyntaxNode<L>`.

The main motivation for this change is that I want to use the `BatchMutation` for removing all `ParenthesizedExpression`s in the formatter but this isn't possible because:

* The formatter accepts any Js node as the root and there's no `JsAnyNode`
* It isn't guaranteed that the `root` type doesn't change in case the `root` node is a `JsParenthesizedExpression` that gets removed.

## Tests

`cargo test && rustcs`
