### PR TITLE
support for jsx reference inside the semantic model

### DIFF
--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js
@@ -42,3 +42,7 @@ export function exported_function() {}
 
 function exported_function_2() {}
 export { exported_function_2 };
+
+let value;
+function Button() {}
+console.log(<Button att={value}/>);

--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js.snap
@@ -49,6 +49,10 @@ export function exported_function() {}
 function exported_function_2() {}
 export { exported_function_2 };
 
+let value;
+function Button() {}
+console.log(<Button att={value}/>);
+
 ```
 
 # Diagnostics

--- a/crates/rome_js_semantic/src/tests/assertions.rs
+++ b/crates/rome_js_semantic/src/tests/assertions.rs
@@ -101,7 +101,11 @@ use std::collections::{BTreeMap, HashMap};
 /// if(true) ;/*NOEVENT*/;
 /// ```
 pub fn assert(code: &str, test_name: &str) {
-    let r = rome_js_parser::parse(code, 0, SourceType::js_module());
+    let r = rome_js_parser::parse(
+        code,
+        0,
+        SourceType::js_module().with_variant(rome_js_syntax::LanguageVariant::Jsx),
+    );
 
     if r.has_errors() {
         let files = SimpleFile::new(test_name.to_string(), code.into());

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -124,6 +124,11 @@ assert_semantics! {
     ok_scope_function_expression_read2, "let f/*#F1*/ = 1; let g = function f/*#F2*/() {console.log(2, f/*READ F2*/);}; console.log(f/*READ F1*/);",
 }
 
+// Imports
+assert_semantics! {
+    ok_import_used_in_jsx, r#"import A/*#A*/ from 'a.js'; console.log(<A/*READ A*//>);"#,
+}
+
 assert_semantics! {
     ok_unmatched_reference, r#"a/*?*/"#,
     ok_function_expression_read,"let f/*#F*/ = function g/*#G*/(){}; g/*?*/();",


### PR DESCRIPTION
## Summary

Expands on https://github.com/rome/tools/issues/2979 with functions, imports that are only used inside JSX.

## Test Plan

