### PR TITLE
feat(rome_js_syntax): Node factories for unknown nodes

### DIFF
--- a/crates/rome_css_factory/src/generated/node_factory.rs
+++ b/crates/rome_css_factory/src/generated/node_factory.rs
@@ -812,3 +812,10 @@ where
         }),
     ))
 }
+pub fn css_unknown<I>(slots: I) -> CssUnknown
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    CssUnknown::unwrap_cast(SyntaxNode::new_detached(CssSyntaxKind::CSS_UNKNOWN, slots))
+}

--- a/crates/rome_js_factory/src/generated/node_factory.rs
+++ b/crates/rome_js_factory/src/generated/node_factory.rs
@@ -6807,3 +6807,90 @@ where
         }),
     ))
 }
+pub fn js_unknown<I>(slots: I) -> JsUnknown
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsUnknown::unwrap_cast(SyntaxNode::new_detached(JsSyntaxKind::JS_UNKNOWN, slots))
+}
+pub fn js_unknown_assignment<I>(slots: I) -> JsUnknownAssignment
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsUnknownAssignment::unwrap_cast(SyntaxNode::new_detached(
+        JsSyntaxKind::JS_UNKNOWN_ASSIGNMENT,
+        slots,
+    ))
+}
+pub fn js_unknown_binding<I>(slots: I) -> JsUnknownBinding
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsUnknownBinding::unwrap_cast(SyntaxNode::new_detached(
+        JsSyntaxKind::JS_UNKNOWN_BINDING,
+        slots,
+    ))
+}
+pub fn js_unknown_expression<I>(slots: I) -> JsUnknownExpression
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsUnknownExpression::unwrap_cast(SyntaxNode::new_detached(
+        JsSyntaxKind::JS_UNKNOWN_EXPRESSION,
+        slots,
+    ))
+}
+pub fn js_unknown_import_assertion_entry<I>(slots: I) -> JsUnknownImportAssertionEntry
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsUnknownImportAssertionEntry::unwrap_cast(SyntaxNode::new_detached(
+        JsSyntaxKind::JS_UNKNOWN_IMPORT_ASSERTION_ENTRY,
+        slots,
+    ))
+}
+pub fn js_unknown_member<I>(slots: I) -> JsUnknownMember
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsUnknownMember::unwrap_cast(SyntaxNode::new_detached(
+        JsSyntaxKind::JS_UNKNOWN_MEMBER,
+        slots,
+    ))
+}
+pub fn js_unknown_named_import_specifier<I>(slots: I) -> JsUnknownNamedImportSpecifier
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsUnknownNamedImportSpecifier::unwrap_cast(SyntaxNode::new_detached(
+        JsSyntaxKind::JS_UNKNOWN_NAMED_IMPORT_SPECIFIER,
+        slots,
+    ))
+}
+pub fn js_unknown_parameter<I>(slots: I) -> JsUnknownParameter
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsUnknownParameter::unwrap_cast(SyntaxNode::new_detached(
+        JsSyntaxKind::JS_UNKNOWN_PARAMETER,
+        slots,
+    ))
+}
+pub fn js_unknown_statement<I>(slots: I) -> JsUnknownStatement
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsUnknownStatement::unwrap_cast(SyntaxNode::new_detached(
+        JsSyntaxKind::JS_UNKNOWN_STATEMENT,
+        slots,
+    ))
+}

--- a/crates/rome_json_factory/src/generated/node_factory.rs
+++ b/crates/rome_json_factory/src/generated/node_factory.rs
@@ -150,3 +150,13 @@ where
         }),
     ))
 }
+pub fn json_unknown<I>(slots: I) -> JsonUnknown
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    JsonUnknown::unwrap_cast(SyntaxNode::new_detached(
+        JsonSyntaxKind::JSON_UNKNOWN,
+        slots,
+    ))
+}


### PR DESCRIPTION
This PR adds node factory methods for unknown nodes. This is certainly more of an edge case, but I have a use case in the formatter when encountering an invalid parenthesized expression in which case the node should be replaced
as an unknown node so, for as far as the formatter is concerned, parenthesized expressions do not exist.

The new API can be used like this:

```rust
let unknown = rome_js_factory::make::js_unknown_expression(
    root.slots().map(|slot| slot.into_syntax_element()),
);
 ```

## Alternatives

An alternative would be to directly use the `SyntaxNode::new_detached` APIs. This works but is less accessible and
it might be convenient to search for all places where we construct unknown nodes.
