### PR TITLE
fix(rome_js_analyze): fix noShoutyConstants with lowercase and being exported

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
@@ -46,11 +46,16 @@ fn is_id_and_string_literal_inner_text_equal(
         .as_js_string_literal_expression()?;
     let literal_text = literal.inner_string_text();
 
-    if id_text == literal_text {
-        Some((id.clone(), literal.clone()))
-    } else {
-        None
+    for (from_id, from_literal) in id_text.chars().zip(literal_text.chars()) {
+        if from_id != from_literal {
+            return None;
+        }
+        if from_id.is_lowercase() || from_literal.is_lowercase() {
+            return None;
+        }
     }
+
+    Some((id.clone(), literal.clone()))
 }
 
 pub struct State {
@@ -74,6 +79,11 @@ impl Rule for NoShoutyConstants {
         if declaration.is_const() {
             if let Some((binding, literal)) = is_id_and_string_literal_inner_text_equal(declarator)
             {
+                let model = ctx.model();
+                if model.is_exported(&binding) {
+                    return None;
+                }
+
                 return Some(State {
                     literal,
                     references: binding.all_references(ctx.model()).collect(),

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_shouty_constants.rs
@@ -23,6 +23,25 @@ declare_rule! {
     /// const FOO = "FOO";
     /// console.log(FOO);
     /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// let FOO = "FOO";
+    /// console.log(FOO);
+    /// ```
+    ///
+    /// ```js
+    /// export const FOO = "FOO";
+    /// console.log(FOO);
+    /// ```
+    ///
+    /// ```js
+    /// function f(FOO = "FOO") {
+    ///     return FOO;
+    /// }
+    /// ```
+    ///
     pub(crate) NoShoutyConstants {
         version: "0.7.0",
         name: "noShoutyConstants",

--- a/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
+++ b/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js
@@ -4,3 +4,8 @@ console.log(FOO, FOO2);
 const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
 
 console.log(FOO, FOO4);
+
+let foo = "foo";
+
+const A = "A";
+export default A;

--- a/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noShoutyConstants.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 97
 expression: noShoutyConstants.js
 ---
 # Input
@@ -12,6 +11,10 @@ const FOO2 = "FOO2", a = "FOO3", FOO4 = "FOO4";
 
 console.log(FOO, FOO4);
 
+let foo = "foo";
+
+const A = "A";
+export default A;
 ```
 
 # Diagnostics
@@ -28,7 +31,7 @@ warning[js/noShoutyConstants]: Redundant constant declaration.
   │             --- Used here.
 
 Suggested fix: Use the constant value directly
-    | @@ -1,6 +2,5 @@
+    | @@ -1,9 +2,8 @@
 0   | - const FOO = "FOO";
 1   | - console.log(FOO, FOO2);
 2 0 |   
@@ -38,6 +41,9 @@ Suggested fix: Use the constant value directly
 4 4 |   
 5   | - console.log(FOO, FOO4);
   5 | + console.log("FOO", FOO4);
+6 6 |   
+7 7 |   let foo = "foo";
+8 8 |   
 
 =  note: You should avoid declaring constants with a string that's the same
     value as the variable name. It introduces a level of unnecessary
@@ -57,7 +63,7 @@ warning[js/noShoutyConstants]: Redundant constant declaration.
   │       -------------
 
 Suggested fix: Use the constant value directly
-    | @@ -1,6 +1,6 @@
+    | @@ -1,7 +1,7 @@
 0 0 |   const FOO = "FOO";
 1   | - console.log(FOO, FOO2);
   1 | + console.log(FOO, "FOO2");
@@ -66,6 +72,7 @@ Suggested fix: Use the constant value directly
   3 | + const a = "FOO3", FOO4 = "FOO4";
 4 4 |   
 5 5 |   console.log(FOO, FOO4);
+6 6 |   
 
 =  note: You should avoid declaring constants with a string that's the same
     value as the variable name. It introduces a level of unnecessary
@@ -85,7 +92,7 @@ warning[js/noShoutyConstants]: Redundant constant declaration.
   │                  ---- Used here.
 
 Suggested fix: Use the constant value directly
-    | @@ -1,6 +1,6 @@
+    | @@ -1,9 +1,9 @@
 0 0 |   const FOO = "FOO";
 1 1 |   console.log(FOO, FOO2);
 2 2 |   
@@ -94,6 +101,9 @@ Suggested fix: Use the constant value directly
 4 4 |   
 5   | - console.log(FOO, FOO4);
   5 | + console.log(FOO, "FOO4");
+6 6 |   
+7 7 |   let foo = "foo";
+8 8 |   
 
 =  note: You should avoid declaring constants with a string that's the same
     value as the variable name. It introduces a level of unnecessary

--- a/crates/rome_rowan/src/cursor/node.rs
+++ b/crates/rome_rowan/src/cursor/node.rs
@@ -603,6 +603,16 @@ impl PreorderWithTokens {
             WalkEvent::Leave(parent) => WalkEvent::Leave(parent),
         })
     }
+
+    pub fn until_next_token(&mut self) -> Option<SyntaxToken> {
+        loop {
+            match self.next() {
+                Some(crate::WalkEvent::Enter(NodeOrToken::Token(t))) => break Some(t),
+                None => break None,
+                _ => continue,
+            }
+        }
+    }
 }
 
 impl Iterator for PreorderWithTokens {

--- a/website/src/docs/lint/rules/noShoutyConstants.md
+++ b/website/src/docs/lint/rules/noShoutyConstants.md
@@ -39,3 +39,21 @@ console.log(FOO);
 
 </code></pre>{% endraw %}
 
+### Valid
+
+```jsx
+let FOO = "FOO";
+console.log(FOO);
+```
+
+```jsx
+export const FOO = "FOO";
+console.log(FOO);
+```
+
+```jsx
+function f(FOO = "FOO") {
+    return FOO;
+}
+```
+


### PR DESCRIPTION
## Summary

Closes https://github.com/rome/tools/issues/3077.

## Test Plan

```
> cargo test -p rome_js_analyze -- shouty
```

with two new cases

```js
let foo = "foo";

const A = "A";
export default A;
``` 
