### PR TITLE
docs(website): fix typo on project-config.md

### DIFF
--- a/website/src/_includes/docs/project-config.md
+++ b/website/src/_includes/docs/project-config.md
@@ -173,7 +173,7 @@ Enables Rome's formatter
 > Default: `true`
 
 
-#### `format.indentStyle`
+#### `formatter.indentStyle`
 
 The style of the indentation. It can be `"tab"` or `"space"`.
 
@@ -181,11 +181,11 @@ The style of the indentation. It can be `"tab"` or `"space"`.
 
 Rome's default is `"tab"`.
 
-#### `format.indentSize`
+#### `formatter.indentSize`
 
 How big the indentation should be.
 
-#### `format.lineWidth`
+#### `formatter.lineWidth`
 
 How many characters can be written on a single line.
 


### PR DESCRIPTION
## Summary

At the current docs the keys are `format`, but when using it in rome.json it causes a crash saying:
```
Error: Rome couldn't load the configuration file, here's why: 
unknown field `format`, expected one of `formatter`, `linter`, `javascript` at line 7 column 10
```
This PR fixes the key to the correct one `formatter`.

## Test Plan

Started the server and it was all ok.