### PR TITLE
fix(rome_bin): fix the parsing of the internal CLI arguments for the daemon server in debug mode

### DIFF
--- a/crates/rome_bin/src/main.rs
+++ b/crates/rome_bin/src/main.rs
@@ -17,13 +17,12 @@ mod service;
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() -> Result<(), Termination> {
-    let mut args = Arguments::from_env();
+    let args = Arguments::from_env();
 
-    if args.contains("__print_socket") {
-        print_server_socket()
-    } else if args.contains("__run_server") {
-        run_server_session()
-    } else {
-        run_cli_session(args)
+    let subcommand = args.clone().subcommand();
+    match subcommand.as_ref().map(Option::as_deref) {
+        Ok(Some("__print_socket")) => print_server_socket(),
+        Ok(Some("__run_server")) => run_server_session(),
+        _ => run_cli_session(args),
     }
 }


### PR DESCRIPTION
## Summary

The `rome_bin` distribution is temporarily using "internal" arguments starting with `__` to control the daemon server process, but the `pico_args` library forbids argument names from starting with anything other than `-` in debug mode. I modified the parsing logic to use a subcommand instead of an argument, since those do not have the same naming restrictions.

## Test Plan

This change sits at the very top-level of the entire binary distribution, so it's not really easily testable except by first building the CLI then having the tests actually run the resulting binary. Not impossible, but for now I've just manually run `cargo rome-cli-dev __run_server` and checked that it didn't panic on start
