### PR TITLE
feat(rome_js_semantic): semantic read events for self invoking functions

### DIFF
--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js
@@ -46,3 +46,5 @@ export { exported_function_2 };
 let value;
 function Button() {}
 console.log(<Button att={value}/>);
+
+(function f(){})()

--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js.snap
@@ -53,6 +53,8 @@ let value;
 function Button() {}
 console.log(<Button att={value}/>);
 
+(function f(){})()
+
 ```
 
 # Diagnostics

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -429,22 +429,16 @@ impl SemanticEventExtractor {
         let call = node.clone().cast::<JsCallExpression>()?;
         let callee = call.callee().ok()?;
 
-        match callee.syntax().kind() {
-            JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION => {
-                let expr = callee.as_js_parenthesized_expression()?;
-                let range = expr.syntax().text_range();
-                match result_of(expr) {
-                    Some(JsAnyExpression::JsFunctionExpression(expr)) => {
-                        let id = expr.id()?;
-                        self.stash.push_back(SemanticEvent::Read {
-                            range,
-                            declared_at: id.syntax().text_range(),
-                        });
-                    }
-                    _ => {}
-                }
+        if let JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION = callee.syntax().kind() {
+            let expr = callee.as_js_parenthesized_expression()?;
+            let range = expr.syntax().text_range();
+            if let Some(JsAnyExpression::JsFunctionExpression(expr)) = result_of(expr) {
+                let id = expr.id()?;
+                self.stash.push_back(SemanticEvent::Read {
+                    range,
+                    declared_at: id.syntax().text_range(),
+                });
             }
-            _ => {}
         }
 
         Some(())

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -3,10 +3,11 @@
 use std::collections::{HashMap, VecDeque};
 
 use rome_js_syntax::{
-    JsAnyAssignment, JsAnyAssignmentPattern, JsAssignmentExpression, JsForVariableDeclaration,
-    JsIdentifierAssignment, JsIdentifierBinding, JsLanguage, JsReferenceIdentifier, JsSyntaxKind,
-    JsSyntaxNode, JsSyntaxToken, JsVariableDeclaration, JsVariableDeclarator,
-    JsVariableDeclaratorList, JsxReferenceIdentifier, TextRange, TextSize, TsIdentifierBinding,
+    JsAnyAssignment, JsAnyAssignmentPattern, JsAnyExpression, JsAssignmentExpression,
+    JsCallExpression, JsForVariableDeclaration, JsIdentifierAssignment, JsIdentifierBinding,
+    JsLanguage, JsParenthesizedExpression, JsReferenceIdentifier, JsSyntaxKind, JsSyntaxNode,
+    JsSyntaxToken, JsVariableDeclaration, JsVariableDeclarator, JsVariableDeclaratorList,
+    JsxReferenceIdentifier, TextRange, TextSize, TsIdentifierBinding,
 };
 use rome_rowan::{syntax::Preorder, AstNode, SyntaxNodeCast, SyntaxTokenText};
 
@@ -197,6 +198,26 @@ struct Scope {
     hoisting: ScopeHoisting,
 }
 
+/// Returns the node that defines the result of the expression
+fn result_of(expr: &JsParenthesizedExpression) -> Option<JsAnyExpression> {
+    let mut expr = Some(JsAnyExpression::JsParenthesizedExpression(expr.clone()));
+    loop {
+        match expr {
+            Some(JsAnyExpression::JsParenthesizedExpression(e)) => {
+                expr = e.expression().ok();
+            }
+            Some(JsAnyExpression::JsSequenceExpression(e)) => {
+                expr = e.right().ok();
+            }
+            Some(JsAnyExpression::JsAssignmentExpression(e)) => {
+                expr = e.right().ok();
+            }
+            Some(expr) => return Some(expr),
+            None => return None,
+        }
+    }
+}
+
 impl SemanticEventExtractor {
     pub fn new() -> Self {
         Self {
@@ -223,6 +244,9 @@ impl SemanticEventExtractor {
             JS_IDENTIFIER_ASSIGNMENT => {
                 self.enter_js_identifier_assignment(node);
             }
+            JS_CALL_EXPRESSION => {
+                self.enter_js_call_expression(node);
+            }
 
             JS_MODULE | JS_SCRIPT => self.push_scope(
                 node.text_range(),
@@ -246,6 +270,7 @@ impl SemanticEventExtractor {
             | JS_CATCH_CLAUSE => {
                 self.push_scope(node.text_range(), ScopeHoisting::HoistDeclarationsToParent);
             }
+
             _ => {}
         }
     }
@@ -394,6 +419,33 @@ impl SemanticEventExtractor {
         references.push(Reference::Write {
             range: node.text_range(),
         });
+
+        Some(())
+    }
+
+    fn enter_js_call_expression(&mut self, node: &JsSyntaxNode) -> Option<()> {
+        debug_assert!(matches!(node.kind(), JsSyntaxKind::JS_CALL_EXPRESSION));
+
+        let call = node.clone().cast::<JsCallExpression>()?;
+        let callee = call.callee().ok()?;
+
+        match callee.syntax().kind() {
+            JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION => {
+                let expr = callee.as_js_parenthesized_expression()?;
+                let range = expr.syntax().text_range();
+                match result_of(expr) {
+                    Some(JsAnyExpression::JsFunctionExpression(expr)) => {
+                        let id = expr.id()?;
+                        self.stash.push_back(SemanticEvent::Read {
+                            range,
+                            declared_at: id.syntax().text_range(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
 
         Some(())
     }

--- a/crates/rome_js_semantic/src/tests/assertions.rs
+++ b/crates/rome_js_semantic/src/tests/assertions.rs
@@ -220,7 +220,7 @@ impl SemanticAssertion {
                 .to_string();
 
             Some(SemanticAssertion::Declaration(DeclarationAssertion {
-                range: token.text_range(),
+                range: token.parent().unwrap().text_range(),
                 declaration_name: name,
             }))
         } else if assertion_text.starts_with("/*READ ") {
@@ -232,7 +232,7 @@ impl SemanticAssertion {
                 .to_string();
 
             Some(SemanticAssertion::Read(ReadAssertion {
-                range: token.text_range(),
+                range: token.parent().unwrap().text_range(),
                 declaration_asertion_name: symbol_name,
             }))
         } else if assertion_text.starts_with("/*WRITE ") {
@@ -244,7 +244,7 @@ impl SemanticAssertion {
                 .to_string();
 
             Some(SemanticAssertion::Write(WriteAssertion {
-                range: token.text_range(),
+                range: token.parent().unwrap().text_range(),
                 declaration_asertion_name: symbol_name,
             }))
         } else if assertion_text.contains("/*START") {
@@ -255,7 +255,7 @@ impl SemanticAssertion {
                 .trim()
                 .to_string();
             Some(SemanticAssertion::ScopeStart(ScopeStartAssertion {
-                range: token.text_range(),
+                range: token.parent().unwrap().text_range(),
                 scope_name,
             }))
         } else if assertion_text.contains("/*END") {
@@ -266,7 +266,7 @@ impl SemanticAssertion {
                 .trim()
                 .to_string();
             Some(SemanticAssertion::ScopeEnd(ScopeEndAssertion {
-                range: token.text_range(),
+                range: token.parent().unwrap().text_range(),
                 scope_name,
             }))
         } else if assertion_text.starts_with("/*@") {
@@ -277,20 +277,20 @@ impl SemanticAssertion {
                 .trim()
                 .to_string();
             Some(SemanticAssertion::AtScope(AtScopeAssertion {
-                range: token.text_range(),
+                range: token.parent().unwrap().text_range(),
                 scope_name,
             }))
         } else if assertion_text.contains("/*NOEVENT") {
             Some(SemanticAssertion::NoEvent(NoEventAssertion {
-                range: token.text_range(),
+                range: token.parent().unwrap().text_range(),
             }))
         } else if assertion_text.contains("/*UNIQUE") {
             Some(SemanticAssertion::Unique(UniqueAssertion {
-                range: token.text_range(),
+                range: token.parent().unwrap().text_range(),
             }))
         } else if assertion_text.contains("/*?") {
             Some(SemanticAssertion::Unmatched(UnmatchedAssertion {
-                range: token.text_range(),
+                range: token.parent().unwrap().text_range(),
             }))
         } else {
             None

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -122,6 +122,10 @@ assert_semantics! {
     ok_scope_function_expression_read, "var f/*#F1*/ = function f/*#F2*/() {console.log(f/*READ F2*/);}; f/*READ F1*/();",
     ok_scope_function_expression_read1 ,"var f/*#F1*/ = function () {console.log(f/*READ F1*/);}",
     ok_scope_function_expression_read2, "let f/*#F1*/ = 1; let g = function f/*#F2*/() {console.log(2, f/*READ F2*/);}; console.log(f/*READ F1*/);",
+    ok_read_self_invoking_function,
+        r#"(function f/*#F*/(){console.log(1)})/*READ F*/()"#,
+    ok_read_self_invoking_function2,
+        r#"(1,2,3,function f/*#F*/(){console.log(1)})/*READ F*/()"#,
 }
 
 // Imports


### PR DESCRIPTION

## Summary

Expands https://github.com/rome/tools/issues/2979 with correctly not flagging self-invoking functions as unused.

I don't consider this implementation complete yet. But we need to think about how to deal with complex expressions in these cases.

## Test Plan

```
> cargo test -p rome_js_analyze -- no_unused_variables
```
