### PR TITLE
feat(rome_formatter): Dedent to Root IR

### DIFF
--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -709,7 +709,7 @@ where
 {
     Dedent {
         content: Argument::new(content),
-        mode: DedentMode::OneLevel,
+        mode: DedentMode::Level,
     }
 }
 
@@ -762,7 +762,7 @@ impl<Context> std::fmt::Debug for Dedent<'_, Context> {
 ///             align(2, &format_args![
 ///                 hard_line_break(),
 ///                 text("two space align"),
-///                 dedent_root(&format_args![
+///                 dedent_to_root(&format_args![
 ///                     hard_line_break(),
 ///                     text("starts at the beginning of the line")
 ///                 ]),
@@ -783,7 +783,7 @@ impl<Context> std::fmt::Debug for Dedent<'_, Context> {
 ///
 /// This resembles the behaviour of Prettier's `align(Number.NEGATIVE_INFINITY, content)` IR element.
 #[inline]
-pub fn dedent_root<Content, Context>(content: &Content) -> Dedent<Context>
+pub fn dedent_to_root<Content, Context>(content: &Content) -> Dedent<Context>
 where
     Content: Format<Context>,
 {

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -40,9 +40,9 @@ pub enum FormatElement {
     /// Nesting (Aligns)[FormatElement::Align] has the effect that all except the most inner align are handled as (Indent)[FormatElement::Indent].
     Align(Align),
 
-    /// Reduces the indention of the specified content by one. Reverse operation of `Indent` and can be used to
-    /// *undo` an `Align` for nested content.
-    Dedent(Content),
+    /// Reduces the indention of the specified content either by one level or to the root, depending on the mode.
+    /// Reverse operation of `Indent` and can be used to *undo* an `Align` for nested content.
+    Dedent { content: Content, mode: DedentMode },
 
     /// Creates a logical group where its content is either consistently printed:
     /// * on a single line: Omitting `LineMode::Soft` line breaks and printing spaces for `LineMode::SoftOrSpace`
@@ -161,7 +161,11 @@ impl std::fmt::Debug for FormatElement {
             FormatElement::Space => write!(fmt, "Space"),
             FormatElement::Line(content) => fmt.debug_tuple("Line").field(content).finish(),
             FormatElement::Indent(content) => fmt.debug_tuple("Indent").field(content).finish(),
-            FormatElement::Dedent(content) => fmt.debug_tuple("Dedent").field(content).finish(),
+            FormatElement::Dedent { content, mode } => fmt
+                .debug_struct("Dedent")
+                .field("content", content)
+                .field("mode", mode)
+                .finish(),
             FormatElement::Align(Align { count, content }) => fmt
                 .debug_struct("Align")
                 .field("count", count)
@@ -332,6 +336,15 @@ impl PrintMode {
     pub const fn is_expanded(&self) -> bool {
         matches!(self, PrintMode::Expanded)
     }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum DedentMode {
+    /// Reduces the indent by one level
+    OneLevel,
+
+    /// Reduces the indent to the root
+    Root,
 }
 
 /// Provides the printer with different representations for the same element so that the printer
@@ -660,7 +673,7 @@ impl FormatElement {
             | FormatElement::Verbatim(Verbatim { content, .. })
             | FormatElement::Label(Label { content, .. })
             | FormatElement::Indent(content)
-            | FormatElement::Dedent(content)
+            | FormatElement::Dedent { content, .. }
             | FormatElement::Align(Align { content, .. }) => {
                 content.iter().any(FormatElement::will_break)
             }
@@ -801,8 +814,18 @@ impl Format<IrFormatContext> for FormatElement {
             FormatElement::Indent(content) => {
                 write!(f, [text("indent("), content.as_ref(), text(")")])
             }
-            FormatElement::Dedent(content) => {
-                write!(f, [text("dedent("), content.as_ref(), text(")")])
+            FormatElement::Dedent { content, mode } => {
+                write!(
+                    f,
+                    [
+                        text("dedent("),
+                        dynamic_text(&std::format!("{mode:?}"), TextSize::default()),
+                        text(","),
+                        space(),
+                        content.as_ref(),
+                        text(")")
+                    ]
+                )
             }
             FormatElement::Align(Align { content, count }) => {
                 write!(

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -340,8 +340,8 @@ impl PrintMode {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DedentMode {
-    /// Reduces the indent by one level
-    OneLevel,
+    /// Reduces the indent by a level (if the current indent is > 0)
+    Level,
 
     /// Reduces the indent to the root
     Root,
@@ -815,17 +815,12 @@ impl Format<IrFormatContext> for FormatElement {
                 write!(f, [text("indent("), content.as_ref(), text(")")])
             }
             FormatElement::Dedent { content, mode } => {
-                write!(
-                    f,
-                    [
-                        text("dedent("),
-                        dynamic_text(&std::format!("{mode:?}"), TextSize::default()),
-                        text(","),
-                        space(),
-                        content.as_ref(),
-                        text(")")
-                    ]
-                )
+                let label = match mode {
+                    DedentMode::Level => "dedent",
+                    DedentMode::Root => "dedentRoot",
+                };
+
+                write!(f, [text(label), text("("), content.as_ref(), text(")")])
             }
             FormatElement::Align(Align { content, count }) => {
                 write!(

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -187,7 +187,7 @@ impl<'a> Printer<'a> {
 
             FormatElement::Dedent { content, mode } => {
                 let args = match mode {
-                    DedentMode::OneLevel => args.decrement_indent(),
+                    DedentMode::Level => args.decrement_indent(),
                     DedentMode::Root => args.reset_indent(),
                 };
                 queue.extend_with_args(content.iter(), args);
@@ -880,7 +880,7 @@ fn fits_element_on_line<'a, 'rest>(
 
         FormatElement::Dedent { content, mode } => {
             let args = match mode {
-                DedentMode::OneLevel => args.decrement_indent(),
+                DedentMode::Level => args.decrement_indent(),
                 DedentMode::Root => args.reset_indent(),
             };
             queue.extend(content.iter(), args)


### PR DESCRIPTION
## Summary

This PR extends the `dedent` IR element to support dedenting by one level or to the start of the line.

I intentionally called the mode `root` because it may become necessary in the future that it's possible to mark a root which is different to the start of the line.

This IR is necessary to correctly format `TemplateLiteral`s where inserting any indent characters that weren't present of the template in the source changes the `template`s content at runtime.

## Test Plan

I added a doc test demonstrating how the IR can be used and verifies that the printer correctly resets the indent level.