### PR TITLE
feat(rome_js_semantic): semantic model is_exported support for type alias, enum, interface

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_unused_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_unused_variables.rs
@@ -75,13 +75,12 @@ declare_rule! {
 // It is ok in some Typescripts constructs for a parameter to be unused.
 fn is_typescript_unused_ok(binding: &JsIdentifierBinding) -> Option<()> {
     match binding.syntax().parent()?.kind() {
-        JsSyntaxKind::JS_FORMAL_PARAMETER => {
-            let parameter = binding.parent::<JsFormalParameter>()?;
-            match parameter.syntax().parent()?.kind() {
+        JsSyntaxKind::JS_FORMAL_PARAMETER | JsSyntaxKind::JS_REST_PARAMETER => {
+            let parameter = binding.syntax().parent()?;
+            let parent = parameter.parent()?;
+            match parent.kind() {
                 JsSyntaxKind::JS_PARAMETER_LIST => {
-                    let parameters = parameter
-                        .parent::<JsParameterList>()?
-                        .parent::<JsParameters>()?;
+                    let parameters = JsParameterList::cast(parent)?.parent::<JsParameters>()?;
                     match parameters.syntax().parent()?.kind() {
                         JsSyntaxKind::TS_METHOD_SIGNATURE_CLASS_MEMBER
                         | JsSyntaxKind::TS_CALL_SIGNATURE_TYPE_MEMBER
@@ -91,8 +90,7 @@ fn is_typescript_unused_ok(binding: &JsIdentifierBinding) -> Option<()> {
                     }
                 }
                 JsSyntaxKind::JS_CONSTRUCTOR_PARAMETER_LIST => {
-                    let parameters = parameter
-                        .parent::<JsConstructorParameterList>()?
+                    let parameters = JsConstructorParameterList::cast(parent)?
                         .parent::<JsConstructorParameters>()?;
                     match parameters.syntax().parent()?.kind() {
                         JsSyntaxKind::TS_CONSTRUCT_SIGNATURE_TYPE_MEMBER

--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts
@@ -33,3 +33,5 @@ function f(fn: (title: string) => boolean) {
 	console.log(fn);
 }
 f();
+
+export type Command = (...args: any[]) => unknown;

--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts.snap
@@ -40,6 +40,8 @@ function f(fn: (title: string) => boolean) {
 }
 f();
 
+export type Command = (...args: any[]) => unknown;
+
 ```
 
 # Diagnostics

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -277,7 +277,7 @@ impl SemanticEventExtractor {
         debug_assert!(matches!(
             node.kind(),
             JS_IDENTIFIER_BINDING | TS_IDENTIFIER_BINDING
-        ));
+        ), "specified node is not a identifier binding (JS_IDENTIFIER_BINDING, TS_IDENTIFIER_BINDING)");
 
         let (name_token, is_var) = match node.kind() {
             JS_IDENTIFIER_BINDING => {
@@ -344,10 +344,13 @@ impl SemanticEventExtractor {
     }
 
     fn enter_reference_identifier(&mut self, node: &JsSyntaxNode) -> Option<()> {
-        debug_assert!(matches!(
-            node.kind(),
-            JsSyntaxKind::JS_REFERENCE_IDENTIFIER | JsSyntaxKind::JSX_REFERENCE_IDENTIFIER
-        ));
+        debug_assert!(
+            matches!(
+                node.kind(),
+                JsSyntaxKind::JS_REFERENCE_IDENTIFIER | JsSyntaxKind::JSX_REFERENCE_IDENTIFIER
+            ),
+            "specified node is not a reference identifier (JS_REFERENCE_IDENTIFIER, JSX_REFERENCE_IDENTIFIER)"
+        );
 
         let (name, is_exported) = match node.kind() {
             JsSyntaxKind::JS_REFERENCE_IDENTIFIER => {
@@ -377,6 +380,11 @@ impl SemanticEventExtractor {
     }
 
     fn enter_js_identifier_assignment(&mut self, node: &JsSyntaxNode) -> Option<()> {
+        debug_assert!(
+            matches!(node.kind(), JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT),
+            "specified node is not a identifier assignment (JS_IDENTIFIER_ASSIGNMENT)"
+        );
+
         let reference = node.clone().cast::<JsIdentifierAssignment>()?;
         let name_token = reference.name_token().ok()?;
         let name = name_token.token_text_trimmed();

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -1,3 +1,2 @@
 // list of commands available in the VS Code extension
-// rome-ignore lint(js/noUnusedVariables): false positive
 export enum Commands { SyntaxTree = "rome.syntaxTree" }

--- a/editors/vscode/src/session.ts
+++ b/editors/vscode/src/session.ts
@@ -3,7 +3,6 @@ import { Commands } from "./commands";
 import { LanguageClient } from "vscode-languageclient/node";
 import { isRomeEditor, RomeEditor } from "./utils";
 
-// rome-ignore lint(js/noUnusedVariables): false positive
 export type Command = (...args: any[]) => unknown;
 
 /**

--- a/website/playground/src/types.ts
+++ b/website/playground/src/types.ts
@@ -3,8 +3,6 @@ import { Dispatch, SetStateAction } from "react";
 export enum IndentStyle { Tab = "tab", Space = "space" }
 export enum SourceType { Module = "module", Script = "script" }
 export enum QuoteStyle { Double = "double", Single = "single" }
-
-// rome-ignore lint(js/noUnusedVariables): false positive
 export enum LoadingState { Loading, Success, Error }
 
 export interface RomeOutput {


### PR DESCRIPTION
## Summary

Address some of the issues of https://github.com/rome/tools/pull/3076

We should be able to remove: 

## Test Plan

```
> cargo test -p rome_js_analyze -- ok_semantic_model_is_exported
```
