### PR TITLE
feat(npm): API facade and first compile pipeline

### DIFF
--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -9,6 +9,7 @@ on:
       - 'website/**'
       - 'editors/**'
       - 'crates/**'
+      - 'npm/rome/**'
 
 env:
   RUST_LOG: info
@@ -54,3 +55,27 @@ jobs:
       - name: Type check
         working-directory: website/playground
         run: pnpm tsc
+  apis-check:
+    name: Checks on APIs project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+      - name: Cache pnpm modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 7
+      - name: Install libraries
+        working-directory: npm/rome
+        run: pnpm i
+      - name: CI checks
+        working-directory: npm/rome
+        run: pnpm ci

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -55,27 +55,3 @@ jobs:
       - name: Type check
         working-directory: website/playground
         run: pnpm tsc
-  apis-check:
-    name: Checks on APIs project
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PR Branch
-        uses: actions/checkout@v3
-        with:
-          submodules: false
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.1.0
-        with:
-          version: 7
-      - name: Install libraries
-        working-directory: npm/rome
-        run: pnpm i
-      - name: CI checks
-        working-directory: npm/rome
-        run: pnpm ci

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,0 +1,45 @@
+# We have code that relies on Rust code AND JS code, we want to run this job when the relevant code changes
+name: Checks for our runtimes
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'npm/**'
+      - 'crates/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'npm/**'
+      - 'crates/**'
+
+env:
+  RUST_LOG: info
+  RUST_BACKTRACE: 1
+
+jobs:
+  apis-check:
+    name: Checks on APIs project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+      - name: Cache pnpm modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 7
+      - name: Install libraries
+        working-directory: npm/rome
+        run: pnpm i
+      - name: CI checks
+        working-directory: npm/rome
+        run: pnpm ci

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -5,9 +5,14 @@
     "scripts": {
         "postinstall": "node scripts/postinstall.js",
         "tsc": "tsc --noEmit",
-        "format": "cargo rome-cli-dev format ./src --write",
-        "check": "cargo rome-cli-dev check ./src"
+        "format": "cargo rome-cli-dev format ./ --write",
+        "ci": "cargo rome-cli-dev ci ./src && pnpm test:ci && tsc --noEmit",
+        "check": "cargo rome-cli-dev check ./src && tsc --noEmit",
+        "test": "vitest",
+        "test:ci": "vitest --run",
+        "build": "tsc "
     },
+    "main": "./dist/index.js",
     "homepage": "https://rome.tools",
     "author": "Sebastian McKenzie",
     "bugs": "https://github.com/rome/tools/issues",
@@ -29,6 +34,8 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "vitest": "^0.22.0",
+        "vite": "^3.0.8"
     }
 }

--- a/npm/rome/pnpm-lock.yaml
+++ b/npm/rome/pnpm-lock.yaml
@@ -2,14 +2,469 @@ lockfileVersion: 5.4
 
 specifiers:
   typescript: ^4.7.4
+  vite: ^3.0.8
+  vitest: ^0.22.0
 
 devDependencies:
   typescript: 4.7.4
+  vite: 3.0.8
+  vitest: 0.22.0
 
 packages:
+
+  /@esbuild/linux-loong64/0.14.54:
+    resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@types/chai-subset/1.3.3:
+    resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
+    dependencies:
+      '@types/chai': 4.3.3
+    dev: true
+
+  /@types/chai/4.3.3:
+    resolution: {integrity: sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==}
+    dev: true
+
+  /@types/node/18.7.6:
+    resolution: {integrity: sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==}
+    dev: true
+
+  /assertion-error/1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+    dev: true
+
+  /chai/4.3.6:
+    resolution: {integrity: sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.2
+      deep-eql: 3.0.1
+      get-func-name: 2.0.0
+      loupe: 2.3.4
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: true
+
+  /check-error/1.0.2:
+    resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
+    dev: true
+
+  /debug/4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: true
+
+  /deep-eql/3.0.1:
+    resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
+  /esbuild-android-64/0.14.54:
+    resolution: {integrity: sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.14.54:
+    resolution: {integrity: sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-64/0.14.54:
+    resolution: {integrity: sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.14.54:
+    resolution: {integrity: sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-64/0.14.54:
+    resolution: {integrity: sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.14.54:
+    resolution: {integrity: sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-32/0.14.54:
+    resolution: {integrity: sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.14.54:
+    resolution: {integrity: sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm/0.14.54:
+    resolution: {integrity: sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.14.54:
+    resolution: {integrity: sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-mips64le/0.14.54:
+    resolution: {integrity: sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.14.54:
+    resolution: {integrity: sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-riscv64/0.14.54:
+    resolution: {integrity: sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.14.54:
+    resolution: {integrity: sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-netbsd-64/0.14.54:
+    resolution: {integrity: sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.14.54:
+    resolution: {integrity: sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-sunos-64/0.14.54:
+    resolution: {integrity: sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.14.54:
+    resolution: {integrity: sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-64/0.14.54:
+    resolution: {integrity: sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.14.54:
+    resolution: {integrity: sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild/0.14.54:
+    resolution: {integrity: sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/linux-loong64': 0.14.54
+      esbuild-android-64: 0.14.54
+      esbuild-android-arm64: 0.14.54
+      esbuild-darwin-64: 0.14.54
+      esbuild-darwin-arm64: 0.14.54
+      esbuild-freebsd-64: 0.14.54
+      esbuild-freebsd-arm64: 0.14.54
+      esbuild-linux-32: 0.14.54
+      esbuild-linux-64: 0.14.54
+      esbuild-linux-arm: 0.14.54
+      esbuild-linux-arm64: 0.14.54
+      esbuild-linux-mips64le: 0.14.54
+      esbuild-linux-ppc64le: 0.14.54
+      esbuild-linux-riscv64: 0.14.54
+      esbuild-linux-s390x: 0.14.54
+      esbuild-netbsd-64: 0.14.54
+      esbuild-openbsd-64: 0.14.54
+      esbuild-sunos-64: 0.14.54
+      esbuild-windows-32: 0.14.54
+      esbuild-windows-64: 0.14.54
+      esbuild-windows-arm64: 0.14.54
+    dev: true
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /function-bind/1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
+
+  /get-func-name/2.0.0:
+    resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
+    dev: true
+
+  /has/1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: 1.1.1
+    dev: true
+
+  /is-core-module/2.10.0:
+    resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
+  /local-pkg/0.4.2:
+    resolution: {integrity: sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==}
+    engines: {node: '>=14'}
+    dev: true
+
+  /loupe/2.3.4:
+    resolution: {integrity: sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==}
+    dependencies:
+      get-func-name: 2.0.0
+    dev: true
+
+  /ms/2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: true
+
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
+  /path-parse/1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /pathval/1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
+
+  /picocolors/1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: true
+
+  /postcss/8.4.16:
+    resolution: {integrity: sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
+  /resolve/1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.10.0
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /rollup/2.77.3:
+    resolution: {integrity: sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /source-map-js/1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /supports-preserve-symlinks-flag/1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /tinypool/0.2.4:
+    resolution: {integrity: sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy/1.0.0:
+    resolution: {integrity: sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /type-detect/4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+    dev: true
 
   /typescript/4.7.4:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
+
+  /vite/3.0.8:
+    resolution: {integrity: sha512-AOZ4eN7mrkJiOLuw8IA7piS4IdOQyQCA81GxGsAQvAZzMRi9ZwGB3TOaYsj4uLAWK46T5L4AfQ6InNGlxX30IQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.14.54
+      postcss: 8.4.16
+      resolve: 1.22.1
+      rollup: 2.77.3
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vitest/0.22.0:
+    resolution: {integrity: sha512-BSIro/QOHLaQY08FHwT6THWhqLQ+VPU+N4Rdo4pcP+16XB6oLmNNAXGcSh/MOLUhfUy+mqCwx7AyKmU7Ms5R+g==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.3
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.7.6
+      chai: 4.3.6
+      debug: 4.3.4
+      local-pkg: 0.4.2
+      tinypool: 0.2.4
+      tinyspy: 1.0.0
+      vite: 3.0.8
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - supports-color
+      - terser
     dev: true

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -5,7 +5,7 @@ interface FormatFilesDebugOptions extends FormatFilesOptions {
 	debug: boolean;
 }
 
-interface FormatContentDebugOptions extends FormatFilesOptions {
+interface FormatContentDebugOptions extends FormatContentOptions {
 	/**
 	 * If `true`, you'll be able to inspect the IR of the formatter
 	 */
@@ -16,7 +16,7 @@ interface FormatFilesOptions {
 	/**
 	 * Writes the new content to disk
 	 */
-	write: boolean;
+	write?: boolean;
 }
 
 interface FormatContentOptions {
@@ -28,7 +28,7 @@ interface FormatContentOptions {
 	/**
 	 * The range where to format the content
 	 */
-	range: [number, number];
+	range?: [number, number];
 }
 
 interface FormatResult {
@@ -68,24 +68,35 @@ interface ParseResult {
 	errors: string[];
 }
 
-function isFormatFilesDebug(options: any): options is FormatFilesDebugOptions {
-	return options.debug !== undefined;
+function isFormatFilesDebug(
+	options: FormatFilesOptions | FormatFilesDebugOptions,
+): options is FormatFilesDebugOptions {
+	return "debug" in options && options.debug !== undefined;
 }
 
 function isFormatContentDebug(
 	options: any,
 ): options is FormatContentDebugOptions {
-	return options.debug !== undefined;
+	return options?.debug !== undefined;
 }
 
 export class Rome {
+	async formatFiles(paths: string[]): Promise<FormatResult>;
 	async formatFiles(
 		paths: string[],
-		options?: Partial<FormatFilesOptions>,
+		options?: FormatFilesOptions,
+	): Promise<FormatResult>;
+	async formatFiles(
+		paths: string[],
+		options?: FormatFilesDebugOptions,
+	): Promise<FormatDebugResult>;
+	async formatFiles(
+		paths: string[],
+		options?: FormatFilesOptions | FormatFilesDebugOptions,
 	): Promise<FormatResult | FormatDebugResult> {
 		paths;
 
-		if (isFormatFilesDebug(options)) {
+		if (options && isFormatFilesDebug(options)) {
 			return {
 				content: "",
 				errors: [],
@@ -100,9 +111,18 @@ export class Rome {
 
 	async formatContent(
 		content: string,
-		options?: Partial<FormatContentOptions>,
+		options: FormatContentOptions,
+	): Promise<FormatResult>;
+	async formatContent(
+		content: string,
+		options: FormatContentDebugOptions,
+	): Promise<FormatDebugResult>;
+	async formatContent(
+		content: string,
+		options: FormatContentOptions | FormatContentDebugOptions,
 	): Promise<FormatResult | FormatDebugResult> {
 		content;
+		options.filePath;
 		if (isFormatContentDebug(options)) {
 			return {
 				content: "",

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -1,0 +1,95 @@
+interface FormatDebugOptions {
+	/**
+	 * If `true`, you'll be able to inspect the IR of the formatter
+	 */
+	debug: boolean;
+}
+
+interface FormatFilesOptions extends FormatDebugOptions {
+	/**
+	 * Writes the new content to disk
+	 */
+	write: boolean;
+}
+
+interface FormatContentOptions extends FormatDebugOptions {
+	/**
+	 * A virtual path of the file. You should add the extension,
+	 * so Rome knows how to parse the content
+	 */
+	filePath: String;
+	/**
+	 * The range where to format the content
+	 */
+	range: [number, number];
+}
+
+interface FormatResult {
+	// Not final
+	content: String;
+	// Not final
+	errors: String[];
+	// Available when in debug mode
+	ir: String | null;
+}
+
+interface ParseOptions {
+	/**
+	 * A virtual path of the file. You should add the extension,
+	 * so Rome knows how to parse the content
+	 */
+	filePath: String;
+}
+
+interface ParseResult {
+	/**
+	 * The CST of the code
+	 */
+	cst: String;
+	/**
+	 * The AST of the code
+	 */
+	ast: String;
+	// Not final
+	errors: String[];
+}
+
+export class Rome {
+	async formatFiles(
+		paths: String[],
+		options: Partial<FormatFilesOptions> | undefined = undefined,
+	): Promise<FormatResult> {
+		paths;
+
+		return {
+			content: "",
+			errors: [],
+			ir: options?.debug ? "" : null,
+		};
+	}
+
+	async formatContent(
+		content: String,
+		options: Partial<FormatContentOptions> | undefined = undefined,
+	): Promise<FormatResult> {
+		content;
+		return {
+			content: "",
+			errors: [],
+			ir: options?.debug ? "" : null,
+		};
+	}
+
+	async parseContent(
+		content: String,
+		options: ParseOptions,
+	): Promise<ParseResult> {
+		content;
+		options;
+		return {
+			ast: "",
+			cst: "",
+			errors: [],
+		};
+	}
+}

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -1,23 +1,30 @@
-interface FormatDebugOptions {
+interface FormatFilesDebugOptions extends FormatFilesOptions {
 	/**
 	 * If `true`, you'll be able to inspect the IR of the formatter
 	 */
 	debug: boolean;
 }
 
-interface FormatFilesOptions extends FormatDebugOptions {
+interface FormatContentDebugOptions extends FormatFilesOptions {
+	/**
+	 * If `true`, you'll be able to inspect the IR of the formatter
+	 */
+	debug: boolean;
+}
+
+interface FormatFilesOptions {
 	/**
 	 * Writes the new content to disk
 	 */
 	write: boolean;
 }
 
-interface FormatContentOptions extends FormatDebugOptions {
+interface FormatContentOptions {
 	/**
 	 * A virtual path of the file. You should add the extension,
 	 * so Rome knows how to parse the content
 	 */
-	filePath: String;
+	filePath: string;
 	/**
 	 * The range where to format the content
 	 */
@@ -26,11 +33,18 @@ interface FormatContentOptions extends FormatDebugOptions {
 
 interface FormatResult {
 	// Not final
-	content: String;
+	content: string;
 	// Not final
-	errors: String[];
+	errors: string[];
+}
+
+interface FormatDebugResult {
+	// Not final
+	content: string;
+	// Not final
+	errors: string[];
 	// Available when in debug mode
-	ir: String | null;
+	ir: string | null;
 }
 
 interface ParseOptions {
@@ -38,50 +52,71 @@ interface ParseOptions {
 	 * A virtual path of the file. You should add the extension,
 	 * so Rome knows how to parse the content
 	 */
-	filePath: String;
+	filePath: string;
 }
 
 interface ParseResult {
 	/**
 	 * The CST of the code
 	 */
-	cst: String;
+	cst: string;
 	/**
 	 * The AST of the code
 	 */
-	ast: String;
+	ast: string;
 	// Not final
-	errors: String[];
+	errors: string[];
+}
+
+function isFormatFilesDebug(options: any): options is FormatFilesDebugOptions  {
+	return options.debug !== undefined
+}
+
+function isFormatContentDebug(options: any): options is FormatContentDebugOptions  {
+	return options.debug !== undefined
 }
 
 export class Rome {
 	async formatFiles(
-		paths: String[],
-		options: Partial<FormatFilesOptions> | undefined = undefined,
-	): Promise<FormatResult> {
+		paths: string[],
+		options?: Partial<FormatFilesOptions>,
+	): Promise<FormatResult | FormatDebugResult> {
 		paths;
 
+		if (isFormatFilesDebug(options)) {
+			return {
+				content: "",
+				errors: [],
+				ir: "",
+			};
+		}
 		return {
 			content: "",
 			errors: [],
-			ir: options?.debug ? "" : null,
 		};
+
 	}
 
 	async formatContent(
-		content: String,
-		options: Partial<FormatContentOptions> | undefined = undefined,
-	): Promise<FormatResult> {
+		content: string,
+		options?: Partial<FormatContentOptions>,
+	): Promise<FormatResult | FormatDebugResult> {
 		content;
+		if (isFormatContentDebug(options)) {
+			return {
+				content: "",
+				errors: [],
+				ir: "",
+			};
+		}
 		return {
 			content: "",
 			errors: [],
-			ir: options?.debug ? "" : null,
 		};
 	}
 
 	async parseContent(
-		content: String,
+		content: string,
 		options: ParseOptions,
 	): Promise<ParseResult> {
 		content;

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -68,12 +68,14 @@ interface ParseResult {
 	errors: string[];
 }
 
-function isFormatFilesDebug(options: any): options is FormatFilesDebugOptions  {
-	return options.debug !== undefined
+function isFormatFilesDebug(options: any): options is FormatFilesDebugOptions {
+	return options.debug !== undefined;
 }
 
-function isFormatContentDebug(options: any): options is FormatContentDebugOptions  {
-	return options.debug !== undefined
+function isFormatContentDebug(
+	options: any,
+): options is FormatContentDebugOptions {
+	return options.debug !== undefined;
 }
 
 export class Rome {
@@ -94,7 +96,6 @@ export class Rome {
 			content: "",
 			errors: [],
 		};
-
 	}
 
 	async formatContent(

--- a/npm/rome/tests/index.test.ts
+++ b/npm/rome/tests/index.test.ts
@@ -11,24 +11,66 @@ describe("Rome formatter", () => {
 		expect(result.errors).toEqual([]);
 	});
 
-	it("should not format content", async () => {
+	it("should not format files in debug mode", async () => {
 		const rome = new Rome();
 
-		let result = await rome.formatContent("function f() {}");
+		let result = await rome.formatFiles(["./path/to/file.js"], {
+			debug: true,
+		});
 
 		expect(result.content).toEqual("");
 		expect(result.errors).toEqual([]);
+		expect(result.ir).toEqual("");
+	});
+
+	it("should not format content", async () => {
+		const rome = new Rome();
+
+		let result = await rome.formatContent("function f() {}", {
+			filePath: "example.js",
+		});
+
+		expect(result.content).toEqual("");
+		expect(result.errors).toEqual([]);
+	});
+
+	it("should not format content in debug mode", async () => {
+		const rome = new Rome();
+
+		let result = await rome.formatContent("function f() {}", {
+			filePath: "example.js",
+			debug: true,
+		});
+
+		expect(result.content).toEqual("");
+		expect(result.errors).toEqual([]);
+		expect(result.ir).toEqual("");
 	});
 
 	it("should not format content with range", async () => {
 		const rome = new Rome();
 
 		let result = await rome.formatContent("function f() {}", {
+			filePath: "file.js",
 			range: [5, 10],
 		});
 
 		expect(result.content).toEqual("");
 		expect(result.errors).toEqual([]);
+	});
+
+	it("should not format content with range in debug mode", async () => {
+		const rome = new Rome();
+
+		let result = await rome.formatContent("function f() {}", {
+			filePath: "file.js",
+			range: [5, 10],
+			debug: true,
+		});
+
+		expect(result.content).toEqual("");
+		expect(result.errors).toEqual([]);
+		expect(result.ir).toEqual("");
 	});
 });
 

--- a/npm/rome/tests/index.test.ts
+++ b/npm/rome/tests/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { Rome } from "../src/index";
+
+describe("Rome formatter", () => {
+	it("should not format files", async () => {
+		const rome = new Rome();
+
+		let result = await rome.formatFiles(["./path/to/file.js"]);
+
+		expect(result.content).toEqual("");
+		expect(result.errors).toEqual([]);
+	});
+
+	it("should not format content", async () => {
+		const rome = new Rome();
+
+		let result = await rome.formatContent("function f() {}");
+
+		expect(result.content).toEqual("");
+		expect(result.errors).toEqual([]);
+	});
+
+	it("should not format content with range", async () => {
+		const rome = new Rome();
+
+		let result = await rome.formatContent("function f() {}", {
+			range: [5, 10],
+		});
+
+		expect(result.content).toEqual("");
+		expect(result.errors).toEqual([]);
+	});
+});
+
+describe("Rome parser", () => {
+	it("should not parse content", async () => {
+		const rome = new Rome();
+
+		let result = await rome.parseContent("function f() {}", {
+			filePath: "example.js",
+		});
+
+		expect(result.ast).toEqual("");
+		expect(result.cst).toEqual("");
+		expect(result.errors).toEqual([]);
+	});
+});

--- a/npm/rome/tsconfig.json
+++ b/npm/rome/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+//     "rootDir": "./src/",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -44,11 +44,11 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+     "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+     "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+     "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+//     "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
      "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
@@ -99,5 +99,9 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": [
+    "./tests",
+    "./dist"
+  ]
 }

--- a/npm/rome/vitest.config.js
+++ b/npm/rome/vitest.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {},
+});


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Part of https://github.com/rome/tools/issues/3073

This PR starts works around the runtime APIs. This PR implements only few methods compared to the one proposed:
- `formatFiles`
- `formatContent`
- `parseContent`

The return type of these methods are not final yet and should not be part of the review. For example having `content` for `formatFiles` doesn't make sense. 

What's should be reviewed should be the input types for each API.

There are some tests that will fail once we start the actual work, there's some workflow with the GitHub actions and a compilation test with just TypeScript. Not sure if we really need a bundler for now.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new tests and updated an existing workflow. The reason why I didn't add `npm/rome` path to the existing format workflow is because we use `setup-rome`, which contains the old version, while I am using the current version on `main` to format and check the JS code.

I will make a new PR to change that across the board, so we are able to dogfood our JS code base while we develop. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
