### PR TITLE
Fix typo in project-config.md

### DIFF
--- a/website/src/_includes/docs/project-config.md
+++ b/website/src/_includes/docs/project-config.md
@@ -15,7 +15,7 @@ We aim to offer everything out of the box and only introduce configuration if [a
 ```json
 {
   "formatter": {
-    "identStyle": "tab",
+    "indentStyle": "tab",
     "lineWidth": 120
   },
   "linter": {


### PR DESCRIPTION
## Summary
`indentStyle` was misspelled as `identStyle` in example at the top.
I don't really know why GitHub marks the last line as changed, I haven't touched it.


Sorry I removed a lot of the template, didn't feel it was necessary for such a simple change. Sorry if this was out of line.