### PR TITLE
fix(cargo): fix a typo in cargo manifests and add a repository field

### DIFF
--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_analyze"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_cli"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_console/Cargo.toml
+++ b/crates/rome_console/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_console"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_control_flow/Cargo.toml
+++ b/crates/rome_control_flow/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_control_flow"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_css_factory/Cargo.toml
+++ b/crates/rome_css_factory/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_css_factory"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 

--- a/crates/rome_css_syntax/Cargo.toml
+++ b/crates/rome_css_syntax/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_css_syntax"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 

--- a/crates/rome_flags/Cargo.toml
+++ b/crates/rome_flags/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_flags"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_formatter/Cargo.toml
+++ b/crates/rome_formatter/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_formatter"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_fs/Cargo.toml
+++ b/crates/rome_fs/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_fs"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_js_analyze"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 [dependencies]

--- a/crates/rome_js_factory/Cargo.toml
+++ b/crates/rome_js_factory/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_js_factory"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_js_formatter/Cargo.toml
+++ b/crates/rome_js_formatter/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_js_formatter"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_js_parser/Cargo.toml
+++ b/crates/rome_js_parser/Cargo.toml
@@ -3,7 +3,6 @@ edition = "2021"
 name = "rome_js_parser"
 version = "0.0.0"
 authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
 license = "MIT"
 description = "An extremely fast ECMAScript parser made for the rslint project"
 repository = "https://github.com/rome/tools"

--- a/crates/rome_js_parser/Cargo.toml
+++ b/crates/rome_js_parser/Cargo.toml
@@ -2,7 +2,8 @@
 edition = "2021"
 name = "rome_js_parser"
 version = "0.0.0"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 description = "An extremely fast ECMAScript parser made for the rslint project"
 repository = "https://github.com/rome/tools"

--- a/crates/rome_js_semantic/Cargo.toml
+++ b/crates/rome_js_semantic/Cargo.toml
@@ -3,7 +3,6 @@ edition = "2021"
 name = "rome_js_semantic"
 version = "0.0.0"
 authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
 license = "MIT"
 description = "Semantic model for the JavaScript language"
 repository = "https://github.com/rome/tools"

--- a/crates/rome_js_semantic/Cargo.toml
+++ b/crates/rome_js_semantic/Cargo.toml
@@ -2,7 +2,8 @@
 edition = "2021"
 name = "rome_js_semantic"
 version = "0.0.0"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 description = "Semantic model for the JavaScript language"
 repository = "https://github.com/rome/tools"

--- a/crates/rome_json_factory/Cargo.toml
+++ b/crates/rome_json_factory/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_json_factory"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_lsp"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_markup/Cargo.toml
+++ b/crates/rome_markup/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.0.0"
 description = ""
 license = "MIT"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 
 [lib]
 proc-macro = true

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_service"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/website/playground/Cargo.toml
+++ b/website/playground/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rome_playground"
 version = "0.0.0"
 edition = "2021"
-authors = ["Rome Tools Developers and Contributros"]
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 license = "MIT"
 
 [package.metadata.wasm-pack.profile.dev]


### PR DESCRIPTION
## Summary

Fix a typo that got copy-pasted in many `Cargo.toml` files, and add a `repository` field to the manifests

## Test Plan

N/A
