### PR TITLE
refactor(rome_formatter): Extract `FormatOptions`

### DIFF
--- a/crates/rome_formatter/src/buffer.rs
+++ b/crates/rome_formatter/src/buffer.rs
@@ -451,13 +451,7 @@ pub trait BufferExtensions: Buffer + Sized {
     /// use rome_formatter::{format, format_args, write, LineWidth};
     /// use rome_formatter::prelude::*;
     ///
-    /// let context = SimpleFormatContext {
-    ///     line_width: LineWidth::try_from(20).unwrap(),
-    ///     ..SimpleFormatContext::default()
-    /// };
-    ///
-    ///
-    /// let formatted = format!(context, [format_with(|f| {
+    /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
     ///
     ///     let element = format_with(|f| {
     ///         write!(f, [
@@ -508,13 +502,8 @@ pub trait BufferExtensions: Buffer + Sized {
     ///
     /// enum SomeLabelId {}
     ///
-    /// let context = SimpleFormatContext {
-    ///     line_width: LineWidth::try_from(20).unwrap(),
-    ///     ..SimpleFormatContext::default()
-    /// };
-    ///
     /// let formatted = format!(
-    ///     context,
+    ///     SimpleFormatContext::default(),
     ///     [format_with(|f| {
     ///         let mut buffer = f.inspect_is_labelled::<SomeLabelId>();
     ///

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -37,13 +37,13 @@ use std::ops::Deref;
 ///
 /// Soft line breaks are emitted if the enclosing `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{format, format_args, LineWidth};
+/// use rome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use rome_formatter::prelude::*;
 ///
-/// let context = SimpleFormatContext {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
-///     ..SimpleFormatContext::default()
-/// };
+///     ..SimpleFormatOptions::default()
+/// });
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
@@ -146,13 +146,13 @@ pub const fn empty_line() -> Line {
 ///
 /// The printer breaks the lines if the enclosing `Group` doesn't fit on a single line:
 /// ```
-/// use rome_formatter::{format_args, format, LineWidth};
+/// use rome_formatter::{format_args, format, LineWidth, SimpleFormatOptions};
 /// use rome_formatter::prelude::*;
 ///
-/// let context = SimpleFormatContext {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
-///     ..SimpleFormatContext::default()
-/// };
+///     ..SimpleFormatOptions::default()
+/// });
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
@@ -849,13 +849,13 @@ where
 ///
 /// ```
 /// use std::num::NonZeroU8;
-/// use rome_formatter::{format, format_args, IndentStyle};
+/// use rome_formatter::{format, format_args, IndentStyle, SimpleFormatOptions};
 /// use rome_formatter::prelude::*;
 ///
-/// let context = SimpleFormatContext {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     indent_style: IndentStyle::Space(4),
-///     ..SimpleFormatContext::default()
-/// };
+///     ..SimpleFormatOptions::default()
+/// });
 ///
 /// let block = format!(context, [
 ///     text("a"),
@@ -980,13 +980,13 @@ pub fn block_indent<Context>(content: &impl Format<Context>) -> BlockIndent<Cont
 /// Indents the content by one level and puts in new lines if the enclosing `Group` doesn't fit on a single line
 ///
 /// ```
-/// use rome_formatter::{format, format_args, LineWidth};
+/// use rome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use rome_formatter::prelude::*;
 ///
-/// let context = SimpleFormatContext {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
-///     ..SimpleFormatContext::default()
-/// };
+///     ..SimpleFormatOptions::default()
+/// });
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
@@ -1048,13 +1048,13 @@ pub fn soft_block_indent<Context>(content: &impl Format<Context>) -> BlockIndent
 /// fit on a single line. Otherwise, just inserts a space.
 ///
 /// ```
-/// use rome_formatter::{format, format_args, LineWidth};
+/// use rome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use rome_formatter::prelude::*;
 ///
-/// let context = SimpleFormatContext {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(10).unwrap(),
-///     ..SimpleFormatContext::default()
-/// };
+///     ..SimpleFormatOptions::default()
+/// });
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
@@ -1199,13 +1199,13 @@ impl<Context> std::fmt::Debug for BlockIndent<'_, Context> {
 ///
 /// The printer breaks the `Group` over multiple lines if its content doesn't fit on a single line
 /// ```
-/// use rome_formatter::{format, format_args, LineWidth};
+/// use rome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use rome_formatter::prelude::*;
 ///
-/// let context = SimpleFormatContext {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(20).unwrap(),
-///     ..SimpleFormatContext::default()
-/// };
+///     ..SimpleFormatOptions::default()
+/// });
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
@@ -1502,14 +1502,14 @@ impl<Context> Format<Context> for ExpandParent {
 ///
 /// Prints the trailing comma for the last array element if the `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{format_args, format, LineWidth};
+/// use rome_formatter::{format_args, format, LineWidth, SimpleFormatOptions};
 /// use rome_formatter::prelude::*;
 /// use rome_formatter::printer::PrintWidth;
 ///
-/// let context = SimpleFormatContext {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(20).unwrap(),
-///     ..SimpleFormatContext::default()
-/// };
+///     ..SimpleFormatOptions::default()
+/// });
 ///
 /// let elements = format!(context, [
 ///     group(&format_args![
@@ -1578,13 +1578,13 @@ where
 ///
 /// Omits the trailing comma for the last array element if the `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{format, format_args, LineWidth};
+/// use rome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
 /// use rome_formatter::prelude::*;
 ///
-/// let context = SimpleFormatContext {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
 ///     line_width: LineWidth::try_from(20).unwrap(),
-///     ..SimpleFormatContext::default()
-/// };
+///     ..SimpleFormatOptions::default()
+/// });
 ///
 /// let formatted = format!(context, [
 ///     group(&format_args![
@@ -1637,13 +1637,13 @@ impl<Context> IfGroupBreaks<'_, Context> {
     /// The item `[4]` in this example fits on a single line but the trailing comma should still be printed
     ///
     /// ```
-    /// use rome_formatter::{format, format_args, write, LineWidth};
+    /// use rome_formatter::{format, format_args, write, LineWidth, SimpleFormatOptions};
     /// use rome_formatter::prelude::*;
     ///
-    /// let context = SimpleFormatContext {
+    /// let context = SimpleFormatContext::new(SimpleFormatOptions {
     ///     line_width: LineWidth::try_from(20).unwrap(),
-    ///     ..SimpleFormatContext::default()
-    /// };
+    ///     ..SimpleFormatOptions::default()
+    /// });
     ///
     /// let formatted = format!(context, [format_with(|f| {
     ///     let group_id = f.group_id("array");

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -2,8 +2,8 @@ use crate::prelude::{dynamic_text, format_with};
 use crate::printer::LineEnding;
 use crate::{
     format, format_args, group, soft_block_indent, soft_line_break_or_space,
-    soft_line_indent_or_space, space, text, write, Buffer, Format, FormatContext, FormatResult,
-    Formatter, GroupId, IndentStyle, LineWidth, PrinterOptions, TextSize,
+    soft_line_indent_or_space, space, text, write, Buffer, Format, FormatContext, FormatOptions,
+    FormatResult, Formatter, GroupId, IndentStyle, LineWidth, PrinterOptions, TextSize,
 };
 use indexmap::IndexSet;
 #[cfg(target_pointer_width = "64")]
@@ -766,6 +766,17 @@ struct IrFormatContext {
 }
 
 impl FormatContext for IrFormatContext {
+    type Options = IrFormatOptions;
+
+    fn options(&self) -> &Self::Options {
+        &IrFormatOptions
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct IrFormatOptions;
+
+impl FormatOptions for IrFormatOptions {
     fn indent_style(&self) -> IndentStyle {
         IndentStyle::Space(2)
     }

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -18,6 +18,14 @@ impl<'buf, Context> Formatter<'buf, Context> {
         Self { buffer }
     }
 
+    /// Returns the format options
+    pub fn options(&self) -> &Context::Options
+    where
+        Context: FormatContext,
+    {
+        self.context().options()
+    }
+
     /// Returns the Context specifying how to format the current CST
     pub fn context(&self) -> &Context {
         self.state().context()

--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -148,7 +148,7 @@ macro_rules! format {
 /// ## Examples
 ///
 /// ```
-/// use rome_formatter::{Formatted, LineWidth, format, format_args};
+/// use rome_formatter::{Formatted, LineWidth, format, format_args, SimpleFormatOptions};
 /// use rome_formatter::prelude::*;
 ///
 /// let formatted = format!(
@@ -216,7 +216,7 @@ macro_rules! format {
 /// // has some additional line breaks to make sure inner groups don't break
 /// assert_eq!(
 ///     "aVeryLongIdentifier([\n\t1, 2, 3\n])",
-///     Formatted::new(elements.clone(), SimpleFormatContext { line_width: 21.try_into().unwrap(), ..SimpleFormatContext::default() })
+///     Formatted::new(elements.clone(), SimpleFormatContext::new(SimpleFormatOptions { line_width: 21.try_into().unwrap(), ..SimpleFormatOptions::default() }))
 ///         .print()
 ///         .as_code()
 /// );
@@ -224,7 +224,7 @@ macro_rules! format {
 /// // Prints the last option as last resort
 /// assert_eq!(
 ///     "aVeryLongIdentifier(\n\t[\n\t\t1,\n\t\t2,\n\t\t3\n\t]\n)",
-///     Formatted::new(elements.clone(), SimpleFormatContext { line_width: 20.try_into().unwrap(), ..SimpleFormatContext::default() })
+///     Formatted::new(elements.clone(), SimpleFormatContext::new(SimpleFormatOptions { line_width: 20.try_into().unwrap(), ..SimpleFormatOptions::default() }))
 ///         .print()
 ///         .as_code()
 /// );
@@ -263,7 +263,7 @@ macro_rules! best_fitting {
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
-    use crate::{write, FormatState, VecBuffer};
+    use crate::{write, FormatState, SimpleFormatOptions, VecBuffer};
 
     struct TestFormat;
 
@@ -397,10 +397,10 @@ mod tests {
 
         let best_fitting_code = Formatted::new(
             formatted_best_fitting.into_format_element(),
-            SimpleFormatContext {
+            SimpleFormatContext::new(SimpleFormatOptions {
                 line_width: 30.try_into().unwrap(),
-                ..SimpleFormatContext::default()
-            },
+                ..SimpleFormatOptions::default()
+            }),
         )
         .print()
         .as_code()
@@ -408,10 +408,10 @@ mod tests {
 
         let normal_list_code = Formatted::new(
             formatted_normal_list.into_format_element(),
-            SimpleFormatContext {
+            SimpleFormatContext::new(SimpleFormatOptions {
                 line_width: 30.try_into().unwrap(),
-                ..SimpleFormatContext::default()
-            },
+                ..SimpleFormatOptions::default()
+            }),
         )
         .print()
         .as_code()

--- a/crates/rome_js_formatter/src/check_reformat.rs
+++ b/crates/rome_js_formatter/src/check_reformat.rs
@@ -1,4 +1,4 @@
-use crate::{format_node, JsFormatContext};
+use crate::{format_node, JsFormatOptions};
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
 use rome_js_parser::parse;
 use rome_js_syntax::{JsSyntaxNode, SourceType};
@@ -8,7 +8,7 @@ pub struct CheckReformatParams<'a> {
     pub text: &'a str,
     pub source_type: SourceType,
     pub file_name: &'a str,
-    pub format_context: JsFormatContext,
+    pub options: JsFormatOptions,
 }
 
 /// Perform a second pass of formatting on a file, printing a diff if the
@@ -19,7 +19,7 @@ pub fn check_reformat(params: CheckReformatParams) {
         text,
         source_type,
         file_name,
-        format_context: context,
+        options,
     } = params;
 
     let re_parse = parse(text, 0, source_type);
@@ -44,11 +44,11 @@ pub fn check_reformat(params: CheckReformatParams) {
         )
     }
 
-    let formatted = format_node(context.clone(), &re_parse.syntax()).unwrap();
+    let formatted = format_node(options.clone(), &re_parse.syntax()).unwrap();
     let printed = formatted.print();
 
     if text != printed.as_code() {
-        let input_formatted = format_node(context, root).unwrap().into_format_element();
+        let input_formatted = format_node(options, root).unwrap().into_format_element();
 
         let pretty_input_ir = format!("{input_formatted}");
         let pretty_reformat_ir = format!("{}", formatted.into_format_element());

--- a/crates/rome_js_formatter/src/js/expressions/template_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_element.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use rome_formatter::printer::{PrintWidth, Printer};
-use rome_formatter::{format_args, write, FormatContext, FormatRuleWithOptions, VecBuffer};
+use rome_formatter::{format_args, write, FormatOptions, FormatRuleWithOptions, VecBuffer};
 
 use crate::context::TabWidth;
 use crate::js::lists::template_element_list::{TemplateElementIndention, TemplateElementLayout};
@@ -91,7 +91,7 @@ impl Format<JsFormatContext> for FormatTemplateElement {
                 let root = buffer.into_element();
 
                 let print_options = f
-                    .context()
+                    .options()
                     .as_print_options()
                     .with_print_width(PrintWidth::infinite());
                 let printed = Printer::new(print_options).print(&root);
@@ -145,7 +145,7 @@ impl Format<JsFormatContext> for FormatTemplateElement {
                 write_with_indention(
                     &format_inner,
                     self.options.indention,
-                    f.context().tab_width(),
+                    f.options().tab_width(),
                     f,
                 )
             }

--- a/crates/rome_js_formatter/src/js/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/template_element_list.rs
@@ -68,7 +68,7 @@ impl Format<JsFormatContext> for AnyTemplateElementList {
                     let chunk_token = chunk.template_chunk_token()?;
                     let chunk_text = chunk_token.text();
 
-                    let tab_width = f.context().tab_width();
+                    let tab_width = f.options().tab_width();
 
                     indention =
                         TemplateElementIndention::after_last_new_line(chunk_text, tab_width);

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -542,7 +542,6 @@ mod tests {
 
     use super::format_range;
 
-    
     use crate::JsFormatOptions;
     use rome_formatter::IndentStyle;
     use rome_js_parser::parse_script;

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -381,7 +381,7 @@ impl JsAnyAssignmentLike {
 
                 let width = write_member_name(&name.into(), f)?;
                 let text_width_for_break =
-                    (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
+                    (u8::from(f.options().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
                 Ok(width < text_width_for_break)
             }
             JsAnyAssignmentLike::JsAssignmentExpression(assignment) => {
@@ -401,7 +401,7 @@ impl JsAnyAssignmentLike {
 
                 let width = write_member_name(&member_name.into(), f)?;
                 let text_width_for_break =
-                    (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
+                    (u8::from(f.options().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
                 Ok(width < text_width_for_break)
             }
             JsAnyAssignmentLike::JsVariableDeclarator(variable_declarator) => {
@@ -439,7 +439,7 @@ impl JsAnyAssignmentLike {
                 } else {
                     let width = write_member_name(&name.into(), f)?;
                     let text_width_for_break =
-                        (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
+                        (u8::from(f.options().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
                     width < text_width_for_break
                 };
 
@@ -463,7 +463,7 @@ impl JsAnyAssignmentLike {
 
                 write!(f, [property_annotation.format()])?;
                 let text_width_for_break =
-                    (u8::from(f.context().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
+                    (u8::from(f.options().tab_width()) + MIN_OVERLAP_FOR_BREAK) as usize;
                 Ok(width < text_width_for_break)
             }
         }
@@ -1032,7 +1032,7 @@ fn is_poorly_breakable_member_or_call_chain(
     expression: &JsAnyExpression,
     f: &mut Formatter<JsFormatContext>,
 ) -> SyntaxResult<bool> {
-    let threshold = f.context().line_width().value() / 4;
+    let threshold = f.options().line_width().value() / 4;
 
     // Only call and member chains are poorly breakable
     // - `obj.member.prop`

--- a/crates/rome_js_formatter/src/utils/jsx.rs
+++ b/crates/rome_js_formatter/src/utils/jsx.rs
@@ -162,7 +162,7 @@ pub struct JsxSpace {}
 
 impl Format<JsFormatContext> for JsxSpace {
     fn fmt(&self, formatter: &mut JsFormatter) -> FormatResult<()> {
-        let jsx_space = match formatter.context().quote_style() {
+        let jsx_space = match formatter.options().quote_style() {
             QuoteStyle::Double => "{\" \"}",
             QuoteStyle::Single => "{\' \'}",
         };

--- a/crates/rome_js_formatter/src/utils/member_chain/mod.rs
+++ b/crates/rome_js_formatter/src/utils/member_chain/mod.rs
@@ -325,7 +325,7 @@ fn compute_groups(
 ) -> MemberChainGroups {
     let mut has_seen_call_expression = false;
     let mut groups_builder =
-        MemberChainGroupsBuilder::new(in_expression_statement, f.context().tab_width());
+        MemberChainGroupsBuilder::new(in_expression_statement, f.options().tab_width());
     for item in flatten_items {
         let has_trailing_comments = item.member().syntax().has_trailing_comments();
 

--- a/crates/rome_js_formatter/src/utils/object.rs
+++ b/crates/rome_js_formatter/src/utils/object.rs
@@ -39,7 +39,7 @@ pub(crate) fn write_member_name(
 
             if value.kind() == JS_STRING_LITERAL {
                 let format = FormatLiteralStringToken::new(&value, StringLiteralParentKind::Member);
-                let cleaned = format.clean_text(f.context());
+                let cleaned = format.clean_text(f.options());
 
                 write!(f, [cleaned])?;
 

--- a/crates/rome_js_formatter/src/utils/string_utils.rs
+++ b/crates/rome_js_formatter/src/utils/string_utils.rs
@@ -1,4 +1,4 @@
-use crate::context::{QuoteProperties, QuoteStyle};
+use crate::context::{JsFormatOptions, QuoteProperties, QuoteStyle};
 use crate::prelude::*;
 use crate::utils::string_utils::CharSignal::AlreadyPrinted;
 use rome_js_syntax::JsSyntaxKind::JS_STRING_LITERAL;
@@ -70,17 +70,17 @@ impl<'token> FormatLiteralStringToken<'token> {
         self.token
     }
 
-    pub fn clean_text(&self, context: &JsFormatContext) -> CleanedStringLiteralText {
+    pub fn clean_text(&self, options: &JsFormatOptions) -> CleanedStringLiteralText {
         let token = self.token();
         debug_assert_eq!(token.kind(), JS_STRING_LITERAL);
 
-        let chosen_quote_style = context.quote_style();
-        let chosen_quote_properties = context.quote_properties();
+        let chosen_quote_style = options.quote_style();
+        let chosen_quote_properties = options.quote_properties();
 
         let mut string_cleaner =
             LiteralStringNormaliser::new(self, chosen_quote_style, chosen_quote_properties);
 
-        let content = string_cleaner.normalise_text(context.source_type().into());
+        let content = string_cleaner.normalise_text(options.source_type().into());
         let normalized_text_width = content.width();
 
         CleanedStringLiteralText {
@@ -119,7 +119,7 @@ impl Format<JsFormatContext> for CleanedStringLiteralText<'_> {
 
 impl Format<JsFormatContext> for FormatLiteralStringToken<'_> {
     fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
-        let cleaned = self.clean_text(f.context());
+        let cleaned = self.clean_text(f.options());
 
         cleaned.fmt(f)
     }

--- a/crates/rome_js_formatter/tests/check_reformat.rs
+++ b/crates/rome_js_formatter/tests/check_reformat.rs
@@ -1,5 +1,5 @@
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
-use rome_js_formatter::context::{JsFormatOptions};
+use rome_js_formatter::context::JsFormatOptions;
 use rome_js_formatter::format_node;
 use rome_js_parser::parse;
 use rome_js_syntax::{JsSyntaxNode, SourceType};

--- a/crates/rome_js_formatter/tests/check_reformat.rs
+++ b/crates/rome_js_formatter/tests/check_reformat.rs
@@ -1,5 +1,5 @@
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
-use rome_js_formatter::context::JsFormatContext;
+use rome_js_formatter::context::{JsFormatOptions};
 use rome_js_formatter::format_node;
 use rome_js_parser::parse;
 use rome_js_syntax::{JsSyntaxNode, SourceType};
@@ -9,7 +9,7 @@ pub struct CheckReformatParams<'a> {
     pub text: &'a str,
     pub source_type: SourceType,
     pub file_name: &'a str,
-    pub format_context: JsFormatContext,
+    pub options: JsFormatOptions,
 }
 
 /// Perform a second pass of formatting on a file, printing a diff if the
@@ -20,7 +20,7 @@ pub fn check_reformat(params: CheckReformatParams) {
         text,
         source_type,
         file_name,
-        format_context: context,
+        options,
     } = params;
 
     let re_parse = parse(text, 0, source_type);
@@ -45,11 +45,11 @@ pub fn check_reformat(params: CheckReformatParams) {
         )
     }
 
-    let formatted = format_node(context.clone(), &re_parse.syntax()).unwrap();
+    let formatted = format_node(options.clone(), &re_parse.syntax()).unwrap();
     let printed = formatted.print();
 
     if text != printed.as_code() {
-        let input_format_element = format_node(context, root).unwrap();
+        let input_format_element = format_node(options, root).unwrap();
         let pretty_input_ir = format!("{}", formatted.into_format_element());
         let pretty_reformat_ir = format!("{}", input_format_element.into_format_element());
 

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -15,8 +15,8 @@ use std::{
 };
 
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
-use rome_formatter::{IndentStyle};
-use rome_js_formatter::context::{JsFormatOptions};
+use rome_formatter::IndentStyle;
+use rome_js_formatter::context::JsFormatOptions;
 use rome_js_parser::parse;
 use rome_js_syntax::SourceType;
 use serde::Serialize;

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -15,8 +15,8 @@ use std::{
 };
 
 use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
-use rome_formatter::IndentStyle;
-use rome_js_formatter::context::JsFormatContext;
+use rome_formatter::{IndentStyle};
+use rome_js_formatter::context::{JsFormatOptions};
 use rome_js_parser::parse;
 use rome_js_syntax::SourceType;
 use serde::Serialize;
@@ -66,7 +66,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
     let has_errors = parsed.has_errors();
     let syntax = parsed.syntax();
 
-    let context = JsFormatContext::default().with_indent_style(IndentStyle::Space(2));
+    let options = JsFormatOptions::default().with_indent_style(IndentStyle::Space(2));
 
     let result = match (range_start_index, range_end_index) {
         (Some(start), Some(end)) => {
@@ -77,7 +77,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
             }
 
             rome_js_formatter::format_range(
-                context.clone(),
+                options.clone(),
                 &syntax,
                 TextRange::new(
                     TextSize::try_from(start).unwrap(),
@@ -85,7 +85,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
                 ),
             )
         }
-        _ => rome_js_formatter::format_node(context.clone(), &syntax)
+        _ => rome_js_formatter::format_node(options.clone(), &syntax)
             .map(|formatted| formatted.print()),
     };
 
@@ -110,7 +110,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
                     text: &result,
                     source_type,
                     file_name,
-                    format_context: context.clone(),
+                    options: options.clone(),
                 });
             }
 
@@ -236,7 +236,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
         writeln!(snapshot).unwrap();
     }
 
-    let max_width = context.line_width().value() as usize;
+    let max_width = options.line_width().value() as usize;
     let mut lines_exceeding_max_width = formatted
         .lines()
         .enumerate()

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -1,4 +1,4 @@
-use rome_formatter::{LineWidth};
+use rome_formatter::LineWidth;
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
 use rome_js_formatter::context::{JsFormatOptions, QuoteProperties, QuoteStyle};

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -1,7 +1,7 @@
-use rome_formatter::LineWidth;
+use rome_formatter::{LineWidth};
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
-use rome_js_formatter::context::{JsFormatContext, QuoteProperties, QuoteStyle};
+use rome_js_formatter::context::{JsFormatOptions, QuoteProperties, QuoteStyle};
 use rome_js_formatter::format_node;
 use rome_js_parser::parse;
 use rome_js_syntax::{ModuleKind, SourceType};
@@ -65,7 +65,7 @@ impl From<SerializableQuoteProperties> for QuoteProperties {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
-pub struct SerializableFormatContext {
+pub struct SerializableFormatOptions {
     /// The indent style.
     pub indent_style: Option<SerializableIndentStyle>,
 
@@ -79,8 +79,8 @@ pub struct SerializableFormatContext {
     pub quote_properties: Option<SerializableQuoteProperties>,
 }
 
-impl From<SerializableFormatContext> for JsFormatContext {
-    fn from(test: SerializableFormatContext) -> Self {
+impl From<SerializableFormatOptions> for JsFormatOptions {
+    fn from(test: SerializableFormatOptions) -> Self {
         Self::new(SourceType::default())
             .with_indent_style(
                 test.indent_style
@@ -104,17 +104,17 @@ impl From<SerializableFormatContext> for JsFormatContext {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct TestOptions {
-    cases: Vec<SerializableFormatContext>,
+    cases: Vec<SerializableFormatOptions>,
 }
 
 #[derive(Debug, Default)]
 struct SnapshotContent {
     input: String,
-    output: Vec<(String, JsFormatContext)>,
+    output: Vec<(String, JsFormatOptions)>,
 }
 
 impl SnapshotContent {
-    fn add_output(&mut self, formatted: Printed, context: JsFormatContext) {
+    fn add_output(&mut self, formatted: Printed, options: JsFormatOptions) {
         let code = formatted.as_code();
         let mut output: String = code.to_string();
         if !formatted.verbatim_ranges().is_empty() {
@@ -126,7 +126,7 @@ impl SnapshotContent {
             }
         }
 
-        let line_width_limit = context.line_width().value() as usize;
+        let line_width_limit = options.line_width().value() as usize;
         let mut exceeding_lines = code
             .lines()
             .enumerate()
@@ -146,7 +146,7 @@ impl SnapshotContent {
             }
         }
 
-        self.output.push((output, context));
+        self.output.push((output, options));
     }
 
     fn set_input(&mut self, content: impl Into<String>) {
@@ -226,7 +226,8 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
         let root = parsed.syntax();
 
         // we ignore the error for now
-        let formatted = format_node(JsFormatContext::default(), &root).unwrap();
+        let options = JsFormatOptions::default();
+        let formatted = format_node(options.clone(), &root).unwrap();
         let printed = formatted.print();
         let file_name = spec_input_file.file_name().unwrap().to_str().unwrap();
 
@@ -236,11 +237,11 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
                 text: printed.as_code(),
                 source_type,
                 file_name,
-                format_context: JsFormatContext::default(),
+                options,
             });
         }
 
-        snapshot_content.add_output(printed, JsFormatContext::default());
+        snapshot_content.add_output(printed, JsFormatOptions::default());
 
         let test_directory = PathBuf::from(test_directory);
         let options_path = test_directory.join("options.json");
@@ -252,11 +253,11 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
                     serde_json::from_str(options_path.get_buffer_from_file().as_str()).unwrap();
 
                 for test_case in options.cases {
-                    let mut format_context: JsFormatContext = test_case.into();
+                    let mut format_options: JsFormatOptions = test_case.into();
                     // we don't track the source type inside the serializable structs, so we
                     // inject it here
-                    format_context = format_context.with_source_type(source_type);
-                    let formatted = format_node(format_context.clone(), &root).unwrap();
+                    format_options = format_options.with_source_type(source_type);
+                    let formatted = format_node(format_options.clone(), &root).unwrap();
                     let printed = formatted.print();
 
                     if !has_errors {
@@ -265,11 +266,11 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
                             text: printed.as_code(),
                             source_type,
                             file_name,
-                            format_context: format_context.clone(),
+                            options: format_options.clone(),
                         });
                     }
 
-                    snapshot_content.add_output(printed, format_context);
+                    snapshot_content.add_output(printed, format_options);
                 }
             }
         }

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -187,10 +187,10 @@ fn debug_formatter_ir(
     parse: AnyParse,
     settings: SettingsHandle,
 ) -> Result<String, RomeError> {
-    let context = settings.format_options::<JsLanguage>(rome_path);
+    let options = settings.format_options::<JsLanguage>(rome_path);
 
     let tree = parse.syntax();
-    let formatted = format_node(context, &tree)?;
+    let formatted = format_node(options, &tree)?;
 
     let root_element = formatted.into_format_element();
     Ok(root_element.to_string())
@@ -374,10 +374,10 @@ fn format(
     parse: AnyParse,
     settings: SettingsHandle,
 ) -> Result<Printed, RomeError> {
-    let context = settings.format_options::<JsLanguage>(rome_path);
+    let options = settings.format_options::<JsLanguage>(rome_path);
 
     let tree = parse.syntax();
-    let formatted = format_node(context, &tree)?;
+    let formatted = format_node(options, &tree)?;
     let printed = formatted.print();
     Ok(printed)
 }
@@ -388,10 +388,10 @@ fn format_range(
     settings: SettingsHandle,
     range: TextRange,
 ) -> Result<Printed, RomeError> {
-    let context = settings.format_options::<JsLanguage>(rome_path);
+    let options = settings.format_options::<JsLanguage>(rome_path);
 
     let tree = parse.syntax();
-    let printed = rome_js_formatter::format_range(context, &tree, range)?;
+    let printed = rome_js_formatter::format_range(options, &tree, range)?;
     Ok(printed)
 }
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -5,7 +5,7 @@ use rome_fs::RomePath;
 use rome_js_analyze::utils::rename::RenameError;
 use rome_js_analyze::{analyze, analyze_with_inspect_matcher, metadata, RuleError};
 use rome_js_formatter::context::{JsFormatOptions, QuoteProperties, QuoteStyle};
-use rome_js_formatter::{format_node};
+use rome_js_formatter::format_node;
 use rome_js_parser::Parse;
 use rome_js_semantic::semantic_model;
 use rome_js_syntax::{

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -137,18 +137,18 @@ pub trait Language: rome_rowan::Language {
         + schemars::JsonSchema;
 
     /// Fully resolved formatter options type for this language
-    type FormatContext: rome_formatter::FormatContext;
+    type FormatOptions: rome_formatter::FormatOptions;
 
     /// Read the settings type for this language from the [LanguagesSettings] map
     fn lookup_settings(languages: &LanguagesSettings) -> &LanguageSettings<Self>;
 
     /// Resolve the formatter options from the global (workspace level),
     /// per-language and editor provided formatter settings
-    fn resolve_format_context(
+    fn resolve_format_options(
         global: &FormatSettings,
         language: &Self::FormatSettings,
         path: &RomePath,
-    ) -> Self::FormatContext;
+    ) -> Self::FormatOptions;
 }
 
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -194,11 +194,11 @@ impl<'a> AsRef<WorkspaceSettings> for SettingsHandle<'a> {
 
 impl<'a> SettingsHandle<'a> {
     /// Resolve the formatting context for the given language
-    pub(crate) fn format_context<L>(self, path: &RomePath) -> L::FormatContext
+    pub(crate) fn format_options<L>(self, path: &RomePath) -> L::FormatOptions
     where
         L: Language,
     {
-        L::resolve_format_context(
+        L::resolve_format_options(
             &self.inner.format,
             &L::lookup_settings(&self.inner.languages).format,
             path,

--- a/crates/rome_wasm/build.rs
+++ b/crates/rome_wasm/build.rs
@@ -6,7 +6,7 @@ use rome_js_factory::{
     make,
     syntax::{JsAnyDeclaration, JsAnyModuleItem, JsAnyStatement},
 };
-use rome_js_formatter::{context::JsFormatContext, format_node};
+use rome_js_formatter::{context::JsFormatOptions, format_node};
 use rome_rowan::AstNode;
 use rome_service::workspace_types::{generate_type, methods, ModuleQueue};
 
@@ -66,7 +66,7 @@ fn main() -> io::Result<()> {
 
     // Wasm-bindgen will paste the generated TS code as-is into the final .d.ts file,
     // ensure it looks good by running it through the formatter
-    let formatted = format_node(JsFormatContext::default(), module.syntax()).unwrap();
+    let formatted = format_node(JsFormatOptions::default(), module.syntax()).unwrap();
     let printed = formatted.print();
     let definitions = printed.into_code();
 

--- a/xtask/bench/src/features/formatter.rs
+++ b/xtask/bench/src/features/formatter.rs
@@ -2,7 +2,7 @@
 use crate::features::print_diff;
 use crate::BenchmarkSummary;
 use rome_formatter::Printed;
-use rome_js_formatter::context::JsFormatContext;
+use rome_js_formatter::context::{JsFormatOptions};
 use rome_js_formatter::format_node;
 use rome_js_syntax::JsSyntaxNode;
 use std::fmt::{Display, Formatter};
@@ -31,7 +31,7 @@ pub fn run_format(root: &JsSyntaxNode) -> Printed {
         dhat::get_stats().unwrap()
     };
 
-    let formatted = format_node(JsFormatContext::default(), root).unwrap();
+    let formatted = format_node(JsFormatOptions::default(), root).unwrap();
 
     #[cfg(feature = "dhat-on")]
     let stats = {

--- a/xtask/bench/src/features/formatter.rs
+++ b/xtask/bench/src/features/formatter.rs
@@ -2,7 +2,7 @@
 use crate::features::print_diff;
 use crate::BenchmarkSummary;
 use rome_formatter::Printed;
-use rome_js_formatter::context::{JsFormatOptions};
+use rome_js_formatter::context::JsFormatOptions;
 use rome_js_formatter::format_node;
 use rome_js_syntax::JsSyntaxNode;
 use std::fmt::{Display, Formatter};

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -1,5 +1,5 @@
 use rome_js_factory::make;
-use rome_js_formatter::{context::JsFormatContext, format_node};
+use rome_js_formatter::{context::JsFormatOptions, format_node};
 use rome_js_syntax::{
     JsAnyBinding, JsAnyBindingPattern, JsAnyCallArgument, JsAnyDeclaration, JsAnyDeclarationClause,
     JsAnyExportClause, JsAnyExpression, JsAnyFormalParameter, JsAnyImportClause,
@@ -384,7 +384,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
     )
     .build();
 
-    let formatted = format_node(JsFormatContext::default(), module.syntax()).unwrap();
+    let formatted = format_node(JsFormatOptions::default(), module.syntax()).unwrap();
     let printed = formatted.print();
     let code = printed.into_code();
 


### PR DESCRIPTION
## Summary

This PR extracts a `FormatOptions` trait from the `FormatContext`. 

The reason for splitting `FormatOptions` and `FormatContext` is the context is intended to store data that is relevant for the formatting of an object like the extracted comments, a source map etc. The information about source maps, comments etc. things that consumers shouldn't be concerned about.

The `FormatOptions` on the other hand are relevant for users because it allows them to customize the formatting of an object.

## Tests

This PR isn't adding any new behaviour.

`cargo test`
