### PR TITLE
fix(rome_formatter): `write!` dropped while still borrowed 

### DIFF
--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -67,7 +67,8 @@ macro_rules! format_args {
 #[macro_export]
 macro_rules! write {
     ($dst:expr, [$($arg:expr),+ $(,)?]) => {{
-        $dst.write_fmt($crate::format_args!($($arg),+))
+        let result = $dst.write_fmt($crate::format_args!($($arg),+));
+        result
     }}
 }
 
@@ -103,7 +104,8 @@ macro_rules! dbg_write {
             );
             count += 1;
         });
-        inspect.write_fmt($crate::format_args!($($arg),+))
+        let result = inspect.write_fmt($crate::format_args!($($arg),+));
+        result
     }}
 }
 

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -526,8 +526,7 @@ impl FlattenedBinaryExpressionPart {
             FlattenedBinaryExpressionPart::Right { parent } => {
                 let right = JsAnyBinaryLikeLeftExpression::JsAnyExpression(parent.right()?);
 
-                write!(f, [format_sub_expression(parent.operator()?, &right)])?;
-                Ok(())
+                write!(f, [format_sub_expression(parent.operator()?, &right)])
             }
             FlattenedBinaryExpressionPart::Left { expression } => {
                 write!(f, [expression])


### PR DESCRIPTION
This fixes an issue where using `write!` with a borrowed value didn't compile at the end of a block

```
error[E0597]: `right` does not live long enough
   --> crates/rome_js_formatter/src/utils/binary_like_expression.rs:529:70
    |
529 |                 write!(f, [format_sub_expression(parent.operator()?, &right)])
    |                            ------------------------------------------^^^^^^-
    |                            |                                         |
    |                            |                                         borrowed value does not live long enough
    |                            a temporary with access to the borrow is created here ...
530 |             }
    |             -
    |             |
    |             `right` dropped here while still borrowed
    |             ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `impl rome_formatter::Format<context::JsFormatContext>`
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
   --> |/home/micha/git/rome/crates/rome_formatter/src/macros.rs:70:9
    |
70  |         let x = $dst.write_fmt($crate::format_args!($($arg),+)); x
```

This PR implements the recommended fix as part of the macro, similar to `std::write!`

## Test

Having the `write!` call as  the last expression in the block compiles successfully (see binary expression formatting)
