### PR TITLE
test(rome_cli): add snapshots for file system and console session

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,5 @@ crates/rome_js_formatter/tests/**/*.ts.prettier-snap linguist-language=TypeScrip
 crates/rome_js_formatter/tests/**/*.js.prettier-snap linguist-language=JavaScript
 crates/rome_js_formatter/tests/**/*.ts.snap linguist-language=Markdown
 crates/rome_js_formatter/tests/**/*.js.snap linguist-language=Markdown
+crates/rome_cli/tests/**/*.snap linguist-language=Markdown
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,18 +796,18 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e21173d5699a654cf191b0c05b0a937bb4f7cf07ee2e32da2af07a963e31577"
+checksum = "49de01ff8a0781c5414e674b4469b81f6693d6bda6a4d405600c2acd06ebc6d3"
 dependencies = [
  "console",
  "globset",
+ "linked-hash-map",
  "once_cell",
  "serde",
- "serde_json",
- "serde_yaml",
  "similar",
  "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -1398,6 +1398,7 @@ version = "0.0.0"
 dependencies = [
  "crossbeam",
  "hdrhistogram",
+ "insta",
  "lazy_static",
  "mimalloc",
  "parking_lot",

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -24,5 +24,8 @@ crossbeam = "0.8.1"
 thiserror = "1.0.30"
 rayon = "1.5.1"
 
+[dev-dependencies]
+insta = "1.17.1"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.29"

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -54,7 +54,11 @@ impl CliSnapshot {
                 //
                 // This is a workaround, and it might not work for all cases.
                 if !message_content.contains("files") {
+                    content.push_str("```block");
+                    content.push('\n');
                     content.push_str(message_content);
+                    content.push('\n');
+                    content.push_str("```");
                     content.push_str("\n\n")
                 }
             }

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -3,6 +3,7 @@ use rome_console::{markup, BufferConsole, Markup};
 use rome_diagnostics::termcolor::NoColor;
 use rome_fs::{FileSystemExt, MemoryFileSystem};
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 #[derive(Default)]
@@ -31,9 +32,10 @@ impl CliSnapshot {
 
         for (name, file_content) in &self.files {
             if !name.starts_with("rome.json") {
-                let extension = name.split(".").last().unwrap();
-                content.push_str(&format!("## `{name}`\n\n"));
-                content.push_str(&format!("```{extension}"));
+                let extension = name.split('.').last().unwrap();
+
+                let _ = write!(content, "## `{name}`\n\n");
+                let _ = write!(content, "```{extension}");
                 content.push('\n');
                 content.push_str(&*file_content);
                 content.push('\n');
@@ -42,7 +44,7 @@ impl CliSnapshot {
             }
         }
 
-        if self.messages.len() > 0 {
+        if !self.messages.is_empty() {
             content.push_str("## Messages\n\n");
 
             for message in &self.messages {
@@ -78,7 +80,7 @@ pub fn assert_cli_snapshot(test_name: &str, fs: MemoryFileSystem, console: Buffe
     let configuration = fs.read(&config_path).ok();
     if let Some(mut configuration) = configuration {
         let mut buffer = String::new();
-        if let Ok(_) = configuration.read_to_string(&mut buffer) {
+        if configuration.read_to_string(&mut buffer).is_ok() {
             cli_snapshot.configuration = Some(buffer);
         }
     }

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -1,0 +1,109 @@
+use rome_console::fmt::{Formatter, Termcolor};
+use rome_console::{markup, BufferConsole, Markup};
+use rome_diagnostics::termcolor::NoColor;
+use rome_fs::{FileSystemExt, MemoryFileSystem};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[derive(Default)]
+struct CliSnapshot {
+    /// the configuration, if set
+    pub configuration: Option<String>,
+    /// file name -> content
+    pub files: HashMap<String, String>,
+    /// messages written in console
+    pub messages: Vec<String>,
+}
+
+impl CliSnapshot {
+    fn emit_content_snapshot(&self) -> String {
+        let mut content = String::new();
+
+        if let Some(configuration) = &self.configuration {
+            content.push_str("## `rome.json`\n\n");
+            content.push_str("```json");
+            content.push('\n');
+            content.push_str(configuration);
+            content.push('\n');
+            content.push_str("```");
+            content.push_str("\n\n")
+        }
+
+        for (name, file_content) in &self.files {
+            if !name.starts_with("rome.json") {
+                let extension = name.split(".").last().unwrap();
+                content.push_str(&format!("## `{name}`\n\n"));
+                content.push_str(&format!("```{extension}"));
+                content.push('\n');
+                content.push_str(&*file_content);
+                content.push('\n');
+                content.push_str("```");
+                content.push_str("\n\n")
+            }
+        }
+
+        if self.messages.len() > 0 {
+            content.push_str("## Messages\n\n");
+
+            for message in &self.messages {
+                let message_content = &*message;
+                // There are some logs that print the timing, and we can't snapshot that message
+                // otherwise at each run we invalid the previous snapshot.
+                //
+                // This is a workaround, and it might not work for all cases.
+                if !message_content.contains("files") {
+                    content.push_str(message_content);
+                    content.push_str("\n\n")
+                }
+            }
+        }
+
+        content
+    }
+}
+
+fn markup_to_string(markup: Markup) -> String {
+    let mut buffer = Vec::new();
+    let mut write = Termcolor(NoColor::new(&mut buffer));
+    let mut fmt = Formatter::new(&mut write);
+    fmt.write_markup(markup).unwrap();
+
+    String::from_utf8(buffer).unwrap()
+}
+
+/// Function used to snapshot a session test of the a CLI run.
+pub fn assert_cli_snapshot(test_name: &str, fs: MemoryFileSystem, console: BufferConsole) {
+    let mut cli_snapshot = CliSnapshot::default();
+    let config_path = PathBuf::from("rome.json");
+    let configuration = fs.read(&config_path).ok();
+    if let Some(mut configuration) = configuration {
+        let mut buffer = String::new();
+        if let Ok(_) = configuration.read_to_string(&mut buffer) {
+            cli_snapshot.configuration = Some(buffer);
+        }
+    }
+
+    for (file, entry) in fs.files() {
+        let content = entry.lock();
+        let content = std::str::from_utf8(content.as_slice()).unwrap();
+
+        cli_snapshot
+            .files
+            .insert(file.to_str().unwrap().to_string(), String::from(content));
+    }
+
+    for message in console.buffer {
+        let content = markup_to_string(markup! {
+            {message.content}
+        });
+        cli_snapshot.messages.push(content)
+    }
+
+    let content = cli_snapshot.emit_content_snapshot();
+
+    insta::with_settings!({
+        prepend_module_to_snapshot => false,
+    }, {
+        insta::assert_snapshot!(test_name, content);
+    });
+}

--- a/crates/rome_cli/tests/snapshots/apply_noop.snap
+++ b/crates/rome_cli/tests/snapshots/apply_noop.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `fix.js`
+
+```js
+
+if(a != 0) {}
+
+```
+
+## Messages
+
+Skipped 1 suggested fixes.
+If you wish to apply the suggested fixes, use the command rome check --apply-suggested
+
+
+

--- a/crates/rome_cli/tests/snapshots/apply_noop.snap
+++ b/crates/rome_cli/tests/snapshots/apply_noop.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 107
+assertion_line: 113
 expression: content
 ---
 ## `fix.js`
@@ -13,8 +13,10 @@ if(a != 0) {}
 
 ## Messages
 
+```block
 Skipped 1 suggested fixes.
 If you wish to apply the suggested fixes, use the command rome check --apply-suggested
 
+```
 
 

--- a/crates/rome_cli/tests/snapshots/apply_ok.snap
+++ b/crates/rome_cli/tests/snapshots/apply_ok.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `fix.js`
+
+```js
+
+if(a != 0) {}
+
+```
+
+## Messages
+
+Skipped 1 suggested fixes.
+If you wish to apply the suggested fixes, use the command rome check --apply-suggested
+
+
+

--- a/crates/rome_cli/tests/snapshots/apply_ok.snap
+++ b/crates/rome_cli/tests/snapshots/apply_ok.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 107
+assertion_line: 113
 expression: content
 ---
 ## `fix.js`
@@ -13,8 +13,10 @@ if(a != 0) {}
 
 ## Messages
 
+```block
 Skipped 1 suggested fixes.
 If you wish to apply the suggested fixes, use the command rome check --apply-suggested
 
+```
 
 

--- a/crates/rome_cli/tests/snapshots/apply_suggested.snap
+++ b/crates/rome_cli/tests/snapshots/apply_suggested.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `fix.js`
+
+```js
+let a = 4;
+
+```
+
+## Messages
+
+

--- a/crates/rome_cli/tests/snapshots/apply_suggested_error.snap
+++ b/crates/rome_cli/tests/snapshots/apply_suggested_error.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `fix.js`
+
+```js
+let a = 4;
+debugger;
+
+```
+
+

--- a/crates/rome_cli/tests/snapshots/downgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/downgrade_severity.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 107
+assertion_line: 113
 expression: content
 ---
 ## `rome.json`
@@ -28,6 +28,7 @@ debugger;
 
 ## Messages
 
+```block
 warning[js/noDebugger]: This is an unexpected use of the debugger statement.
   ┌─ file.js:1:1
   │
@@ -39,5 +40,6 @@ Suggested fix: Remove debugger statement
 0   | - debugger;
 
 
+```
 
 

--- a/crates/rome_cli/tests/snapshots/downgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/downgrade_severity.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+        "recommended": true,
+        "js": {
+            "rules": {
+                "noDebugger": "warn"
+            }
+        }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+debugger;
+```
+
+## Messages
+
+warning[js/noDebugger]: This is an unexpected use of the debugger statement.
+  ┌─ file.js:1:1
+  │
+1 │ debugger;
+  │ ---------
+
+Suggested fix: Remove debugger statement
+    | @@ -1 +0,0 @@
+0   | - debugger;
+
+
+
+

--- a/crates/rome_cli/tests/snapshots/lint_error.snap
+++ b/crates/rome_cli/tests/snapshots/lint_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 107
+assertion_line: 113
 expression: content
 ---
 ## `ci.js`
@@ -12,6 +12,7 @@ for(;true;);
 
 ## Messages
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ ci.js:1:1
   │
@@ -24,7 +25,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
   0 | + for(;true;) {}
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ ci.js:1:1
   │
@@ -37,5 +40,6 @@ Suggested fix: Use a while loop
   0 | + while (true);
 
 
+```
 
 

--- a/crates/rome_cli/tests/snapshots/lint_error.snap
+++ b/crates/rome_cli/tests/snapshots/lint_error.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `ci.js`
+
+```js
+for(;true;);
+
+```
+
+## Messages
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ ci.js:1:1
+  │
+1 │ for(;true;);
+  │ ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1 +1 @@
+0   | - for(;true;);
+  0 | + for(;true;) {}
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ ci.js:1:1
+  │
+1 │ for(;true;);
+  │ ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1 +1 @@
+0   | - for(;true;);
+  0 | + while (true);
+
+
+
+

--- a/crates/rome_cli/tests/snapshots/maximum_diagnostics.snap
+++ b/crates/rome_cli/tests/snapshots/maximum_diagnostics.snap
@@ -1,0 +1,374 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `check.js`
+
+```js
+
+for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+```
+
+## Messages
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:2:1
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │ ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;) {}for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:2:1
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │ ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + while (true);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:2:13
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │             ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;) {}for(;true;);for(;true;);for(;true;);for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:2:13
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │             ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);while (true);for(;true;);for(;true;);for(;true;);for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:2:25
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                         ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;) {}for(;true;);for(;true;);for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:2:25
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                         ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);while (true);for(;true;);for(;true;);for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:2:37
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                                     ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;);for(;true;) {}for(;true;);for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:2:37
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                                     ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;);while (true);for(;true;);for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:2:49
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                                                 ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;);for(;true;);for(;true;) {}for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:2:49
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                                                 ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;);for(;true;);while (true);for(;true;);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:2:61
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                                                             ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;) {}
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:2:61
+  │
+2 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                                                             ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,5 +1,5 @@
+0 0 |   
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);while (true);
+2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:3:1
+  │
+3 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │ ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,6 +1,6 @@
+0 0 |   
+1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  2 | + for(;true;) {}for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:3:1
+  │
+3 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │ ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,6 +1,6 @@
+0 0 |   
+1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  2 | + while (true);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:3:13
+  │
+3 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │             ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,6 +1,6 @@
+0 0 |   
+1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  2 | + for(;true;);for(;true;) {}for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:3:13
+  │
+3 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │             ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,6 +1,6 @@
+0 0 |   
+1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  2 | + for(;true;);while (true);for(;true;);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:3:25
+  │
+3 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                         ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,6 +1,6 @@
+0 0 |   
+1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  2 | + for(;true;);for(;true;);for(;true;) {}for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:3:25
+  │
+3 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                         ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,6 +1,6 @@
+0 0 |   
+1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  2 | + for(;true;);for(;true;);while (true);for(;true;);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useBlockStatements]: Block statements are preferred in this position.
+  ┌─ check.js:3:37
+  │
+3 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                                     ^^^^^^^^^^^^
+
+Suggested fix: Wrap the statement with a `JsBlockStatement`
+    | @@ -1,6 +1,6 @@
+0 0 |   
+1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  2 | + for(;true;);for(;true;);for(;true;);for(;true;) {}for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+error[js/useWhile]: Use while loops instead of for loops.
+  ┌─ check.js:3:37
+  │
+3 │ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  │                                     ^^^^^^^^^^^
+
+Suggested fix: Use a while loop
+    | @@ -1,6 +1,6 @@
+0 0 |   
+1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  2 | + for(;true;);for(;true;);for(;true;);while (true);for(;true;);for(;true;);
+3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+
+
+
+The number of diagnostics exceeds the number allowed by Rome.
+Diagnostics not shown: 76.
+
+

--- a/crates/rome_cli/tests/snapshots/maximum_diagnostics.snap
+++ b/crates/rome_cli/tests/snapshots/maximum_diagnostics.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 107
+assertion_line: 113
 expression: content
 ---
 ## `check.js`
@@ -20,6 +20,7 @@ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 ## Messages
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:2:1
   │
@@ -36,7 +37,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:2:1
   │
@@ -53,7 +56,9 @@ Suggested fix: Use a while loop
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:2:13
   │
@@ -70,7 +75,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:2:13
   │
@@ -87,7 +94,9 @@ Suggested fix: Use a while loop
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:2:25
   │
@@ -104,7 +113,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:2:25
   │
@@ -121,7 +132,9 @@ Suggested fix: Use a while loop
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:2:37
   │
@@ -138,7 +151,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:2:37
   │
@@ -155,7 +170,9 @@ Suggested fix: Use a while loop
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:2:49
   │
@@ -172,7 +189,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:2:49
   │
@@ -189,7 +208,9 @@ Suggested fix: Use a while loop
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:2:61
   │
@@ -206,7 +227,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:2:61
   │
@@ -223,7 +246,9 @@ Suggested fix: Use a while loop
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:3:1
   │
@@ -241,7 +266,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:3:1
   │
@@ -259,7 +286,9 @@ Suggested fix: Use a while loop
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:3:13
   │
@@ -277,7 +306,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:3:13
   │
@@ -295,7 +326,9 @@ Suggested fix: Use a while loop
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:3:25
   │
@@ -313,7 +346,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:3:25
   │
@@ -331,7 +366,9 @@ Suggested fix: Use a while loop
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useBlockStatements]: Block statements are preferred in this position.
   ┌─ check.js:3:37
   │
@@ -349,7 +386,9 @@ Suggested fix: Wrap the statement with a `JsBlockStatement`
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 error[js/useWhile]: Use while loops instead of for loops.
   ┌─ check.js:3:37
   │
@@ -367,8 +406,11 @@ Suggested fix: Use a while loop
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
+```
 
+```block
 The number of diagnostics exceeds the number allowed by Rome.
 Diagnostics not shown: 76.
+```
 
 

--- a/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled.snap
+++ b/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "enabled": false
+  }
+}
+```
+
+## `fix.js`
+
+```js
+
+if(a != -0) {}
+
+```
+
+## Messages
+
+fix.js: error[IO]: unhandled file type
+
+

--- a/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled.snap
+++ b/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 107
+assertion_line: 113
 expression: content
 ---
 ## `rome.json`
@@ -23,6 +23,8 @@ if(a != -0) {}
 
 ## Messages
 
+```block
 fix.js: error[IO]: unhandled file type
+```
 
 

--- a/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled_when_run_apply.snap
+++ b/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled_when_run_apply.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "enabled": false
+  }
+}
+```
+
+## `fix.js`
+
+```js
+
+if(a != -0) {}
+
+```
+
+## Messages
+
+fix.js: error[IO]: unhandled file type
+
+

--- a/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled_when_run_apply.snap
+++ b/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled_when_run_apply.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 107
+assertion_line: 113
 expression: content
 ---
 ## `rome.json`
@@ -23,6 +23,8 @@ if(a != -0) {}
 
 ## Messages
 
+```block
 fix.js: error[IO]: unhandled file type
+```
 
 

--- a/crates/rome_cli/tests/snapshots/should_disable_a_rule.snap
+++ b/crates/rome_cli/tests/snapshots/should_disable_a_rule.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+        "recommended": true,
+        "js": {
+            "rules": {
+                "noDebugger": "off"
+            }
+        }
+    }
+  }
+}
+```
+
+## `fix.js`
+
+```js
+debugger;
+```
+
+## Messages
+
+

--- a/crates/rome_cli/tests/snapshots/should_disable_a_rule_group.snap
+++ b/crates/rome_cli/tests/snapshots/should_disable_a_rule_group.snap
@@ -1,0 +1,34 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 107
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+        "recommended": true,
+        "js": {
+            "recommended": false
+        }
+    }
+  }
+}
+```
+
+## `fix.js`
+
+```js
+try {
+    !a && !b;
+} catch (err) {
+    err = 24;
+}
+
+```
+
+## Messages
+
+

--- a/crates/rome_cli/tests/snapshots/upgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/upgrade_severity.snap
@@ -1,0 +1,46 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 97
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+        "recommended": true,
+        "js": {
+            "rules": {
+                "noDeadCode": "error"
+            }
+        }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```json
+function f() {
+    for (;;) {
+        continue;
+        break;
+    }
+}
+
+```
+
+## Messages
+
+error[js/noDeadCode]: This code is unreachable
+  ┌─ file.js:3:9
+  │  
+3 │ ┌         continue;
+4 │ │         break;
+  │ └──────────────^
+
+
+
+

--- a/crates/rome_console/src/markup.rs
+++ b/crates/rome_console/src/markup.rs
@@ -130,7 +130,7 @@ pub struct Markup<'fmt>(pub &'fmt [MarkupNode<'fmt>]);
 impl<'fmt> Markup<'fmt> {
     pub fn to_owned(&self) -> MarkupBuf {
         let mut result = MarkupBuf(Vec::new());
-        // SAFETY: The implementation of Write for MarkupBuf bellow always returns Ok
+        // SAFETY: The implementation of Write for MarkupBuf below always returns Ok
         Formatter::new(&mut result).write_markup(*self).unwrap();
         result
     }

--- a/crates/rome_fs/src/fs.rs
+++ b/crates/rome_fs/src/fs.rs
@@ -100,6 +100,10 @@ pub trait FileSystemExt: FileSystem {
     fn create(&self, path: &Path) -> io::Result<Box<dyn File>> {
         self.open_with_options(path, OpenOptions::default().write(true).create_new(true))
     }
+    /// Opens a file with read options
+    fn read(&self, path: &Path) -> io::Result<Box<dyn File>> {
+        self.open_with_options(path, OpenOptions::default().read(true).create_new(true))
+    }
 }
 
 type BoxedTraversal<'fs, 'scope> = Box<dyn FnOnce(&dyn TraversalScope<'scope>) + Send + 'fs>;

--- a/crates/rome_fs/src/fs/memory.rs
+++ b/crates/rome_fs/src/fs/memory.rs
@@ -45,8 +45,7 @@ impl MemoryFileSystem {
 
     pub fn files(self) -> IntoIter<PathBuf, FileEntry> {
         let files = self.files.0.into_inner();
-        let iter = files.into_iter();
-        iter
+        files.into_iter()
     }
 }
 

--- a/crates/rome_fs/src/fs/memory.rs
+++ b/crates/rome_fs/src/fs/memory.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::IntoIter;
 use std::{
     collections::HashMap,
     io,
@@ -41,6 +42,12 @@ impl MemoryFileSystem {
         let files = &mut self.files.0.write();
         files.insert(path, Arc::new(Mutex::new(content.into())));
     }
+
+    pub fn files(self) -> IntoIter<PathBuf, FileEntry> {
+        let files = self.files.0.into_inner();
+        let iter = files.into_iter();
+        iter
+    }
 }
 
 impl FileSystem for MemoryFileSystem {
@@ -71,6 +78,20 @@ impl FileSystemExt for MemoryFileSystem {
     }
 
     fn open(&self, path: &Path) -> io::Result<Box<dyn File>> {
+        let files = &self.files.0.read();
+        let entry = files.get(path).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("path {path:?} does not exists in memory filesystem"),
+            )
+        })?;
+
+        let lock = entry.lock_arc();
+
+        Ok(Box::new(MemoryFile { inner: lock }))
+    }
+
+    fn read(&self, path: &Path) -> io::Result<Box<dyn File>> {
         let files = &self.files.0.read();
         let entry = files.get(path).ok_or_else(|| {
             io::Error::new(


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR improves the CLI tests by creating a snapshot. The snapshot will contain:
- the content of the configuration file, if it exists
- the files contained inside the memory file system during the test run of a single test (excluded the configuration file)
- the messages printed by the console, if any (excluded the timing messages)

The reason why I created snapshots it's because I found myself at struggle sometimes, when I needed to test specific cases. Also, there have been few issue before where some messages where not supposed to be there, and I couldn't catch them early. The snapshots, somehow, might help the testing experience a bit.

The snapshot have been added to some existing cases, but not all of them. I had to exclude some runs because of some issue that I couldn't debug (some test stalls for some reason).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The CI should not fail

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
