### PR TITLE
feat(rome_cli): format code via `stdin`

### DIFF
--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -1,8 +1,5 @@
 use crate::commands::format::apply_format_settings_from_cli;
-use crate::{
-    traversal::{traverse, TraversalMode},
-    CliSession, Termination,
-};
+use crate::{execute_mode, CliSession, ExecutionMode, Termination};
 use rome_diagnostics::MAXIMUM_DISPLAYABLE_DIAGNOSTICS;
 use rome_service::load_config;
 use rome_service::settings::WorkspaceSettings;
@@ -63,8 +60,8 @@ pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
         Some(FixFileMode::SafeAndSuggestedFixes)
     };
 
-    traverse(
-        TraversalMode::Check {
+    execute_mode(
+        ExecutionMode::Check {
             max_diagnostics,
             fix_file_mode,
         },

--- a/crates/rome_cli/src/commands/ci.rs
+++ b/crates/rome_cli/src/commands/ci.rs
@@ -1,7 +1,4 @@
-use crate::{
-    traversal::{traverse, TraversalMode},
-    CliSession, Termination,
-};
+use crate::{execute_mode, CliSession, ExecutionMode, Termination};
 use rome_service::load_config;
 use rome_service::settings::WorkspaceSettings;
 use rome_service::workspace::UpdateSettingsParams;
@@ -26,5 +23,5 @@ pub(crate) fn ci(mut session: CliSession) -> Result<(), Termination> {
             settings: workspace_settings,
         })?;
 
-    traverse(TraversalMode::CI, session)
+    execute_mode(ExecutionMode::CI, session)
 }

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -9,11 +9,6 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
     let configuration = load_config(&session.app.fs)?;
     let mut workspace_settings = WorkspaceSettings::default();
 
-    if let Some(configuration) = &configuration {
-        if configuration.is_formatter_disabled() {
-            return Ok(());
-        }
-    }
     if let Some(configuration) = configuration {
         workspace_settings.merge_with_configuration(configuration);
     }

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -27,7 +27,7 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
 
     let stdin = if let Some(stdin_file_path) = stdin_file_path {
         let console = &mut session.app.console;
-        let input_code = console.read(None);
+        let input_code = console.read();
         if let Some(input_code) = input_code {
             let path = PathBuf::from(stdin_file_path);
             Some((path, input_code))

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -2,10 +2,7 @@ use rome_formatter::IndentStyle;
 use rome_service::{load_config, settings::WorkspaceSettings, workspace::UpdateSettingsParams};
 use std::path::PathBuf;
 
-use crate::{
-    traversal::{traverse, TraversalMode},
-    CliSession, Termination,
-};
+use crate::{execute_mode, CliSession, ExecutionMode, Termination};
 
 /// Handler for the "format" command of the Rome CLI
 pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
@@ -54,8 +51,8 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
             settings: workspace_settings,
         })?;
 
-    traverse(
-        TraversalMode::Format {
+    execute_mode(
+        ExecutionMode::Format {
             ignore_errors,
             write: is_write,
             stdin,

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -43,6 +43,7 @@ const FORMAT_OPTIONS: Markup = markup! {
     "<Dim>"--indent-size <number>"</Dim>"        If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
     "<Dim>"--line-width <number>"</Dim>"         Determine how many characters the formatter is allowed to print in a single line (default: 80)
     "<Dim>"--quote-style <single|double>"</Dim>" Determine whether the formatter should use single or double quotes for strings (default: double)
+    "<Dim>"--stdin-file-path <string>"</Dim>"     Mandatory argument to use when piping content via standard input, e.g. echo 'let a;' | rome format --stdin-filepath file.js
 "
 };
 

--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -75,7 +75,7 @@ impl ExecutionMode {
 }
 
 /// Based on the [mode](ExecutionMode), the function might launch a traversal of the file system
-/// or  
+/// or handles the stdin file.
 pub(crate) fn execute_mode(
     mode: ExecutionMode,
     mut session: CliSession,
@@ -102,6 +102,13 @@ pub(crate) fn execute_mode(
                 console.log(markup! {
                     {printed.as_code()}
                 });
+            } else {
+                console.log(markup! {
+                    {content}
+                });
+                console.error(markup!{
+                    <Warn>"The content was not formatted because the formatter is currently disabled."</Warn>
+                })
             }
         }
 

--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -1,0 +1,112 @@
+use crate::traversal::traverse;
+use crate::{CliSession, Termination};
+use rome_console::{markup, ConsoleExt};
+use rome_fs::RomePath;
+use rome_service::workspace::{
+    FeatureName, FixFileMode, FormatFileParams, OpenFileParams, SupportsFeatureParams,
+};
+use std::path::PathBuf;
+
+#[derive(Clone)]
+pub(crate) enum ExecutionMode {
+    /// This mode is enabled when running the command `rome check`
+    Check {
+        /// The maximum number of diagnostics that can be printed in console
+        max_diagnostics: u16,
+
+        /// The type of fixes that should be applied when analyzing a file.
+        ///
+        /// It's [None] if the `check` command is called without `--apply` or `--apply-suggested`
+        /// arguments.
+        fix_file_mode: Option<FixFileMode>,
+    },
+    /// This mode is enabled when running the command `rome ci`
+    CI,
+    /// This mode is enabled when running the command `rome format`
+    Format {
+        /// It ignores parse errors
+        ignore_errors: bool,
+        /// It writes the new content on file
+        write: bool,
+        /// An optional tuple.
+        /// 1. The virtual path to the file
+        /// 2. The content of the file
+        stdin: Option<(PathBuf, String)>,
+    },
+}
+
+impl ExecutionMode {
+    pub(crate) fn get_max_diagnostics(&self) -> Option<u16> {
+        match self {
+            ExecutionMode::Check {
+                max_diagnostics, ..
+            } => Some(*max_diagnostics),
+            _ => None,
+        }
+    }
+
+    /// `true` only when running the traversal in [TraversalMode::Check] and `should_fix` is `true`
+    pub(crate) fn as_fix_file_mode(&self) -> Option<&FixFileMode> {
+        if let ExecutionMode::Check { fix_file_mode, .. } = self {
+            fix_file_mode.as_ref()
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn is_ci(&self) -> bool {
+        matches!(self, ExecutionMode::CI { .. })
+    }
+
+    pub(crate) fn is_check(&self) -> bool {
+        matches!(self, ExecutionMode::Check { .. })
+    }
+
+    pub(crate) fn is_format(&self) -> bool {
+        matches!(self, ExecutionMode::Format { .. })
+    }
+
+    pub(crate) fn as_stdin_file(&self) -> Option<&(PathBuf, String)> {
+        match self {
+            ExecutionMode::Format { stdin, .. } => stdin.as_ref(),
+            _ => None,
+        }
+    }
+}
+
+/// Based on the [mode](ExecutionMode), the function might launch a traversal of the file system
+/// or  
+pub(crate) fn execute_mode(
+    mode: ExecutionMode,
+    mut session: CliSession,
+) -> Result<(), Termination> {
+    // don't do any traversal if there's some content coming from stdin
+    if let Some((path, content)) = mode.as_stdin_file() {
+        let workspace = &*session.app.workspace;
+        let console = &mut *session.app.console;
+        let rome_path = RomePath::new(path, 0);
+
+        if mode.is_format() {
+            let can_format = workspace.supports_feature(SupportsFeatureParams {
+                path: rome_path.clone(),
+                feature: FeatureName::Format,
+            });
+            if can_format {
+                workspace.open_file(OpenFileParams {
+                    path: rome_path.clone(),
+                    version: 0,
+                    content: content.into(),
+                })?;
+                let printed = workspace.format_file(FormatFileParams { path: rome_path })?;
+
+                console.log(markup! {
+                    {printed.as_code()}
+                });
+            }
+        }
+
+        Ok(())
+    } else {
+        traverse(mode, session)
+    }
+}

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -7,11 +7,13 @@ use rome_flags::FeatureFlags;
 use rome_service::App;
 
 mod commands;
+mod execute;
 mod metrics;
 mod panic;
 mod termination;
 mod traversal;
 
+pub(crate) use execute::{execute_mode, ExecutionMode};
 pub use panic::setup_panic_handler;
 pub use termination::Termination;
 

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -336,7 +336,9 @@ pub(crate) enum TraversalMode {
         ignore_errors: bool,
         /// It writes the new content on file
         write: bool,
-        ///
+        /// An optional tuple.
+        /// 1. The virtual path to the file
+        /// 2. The content of the file
         stdin: Option<(PathBuf, String)>,
     },
 }

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -1052,7 +1052,7 @@ mod format {
 
         assert_eq!(content, "function f() {return{}}".to_string());
 
-        assert_cli_snapshot("format_stdin_with_errors", fs, console);
+        assert_cli_snapshot("does_not_format_if_disabled", fs, console);
     }
 }
 

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -974,8 +974,7 @@ mod format {
 
         let message = console
             .out_buffer
-            .iter()
-            .next()
+            .get(0)
             .expect("Console should have written a message");
 
         let content = markup_to_string(markup! {

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -164,11 +164,11 @@ mod check {
             args: Arguments::from_vec(vec![OsString::from("check"), file_path.as_os_str().into()]),
         });
 
-        eprintln!("{:?}", console.buffer);
+        eprintln!("{:?}", console.out_buffer);
 
         assert!(result.is_err());
 
-        let messages = &console.buffer;
+        let messages = &console.out_buffer;
 
         assert_eq!(
             messages
@@ -497,8 +497,8 @@ mod ci {
 
         assert_eq!(content, FORMATTED);
 
-        if console.buffer.len() != 1 {
-            panic!("unexpected console content: {:#?}", console.buffer);
+        if console.out_buffer.len() != 1 {
+            panic!("unexpected console content: {:#?}", console.out_buffer);
         }
     }
 
@@ -560,7 +560,7 @@ mod ci {
             args: Arguments::from_vec(vec![OsString::from("ci"), file_path.as_os_str().into()]),
         });
 
-        eprintln!("{:?}", console.buffer);
+        eprintln!("{:?}", console.out_buffer);
 
         match result {
             Err(Termination::CheckError) => {}
@@ -630,7 +630,7 @@ mod format {
             ]),
         });
 
-        eprintln!("{:?}", console.buffer);
+        eprintln!("{:?}", console.out_buffer);
 
         assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -644,7 +644,7 @@ mod format {
 
         assert_eq!(content, FORMATTED);
 
-        assert_eq!(console.buffer.len(), 1);
+        assert_eq!(console.out_buffer.len(), 1);
     }
 
     // Ensures lint warnings are not printed in format mode
@@ -679,7 +679,12 @@ mod format {
         // The console buffer is expected to contain the following message:
         // 0: "Formatter would have printed the following content"
         // 1: "Compared 1 files"
-        assert_eq!(console.buffer.len(), 2, "console {:#?}", console.buffer);
+        assert_eq!(
+            console.out_buffer.len(),
+            2,
+            "console {:#?}",
+            console.out_buffer
+        );
     }
 
     #[test]
@@ -888,7 +893,7 @@ mod format {
 
         assert!(result.is_ok(), "run_cli returned {result:?}");
 
-        let messages = &console.buffer;
+        let messages = &console.out_buffer;
 
         assert_eq!(
             messages
@@ -929,7 +934,7 @@ mod format {
 
         assert!(result.is_err(), "run_cli returned {result:?}");
 
-        let messages = &console.buffer;
+        let messages = &console.out_buffer;
 
         assert_eq!(
             messages

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -1,5 +1,5 @@
 use rome_console::fmt::{Formatter, Termcolor};
-use rome_console::{markup, BufferConsole, Markup};
+use rome_console::{markup, BufferConsole, Markup, Message};
 use rome_diagnostics::termcolor::NoColor;
 use rome_fs::{FileSystemExt, MemoryFileSystem};
 use std::collections::HashMap;
@@ -7,7 +7,14 @@ use std::fmt::Write as _;
 use std::path::PathBuf;
 
 #[derive(Default)]
+struct InMessages {
+    stdin: Option<String>,
+}
+
+#[derive(Default)]
 struct CliSnapshot {
+    /// input messages, coming from different sources
+    pub in_messages: InMessages,
     /// the configuration, if set
     pub configuration: Option<String>,
     /// file name -> content
@@ -44,8 +51,18 @@ impl CliSnapshot {
             }
         }
 
+        if let Some(stdin) = &self.in_messages.stdin {
+            content.push_str("# Input messages\n\n");
+            content.push_str("```block");
+            content.push('\n');
+            content.push_str(stdin);
+            content.push('\n');
+            content.push_str("```");
+            content.push_str("\n\n")
+        }
+
         if !self.messages.is_empty() {
-            content.push_str("## Messages\n\n");
+            content.push_str("# Emitted Messages\n\n");
 
             for message in &self.messages {
                 let message_content = &*message;
@@ -68,7 +85,7 @@ impl CliSnapshot {
     }
 }
 
-fn markup_to_string(markup: Markup) -> String {
+pub fn markup_to_string(markup: Markup) -> String {
     let mut buffer = Vec::new();
     let mut write = Termcolor(NoColor::new(&mut buffer));
     let mut fmt = Formatter::new(&mut write);
@@ -98,7 +115,14 @@ pub fn assert_cli_snapshot(test_name: &str, fs: MemoryFileSystem, console: Buffe
             .insert(file.to_str().unwrap().to_string(), String::from(content));
     }
 
-    for message in console.buffer {
+    let in_buffer = &console.in_buffer;
+    for (index, message) in in_buffer.iter().enumerate() {
+        if index == 0 {
+            cli_snapshot.in_messages.stdin = Some(message.to_string());
+        }
+    }
+
+    for message in &console.out_buffer {
         let content = markup_to_string(markup! {
             {message.content}
         });

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -1,5 +1,5 @@
 use rome_console::fmt::{Formatter, Termcolor};
-use rome_console::{markup, BufferConsole, Markup, Message};
+use rome_console::{markup, BufferConsole, Markup};
 use rome_diagnostics::termcolor::NoColor;
 use rome_fs::{FileSystemExt, MemoryFileSystem};
 use std::collections::HashMap;

--- a/crates/rome_cli/tests/snapshots/apply_noop.snap
+++ b/crates/rome_cli/tests/snapshots/apply_noop.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 113
+assertion_line: 137
 expression: content
 ---
 ## `fix.js`
@@ -11,7 +11,7 @@ if(a != 0) {}
 
 ```
 
-## Messages
+# Emitted Messages
 
 ```block
 Skipped 1 suggested fixes.

--- a/crates/rome_cli/tests/snapshots/apply_ok.snap
+++ b/crates/rome_cli/tests/snapshots/apply_ok.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 113
+assertion_line: 137
 expression: content
 ---
 ## `fix.js`
@@ -11,7 +11,7 @@ if(a != 0) {}
 
 ```
 
-## Messages
+# Emitted Messages
 
 ```block
 Skipped 1 suggested fixes.

--- a/crates/rome_cli/tests/snapshots/does_not_format_if_disabled.snap
+++ b/crates/rome_cli/tests/snapshots/does_not_format_if_disabled.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 137
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "formatter": {
+    "enabled": false
+  }
+}
+
+```
+
+# Input messages
+
+```block
+function f() {return{}}
+```
+
+# Emitted Messages
+
+```block
+function f() {return{}}
+```
+
+```block
+The content was not formatted because the formatter is currently disabled.
+```
+
+

--- a/crates/rome_cli/tests/snapshots/downgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/downgrade_severity.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 113
+assertion_line: 137
 expression: content
 ---
 ## `rome.json`
@@ -25,7 +25,7 @@ expression: content
 debugger;
 ```
 
-## Messages
+# Emitted Messages
 
 ```block
 warning[js/noDebugger]: This is an unexpected use of the debugger statement.

--- a/crates/rome_cli/tests/snapshots/format_stdin_successfully.snap
+++ b/crates/rome_cli/tests/snapshots/format_stdin_successfully.snap
@@ -3,13 +3,19 @@ source: crates/rome_cli/tests/snap_test.rs
 assertion_line: 137
 expression: content
 ---
-## `fix.js`
+# Input messages
 
-```js
-let a = 4;
-
+```block
+function f() {return{}}
 ```
 
 # Emitted Messages
+
+```block
+function f() {
+	return {};
+}
+
+```
 
 

--- a/crates/rome_cli/tests/snapshots/format_stdin_with_errors.snap
+++ b/crates/rome_cli/tests/snapshots/format_stdin_with_errors.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 113
+assertion_line: 137
 expression: content
 ---
 

--- a/crates/rome_cli/tests/snapshots/format_stdin_with_errors.snap
+++ b/crates/rome_cli/tests/snapshots/format_stdin_with_errors.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 113
+expression: content
+---
+

--- a/crates/rome_cli/tests/snapshots/lint_error.snap
+++ b/crates/rome_cli/tests/snapshots/lint_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 113
+assertion_line: 137
 expression: content
 ---
 ## `ci.js`
@@ -10,7 +10,7 @@ for(;true;);
 
 ```
 
-## Messages
+# Emitted Messages
 
 ```block
 error[js/useBlockStatements]: Block statements are preferred in this position.

--- a/crates/rome_cli/tests/snapshots/maximum_diagnostics.snap
+++ b/crates/rome_cli/tests/snapshots/maximum_diagnostics.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 113
+assertion_line: 137
 expression: content
 ---
 ## `check.js`
@@ -18,7 +18,7 @@ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 ```
 
-## Messages
+# Emitted Messages
 
 ```block
 error[js/useBlockStatements]: Block statements are preferred in this position.

--- a/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled.snap
+++ b/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 113
+assertion_line: 137
 expression: content
 ---
 ## `rome.json`
@@ -21,7 +21,7 @@ if(a != -0) {}
 
 ```
 
-## Messages
+# Emitted Messages
 
 ```block
 fix.js: error[IO]: unhandled file type

--- a/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled_when_run_apply.snap
+++ b/crates/rome_cli/tests/snapshots/no_lint_if_linter_is_disabled_when_run_apply.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 113
+assertion_line: 137
 expression: content
 ---
 ## `rome.json`
@@ -21,7 +21,7 @@ if(a != -0) {}
 
 ```
 
-## Messages
+# Emitted Messages
 
 ```block
 fix.js: error[IO]: unhandled file type

--- a/crates/rome_cli/tests/snapshots/should_disable_a_rule.snap
+++ b/crates/rome_cli/tests/snapshots/should_disable_a_rule.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 113
+assertion_line: 137
 expression: content
 ---
 ## `rome.json`
@@ -24,6 +24,6 @@ expression: content
 debugger;
 ```
 
-## Messages
+# Emitted Messages
 
 

--- a/crates/rome_cli/tests/snapshots/should_disable_a_rule_group.snap
+++ b/crates/rome_cli/tests/snapshots/should_disable_a_rule_group.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 107
+assertion_line: 137
 expression: content
 ---
 ## `rome.json`
@@ -29,6 +29,6 @@ try {
 
 ```
 
-## Messages
+# Emitted Messages
 
 

--- a/crates/rome_cli/tests/snapshots/upgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/upgrade_severity.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 97
+assertion_line: 137
 expression: content
 ---
 ## `rome.json`
@@ -11,9 +11,7 @@ expression: content
     "rules": {
         "recommended": true,
         "js": {
-            "rules": {
-                "noDeadCode": "error"
-            }
+            "noDeadCode": "error"
         }
     }
   }
@@ -22,7 +20,7 @@ expression: content
 
 ## `file.js`
 
-```json
+```js
 function f() {
     for (;;) {
         continue;
@@ -32,8 +30,9 @@ function f() {
 
 ```
 
-## Messages
+# Emitted Messages
 
+```block
 error[js/noDeadCode]: This code is unreachable
   ┌─ file.js:3:9
   │  
@@ -42,5 +41,6 @@ error[js/noDeadCode]: This code is unreachable
   │ └──────────────^
 
 
+```
 
 

--- a/crates/rome_console/src/codespan/mod.rs
+++ b/crates/rome_console/src/codespan/mod.rs
@@ -615,7 +615,7 @@ labore et dolore magna aliqua";
             {codespan}
         });
 
-        let mut iter = console.buffer.into_iter();
+        let mut iter = console.out_buffer.into_iter();
 
         let message = iter
             .next()

--- a/crates/rome_console/src/diff.rs
+++ b/crates/rome_console/src/diff.rs
@@ -423,7 +423,7 @@ function name(args) {
             {diff}
         });
 
-        let mut messages = console.buffer.into_iter();
+        let mut messages = console.out_buffer.into_iter();
         let message = match messages.next() {
             Some(msg) => msg,
             other => panic!("unexpected message {other:?}"),
@@ -447,7 +447,7 @@ function name(args) {
             {diff}
         });
 
-        let mut messages = console.buffer.into_iter();
+        let mut messages = console.out_buffer.into_iter();
         let message = match messages.next() {
             Some(msg) => msg,
             other => panic!("unexpected message {other:?}"),

--- a/crates/rome_console/src/lib.rs
+++ b/crates/rome_console/src/lib.rs
@@ -32,7 +32,7 @@ pub trait Console: Send + Sync + RefUnwindSafe {
     fn print(&mut self, level: LogLevel, args: Markup);
 
     /// It reads from a source, and if this source contains something, it's converted into a [String]
-    fn read(&mut self, prompt: Option<Markup>) -> Option<String>;
+    fn read(&mut self) -> Option<String>;
 }
 
 /// Extension trait for [Console] providing convenience printing methods
@@ -99,8 +99,8 @@ impl Console for EnvConsole {
         writeln!(out).unwrap();
     }
 
-    fn read(&mut self, _prompt: Option<Markup>) -> Option<String> {
-        // Here we check stdin is redirected. If not, we bail.
+    fn read(&mut self) -> Option<String> {
+        // Here we check if stdin is redirected. If not, we bail.
         //
         // Doing this check allows us to pipe stdin to rome, without expecting
         // user content when we call `read_to_string`
@@ -140,7 +140,7 @@ impl Console for BufferConsole {
             content: args.to_owned(),
         });
     }
-    fn read(&mut self, _prompt: Option<Markup>) -> Option<String> {
+    fn read(&mut self) -> Option<String> {
         if self.in_buffer.is_empty() {
             None
         } else {

--- a/crates/rome_console/src/lib.rs
+++ b/crates/rome_console/src/lib.rs
@@ -1,8 +1,7 @@
 use atty::Stream;
 use std::io;
-use std::io::{BufRead, Read, Stdin, Write};
+use std::io::{Read, Stdin, Write};
 use std::panic::RefUnwindSafe;
-
 use termcolor::{ColorChoice, StandardStream};
 use write::Termcolor;
 
@@ -142,6 +141,12 @@ impl Console for BufferConsole {
         });
     }
     fn read(&mut self, _prompt: Option<Markup>) -> Option<String> {
-        todo!()
+        if self.in_buffer.is_empty() {
+            None
+        } else {
+            // for the time being we simple return the first message, as we don't
+            // particular use case for multiple prompts
+            Some(self.in_buffer[0].clone())
+        }
     }
 }

--- a/crates/rome_diagnostics/src/emit.rs
+++ b/crates/rome_diagnostics/src/emit.rs
@@ -348,7 +348,7 @@ labore et dolore magna aliqua";
             {diag.display(&files)}
         });
 
-        let mut iter = console.buffer.into_iter();
+        let mut iter = console.out_buffer.into_iter();
 
         let message = match iter.next() {
             Some(msg) => msg,

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -65,12 +65,16 @@ impl Display for RomeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             RomeError::SourceFileNotSupported(path) => {
-                let ext = path
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .unwrap_or("<unknown>");
+                let ext = path.extension().and_then(|ext| ext.to_str());
 
-                write!(f, "Rome doesn't support the file extension {ext:?} yet")
+                if let Some(ext) = ext {
+                    write!(f, "Rome doesn't support the file extension {ext:?} yet")
+                } else {
+                    write!(
+                        f,
+                        "Rome can't process the file because it doesn't have a clear extension"
+                    )
+                }
             }
             RomeError::NotFound => {
                 write!(f, "the file does not exist in the workspace")


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #3042 

The implementation of `read` is very simple at the moment and it doesn't take in consideration the `prompt` for now. But it's there because it will be needed in the future.

I also enhanced the CLI snapshot to take the "in" messages in consideration.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

New test cases added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
