### PR TITLE
feat(npm): hook `*Conent` APIs to WASM bindings

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,3 @@
-_
 # Jobs run on pull request
 name: Pull request
 on:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-
+_
 # Jobs run on pull request
 name: Pull request
 on:

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -55,3 +55,27 @@ jobs:
       - name: Type check
         working-directory: website/playground
         run: pnpm tsc
+  apis-check:
+    name: Checks on APIs project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+      - name: Cache pnpm modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 7
+      - name: Install libraries
+        working-directory: npm/rome
+        run: pnpm i
+      - name: CI checks
+        working-directory: npm/rome
+        run: pnpm ci

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -55,27 +55,3 @@ jobs:
       - name: Type check
         working-directory: website/playground
         run: pnpm tsc
-  apis-check:
-    name: Checks on APIs project
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PR Branch
-        uses: actions/checkout@v3
-        with:
-          submodules: false
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.1.0
-        with:
-          version: 7
-      - name: Install libraries
-        working-directory: npm/rome
-        run: pnpm i
-      - name: CI checks
-        working-directory: npm/rome
-        run: pnpm ci

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install libraries
         working-directory: npm/rome
         run: pnpm i
+      - name: Compile WASM bindings
+        working-directory: npm/rome
+        run: pnpm build:wasm
       - name: CI checks
         working-directory: npm/rome
         run: pnpm ci

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -42,7 +42,9 @@ jobs:
         run: pnpm i
       - name: Compile WASM bindings
         working-directory: npm/rome
-        run: pnpm build:wasm
+        run: |
+          pnpm build:wasm
+          pnpm i
       - name: CI checks
         working-directory: npm/rome
         run: pnpm ci

--- a/npm/backend-jsonrpc/package.json
+++ b/npm/backend-jsonrpc/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "vitest",
     "test:ci": "vitest --run",
-    "tsc": "tsc"
+    "tsc": "tsc --noEmit",
+    "build": "tsc"
   },
   "homepage": "https://rome.tools",
   "author": "Rome Tools Developers and Contributors",

--- a/npm/backend-jsonrpc/src/index.ts
+++ b/npm/backend-jsonrpc/src/index.ts
@@ -1,7 +1,7 @@
 import { getCommand } from "./command";
 import { createSocket } from "./socket";
 import { Transport } from "./transport";
-import { createWorkspace as wrapTransport, type Workspace } from "./workspace";
+import { createWorkspace as wrapTransport, type Workspace, type RomePath } from "./workspace";
 
 /**
  * Create an instance of the Workspace client connected to a remote daemon
@@ -42,3 +42,5 @@ export async function createWorkspaceWithBinary(
 
 	return wrapTransport(transport);
 }
+
+export * from "./workspace";

--- a/npm/backend-jsonrpc/tsconfig.json
+++ b/npm/backend-jsonrpc/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -35,9 +35,6 @@
         "node": ">=14.*"
     },
     "license": "MIT",
-    "dependencies": {
-        "@rometools/backend-jsonrpc": "../backend-jsonrpc"
-    },
     "devDependencies": {
         "typescript": "^4.7.4",
         "vitest": "^0.22.0",

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -7,9 +7,9 @@
         "tsc": "tsc --noEmit",
         "format": "cargo rome-cli-dev format ./ --write",
         "ci": "cargo rome-cli-dev ci ./src && pnpm test:ci && tsc --noEmit",
+        "check": "cargo rome-cli-dev check ./src && tsc --noEmit",
         "build:wasm-dev": "wasm-pack build --out-dir ../../npm/wasm-nodejs --target nodejs --dev --scope rometools ../../crates/rome_wasm",
         "build:wasm": "wasm-pack build --out-dir ../../npm/wasm-nodejs --target nodejs --release --scope rometools ../../crates/rome_wasm",
-        "check": "cargo rome-cli-dev check ./src && tsc --noEmit",
         "test": "vitest",
         "test:ci": "vitest --run",
         "build": "tsc "

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -7,6 +7,8 @@
         "tsc": "tsc --noEmit",
         "format": "cargo rome-cli-dev format ./ --write",
         "ci": "cargo rome-cli-dev ci ./src && pnpm test:ci && tsc --noEmit",
+        "build:wasm-dev": "wasm-pack build --out-dir ../../npm/wasm-nodejs --target nodejs --dev --scope rometools ../../crates/rome_wasm",
+        "build:wasm": "wasm-pack build --out-dir ../../npm/wasm-nodejs --target nodejs --release --scope rometools ../../crates/rome_wasm",
         "check": "cargo rome-cli-dev check ./src && tsc --noEmit",
         "test": "vitest",
         "test:ci": "vitest --run",
@@ -33,9 +35,14 @@
         "node": ">=14.*"
     },
     "license": "MIT",
+    "dependencies": {
+        "@rometools/backend-jsonrpc": "../backend-jsonrpc"
+    },
     "devDependencies": {
         "typescript": "^4.7.4",
         "vitest": "^0.22.0",
-        "vite": "^3.0.8"
+        "vite": "^3.0.8",
+        "@rometools/wasm-nodejs": "../wasm-nodejs",
+        "wasm-pack": "^0.10.3"
     }
 }

--- a/npm/rome/pnpm-lock.yaml
+++ b/npm/rome/pnpm-lock.yaml
@@ -1,20 +1,18 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@rometools/backend-jsonrpc': ../backend-jsonrpc
   '@rometools/wasm-nodejs': ../wasm-nodejs
   typescript: ^4.7.4
   vite: ^3.0.8
   vitest: ^0.22.0
-
-dependencies:
-  '@rometools/backend-jsonrpc': link:../backend-jsonrpc
+  wasm-pack: ^0.10.3
 
 devDependencies:
   '@rometools/wasm-nodejs': link:../wasm-nodejs
   typescript: 4.7.4
   vite: 3.0.8
   vitest: 0.22.0
+  wasm-pack: 0.10.3
 
 packages:
 
@@ -45,6 +43,36 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
+  /axios/0.21.4:
+    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
+    dependencies:
+      follow-redirects: 1.15.1
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
+
+  /binary-install/0.1.1:
+    resolution: {integrity: sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      axios: 0.21.4
+      rimraf: 3.0.2
+      tar: 6.1.11
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
+  /brace-expansion/1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: true
+
   /chai/4.3.6:
     resolution: {integrity: sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==}
     engines: {node: '>=4'}
@@ -60,6 +88,15 @@ packages:
 
   /check-error/1.0.2:
     resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
+    dev: true
+
+  /chownr/2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /concat-map/0.0.1:
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: true
 
   /debug/4.3.4:
@@ -290,6 +327,27 @@ packages:
       esbuild-windows-arm64: 0.14.54
     dev: true
 
+  /follow-redirects/1.15.1:
+    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: true
+
+  /fs-minipass/2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.3.4
+    dev: true
+
+  /fs.realpath/1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
+
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -306,11 +364,33 @@ packages:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
     dev: true
 
+  /glob/7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
   /has/1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+    dev: true
+
+  /inflight/1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: true
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
 
   /is-core-module/2.10.0:
@@ -330,6 +410,33 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /minimatch/3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /minipass/3.3.4:
+    resolution: {integrity: sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==}
+    engines: {node: '>=8'}
+    dependencies:
+      yallist: 4.0.0
+    dev: true
+
+  /minizlib/2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.3.4
+      yallist: 4.0.0
+    dev: true
+
+  /mkdirp/1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -338,6 +445,17 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: true
+
+  /once/1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    dependencies:
+      wrappy: 1.0.2
+    dev: true
+
+  /path-is-absolute/1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /path-parse/1.0.7:
@@ -370,6 +488,13 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
+  /rimraf/3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+    dev: true
+
   /rollup/2.77.3:
     resolution: {integrity: sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==}
     engines: {node: '>=10.0.0'}
@@ -386,6 +511,18 @@ packages:
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /tar/6.1.11:
+    resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
+    engines: {node: '>= 10'}
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 3.3.4
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
     dev: true
 
   /tinypool/0.2.4:
@@ -473,4 +610,22 @@ packages:
       - stylus
       - supports-color
       - terser
+    dev: true
+
+  /wasm-pack/0.10.3:
+    resolution: {integrity: sha512-dg1PPyp+QwWrhfHsgG12K/y5xzwfaAoK1yuVC/DUAuQsDy5JywWDuA7Y/ionGwQz+JBZVw8jknaKBnaxaJfwTA==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      binary-install: 0.1.1
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
+  /wrappy/1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
+
+  /yallist/4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true

--- a/npm/rome/pnpm-lock.yaml
+++ b/npm/rome/pnpm-lock.yaml
@@ -1,11 +1,17 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@rometools/backend-jsonrpc': ../backend-jsonrpc
+  '@rometools/wasm-nodejs': ../wasm-nodejs
   typescript: ^4.7.4
   vite: ^3.0.8
   vitest: ^0.22.0
 
+dependencies:
+  '@rometools/backend-jsonrpc': link:../backend-jsonrpc
+
 devDependencies:
+  '@rometools/wasm-nodejs': link:../wasm-nodejs
   typescript: 4.7.4
   vite: 3.0.8
   vitest: 0.22.0

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -157,7 +157,7 @@ export class Rome {
 			id: 0,
 			path: options.filePath,
 		};
-		await this.workspace.change_file({
+		await this.workspace.open_file({
 			content,
 			version: 0,
 			path,

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -5,7 +5,7 @@ interface FormatFilesDebugOptions extends FormatFilesOptions {
 	debug: boolean;
 }
 
-interface FormatContentDebugOptions extends FormatFilesOptions {
+interface FormatContentDebugOptions extends FormatContentOptions {
 	/**
 	 * If `true`, you'll be able to inspect the IR of the formatter
 	 */
@@ -16,7 +16,7 @@ interface FormatFilesOptions {
 	/**
 	 * Writes the new content to disk
 	 */
-	write: boolean;
+	write?: boolean;
 }
 
 interface FormatContentOptions {
@@ -28,7 +28,7 @@ interface FormatContentOptions {
 	/**
 	 * The range where to format the content
 	 */
-	range: [number, number];
+	range?: [number, number];
 }
 
 interface FormatResult {
@@ -68,24 +68,35 @@ interface ParseResult {
 	errors: string[];
 }
 
-function isFormatFilesDebug(options: any): options is FormatFilesDebugOptions {
-	return options.debug !== undefined;
+function isFormatFilesDebug(
+	options: FormatFilesOptions | FormatFilesDebugOptions,
+): options is FormatFilesDebugOptions {
+	return "debug" in options && options.debug !== undefined;
 }
 
 function isFormatContentDebug(
 	options: any,
 ): options is FormatContentDebugOptions {
-	return options.debug !== undefined;
+	return options?.debug !== undefined;
 }
 
 export class Rome {
+	async formatFiles(paths: string[]): Promise<FormatResult>;
 	async formatFiles(
 		paths: string[],
-		options?: Partial<FormatFilesOptions>,
+		options?: FormatFilesOptions,
+	): Promise<FormatResult>;
+	async formatFiles(
+		paths: string[],
+		options?: FormatFilesDebugOptions,
+	): Promise<FormatDebugResult>;
+	async formatFiles(
+		paths: string[],
+		options?: FormatFilesOptions | FormatFilesDebugOptions,
 	): Promise<FormatResult | FormatDebugResult> {
 		paths;
 
-		if (isFormatFilesDebug(options)) {
+		if (options && isFormatFilesDebug(options)) {
 			return {
 				content: "",
 				errors: [],
@@ -100,9 +111,18 @@ export class Rome {
 
 	async formatContent(
 		content: string,
-		options?: Partial<FormatContentOptions>,
+		options: FormatContentOptions,
+	): Promise<FormatResult>;
+	async formatContent(
+		content: string,
+		options: FormatContentDebugOptions,
+	): Promise<FormatDebugResult>;
+	async formatContent(
+		content: string,
+		options: FormatContentOptions | FormatContentDebugOptions,
 	): Promise<FormatResult | FormatDebugResult> {
 		content;
+		options.filePath;
 		if (isFormatContentDebug(options)) {
 			return {
 				content: "",

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -1,23 +1,30 @@
-interface FormatDebugOptions {
+interface FormatFilesDebugOptions extends FormatFilesOptions {
 	/**
 	 * If `true`, you'll be able to inspect the IR of the formatter
 	 */
 	debug: boolean;
 }
 
-interface FormatFilesOptions extends FormatDebugOptions {
+interface FormatContentDebugOptions extends FormatFilesOptions {
+	/**
+	 * If `true`, you'll be able to inspect the IR of the formatter
+	 */
+	debug: boolean;
+}
+
+interface FormatFilesOptions {
 	/**
 	 * Writes the new content to disk
 	 */
 	write: boolean;
 }
 
-interface FormatContentOptions extends FormatDebugOptions {
+interface FormatContentOptions {
 	/**
 	 * A virtual path of the file. You should add the extension,
 	 * so Rome knows how to parse the content
 	 */
-	filePath: String;
+	filePath: string;
 	/**
 	 * The range where to format the content
 	 */
@@ -26,11 +33,18 @@ interface FormatContentOptions extends FormatDebugOptions {
 
 interface FormatResult {
 	// Not final
-	content: String;
+	content: string;
 	// Not final
-	errors: String[];
+	errors: string[];
+}
+
+interface FormatDebugResult {
+	// Not final
+	content: string;
+	// Not final
+	errors: string[];
 	// Available when in debug mode
-	ir: String | null;
+	ir: string | null;
 }
 
 interface ParseOptions {
@@ -38,50 +52,71 @@ interface ParseOptions {
 	 * A virtual path of the file. You should add the extension,
 	 * so Rome knows how to parse the content
 	 */
-	filePath: String;
+	filePath: string;
 }
 
 interface ParseResult {
 	/**
 	 * The CST of the code
 	 */
-	cst: String;
+	cst: string;
 	/**
 	 * The AST of the code
 	 */
-	ast: String;
+	ast: string;
 	// Not final
-	errors: String[];
+	errors: string[];
+}
+
+function isFormatFilesDebug(options: any): options is FormatFilesDebugOptions  {
+	return options.debug !== undefined
+}
+
+function isFormatContentDebug(options: any): options is FormatContentDebugOptions  {
+	return options.debug !== undefined
 }
 
 export class Rome {
 	async formatFiles(
-		paths: String[],
-		options: Partial<FormatFilesOptions> | undefined = undefined,
-	): Promise<FormatResult> {
+		paths: string[],
+		options?: Partial<FormatFilesOptions>,
+	): Promise<FormatResult | FormatDebugResult> {
 		paths;
 
+		if (isFormatFilesDebug(options)) {
+			return {
+				content: "",
+				errors: [],
+				ir: "",
+			};
+		}
 		return {
 			content: "",
 			errors: [],
-			ir: options?.debug ? "" : null,
 		};
+
 	}
 
 	async formatContent(
-		content: String,
-		options: Partial<FormatContentOptions> | undefined = undefined,
-	): Promise<FormatResult> {
+		content: string,
+		options?: Partial<FormatContentOptions>,
+	): Promise<FormatResult | FormatDebugResult> {
 		content;
+		if (isFormatContentDebug(options)) {
+			return {
+				content: "",
+				errors: [],
+				ir: "",
+			};
+		}
 		return {
 			content: "",
 			errors: [],
-			ir: options?.debug ? "" : null,
 		};
 	}
 
 	async parseContent(
-		content: String,
+		content: string,
 		options: ParseOptions,
 	): Promise<ParseResult> {
 		content;

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -1,50 +1,36 @@
-interface FormatFilesDebugOptions extends FormatFilesOptions {
+interface FormatDebugOptions {
 	/**
 	 * If `true`, you'll be able to inspect the IR of the formatter
 	 */
 	debug: boolean;
 }
 
-interface FormatContentDebugOptions extends FormatContentOptions {
-	/**
-	 * If `true`, you'll be able to inspect the IR of the formatter
-	 */
-	debug: boolean;
-}
-
-interface FormatFilesOptions {
+interface FormatFilesOptions extends FormatDebugOptions {
 	/**
 	 * Writes the new content to disk
 	 */
-	write?: boolean;
+	write: boolean;
 }
 
-interface FormatContentOptions {
+interface FormatContentOptions extends FormatDebugOptions {
 	/**
 	 * A virtual path of the file. You should add the extension,
 	 * so Rome knows how to parse the content
 	 */
-	filePath: string;
+	filePath: String;
 	/**
 	 * The range where to format the content
 	 */
-	range?: [number, number];
+	range: [number, number];
 }
 
 interface FormatResult {
 	// Not final
-	content: string;
+	content: String;
 	// Not final
-	errors: string[];
-}
-
-interface FormatDebugResult {
-	// Not final
-	content: string;
-	// Not final
-	errors: string[];
+	errors: String[];
 	// Available when in debug mode
-	ir: string | null;
+	ir: String | null;
 }
 
 interface ParseOptions {
@@ -52,92 +38,50 @@ interface ParseOptions {
 	 * A virtual path of the file. You should add the extension,
 	 * so Rome knows how to parse the content
 	 */
-	filePath: string;
+	filePath: String;
 }
 
 interface ParseResult {
 	/**
 	 * The CST of the code
 	 */
-	cst: string;
+	cst: String;
 	/**
 	 * The AST of the code
 	 */
-	ast: string;
+	ast: String;
 	// Not final
-	errors: string[];
-}
-
-function isFormatFilesDebug(
-	options: FormatFilesOptions | FormatFilesDebugOptions,
-): options is FormatFilesDebugOptions {
-	return "debug" in options && options.debug !== undefined;
-}
-
-function isFormatContentDebug(
-	options: any,
-): options is FormatContentDebugOptions {
-	return options?.debug !== undefined;
+	errors: String[];
 }
 
 export class Rome {
-	async formatFiles(paths: string[]): Promise<FormatResult>;
 	async formatFiles(
-		paths: string[],
-		options?: FormatFilesOptions,
-	): Promise<FormatResult>;
-	async formatFiles(
-		paths: string[],
-		options?: FormatFilesDebugOptions,
-	): Promise<FormatDebugResult>;
-	async formatFiles(
-		paths: string[],
-		options?: FormatFilesOptions | FormatFilesDebugOptions,
-	): Promise<FormatResult | FormatDebugResult> {
+		paths: String[],
+		options: Partial<FormatFilesOptions> | undefined = undefined,
+	): Promise<FormatResult> {
 		paths;
 
-		if (options && isFormatFilesDebug(options)) {
-			return {
-				content: "",
-				errors: [],
-				ir: "",
-			};
-		}
 		return {
 			content: "",
 			errors: [],
+			ir: options?.debug ? "" : null,
 		};
 	}
 
 	async formatContent(
-		content: string,
-		options: FormatContentOptions,
-	): Promise<FormatResult>;
-	async formatContent(
-		content: string,
-		options: FormatContentDebugOptions,
-	): Promise<FormatDebugResult>;
-	async formatContent(
-		content: string,
-		options: FormatContentOptions | FormatContentDebugOptions,
-	): Promise<FormatResult | FormatDebugResult> {
+		content: String,
+		options: Partial<FormatContentOptions> | undefined = undefined,
+	): Promise<FormatResult> {
 		content;
-		options.filePath;
-		if (isFormatContentDebug(options)) {
-			return {
-				content: "",
-				errors: [],
-				ir: "",
-			};
-		}
 		return {
 			content: "",
 			errors: [],
+			ir: options?.debug ? "" : null,
 		};
 	}
 
 	async parseContent(
-		content: string,
+		content: String,
 		options: ParseOptions,
 	): Promise<ParseResult> {
 		content;

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -68,12 +68,14 @@ interface ParseResult {
 	errors: string[];
 }
 
-function isFormatFilesDebug(options: any): options is FormatFilesDebugOptions  {
-	return options.debug !== undefined
+function isFormatFilesDebug(options: any): options is FormatFilesDebugOptions {
+	return options.debug !== undefined;
 }
 
-function isFormatContentDebug(options: any): options is FormatContentDebugOptions  {
-	return options.debug !== undefined
+function isFormatContentDebug(
+	options: any,
+): options is FormatContentDebugOptions {
+	return options.debug !== undefined;
 }
 
 export class Rome {
@@ -94,7 +96,6 @@ export class Rome {
 			content: "",
 			errors: [],
 		};
-
 	}
 
 	async formatContent(

--- a/npm/rome/tests/index.test.ts
+++ b/npm/rome/tests/index.test.ts
@@ -3,7 +3,7 @@ import { Rome } from "../src/index";
 
 describe("Rome formatter", () => {
 	it("should not format files", async () => {
-		const rome = new Rome();
+		const rome = await Rome.create();
 
 		let result = await rome.formatFiles(["./path/to/file.js"]);
 
@@ -12,7 +12,7 @@ describe("Rome formatter", () => {
 	});
 
 	it("should not format files in debug mode", async () => {
-		const rome = new Rome();
+		const rome = await Rome.create();
 
 		let result = await rome.formatFiles(["./path/to/file.js"], {
 			debug: true,
@@ -24,7 +24,7 @@ describe("Rome formatter", () => {
 	});
 
 	it("should format content", async () => {
-		const rome = new Rome();
+		const rome = await Rome.create();
 
 		let result = await rome.formatContent("function f   () {  }", {
 			filePath: "example.js",
@@ -35,7 +35,7 @@ describe("Rome formatter", () => {
 	});
 
 	it("should format content in debug mode", async () => {
-		const rome = new Rome();
+		const rome = await Rome.create();
 
 		let result = await rome.formatContent("function f() {}", {
 			filePath: "example.js",
@@ -50,7 +50,7 @@ describe("Rome formatter", () => {
 	});
 
 	it("should not format content with range", async () => {
-		const rome = new Rome();
+		const rome = await Rome.create();
 
 		let result = await rome.formatContent("let a   ; function g () {  }", {
 			filePath: "file.js",
@@ -62,7 +62,7 @@ describe("Rome formatter", () => {
 	});
 
 	it("should not format content with range in debug mode", async () => {
-		const rome = new Rome();
+		const rome = await Rome.create();
 
 		let result = await rome.formatContent("let a   ; function g () {  }", {
 			filePath: "file.js",
@@ -95,7 +95,7 @@ describe("Rome formatter", () => {
 
 describe("Rome parser", () => {
 	it("should not parse content", async () => {
-		const rome = new Rome();
+		const rome = await Rome.create();
 
 		let result = await rome.parseContent("function f() {}", {
 			filePath: "example.js",

--- a/npm/rome/tests/index.test.ts
+++ b/npm/rome/tests/index.test.ts
@@ -23,18 +23,18 @@ describe("Rome formatter", () => {
 		expect(result.ir).toEqual("");
 	});
 
-	it("should not format content", async () => {
+	it("should format content", async () => {
 		const rome = new Rome();
 
-		let result = await rome.formatContent("function f() {}", {
+		let result = await rome.formatContent("function f   () {  }", {
 			filePath: "example.js",
 		});
 
-		expect(result.content).toEqual("");
+		expect(result.content).toEqual("function f() {}\n");
 		expect(result.errors).toEqual([]);
 	});
 
-	it("should not format content in debug mode", async () => {
+	it("should format content in debug mode", async () => {
 		const rome = new Rome();
 
 		let result = await rome.formatContent("function f() {}", {
@@ -42,35 +42,51 @@ describe("Rome formatter", () => {
 			debug: true,
 		});
 
-		expect(result.content).toEqual("");
+		expect(result.content).toEqual("function f() {}\n");
 		expect(result.errors).toEqual([]);
-		expect(result.ir).toEqual("");
+		expect(result.ir).toEqual('["function", " ", "f", group(["(", ")"]), " ", "{", "}", hard_line_break]');
 	});
 
 	it("should not format content with range", async () => {
 		const rome = new Rome();
 
-		let result = await rome.formatContent("function f() {}", {
+		let result = await rome.formatContent("let a   ; function g () {  }", {
 			filePath: "file.js",
-			range: [5, 10],
+			range: [20, 25],
 		});
 
-		expect(result.content).toEqual("");
+		expect(result.content).toEqual("function g() {}");
 		expect(result.errors).toEqual([]);
 	});
 
 	it("should not format content with range in debug mode", async () => {
 		const rome = new Rome();
 
-		let result = await rome.formatContent("function f() {}", {
+
+		let result = await rome.formatContent("let a   ; function g () {  }", {
 			filePath: "file.js",
-			range: [5, 10],
+			range: [20, 25],
 			debug: true,
 		});
 
-		expect(result.content).toEqual("");
+		console.log(result.ir);
+		expect(result.content).toEqual("function g() {}");
 		expect(result.errors).toEqual([]);
-		expect(result.ir).toEqual("");
+		expect(result.ir).toEqual(`[
+  "let",
+  " ",
+  group(["a"]),
+  ";",
+  hard_line_break,
+  "function",
+  " ",
+  "g",
+  group(["(", ")"]),
+  " ",
+  "{",
+  "}",
+  hard_line_break
+]`);
 	});
 });
 

--- a/npm/rome/tests/index.test.ts
+++ b/npm/rome/tests/index.test.ts
@@ -11,24 +11,66 @@ describe("Rome formatter", () => {
 		expect(result.errors).toEqual([]);
 	});
 
-	it("should not format content", async () => {
+	it("should not format files in debug mode", async () => {
 		const rome = new Rome();
 
-		let result = await rome.formatContent("function f() {}");
+		let result = await rome.formatFiles(["./path/to/file.js"], {
+			debug: true,
+		});
 
 		expect(result.content).toEqual("");
 		expect(result.errors).toEqual([]);
+		expect(result.ir).toEqual("");
+	});
+
+	it("should not format content", async () => {
+		const rome = new Rome();
+
+		let result = await rome.formatContent("function f() {}", {
+			filePath: "example.js",
+		});
+
+		expect(result.content).toEqual("");
+		expect(result.errors).toEqual([]);
+	});
+
+	it("should not format content in debug mode", async () => {
+		const rome = new Rome();
+
+		let result = await rome.formatContent("function f() {}", {
+			filePath: "example.js",
+			debug: true,
+		});
+
+		expect(result.content).toEqual("");
+		expect(result.errors).toEqual([]);
+		expect(result.ir).toEqual("");
 	});
 
 	it("should not format content with range", async () => {
 		const rome = new Rome();
 
 		let result = await rome.formatContent("function f() {}", {
+			filePath: "file.js",
 			range: [5, 10],
 		});
 
 		expect(result.content).toEqual("");
 		expect(result.errors).toEqual([]);
+	});
+
+	it("should not format content with range in debug mode", async () => {
+		const rome = new Rome();
+
+		let result = await rome.formatContent("function f() {}", {
+			filePath: "file.js",
+			range: [5, 10],
+			debug: true,
+		});
+
+		expect(result.content).toEqual("");
+		expect(result.errors).toEqual([]);
+		expect(result.ir).toEqual("");
 	});
 });
 

--- a/npm/rome/tests/index.test.ts
+++ b/npm/rome/tests/index.test.ts
@@ -44,7 +44,9 @@ describe("Rome formatter", () => {
 
 		expect(result.content).toEqual("function f() {}\n");
 		expect(result.errors).toEqual([]);
-		expect(result.ir).toEqual('["function", " ", "f", group(["(", ")"]), " ", "{", "}", hard_line_break]');
+		expect(result.ir).toEqual(
+			'["function", " ", "f", group(["(", ")"]), " ", "{", "}", hard_line_break]',
+		);
 	});
 
 	it("should not format content with range", async () => {
@@ -62,7 +64,6 @@ describe("Rome formatter", () => {
 	it("should not format content with range in debug mode", async () => {
 		const rome = new Rome();
 
-
 		let result = await rome.formatContent("let a   ; function g () {  }", {
 			filePath: "file.js",
 			range: [20, 25],
@@ -72,7 +73,8 @@ describe("Rome formatter", () => {
 		console.log(result.ir);
 		expect(result.content).toEqual("function g() {}");
 		expect(result.errors).toEqual([]);
-		expect(result.ir).toEqual(`[
+		expect(result.ir).toEqual(
+			`[
   "let",
   " ",
   group(["a"]),
@@ -86,7 +88,8 @@ describe("Rome formatter", () => {
   "{",
   "}",
   hard_line_break
-]`);
+]`,
+		);
 	});
 });
 

--- a/npm/rome/tests/index.test.ts
+++ b/npm/rome/tests/index.test.ts
@@ -11,66 +11,24 @@ describe("Rome formatter", () => {
 		expect(result.errors).toEqual([]);
 	});
 
-	it("should not format files in debug mode", async () => {
-		const rome = new Rome();
-
-		let result = await rome.formatFiles(["./path/to/file.js"], {
-			debug: true,
-		});
-
-		expect(result.content).toEqual("");
-		expect(result.errors).toEqual([]);
-		expect(result.ir).toEqual("");
-	});
-
 	it("should not format content", async () => {
 		const rome = new Rome();
 
-		let result = await rome.formatContent("function f() {}", {
-			filePath: "example.js",
-		});
+		let result = await rome.formatContent("function f() {}");
 
 		expect(result.content).toEqual("");
 		expect(result.errors).toEqual([]);
-	});
-
-	it("should not format content in debug mode", async () => {
-		const rome = new Rome();
-
-		let result = await rome.formatContent("function f() {}", {
-			filePath: "example.js",
-			debug: true,
-		});
-
-		expect(result.content).toEqual("");
-		expect(result.errors).toEqual([]);
-		expect(result.ir).toEqual("");
 	});
 
 	it("should not format content with range", async () => {
 		const rome = new Rome();
 
 		let result = await rome.formatContent("function f() {}", {
-			filePath: "file.js",
 			range: [5, 10],
 		});
 
 		expect(result.content).toEqual("");
 		expect(result.errors).toEqual([]);
-	});
-
-	it("should not format content with range in debug mode", async () => {
-		const rome = new Rome();
-
-		let result = await rome.formatContent("function f() {}", {
-			filePath: "file.js",
-			range: [5, 10],
-			debug: true,
-		});
-
-		expect(result.content).toEqual("");
-		expect(result.errors).toEqual([]);
-		expect(result.ir).toEqual("");
 	});
 });
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Part of https://github.com/rome/tools/issues/3073

In this PR the Node.js API are hooked to the WASM bindings. 

**This PR only focuses on hooking the `*Content` APIs**. The file system APIs are left out on purpose. For the being also custom configuration left out on purpose, and will be implemented as part of a different PR.

Things that are relevant for the review:
- error handling is left out on purpose until I understand how to handle errors coming from the workspace;
- this PR focuses only on the happy path
- all methods of the `Workspace` of the WASM bindings are synchronous, but there were made asynchronous ( with `await`) because it would allow us to easily swap backend in the future without too many problems.
- I changed the release target of `@rometools/backend-jsonrpc` to `es2020` because we don't need to support old syntax. This has also the benefit that the emitted code is easier to debug
- there's an issue with  emitted types; for now I turned off the error with `@ts-expect-error`. Once fixed, we can remove the suppression


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I updated the tests we had with real expected output

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
