### PR TITLE
refactor(rome_wasm): change method names to be camel case

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -116,7 +116,7 @@ jobs:
           run_install: |
             args: [--prefix npm/backend-jsonrpc]
       - name: Build TypeScript code
-        run: pnpm --prefix npm/backend-jsonrpc run tsc
+        run: pnpm --prefix npm/backend-jsonrpc run build
       - name: Run JS tests
         run: pnpm --prefix npm/backend-jsonrpc test:ci
 

--- a/crates/rome_wasm/src/lib.rs
+++ b/crates/rome_wasm/src/lib.rs
@@ -35,21 +35,25 @@ impl Workspace {
         }
     }
 
+    #[wasm_bindgen(js_name = supportsFeature)]
     pub fn supports_feature(&self, params: ISupportsFeatureParams) -> Result<bool, Error> {
         let params: SupportsFeatureParams = params.into_serde().map_err(into_error)?;
         Ok(self.inner.supports_feature(params))
     }
 
+    #[wasm_bindgen(js_name = updateSettings)]
     pub fn update_settings(&self, params: IUpdateSettingsParams) -> Result<(), Error> {
         let params: UpdateSettingsParams = params.into_serde().map_err(into_error)?;
         self.inner.update_settings(params).map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = openFile)]
     pub fn open_file(&self, params: IOpenFileParams) -> Result<(), Error> {
         let params: OpenFileParams = params.into_serde().map_err(into_error)?;
         self.inner.open_file(params).map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = getSyntaxTree)]
     pub fn get_syntax_tree(
         &self,
         params: IGetSyntaxTreeParams,
@@ -61,6 +65,7 @@ impl Workspace {
             .map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = getControlFlowGraph)]
     pub fn get_control_flow_graph(
         &self,
         params: IGetControlFlowGraphParams,
@@ -71,21 +76,25 @@ impl Workspace {
             .map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = getFormatterIr)]
     pub fn get_formatter_ir(&self, params: IGetFormatterIRParams) -> Result<String, Error> {
         let params: GetFormatterIRParams = params.into_serde().map_err(into_error)?;
         self.inner.get_formatter_ir(params).map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = changeFile)]
     pub fn change_file(&self, params: IChangeFileParams) -> Result<(), Error> {
         let params: ChangeFileParams = params.into_serde().map_err(into_error)?;
         self.inner.change_file(params).map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = closeFile)]
     pub fn close_file(&self, params: ICloseFileParams) -> Result<(), Error> {
         let params: CloseFileParams = params.into_serde().map_err(into_error)?;
         self.inner.close_file(params).map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = pullDiagnostics)]
     pub fn pull_diagnostics(
         &self,
         params: IPullDiagnosticsParams,
@@ -97,6 +106,7 @@ impl Workspace {
             .map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = pullActions)]
     pub fn pull_actions(&self, params: IPullActionsParams) -> Result<IPullActionsResult, Error> {
         let params: PullActionsParams = params.into_serde().map_err(into_error)?;
         let result = self.inner.pull_actions(params).map_err(into_error)?;
@@ -105,24 +115,28 @@ impl Workspace {
             .map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = formatFile)]
     pub fn format_file(&self, params: IFormatFileParams) -> Result<JsValue, Error> {
         let params: FormatFileParams = params.into_serde().map_err(into_error)?;
         let result = self.inner.format_file(params).map_err(into_error)?;
         JsValue::from_serde(&result).map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = formatRange)]
     pub fn format_range(&self, params: IFormatRangeParams) -> Result<JsValue, Error> {
         let params: FormatRangeParams = params.into_serde().map_err(into_error)?;
         let result = self.inner.format_range(params).map_err(into_error)?;
         JsValue::from_serde(&result).map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = formatOnType)]
     pub fn format_on_type(&self, params: IFormatOnTypeParams) -> Result<JsValue, Error> {
         let params: FormatOnTypeParams = params.into_serde().map_err(into_error)?;
         let result = self.inner.format_on_type(params).map_err(into_error)?;
         JsValue::from_serde(&result).map_err(into_error)
     }
 
+    #[wasm_bindgen(js_name = fixFile)]
     pub fn fix_file(&self, params: IFixFileParams) -> Result<IFixFileResult, Error> {
         let params: FixFileParams = params.into_serde().map_err(into_error)?;
         let result = self.inner.fix_file(params).map_err(into_error)?;

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -157,7 +157,7 @@ export class Rome {
 			id: 0,
 			path: options.filePath,
 		};
-		await this.workspace.open_file({
+		await this.workspace.openFile({
 			content,
 			version: 0,
 			path,
@@ -165,31 +165,31 @@ export class Rome {
 
 		let code;
 		if (options.range) {
-			const result = await this.workspace.format_range({
+			const result = await this.workspace.formatRange({
 				path: path,
-				// @ts-expect-error Types are currently wrong for range, need to fix them
+				// @ts-expect-error For some reason, passing the tuple works but. Need to understand what's going on
 				range: options.range,
 			});
 			code = result.code;
 		} else {
-			const result = await this.workspace.format_file({
+			const result = await this.workspace.formatFile({
 				path,
 			});
 			code = result.code;
 		}
 
 		if (isFormatContentDebug(options)) {
-			const ir = await this.workspace.get_formatter_ir({
+			const ir = await this.workspace.getFormatterIr({
 				path,
 			});
-			this.workspace.close_file({ path });
+			this.workspace.closeFile({ path });
 			return {
 				content: code,
 				errors: [],
 				ir,
 			};
 		}
-		this.workspace.close_file({ path });
+		this.workspace.closeFile({ path });
 		return {
 			content: code,
 			errors: [],

--- a/website/playground/src/romeWorker.ts
+++ b/website/playground/src/romeWorker.ts
@@ -81,7 +81,7 @@ self.addEventListener("message", async (e) => {
 				cursorPosition,
 			} = playgroundState;
 
-			workspace.update_settings({
+			workspace.updateSettings({
 				settings: {
 					format: {
 						enabled: true,
@@ -106,14 +106,14 @@ self.addEventListener("message", async (e) => {
 
 			const path = getPathForType(sourceType, isTypeScript, isJsx);
 			if (currentFile?.path === path) {
-				workspace.change_file({
+				workspace.changeFile({
 					path,
 					version: currentFile.version++,
 					content: code,
 				});
 			} else {
 				if (currentFile) {
-					workspace.close_file({
+					workspace.closeFile({
 						path: currentFile.path,
 					});
 				}
@@ -123,25 +123,25 @@ self.addEventListener("message", async (e) => {
 					version: 0,
 				};
 
-				workspace.open_file({
+				workspace.openFile({
 					path,
 					version: currentFile.version++,
 					content: code,
 				});
 			}
 
-			const syntax_tree = workspace.get_syntax_tree({
+			const syntax_tree = workspace.getSyntaxTree({
 				path,
 			});
-			const control_flow_graph = workspace.get_control_flow_graph({
+			const control_flow_graph = workspace.getControlFlowGraph({
 				path,
 				cursor: cursorPosition,
 			});
-			const formatter_ir = workspace.get_formatter_ir({
+			const formatter_ir = workspace.getFormatterIr({
 				path,
 			});
 
-			const diagnostics = workspace.pull_diagnostics({
+			const diagnostics = workspace.pullDiagnostics({
 				path,
 				categories: ["Syntax", "Lint"],
 			});
@@ -151,7 +151,7 @@ self.addEventListener("message", async (e) => {
 				printer.print(diag);
 			}
 
-			const printed = workspace.format_file({
+			const printed = workspace.formatFile({
 				path,
 			});
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR makes the methods compiled by `wasm_bindgen` camel case. The reason why I changed it is because now the emitted types will be inline with the types emitted by the [`backend-jsonrpc` package](https://github.com/rome/tools/blob/main/npm/backend-jsonrpc/src/workspace.ts#L227-L245), and this make the integration between the two backend easier.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

This is mostly a compile time change, as you can see the changes are reflected in the playground. The CI should pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
