### PR TITLE
feature(rome_js_semantic): Semantic model supporting "module.exports"

### DIFF
--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -720,18 +720,19 @@ impl SemanticEventExtractor {
         let reference_parent = reference.parent();
         let reference_greatparent = reference_parent.as_ref().and_then(|p| p.parent());
 
-        // export
+        // check export keyword
         matches!(
             reference_parent.as_ref().map(|p| p.kind()),
             Some(JS_EXPORT_NAMED_SHORTHAND_SPECIFIER | JS_EXPORT_NAMED_SPECIFIER)
         ) | {
-            let is_export_default = matches!(
+            // check "export default" keyword
+            matches!(
                 reference_greatparent.as_ref().map(|p| p.kind()),
                 Some(JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE)
-            );
-            is_export_default
+            )
         } | {
-            let is_module_exports = match reference_parent.map(|x| x.kind()) {
+            // check module.exports
+            match reference_parent.map(|x| x.kind()) {
                 Some(JS_IDENTIFIER_EXPRESSION) => reference_greatparent
                     .map(|x| self.is_assignment_left_side_module_exports(&x))
                     .unwrap_or(false),
@@ -740,8 +741,7 @@ impl SemanticEventExtractor {
                     .map(|x| self.is_assignment_left_side_module_exports(&x))
                     .unwrap_or(false),
                 _ => false,
-            };
-            is_module_exports
+            }
         }
     }
 

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -1049,8 +1049,12 @@ mod test {
     #[test]
     pub fn ok_semantic_model_is_exported() {
         // Variables
-        assert_is_exported(true, "A", "const A = 1; export {A}");
+        assert_is_exported(false, "A", "const A = 1");
         assert_is_exported(true, "A", "export const A = 1");
+        assert_is_exported(true, "A", "const A = 1; export default A");
+        assert_is_exported(true, "A", "const A = 1; export {A}");
+        assert_is_exported(true, "A", "const A = 1; module.exports = A;");
+        assert_is_exported(true, "A", "const A = 1; module.exports = {A};");
 
         // Functions
         assert_is_exported(false, "f", "function f() {}");
@@ -1059,13 +1063,19 @@ mod test {
         assert_is_exported(true, "f", "function f() {} export default f");
         assert_is_exported(true, "f", "function f() {} export {f}");
         assert_is_exported(true, "f", "function f() {} export {f as g}");
+        assert_is_exported(true, "f", "module.exports = function f() {}");
+        assert_is_exported(true, "f", "function f() {} module.exports = f");
+        assert_is_exported(true, "f", "function f() {} module.exports = {f}");
 
-        // Class
+        // Classess
         assert_is_exported(false, "A", "class A{}");
         assert_is_exported(true, "A", "export class A{}");
         assert_is_exported(true, "A", "export default class A{}");
         assert_is_exported(true, "A", "class A{} export default A");
         assert_is_exported(true, "A", "class A{} export {A}");
         assert_is_exported(true, "A", "class A{} export {A as B}");
+        assert_is_exported(true, "A", "module.exports = class A{}");
+        assert_is_exported(true, "A", "class A{} module.exports = A");
+        assert_is_exported(true, "A", "class A{} module.exports = {A}");
     }
 }

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -1055,6 +1055,8 @@ mod test {
         assert_is_exported(true, "A", "const A = 1; export {A}");
         assert_is_exported(true, "A", "const A = 1; module.exports = A;");
         assert_is_exported(true, "A", "const A = 1; module.exports = {A};");
+        assert_is_exported(true, "A", "const A = 1; exports = A;");
+        assert_is_exported(true, "A", "const A = 1; exports.A = A;");
 
         // Functions
         assert_is_exported(false, "f", "function f() {}");
@@ -1064,8 +1066,12 @@ mod test {
         assert_is_exported(true, "f", "function f() {} export {f}");
         assert_is_exported(true, "f", "function f() {} export {f as g}");
         assert_is_exported(true, "f", "module.exports = function f() {}");
+        assert_is_exported(true, "f", "exports = function f() {}");
+        assert_is_exported(true, "f", "exports.f = function f() {}");
         assert_is_exported(true, "f", "function f() {} module.exports = f");
         assert_is_exported(true, "f", "function f() {} module.exports = {f}");
+        assert_is_exported(true, "f", "function f() {} exports = f");
+        assert_is_exported(true, "f", "function f() {} exports.f = f");
 
         // Classess
         assert_is_exported(false, "A", "class A{}");
@@ -1075,7 +1081,9 @@ mod test {
         assert_is_exported(true, "A", "class A{} export {A}");
         assert_is_exported(true, "A", "class A{} export {A as B}");
         assert_is_exported(true, "A", "module.exports = class A{}");
+        assert_is_exported(true, "A", "exports = class A{}");
         assert_is_exported(true, "A", "class A{} module.exports = A");
-        assert_is_exported(true, "A", "class A{} module.exports = {A}");
+        assert_is_exported(true, "A", "class A{} exports = A");
+        assert_is_exported(true, "A", "class A{} exports.A = A");
     }
 }

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -119,9 +119,9 @@ f();",
 assert_semantics! {
     ok_read_function, r#"function f/*#F*/() {} console.log(f/*READ F*/);"#,
     ok_write_function, r#"function f/*#F*/() {} f/*WRITE F*/ = null;"#,
-    ok_scope_function_expression_read, "var f/*#F1*/ = function f/*#F2*/() {console.log(f/*READ F2*/);}",
+    ok_scope_function_expression_read, "var f/*#F1*/ = function f/*#F2*/() {console.log(f/*READ F2*/);}; f/*READ F1*/();",
     ok_scope_function_expression_read1 ,"var f/*#F1*/ = function () {console.log(f/*READ F1*/);}",
-    ok_scope_function_expression_read2, "let f/*#F1*/ = 1; let g = function f/*#F2*/() {console.log(2, f/*READ F2*/);}",
+    ok_scope_function_expression_read2, "let f/*#F1*/ = 1; let g = function f/*#F2*/() {console.log(2, f/*READ F2*/);}; console.log(f/*READ F1*/);",
 }
 
 assert_semantics! {


### PR DESCRIPTION
## Summary

This PR improves the semantic model ```ìs_exported``` query to take ```module.exports``` into consideration.

## Test Plan

```
 cargo test -p rome_js_semantic -- ok_semantic_model_is_exported
```
