### PR TITLE
feat(playground): Use full height for right side panels

### DIFF
--- a/website/playground/src/DesktopPlayground.tsx
+++ b/website/playground/src/DesktopPlayground.tsx
@@ -83,25 +83,29 @@ export default function DesktopPlayground({
 	}, []);
 
 	return (
-		<div className="divide-y divide-slate-300">
+		<div className="divide-y divide-slate-300 h-screen flex flex-col">
 			<h1 className="p-4 text-xl">Rome Playground</h1>
 			<SettingsMenu
 				settings={settings}
 				setPlaygroundState={setPlaygroundState}
 			/>
-			<div className="box-border flex h-screen divide-x divide-slate-300">
-				<div className="w-1/2 p-5">
+			<div className="box-border flex divide-x divide-slate-300 grow">
+				<div className="w-1/2 p-5 h-full">
 					<CodeMirror
 						value={code}
-						height="70vh"
+						className="h-full"
+						height="100%"
 						extensions={extensions}
 						placeholder="Enter your code here"
 						onUpdate={onUpdate}
 						onChange={onChange}
 					/>
 				</div>
-				<div className="w-1/2 p-5 flex flex-col">
-					<Tabs>
+				<div className="w-1/2 p-5">
+					<Tabs
+						className="h-full flex flex-col"
+						selectedTabPanelClassName="grow react-tabs__tab-panel--selected"
+					>
 						<TabList>
 							<Tab selectedClassName="bg-slate-300">Formatter</Tab>
 							<Tab selectedClassName="bg-slate-300">CST</Tab>
@@ -119,29 +123,36 @@ export default function DesktopPlayground({
 							</Tab>
 						</TabList>
 						<TabPanel>
-							<h1>Rome</h1>
-							<CodeMirror
-								value={formatted_code}
-								extensions={extensions}
-								placeholder="Rome Output"
-								height="30vh"
-								readOnly={true}
-							/>
-							<h1>Prettier</h1>
-							<CodeMirror
-								value={prettierOutput.code}
-								extensions={extensions}
-								placeholder="Prettier Output"
-								height="30vh"
-								readOnly={true}
-							/>
+							<div className="h-1/2 flex flex-col">
+								<h1>Rome</h1>
+								<CodeMirror
+									className="grow"
+									value={formatted_code}
+									extensions={extensions}
+									placeholder="Rome Output"
+									height="100%"
+									readOnly={true}
+								/>
+							</div>
+							<div className="h-1/2 flex flex-col">
+								<h1>Prettier</h1>
+								<CodeMirror
+									value={prettierOutput.code}
+									extensions={extensions}
+									placeholder="Prettier Output"
+									className="grow"
+									height="100%"
+									readOnly={true}
+								/>
+							</div>
 						</TabPanel>
 						<TabPanel><TreeView tree={cst} /></TabPanel>
 						<TabPanel>
 							<CodeMirror
 								value={ast}
 								extensions={romeAstCodeMirrorExtension}
-								height="70vh"
+								className="h-full"
+								height="100%"
 								readOnly={true}
 							/>
 						</TabPanel>
@@ -149,16 +160,23 @@ export default function DesktopPlayground({
 							<CodeMirror
 								value={formatter_ir}
 								extensions={romeFormatterIrCodeMirrorExtension}
-								height="70vh"
+								className="h-full"
+								height="100%"
 								readOnly={true}
 							/>
 						</TabPanel>
 						<TabPanel>
-							<pre className="h-screen overflow-scroll">{prettierOutput.ir}</pre>
+							<CodeMirror
+								value={prettierOutput.ir}
+								extensions={romeFormatterIrCodeMirrorExtension}
+								className="h-full"
+								height="100%"
+								readOnly={true}
+							/>
 						</TabPanel>
 						<TabPanel>
 							<div
-								className="h-screen overflow-scroll whitespace-pre-wrap text-red-500 text-xs error-panel"
+								className="overflow-scroll whitespace-pre-wrap text-red-500 text-xs error-panel h-full"
 								dangerouslySetInnerHTML={{ __html: errors }}
 							/>
 						</TabPanel>

--- a/website/playground/src/DesktopPlayground.tsx
+++ b/website/playground/src/DesktopPlayground.tsx
@@ -122,8 +122,8 @@ export default function DesktopPlayground({
 						</Tab>
 					</TabList>
 					<TabPanel>
-						<div className="h-1/2 flex flex-col">
-							<h1>Rome</h1>
+						<div className="h-1/2 flex flex-col pb-4">
+							<h1 className="text-lg font-medium pb-2">Rome</h1>
 							<CodeMirror
 								value={formatted_code}
 								extensions={extensions}
@@ -134,7 +134,7 @@ export default function DesktopPlayground({
 							/>
 						</div>
 						<div className="h-1/2 flex flex-col">
-							<h1>Prettier</h1>
+							<h1 className="text-lg font-medium pb-2">Prettier</h1>
 							<CodeMirror
 								value={prettierOutput.code}
 								extensions={extensions}

--- a/website/playground/src/DesktopPlayground.tsx
+++ b/website/playground/src/DesktopPlayground.tsx
@@ -89,22 +89,19 @@ export default function DesktopPlayground({
 				settings={settings}
 				setPlaygroundState={setPlaygroundState}
 			/>
-			<div className="box-border flex divide-x divide-slate-300 grow">
-				<div className="w-1/2 p-5 h-full">
+			<div className="box-border flex divide-x divide-slate-300 flex-1 overflow-auto">
 					<CodeMirror
 						value={code}
-						className="h-full"
+						className="h-full overflow-y-hidden w-1/2 p-5 h-full"
 						height="100%"
 						extensions={extensions}
 						placeholder="Enter your code here"
 						onUpdate={onUpdate}
 						onChange={onChange}
 					/>
-				</div>
-				<div className="w-1/2 p-5">
 					<Tabs
-						className="h-full flex flex-col"
-						selectedTabPanelClassName="grow react-tabs__tab-panel--selected"
+						className="w-1/2 p-5 flex flex-col"
+						selectedTabPanelClassName="flex-1 react-tabs__tab-panel--selected overflow-y-auto"
 					>
 						<TabList>
 							<Tab selectedClassName="bg-slate-300">Formatter</Tab>
@@ -126,10 +123,10 @@ export default function DesktopPlayground({
 							<div className="h-1/2 flex flex-col">
 								<h1>Rome</h1>
 								<CodeMirror
-									className="grow"
 									value={formatted_code}
 									extensions={extensions}
 									placeholder="Rome Output"
+									className="flex-1 overflow-y-auto"
 									height="100%"
 									readOnly={true}
 								/>
@@ -140,7 +137,7 @@ export default function DesktopPlayground({
 									value={prettierOutput.code}
 									extensions={extensions}
 									placeholder="Prettier Output"
-									className="grow"
+									className="flex-1 overflow-y-auto"
 									height="100%"
 									readOnly={true}
 								/>
@@ -182,7 +179,6 @@ export default function DesktopPlayground({
 						</TabPanel>
 						<TabPanel><MermaidGraph graph={control_flow_graph} /></TabPanel>
 					</Tabs>
-				</div>
 			</div>
 		</div>
 	);

--- a/website/playground/src/DesktopPlayground.tsx
+++ b/website/playground/src/DesktopPlayground.tsx
@@ -89,96 +89,98 @@ export default function DesktopPlayground({
 				settings={settings}
 				setPlaygroundState={setPlaygroundState}
 			/>
-			<div className="box-border flex divide-x divide-slate-300 flex-1 overflow-auto">
-					<CodeMirror
-						value={code}
-						className="h-full overflow-y-hidden w-1/2 p-5 h-full"
-						height="100%"
-						extensions={extensions}
-						placeholder="Enter your code here"
-						onUpdate={onUpdate}
-						onChange={onChange}
-					/>
-					<Tabs
-						className="w-1/2 p-5 flex flex-col"
-						selectedTabPanelClassName="flex-1 react-tabs__tab-panel--selected overflow-y-auto"
-					>
-						<TabList>
-							<Tab selectedClassName="bg-slate-300">Formatter</Tab>
-							<Tab selectedClassName="bg-slate-300">CST</Tab>
-							<Tab selectedClassName="bg-slate-300">AST</Tab>
-							<Tab selectedClassName="bg-slate-300">Rome IR</Tab>
-							<Tab selectedClassName="bg-slate-300">Prettier IR</Tab>
-							<Tab disabled={errors === ""} selectedClassName="bg-slate-300">
-								Diagnostics
-							</Tab>
-							<Tab
-								disabled={control_flow_graph === ""}
-								selectedClassName="bg-slate-300"
-							>
-								Control Flow Graph
-							</Tab>
-						</TabList>
-						<TabPanel>
-							<div className="h-1/2 flex flex-col">
-								<h1>Rome</h1>
-								<CodeMirror
-									value={formatted_code}
-									extensions={extensions}
-									placeholder="Rome Output"
-									className="flex-1 overflow-y-auto"
-									height="100%"
-									readOnly={true}
-								/>
-							</div>
-							<div className="h-1/2 flex flex-col">
-								<h1>Prettier</h1>
-								<CodeMirror
-									value={prettierOutput.code}
-									extensions={extensions}
-									placeholder="Prettier Output"
-									className="flex-1 overflow-y-auto"
-									height="100%"
-									readOnly={true}
-								/>
-							</div>
-						</TabPanel>
-						<TabPanel><TreeView tree={cst} /></TabPanel>
-						<TabPanel>
+			<div
+				className="box-border flex divide-x divide-slate-300 flex-1 overflow-auto"
+			>
+				<CodeMirror
+					value={code}
+					className="h-full overflow-y-hidden w-1/2 p-5 h-full"
+					height="100%"
+					extensions={extensions}
+					placeholder="Enter your code here"
+					onUpdate={onUpdate}
+					onChange={onChange}
+				/>
+				<Tabs
+					className="w-1/2 p-5 flex flex-col"
+					selectedTabPanelClassName="flex-1 react-tabs__tab-panel--selected overflow-y-auto"
+				>
+					<TabList>
+						<Tab selectedClassName="bg-slate-300">Formatter</Tab>
+						<Tab selectedClassName="bg-slate-300">CST</Tab>
+						<Tab selectedClassName="bg-slate-300">AST</Tab>
+						<Tab selectedClassName="bg-slate-300">Rome IR</Tab>
+						<Tab selectedClassName="bg-slate-300">Prettier IR</Tab>
+						<Tab disabled={errors === ""} selectedClassName="bg-slate-300">
+							Diagnostics
+						</Tab>
+						<Tab
+							disabled={control_flow_graph === ""}
+							selectedClassName="bg-slate-300"
+						>
+							Control Flow Graph
+						</Tab>
+					</TabList>
+					<TabPanel>
+						<div className="h-1/2 flex flex-col">
+							<h1>Rome</h1>
 							<CodeMirror
-								value={ast}
-								extensions={romeAstCodeMirrorExtension}
-								className="h-full"
+								value={formatted_code}
+								extensions={extensions}
+								placeholder="Rome Output"
+								className="flex-1 overflow-y-auto"
 								height="100%"
 								readOnly={true}
 							/>
-						</TabPanel>
-						<TabPanel>
+						</div>
+						<div className="h-1/2 flex flex-col">
+							<h1>Prettier</h1>
 							<CodeMirror
-								value={formatter_ir}
-								extensions={romeFormatterIrCodeMirrorExtension}
-								className="h-full"
+								value={prettierOutput.code}
+								extensions={extensions}
+								placeholder="Prettier Output"
+								className="flex-1 overflow-y-auto"
 								height="100%"
 								readOnly={true}
 							/>
-						</TabPanel>
-						<TabPanel>
-							<CodeMirror
-								value={prettierOutput.ir}
-								extensions={romeFormatterIrCodeMirrorExtension}
-								className="h-full"
-								height="100%"
-								readOnly={true}
-							/>
-						</TabPanel>
-						<TabPanel>
-							<div
-								className="overflow-scroll whitespace-pre-wrap text-red-500 text-xs error-panel h-full"
-								dangerouslySetInnerHTML={{ __html: errors }}
-							/>
-						</TabPanel>
-						<TabPanel><MermaidGraph graph={control_flow_graph} /></TabPanel>
-					</Tabs>
+						</div>
+					</TabPanel>
+					<TabPanel><TreeView tree={cst} /></TabPanel>
+					<TabPanel>
+						<CodeMirror
+							value={ast}
+							extensions={romeAstCodeMirrorExtension}
+							className="h-full"
+							height="100%"
+							readOnly={true}
+						/>
+					</TabPanel>
+					<TabPanel>
+						<CodeMirror
+							value={formatter_ir}
+							extensions={romeFormatterIrCodeMirrorExtension}
+							className="h-full"
+							height="100%"
+							readOnly={true}
+						/>
+					</TabPanel>
+					<TabPanel>
+						<CodeMirror
+							value={prettierOutput.ir}
+							extensions={romeFormatterIrCodeMirrorExtension}
+							className="h-full"
+							height="100%"
+							readOnly={true}
+						/>
+					</TabPanel>
+					<TabPanel>
+						<div
+							className="overflow-scroll whitespace-pre-wrap text-red-500 text-xs error-panel h-full"
+							dangerouslySetInnerHTML={{ __html: errors }}
+						/>
+					</TabPanel>
+					<TabPanel><MermaidGraph graph={control_flow_graph} /></TabPanel>
+				</Tabs>
 			</div>
 		</div>
 	);

--- a/website/playground/src/TreeView.tsx
+++ b/website/playground/src/TreeView.tsx
@@ -3,5 +3,5 @@ interface Props {
 }
 
 export default function TreeView({ tree }: Props) {
-	return <div className="overflow-scroll"><pre>{tree}</pre></div>;
+	return <div className="overflow-scroll h-full"><pre>{tree}</pre></div>;
 }


### PR DESCRIPTION
This PR improves our playground to make use of the full height for the right hand side panels rather than 70% (which may result in scroll bars on small screens)

## Test Plan

![Screenshot from 2022-08-17 10-07-17](https://user-images.githubusercontent.com/1203881/185068002-8012252c-d329-4ef2-a4e3-3e790026b9eb.png)
![Screenshot from 2022-08-17 10-07-27](https://user-images.githubusercontent.com/1203881/185068009-fbb0e493-0a10-4080-9f5d-71689808af1c.png)
![Screenshot from 2022-08-17 10-07-35](https://user-images.githubusercontent.com/1203881/185068013-db4225e0-959d-4cab-b334-a4f2a3af3579.png)
![Screenshot from 2022-08-17 10-07-45](https://user-images.githubusercontent.com/1203881/185068018-e12eaf7e-dbb9-4af7-b321-9d46a33b71ee.png)


