### PR TITLE
chore(playground): allow vite to reference npm directory

### DIFF
--- a/website/playground/vite.config.ts
+++ b/website/playground/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, searchForWorkspaceRoot } from "vite";
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
 
@@ -11,5 +11,11 @@ export default defineConfig({
 	},
 	resolve: {
 		dedupe: ["@codemirror/state"],
+	},
+	server: {
+		fs: {
+			// https://vitejs.dev/config/server-options.html#server-fs-allow
+			allow: [searchForWorkspaceRoot(process.cwd()), "../../npm/wasm-web"],
+		},
 	},
 });


### PR DESCRIPTION
## Summary

Playground's development environment is broken.
Fixed vite.config.ts

## Details

Error: The request url "/Users/bhbs/Documents/GitHub/tools/npm/wasm-web/rome_wasm_bg.wasm" is outside of Vite serving allow list.

<img width="904" alt="error" src="https://user-images.githubusercontent.com/22282293/186435583-19f07d3d-6ce8-4862-ad69-f4b5c9b47578.png">

<details>
<summary>Full text</summary>

```sh
> playground@0.0.0 start /Users/bhbs/Documents/GitHub/tools/website/playground
> vite


  vite v2.9.5 dev server running at:

  > Local: http://localhost:3000/
  > Network: use `--host` to expose

  ready in 120ms.

Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
The request url "/Users/bhbs/Documents/GitHub/tools/npm/wasm-web/rome_wasm_bg.wasm" is outside of Vite serving allow list.

- /Users/bhbs/Documents/GitHub/tools/website/playground

Refer to docs https://vitejs.dev/config/#server-fs-allow for configurations and more details.
```

</details>

## Test Plan

Exec Installation step
https://github.com/rome/tools/blob/main/website/playground/README.md

```
cd website/playground
pnpm build:wasm
pnpm install
pnpm start
```