### PR TITLE
feat(rome_rowan): `with_*_trivia_pieces`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/jsx/no_implicit_boolean.rs
+++ b/crates/rome_js_analyze/src/analyzers/jsx/no_implicit_boolean.rs
@@ -97,9 +97,8 @@ impl Rule for NoImplicitBoolean {
         let last_token_of_name_syntax = name_syntax.last_token()?;
         // drop the trailing trivia of name_syntax, at CST level it means
         // clean the trailing trivia of last token of name_syntax
-        let next_last_token_of_name_syntax = last_token_of_name_syntax
-            .clone()
-            .with_trailing_trivia(std::iter::empty());
+        let next_last_token_of_name_syntax =
+            last_token_of_name_syntax.with_trailing_trivia(std::iter::empty());
 
         let next_name = name.replace_token_discard_trivia(
             last_token_of_name_syntax,

--- a/crates/rome_rowan/src/ast/mutation.rs
+++ b/crates/rome_rowan/src/ast/mutation.rs
@@ -95,12 +95,9 @@ where
         let next_last = next_node.syntax().last_token();
 
         if let (Some(prev_last), Some(next_last)) = (prev_last, next_last) {
-            let pieces: Vec<_> = prev_last.trailing_trivia().pieces().collect();
-
             next_node = next_node.replace_token_discard_trivia(
                 next_last.clone(),
-                next_last
-                    .with_trailing_trivia(pieces.iter().map(|piece| (piece.kind(), piece.text()))),
+                next_last.with_trailing_trivia_pieces(prev_last.trailing_trivia().pieces()),
             )?;
         }
 
@@ -130,22 +127,14 @@ where
     where
         Self: Sized,
     {
-        let leading_trivia: Vec<_> = prev_token.leading_trivia().pieces().collect();
-        let trailing_trivia: Vec<_> = prev_token.trailing_trivia().pieces().collect();
+        let leading_trivia = prev_token.leading_trivia().pieces();
+        let trailing_trivia = prev_token.trailing_trivia().pieces();
 
         self.replace_token_discard_trivia(
             prev_token,
             next_token
-                .with_leading_trivia(
-                    leading_trivia
-                        .iter()
-                        .map(|piece| (piece.kind(), piece.text())),
-                )
-                .with_trailing_trivia(
-                    trailing_trivia
-                        .iter()
-                        .map(|piece| (piece.kind(), piece.text())),
-                ),
+                .with_leading_trivia_pieces(leading_trivia)
+                .with_trailing_trivia_pieces(trailing_trivia),
         )
     }
 

--- a/crates/rome_rowan/src/cursor/trivia.rs
+++ b/crates/rome_rowan/src/cursor/trivia.rs
@@ -52,7 +52,7 @@ impl SyntaxTrivia {
     }
 
     /// Get the number of TriviaPiece inside this trivia
-    fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.green_trivia().len()
     }
 

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -255,7 +255,7 @@ impl<L: Language> SyntaxNode<L> {
 
     /// Returns the index of this node inside of its parent
     #[inline]
-    pub(crate) fn index(&self) -> usize {
+    pub fn index(&self) -> usize {
         self.raw.index()
     }
 

--- a/crates/rome_rowan/src/syntax/token.rs
+++ b/crates/rome_rowan/src/syntax/token.rs
@@ -219,7 +219,7 @@ impl<L: Language> SyntaxToken<L> {
 
     /// Return a new version of this token with its leading trivia replaced with `trivia`
     #[must_use = "syntax elements are immutable, the result of update methods must be propagated to have any effect"]
-    pub fn with_leading_trivia_pieces<'a, I>(&self, trivia: I) -> Self
+    pub fn with_leading_trivia_pieces<I>(&self, trivia: I) -> Self
     where
         I: IntoIterator<Item = SyntaxTriviaPiece<L>>,
         I::IntoIter: ExactSizeIterator,

--- a/crates/rome_rowan/src/syntax/trivia.rs
+++ b/crates/rome_rowan/src/syntax/trivia.rs
@@ -224,6 +224,10 @@ pub struct SyntaxTriviaPiece<L: Language> {
 }
 
 impl<L: Language> SyntaxTriviaPiece<L> {
+    pub(crate) fn into_raw_piece(self) -> TriviaPiece {
+        self.trivia
+    }
+
     /// Returns the internal kind of this trivia piece
     pub fn kind(&self) -> TriviaPieceKind {
         self.trivia.kind()
@@ -626,6 +630,14 @@ impl<L: Language> SyntaxTrivia<L> {
 
     pub fn text_range(&self) -> TextRange {
         self.raw.text_range()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.raw.len() == 0
+    }
+
+    pub fn has_skipped(&self) -> bool {
+        self.pieces().any(|piece| piece.is_skipped())
     }
 }
 


### PR DESCRIPTION
This PR adds the `with_leading_trivia_pieces` and `with_trailing_trivia_pieces` methods to `SyntaxToken` that accept a `SyntaxTriviaPiece` iterator instead of an iterator over `(kind, &str)` tuple.

The motivation for adding this overload is because it is often necessary to merge trivia from different tokens. Unfortunately, just doing

```
token.with_leading_trivia(existing_pieces.map(|piece| (piece.kind(), piece.text()))
```

It does not work because `text()` returns data owned by `piece` which goes out of scope as soon as the `map closure` returns.

 The workaround thus far has been to collect the pieces and map over the piece references which comes at the cost of an additional vector allocation. Avoiding the extra allocation will be more important in the formatter where this method will soon be called for every parenthesized expression in a program.

## Test

I updated the mutation and batch mutation to use the new API and all analyzer tests continue to run.
