### PR TITLE
fix(playground): 🐛 fix rome  ast grammar error

### DIFF
--- a/rome.json
+++ b/rome.json
@@ -1,0 +1,13 @@
+{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "js": {
+        "rules": {
+          "noUnusedVariables": "off"
+        }
+      }
+    }
+  }
+}

--- a/website/playground/package.json
+++ b/website/playground/package.json
@@ -15,7 +15,7 @@
 	},
 	"dependencies": {
 		"@codemirror/lang-javascript": "^6.0.1",
-		"codemirror-lang-rome-ast": "0.0.4",
+		"codemirror-lang-rome-ast": "0.0.6",
 		"lang-rome-formatter-ir": "0.0.2",
 		"@uiw/react-codemirror": "^4.11.4",
 		"@codemirror/view": "6.1.0",

--- a/website/playground/pnpm-lock.yaml
+++ b/website/playground/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   '@uiw/react-codemirror': ^4.11.4
   '@vitejs/plugin-react': ^1.0.7
   autoprefixer: ^10.4.2
-  codemirror-lang-rome-ast: 0.0.4
+  codemirror-lang-rome-ast: 0.0.6
   lang-rome-formatter-ir: 0.0.2
   postcss: ^8.4.6
   prettier: ^2.7.0
@@ -31,7 +31,7 @@ dependencies:
   '@codemirror/state': 6.1.0
   '@codemirror/view': 6.1.0
   '@uiw/react-codemirror': 4.11.4_j45qn7k5iyiiecf3ysrf6hvqzq
-  codemirror-lang-rome-ast: 0.0.4
+  codemirror-lang-rome-ast: 0.0.6
   lang-rome-formatter-ir: 0.0.2
   prettier: 2.7.0
   react: 17.0.2
@@ -892,8 +892,8 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /codemirror-lang-rome-ast/0.0.4:
-    resolution: {integrity: sha512-fX6ahzHRhN2dNU6YcMDelT74qL4S3w+mu9PqE8xQA0UvBR/auGJsMFuKM6AJTK9ktZQ2y3cwZAa3hOevSZy01g==}
+  /codemirror-lang-rome-ast/0.0.6:
+    resolution: {integrity: sha512-2E4E4rNcj6XxLsVjCZJeOsdEXpfdgiejuLrbq6O4muXzf0KSv5X0ScQrs3LK5LmGwoQUC0AowYbfdj3lsaLWkQ==}
     dependencies:
       '@codemirror/autocomplete': 6.0.4
       '@codemirror/language': 6.2.0


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

1. FIx serval grammar cases see video below: 
for such piece of code
```js
class test {
  declare readonly test = 1;
}
```
**before:** 

https://user-images.githubusercontent.com/17974631/183243944-6a7b1b91-e6df-4ec5-80db-5467492e0f3a.mp4



**after:** 


https://user-images.githubusercontent.com/17974631/183243951-af55c5ba-340c-4b87-add8-caf0d1867961.mp4



2. Adding a new temporary `rome.json` to workaround the false positive `noUnusedVariable` rule.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. See my preview video or testing locally
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
