### PR TITLE
feat(rome_service, rome_formatter): remove `format_with_errors`

### DIFF
--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -27,7 +27,6 @@ pub const CONFIG_DISABLED_FORMATTER: &str = r#"{
 pub const CONFIG_ALL_FIELDS: &str = r#"{
   "formatter": {
     "enabled": true,
-    "formatWithErrors": true,
     "indentStyle": "tab",
     "indentSize": 2,
     "lineWidth": 80

--- a/crates/rome_cli/tests/snapshots/main_configuration/correct_root.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/correct_root.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
+assertion_line: 148
 expression: content
 ---
 ## `rome.json`
@@ -9,7 +9,6 @@ expression: content
 {
   "formatter": {
     "enabled": true,
-    "formatWithErrors": true,
     "indentStyle": "tab",
     "indentSize": 2,
     "lineWidth": 80

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -26,7 +26,7 @@ pub(crate) fn format(
 
     let printed = match result {
         Ok(printed) => printed,
-        Err(RomeError::FormatWithErrorsDisabled) => return Ok(None),
+        Err(RomeError::FormatFailed) => return Ok(None),
         Err(err) => return Err(Error::from(err)),
     };
 
@@ -78,7 +78,7 @@ pub(crate) fn format_range(
 
     let formatted = match result {
         Ok(formatted) => formatted,
-        Err(RomeError::FormatWithErrorsDisabled) => return Ok(None),
+        Err(RomeError::FormatFailed) => return Ok(None),
         Err(err) => return Err(Error::from(err)),
     };
 
@@ -134,7 +134,7 @@ pub(crate) fn format_on_type(
 
     let formatted = match result {
         Ok(formatted) => formatted,
-        Err(RomeError::FormatWithErrorsDisabled) => return Ok(None),
+        Err(RomeError::FormatFailed) => return Ok(None),
         Err(err) => return Err(Error::from(err)),
     };
 

--- a/crates/rome_service/src/configuration/formatter.rs
+++ b/crates/rome_service/src/configuration/formatter.rs
@@ -9,10 +9,6 @@ pub struct FormatterConfiguration {
     // if `false`, it disables the feature. `true` by default
     pub enabled: bool,
 
-    /// Stores whether formatting should be allowed to proceed if a given file
-    /// has syntax errors
-    pub format_with_errors: bool,
-
     /// The indent style.
     pub indent_style: PlainIndentStyle,
 
@@ -31,7 +27,6 @@ impl Default for FormatterConfiguration {
     fn default() -> Self {
         Self {
             enabled: true,
-            format_with_errors: false,
             indent_size: 2,
             indent_style: PlainIndentStyle::default(),
             line_width: LineWidth::default(),
@@ -49,7 +44,6 @@ impl From<FormatterConfiguration> for FormatSettings {
             enabled: conf.enabled,
             indent_style: Some(indent_style),
             line_width: Some(conf.line_width),
-            format_with_errors: conf.format_with_errors,
         }
     }
 }

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -47,7 +47,7 @@ pub enum RomeError {
     /// The formatter encountered an error while formatting the file
     FormatError(FormatError),
     /// The file could not be formatted since it has syntax errors
-    FormatWithErrorsDisabled,
+    FormatFailed,
     /// The file could not be analyzed because a rule caused an error.
     RuleError(RuleError),
     /// Thrown when Rome can't read a generic directory
@@ -93,7 +93,7 @@ impl Display for RomeError {
                     cause
                 )
             }
-            RomeError::FormatWithErrorsDisabled => {
+            RomeError::FormatFailed => {
                 write!(
                     f,
                     "the file could not be formatted since it has syntax errors"

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -46,7 +46,7 @@ pub enum RomeError {
     SourceFileNotSupported(RomePath),
     /// The formatter encountered an error while formatting the file
     FormatError(FormatError),
-    /// The file could not be formatted since it has syntax errors and `format_with_errors` is disabled
+    /// The file could not be formatted since it has syntax errors
     FormatWithErrorsDisabled,
     /// The file could not be analyzed because a rule caused an error.
     RuleError(RuleError),
@@ -94,7 +94,10 @@ impl Display for RomeError {
                 )
             }
             RomeError::FormatWithErrorsDisabled => {
-                write!(f, "the file could not be formatted since it has syntax errors and `format_with_errors` is disabled")
+                write!(
+                    f,
+                    "the file could not be formatted since it has syntax errors"
+                )
             }
             RomeError::CantReadDirectory(path) => {
                 write!(

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -69,9 +69,6 @@ impl WorkspaceSettings {
 pub struct FormatSettings {
     /// Enabled by default
     pub enabled: bool,
-    /// Stores whether formatting should be allowed to proceed if a given file
-    /// has syntax errors
-    pub format_with_errors: bool,
     pub indent_style: Option<IndentStyle>,
     pub line_width: Option<LineWidth>,
 }
@@ -80,7 +77,6 @@ impl Default for FormatSettings {
     fn default() -> Self {
         Self {
             enabled: true,
-            format_with_errors: false,
             indent_style: Some(IndentStyle::default()),
             line_width: Some(LineWidth::default()),
         }

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -214,7 +214,7 @@ impl Workspace for WorkspaceServer {
         let settings = self.settings();
 
         if parse.has_errors() {
-            return Err(RomeError::FormatWithErrorsDisabled);
+            return Err(RomeError::FormatFailed);
         }
 
         debug_formatter_ir(&params.path, parse, settings)
@@ -307,7 +307,7 @@ impl Workspace for WorkspaceServer {
         let settings = self.settings();
 
         if parse.has_errors() {
-            return Err(RomeError::FormatWithErrorsDisabled);
+            return Err(RomeError::FormatFailed);
         }
 
         format(&params.path, parse, settings)
@@ -324,7 +324,7 @@ impl Workspace for WorkspaceServer {
         let settings = self.settings();
 
         if parse.has_errors() {
-            return Err(RomeError::FormatWithErrorsDisabled);
+            return Err(RomeError::FormatFailed);
         }
 
         format_range(&params.path, parse, settings, params.range)
@@ -341,7 +341,7 @@ impl Workspace for WorkspaceServer {
         let settings = self.settings();
 
         if parse.has_errors() {
-            return Err(RomeError::FormatWithErrorsDisabled);
+            return Err(RomeError::FormatFailed);
         }
 
         format_on_type(&params.path, parse, settings, params.offset)

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -213,7 +213,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
 
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
+        if parse.has_errors() {
             return Err(RomeError::FormatWithErrorsDisabled);
         }
 
@@ -306,7 +306,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
 
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
+        if parse.has_errors() {
             return Err(RomeError::FormatWithErrorsDisabled);
         }
 
@@ -323,7 +323,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
 
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
+        if parse.has_errors() {
             return Err(RomeError::FormatWithErrorsDisabled);
         }
 
@@ -340,7 +340,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
 
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
+        if parse.has_errors() {
             return Err(RomeError::FormatWithErrorsDisabled);
         }
 

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -47,11 +47,6 @@
           "default": true,
           "type": "boolean"
         },
-        "formatWithErrors": {
-          "description": "Stores whether formatting should be allowed to proceed if a given file has syntax errors",
-          "default": false,
-          "type": "boolean"
-        },
         "indentSize": {
           "description": "The size of the indentation, 2 by default",
           "default": 2,

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -19,7 +19,6 @@ export interface WorkspaceSettings {
 }
 export interface FormatSettings {
 	enabled: boolean;
-	format_with_errors: boolean;
 	indent_style?: IndentStyle;
 	line_width?: LineWidth;
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This removes the option `formatWithErrors` from our configuration. 

The reason why the team decided to remove it that, despite the cool concept, we reached a wall where if we wanted to improve the formatting experience and algorithm, we needed to assume that the CST is error-free. 

If you have questions and would like more details, @MichaReiser is your guy :)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated existing tests. CI should pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
