### PR TITLE
refactor: Using default derive macro instead of manual implementation for Enum

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -76,7 +76,7 @@ use std::str::FromStr;
 #[derive(Default)]
 pub enum IndentStyle {
     /// Tab
-	#[default]
+    #[default]
     Tab,
     /// Space, with its quantity
     Space(u8),
@@ -95,7 +95,6 @@ impl IndentStyle {
         matches!(self, IndentStyle::Space(_))
     }
 }
-
 
 impl FromStr for IndentStyle {
     type Err = &'static str;

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -73,8 +73,10 @@ use std::str::FromStr;
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
 )]
+#[derive(Default)]
 pub enum IndentStyle {
     /// Tab
+	#[default]
     Tab,
     /// Space, with its quantity
     Space(u8),
@@ -94,11 +96,6 @@ impl IndentStyle {
     }
 }
 
-impl Default for IndentStyle {
-    fn default() -> Self {
-        Self::Tab
-    }
-}
 
 impl FromStr for IndentStyle {
     type Err = &'static str;

--- a/crates/rome_formatter/src/token.rs
+++ b/crates/rome_formatter/src/token.rs
@@ -467,17 +467,13 @@ where
 
 /// Determines if the whitespace separating comment trivia
 /// from their associated tokens should be printed or trimmed
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub enum TriviaPrintMode {
+    #[default]
     Full,
     Trim,
 }
 
-impl Default for TriviaPrintMode {
-    fn default() -> Self {
-        Self::Full
-    }
-}
 
 /// Formats the leading trivia (comments, skipped token trivia) of a token
 pub fn format_leading_trivia<L: Language>(token: &SyntaxToken<L>) -> FormatLeadingTrivia<L> {

--- a/crates/rome_formatter/src/token.rs
+++ b/crates/rome_formatter/src/token.rs
@@ -474,7 +474,6 @@ pub enum TriviaPrintMode {
     Trim,
 }
 
-
 /// Formats the leading trivia (comments, skipped token trivia) of a token
 pub fn format_leading_trivia<L: Language>(token: &SyntaxToken<L>) -> FormatLeadingTrivia<L> {
     FormatLeadingTrivia {

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -193,7 +193,6 @@ pub enum QuoteStyle {
     Single,
 }
 
-
 impl FromStr for QuoteStyle {
     type Err = &'static str;
 

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -186,16 +186,13 @@ impl CommentStyle<JsLanguage> for JsCommentStyle {
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
 )]
+#[derive(Default)]
 pub enum QuoteStyle {
+    #[default]
     Double,
     Single,
 }
 
-impl Default for QuoteStyle {
-    fn default() -> Self {
-        Self::Double
-    }
-}
 
 impl FromStr for QuoteStyle {
     type Err = &'static str;

--- a/crates/rome_js_formatter/src/separated.rs
+++ b/crates/rome_js_formatter/src/separated.rs
@@ -181,7 +181,7 @@ impl<T> FormatAstSeparatedListExtension for T where T: AstSeparatedList<Language
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum TrailingSeparator {
     /// A trailing separator is allowed and preferred
-	#[default]
+    #[default]
     Allowed,
 
     /// A trailing separator is not allowed

--- a/crates/rome_js_formatter/src/separated.rs
+++ b/crates/rome_js_formatter/src/separated.rs
@@ -178,9 +178,10 @@ pub trait FormatAstSeparatedListExtension: AstSeparatedList<Language = JsLanguag
 
 impl<T> FormatAstSeparatedListExtension for T where T: AstSeparatedList<Language = JsLanguage> {}
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum TrailingSeparator {
     /// A trailing separator is allowed and preferred
+	#[default]
     Allowed,
 
     /// A trailing separator is not allowed
@@ -192,12 +193,6 @@ pub enum TrailingSeparator {
     /// A trailing separator might be present, but the consumer
     /// decides to remove it
     Omit,
-}
-
-impl Default for TrailingSeparator {
-    fn default() -> Self {
-        TrailingSeparator::Allowed
-    }
 }
 
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]

--- a/crates/rome_js_parser/src/lexer/mod.rs
+++ b/crates/rome_js_parser/src/lexer/mod.rs
@@ -73,7 +73,7 @@ fn is_id_continue(c: char) -> bool {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum LexContext {
     /// Default context for if the lexer isn't in any specific other context
-	#[default]
+    #[default]
     Regular,
 
     /// For lexing the elements of a JS template literal or TS template type.
@@ -93,7 +93,6 @@ pub enum LexContext {
     /// that isn't `'` or `"`.
     JsxAttributeValue,
 }
-
 
 impl LexContext {
     /// Returns true if this is [LexContext::Regular]

--- a/crates/rome_js_parser/src/lexer/mod.rs
+++ b/crates/rome_js_parser/src/lexer/mod.rs
@@ -70,9 +70,10 @@ fn is_id_continue(c: char) -> bool {
 }
 
 /// Context in which the lexer should lex the next token
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum LexContext {
     /// Default context for if the lexer isn't in any specific other context
+	#[default]
     Regular,
 
     /// For lexing the elements of a JS template literal or TS template type.
@@ -93,11 +94,6 @@ pub enum LexContext {
     JsxAttributeValue,
 }
 
-impl Default for LexContext {
-    fn default() -> Self {
-        LexContext::Regular
-    }
-}
 
 impl LexContext {
     /// Returns true if this is [LexContext::Regular]

--- a/crates/rome_js_syntax/src/source_type.rs
+++ b/crates/rome_js_syntax/src/source_type.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 /// Defaults to the latest stable ECMAScript standard.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default)]
 pub enum LanguageVersion {
-	#[default]
+    #[default]
     ES2022,
 
     /// The next, not yet finalized ECMAScript version
@@ -29,7 +29,7 @@ pub enum ModuleKind {
     Script,
 
     /// AN ECMAScript [Module](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-modules)
-	#[default]
+    #[default]
     Module,
 }
 
@@ -42,11 +42,10 @@ impl ModuleKind {
     }
 }
 
-
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum LanguageVariant {
     /// Standard JavaScript or TypeScript syntax without any extensions
-	#[default]
+    #[default]
     Standard,
 
     /// Allows JSX syntax inside a JavaScript or TypeScript file
@@ -64,14 +63,12 @@ impl LanguageVariant {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum Language {
-	   #[default]
+    #[default]
     JavaScript,
 
     /// TypeScript source with or without JSX.
     /// `definition_file` must be true for `d.ts` files.
-    TypeScript {
-        definition_file: bool,
-    },
+    TypeScript { definition_file: bool },
 }
 
 impl Language {
@@ -82,7 +79,6 @@ impl Language {
         matches!(self, Language::TypeScript { .. })
     }
 }
-
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SourceType {

--- a/crates/rome_js_syntax/src/source_type.rs
+++ b/crates/rome_js_syntax/src/source_type.rs
@@ -5,8 +5,9 @@ use std::path::Path;
 /// The versions are ordered in increasing order; The newest version comes last.
 ///
 /// Defaults to the latest stable ECMAScript standard.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default)]
 pub enum LanguageVersion {
+	#[default]
     ES2022,
 
     /// The next, not yet finalized ECMAScript version
@@ -20,20 +21,15 @@ impl LanguageVersion {
     }
 }
 
-impl Default for LanguageVersion {
-    fn default() -> Self {
-        Self::latest()
-    }
-}
-
 /// Is the source file an ECMAScript Module or Script.
 /// Changes the parsing semantic.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum ModuleKind {
     /// An ECMAScript [Script](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-scripts)
     Script,
 
     /// AN ECMAScript [Module](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-modules)
+	#[default]
     Module,
 }
 
@@ -46,15 +42,11 @@ impl ModuleKind {
     }
 }
 
-impl Default for ModuleKind {
-    fn default() -> Self {
-        ModuleKind::Module
-    }
-}
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum LanguageVariant {
     /// Standard JavaScript or TypeScript syntax without any extensions
+	#[default]
     Standard,
 
     /// Allows JSX syntax inside a JavaScript or TypeScript file
@@ -70,14 +62,9 @@ impl LanguageVariant {
     }
 }
 
-impl Default for LanguageVariant {
-    fn default() -> Self {
-        LanguageVariant::Standard
-    }
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum Language {
+	   #[default]
     JavaScript,
 
     /// TypeScript source with or without JSX.
@@ -96,11 +83,6 @@ impl Language {
     }
 }
 
-impl Default for Language {
-    fn default() -> Self {
-        Language::JavaScript
-    }
-}
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SourceType {

--- a/crates/rome_js_syntax/src/source_type.rs
+++ b/crates/rome_js_syntax/src/source_type.rs
@@ -5,9 +5,8 @@ use std::path::Path;
 /// The versions are ordered in increasing order; The newest version comes last.
 ///
 /// Defaults to the latest stable ECMAScript standard.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum LanguageVersion {
-    #[default]
     ES2022,
 
     /// The next, not yet finalized ECMAScript version
@@ -18,6 +17,12 @@ impl LanguageVersion {
     /// Returns the latest finalized ECMAScript version
     pub const fn latest() -> Self {
         LanguageVersion::ES2022
+    }
+}
+
+impl Default for LanguageVersion {
+    fn default() -> Self {
+        Self::latest()
     }
 }
 

--- a/crates/rome_service/src/configuration/formatter.rs
+++ b/crates/rome_service/src/configuration/formatter.rs
@@ -69,18 +69,13 @@ where
     s.serialize_u16(line_width.value())
 }
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum PlainIndentStyle {
     /// Tab
+    #[default]
     Tab,
     /// Space
     Space,
-}
-
-impl Default for PlainIndentStyle {
-    fn default() -> Self {
-        Self::Tab
-    }
 }

--- a/crates/rome_service/src/configuration/javascript.rs
+++ b/crates/rome_service/src/configuration/javascript.rs
@@ -85,16 +85,11 @@ pub struct JavascriptFormatter {
     pub quote_style: QuoteStyle,
 }
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", remote = "QuoteStyle")]
 pub enum PlainQuoteStyle {
+    #[default]
     Double,
     Single,
-}
-
-impl Default for PlainQuoteStyle {
-    fn default() -> Self {
-        Self::Double
-    }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
1. Part of #3054 
2. From Rust 1.62 it's now possible to derive the Default trait on enums, we could track down and remove the manual implementations for these
3. See https://rust-lang.github.io/rfcs/3107-derive-default-enum.html
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. The CI should pass.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
