### PR TITLE
refactor: use `std::sync::Mutex` instead of `parking_lot::Mutex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ name = "rome_console"
 version = "0.0.0"
 dependencies = [
  "atty",
+ "lazy_static",
  "rome_markup",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,6 @@ dependencies = [
  "hdrhistogram",
  "insta",
  "lazy_static",
- "parking_lot 0.12.1",
  "pico-args",
  "rayon",
  "rome_bin",
@@ -1522,7 +1521,6 @@ name = "rome_console"
 version = "0.0.0"
 dependencies = [
  "atty",
- "lazy_static",
  "rome_markup",
  "schemars",
  "serde",
@@ -1640,7 +1638,6 @@ dependencies = [
  "ctor",
  "iai",
  "insta",
- "parking_lot 0.12.1",
  "quickcheck",
  "quickcheck_macros",
  "rome_diagnostics",
@@ -1726,7 +1723,6 @@ dependencies = [
  "anyhow",
  "futures",
  "indexmap",
- "parking_lot 0.12.1",
  "rome_analyze",
  "rome_console",
  "rome_diagnostics",

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -18,7 +18,6 @@ rome_console = { path = "../rome_console" }
 pico-args = { version ="0.5.0", features=["eq-separator"] }
 tracing = { version = "0.1.31", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.6"
-parking_lot = "0.12.0"
 lazy_static = "1.4.0"
 hdrhistogram = { version = "7.5.0", default-features = false }
 crossbeam = "0.8.1"

--- a/crates/rome_fs/src/interner.rs
+++ b/crates/rome_fs/src/interner.rs
@@ -9,7 +9,7 @@ use std::{
 
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use indexmap::IndexSet;
-use parking_lot::RwLock;
+use std::sync::RwLock;
 
 pub type FileId = usize;
 
@@ -23,7 +23,7 @@ pub struct IndexSetInterner {
 
 impl PathInterner for IndexSetInterner {
     fn intern_path(&self, path: PathBuf) -> FileId {
-        let (index, _) = self.storage.write().insert_full(path);
+        let (index, _) = self.storage.write().unwrap().insert_full(path);
         index
     }
 }

--- a/crates/rome_js_formatter/Cargo.toml
+++ b/crates/rome_js_formatter/Cargo.toml
@@ -29,7 +29,6 @@ tests_macros = { path = "../tests_macros" }
 insta = { version="1.18.2", features = ["glob"] }
 rome_diagnostics = { path = "../rome_diagnostics" }
 countme = { version = "3.0.0", features = ["enable"] }
-parking_lot = "0.12.0"
 similar = "2.1.0"
 similar-asserts = "1.2.0"
 ctor = "0.1.21"

--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -25,7 +25,6 @@ rome_console = { path = "../rome_console" }
 tokio = { version = "1.15.0", features = ["io-std"] }
 tower-lsp = { version = "0.17.0" }
 tracing = { version = "0.1.31", default-features = false, features = ["std", "attributes"] }
-parking_lot = "0.12.0"
 futures = "0.3"
 
 [dev-dependencies]

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -45,6 +45,7 @@ impl LanguageServer for LSPServer {
         self.session
             .client_capabilities
             .write()
+            .unwrap()
             .replace(params.capabilities);
 
         let init = InitializeResult {
@@ -67,7 +68,11 @@ impl LanguageServer for LSPServer {
         match load_config(&self.session.fs) {
             Ok(Some(configuration)) => {
                 info!("Configuration found, and it is valid!");
-                self.session.configuration.write().replace(configuration);
+                self.session
+                    .configuration
+                    .write()
+                    .unwrap()
+                    .replace(configuration);
             }
             Err(err) => {
                 error!("Couldn't load the configuration file, reason:\n {}", err);

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -5,7 +5,6 @@ use crate::url_interner::UrlInterner;
 use crate::utils;
 use futures::stream::futures_unordered::FuturesUnordered;
 use futures::StreamExt;
-use parking_lot::RwLock;
 use rome_analyze::RuleCategories;
 use rome_diagnostics::file::FileId;
 use rome_fs::{FileSystem, OsFileSystem, RomePath};
@@ -16,6 +15,7 @@ use rome_service::Workspace;
 use rome_service::{DynRef, RomeError};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::RwLock;
 use tower_lsp::lsp_types;
 use tracing::{error, trace};
 
@@ -66,6 +66,7 @@ impl Session {
     pub(crate) fn document(&self, url: &lsp_types::Url) -> Result<Document, RomeError> {
         self.documents
             .read()
+            .unwrap()
             .get(url)
             .cloned()
             .ok_or(RomeError::NotFound)
@@ -75,18 +76,18 @@ impl Session {
     ///
     /// Used by [`handlers::text_document] to synchronize documents with the client.
     pub(crate) fn insert_document(&self, url: lsp_types::Url, document: Document) {
-        self.documents.write().insert(url, document);
+        self.documents.write().unwrap().insert(url, document);
     }
 
     /// Remove the [`Document`] matching the provided [`lsp_types::Url`]
     pub(crate) fn remove_document(&self, url: &lsp_types::Url) {
-        self.documents.write().remove(url);
+        self.documents.write().unwrap().remove(url);
     }
 
     /// Return the unique [FileId] associated with the url for this [Session].
     /// This will assign a new FileId if there isn't one for the provided url.
     pub(crate) fn file_id(&self, url: lsp_types::Url) -> FileId {
-        self.url_interner.write().intern(url)
+        self.url_interner.write().unwrap().intern(url)
     }
 
     pub(crate) fn file_path(&self, url: &lsp_types::Url) -> RomePath {
@@ -134,6 +135,7 @@ impl Session {
         let mut futures: FuturesUnordered<_> = self
             .documents
             .read()
+            .unwrap()
             .keys()
             .map(|url| self.update_diagnostics(url.clone()))
             .collect();
@@ -149,6 +151,7 @@ impl Session {
     pub(crate) fn can_register_did_change_configuration(&self) -> bool {
         self.client_capabilities
             .read()
+            .unwrap()
             .as_ref()
             .and_then(|c| c.workspace.as_ref())
             .and_then(|c| c.did_change_configuration)
@@ -170,7 +173,7 @@ impl Session {
                 .into_iter()
                 .next()
                 .and_then(|client_configuration| {
-                    let mut config = self.config.write();
+                    let mut config = self.config.write().unwrap();
 
                     config
                         .set_workspace_settings(client_configuration)
@@ -178,7 +181,7 @@ impl Session {
                             error!("Cannot set workspace settings: {}", err);
                         })
                         .ok()?;
-                    let mut configuration = self.configuration.write();
+                    let mut configuration = self.configuration.write().unwrap();
                     // This operation is intended, we want to consume the configuration because once it's read
                     // from the LSP, it's not needed anymore
                     let settings = config.as_workspace_settings(configuration.take());


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
1. Part of #3054 
2.  With the standard library Mutex and RwLock being const-constructible it's now possible to use these in the DiffReport of the Prettier test suite
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1. Passing CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
