### PR TITLE
feat(rome_js_analyze): support unused bindings inside typescript function type

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_unused_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_unused_variables.rs
@@ -85,7 +85,8 @@ fn is_typescript_unused_ok(binding: &JsIdentifierBinding) -> Option<()> {
                     match parameters.syntax().parent()?.kind() {
                         JsSyntaxKind::TS_METHOD_SIGNATURE_CLASS_MEMBER
                         | JsSyntaxKind::TS_CALL_SIGNATURE_TYPE_MEMBER
-                        | JsSyntaxKind::TS_METHOD_SIGNATURE_TYPE_MEMBER => Some(()),
+                        | JsSyntaxKind::TS_METHOD_SIGNATURE_TYPE_MEMBER
+                        | JsSyntaxKind::TS_FUNCTION_TYPE => Some(()),
                         _ => None,
                     }
                 }

--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts
@@ -28,3 +28,8 @@ class C {
 	f(a: number);
 }
 console.log(new C());
+
+function f(fn: (title: string) => boolean) {
+	console.log(fn);
+}
+f();

--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts.snap
@@ -35,6 +35,11 @@ class C {
 }
 console.log(new C());
 
+function f(fn: (title: string) => boolean) {
+	console.log(fn);
+}
+f();
+
 ```
 
 # Diagnostics


### PR DESCRIPTION
## Summary

Expands https://github.com/rome/tools/issues/2979.  
Accept "unused variable" when it is a binding inside Typescript function type. Example:

```ts
function f(fn: (title: string) => boolean) { }
```

```title``` is not used, but it is useful here.

## Test Plan

```
> cargo test -p rome_js_analyze
```
