### PR TITLE
feat(rome_rowan): `cast_ref` and `match_ast` macro

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -5,9 +5,10 @@ use crate::parentheses::{
     unary_like_expression_needs_parentheses, ExpressionNode, NeedsParentheses,
 };
 
+use rome_js_syntax::JsUnaryExpression;
 use rome_js_syntax::{JsAnyExpression, JsSyntaxNode};
-use rome_js_syntax::{JsSyntaxKind, JsUnaryExpression};
 use rome_js_syntax::{JsUnaryExpressionFields, JsUnaryOperator};
+use rome_rowan::match_ast;
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsUnaryExpression;
@@ -44,16 +45,19 @@ impl FormatNodeRule<JsUnaryExpression> for FormatJsUnaryExpression {
 
 impl NeedsParentheses for JsUnaryExpression {
     fn needs_parentheses_with_parent(&self, parent: &JsSyntaxNode) -> bool {
-        match parent.kind() {
-            JsSyntaxKind::JS_UNARY_EXPRESSION => {
-                let parent_unary = JsUnaryExpression::unwrap_cast(parent.clone());
-                let parent_operator = parent_unary.operator();
-                let operator = self.operator();
+        match_ast! {
+            match parent {
+                JsUnaryExpression(parent_unary) => {
+                    let parent_operator = parent_unary.operator();
+                    let operator = self.operator();
 
-                matches!(operator, Ok(JsUnaryOperator::Plus | JsUnaryOperator::Minus))
-                    && parent_operator == operator
+                    matches!(operator, Ok(JsUnaryOperator::Plus | JsUnaryOperator::Minus))
+                        && parent_operator == operator
+                },
+                _ => {
+                    unary_like_expression_needs_parentheses(self.syntax(), parent)
+                }
             }
-            _ => unary_like_expression_needs_parentheses(self.syntax(), parent),
         }
     }
 }

--- a/crates/rome_js_formatter/src/parentheses.rs
+++ b/crates/rome_js_formatter/src/parentheses.rs
@@ -50,9 +50,10 @@ use rome_js_syntax::{
     JsAnyAssignment, JsAnyAssignmentPattern, JsAnyExpression, JsAnyFunctionBody,
     JsAnyLiteralExpression, JsArrowFunctionExpression, JsAssignmentExpression, JsBinaryExpression,
     JsBinaryOperator, JsComputedMemberAssignment, JsComputedMemberExpression,
-    JsConditionalExpression, JsLanguage, JsSequenceExpression, JsSyntaxKind, JsSyntaxNode,
+    JsConditionalExpression, JsLanguage, JsSequenceExpression, JsStaticMemberAssignment,
+    JsStaticMemberExpression, JsSyntaxKind, JsSyntaxNode,
 };
-use rome_rowan::AstNode;
+use rome_rowan::{match_ast, AstNode};
 
 /// Node that may be parenthesized to ensure it forms valid syntax or to improve readability
 pub trait NeedsParentheses: AstNode<Language = JsLanguage> {
@@ -635,18 +636,15 @@ pub(crate) fn unary_like_expression_needs_parentheses(
     ));
     debug_assert_is_parent(expression, parent);
 
-    match parent.kind() {
-        JsSyntaxKind::JS_BINARY_EXPRESSION => {
-            let binary = JsBinaryExpression::unwrap_cast(parent.clone());
-
-            matches!(binary.operator(), Ok(JsBinaryOperator::Exponent))
-                && binary
-                    .left()
-                    .map(ExpressionNode::into_resolved_syntax)
-                    .as_ref()
-                    == Ok(expression)
-        }
-        _ => update_or_lower_expression_needs_parentheses(expression, parent),
+    if let Some(binary) = JsBinaryExpression::cast_ref(parent) {
+        matches!(binary.operator(), Ok(JsBinaryOperator::Exponent))
+            && binary
+                .left()
+                .map(ExpressionNode::into_resolved_syntax)
+                .as_ref()
+                == Ok(expression)
+    } else {
+        update_or_lower_expression_needs_parentheses(expression, parent)
     }
 }
 
@@ -679,31 +677,27 @@ pub(crate) fn is_member_object(node: &JsSyntaxNode, parent: &JsSyntaxNode) -> bo
     debug_assert_is_expression(node);
     debug_assert_is_parent(node, parent);
 
-    match parent.kind() {
-        // Only allows expression in the `object` child.
-        JsSyntaxKind::JS_STATIC_MEMBER_EXPRESSION => true,
-        JsSyntaxKind::JS_STATIC_MEMBER_ASSIGNMENT => true,
-
-        JsSyntaxKind::JS_COMPUTED_MEMBER_EXPRESSION => {
-            let member_expression = JsComputedMemberExpression::unwrap_cast(parent.clone());
-
-            member_expression
-                .object()
-                .map(ExpressionNode::into_resolved_syntax)
-                .as_ref()
-                == Ok(node)
+    match_ast! {
+        match parent {
+            // Only allows expression in the `object` child.
+            JsStaticMemberExpression(_) => true,
+            JsStaticMemberAssignment(_) => true,
+            JsComputedMemberExpression(member_expression) => {
+                 member_expression
+                    .object()
+                    .map(ExpressionNode::into_resolved_syntax)
+                    .as_ref()
+                    == Ok(node)
+            },
+            JsComputedMemberAssignment(assignment) => {
+                assignment
+                    .object()
+                    .map(ExpressionNode::into_resolved_syntax)
+                    .as_ref()
+                    == Ok(node)
+            },
+            _ => false,
         }
-
-        JsSyntaxKind::JS_COMPUTED_MEMBER_ASSIGNMENT => {
-            let member_assignment = JsComputedMemberAssignment::unwrap_cast(parent.clone());
-
-            member_assignment
-                .object()
-                .map(ExpressionNode::into_resolved_syntax)
-                .as_ref()
-                == Ok(node)
-        }
-        _ => false,
     }
 }
 
@@ -729,35 +723,35 @@ pub(crate) fn is_callee(node: &JsSyntaxNode, parent: &JsSyntaxNode) -> bool {
 /// is_conditional_test(`b`, `a ? b : c`) -> false
 /// ```
 pub(crate) fn is_conditional_test(node: &JsSyntaxNode, parent: &JsSyntaxNode) -> bool {
-    match parent.kind() {
-        JsSyntaxKind::JS_CONDITIONAL_EXPRESSION => {
-            let conditional = JsConditionalExpression::unwrap_cast(parent.clone());
-
-            conditional
-                .test()
-                .map(ExpressionNode::into_resolved_syntax)
-                .as_ref()
-                == Ok(node)
+    match_ast! {
+        match parent {
+            JsConditionalExpression(conditional) => {
+                conditional
+                    .test()
+                    .map(ExpressionNode::into_resolved_syntax)
+                    .as_ref()
+                    == Ok(node)
+            },
+            _ => false
         }
-        _ => false,
     }
 }
 
 pub(crate) fn is_arrow_function_body(node: &JsSyntaxNode, parent: &JsSyntaxNode) -> bool {
     debug_assert_is_expression(node);
 
-    match parent.kind() {
-        JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => {
-            let arrow = JsArrowFunctionExpression::unwrap_cast(parent.clone());
-
-            match arrow.body() {
-                Ok(JsAnyFunctionBody::JsAnyExpression(expression)) => {
-                    &expression.resolve_syntax() == node
+    match_ast! {
+        match parent {
+            JsArrowFunctionExpression(arrow) => {
+                match arrow.body() {
+                    Ok(JsAnyFunctionBody::JsAnyExpression(expression)) => {
+                        &expression.resolve_syntax() == node
+                    }
+                    _ => false,
                 }
-                _ => false,
-            }
+            },
+            _ => false
         }
-        _ => false,
     }
 }
 

--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -124,6 +124,20 @@ pub trait AstNode: Clone {
     where
         Self: Sized;
 
+    /// Takes a reference of a syntax node and tries to cast it to this AST node.
+    ///
+    /// Only creates a clone of the syntax node if casting the node is possible.
+    fn cast_ref(syntax: &SyntaxNode<Self::Language>) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if Self::can_cast(syntax.kind()) {
+            Self::cast(syntax.clone())
+        } else {
+            None
+        }
+    }
+
     /// Tries to cast the passed syntax node to this AST node.
     ///
     /// # Returns
@@ -154,7 +168,7 @@ pub trait AstNode: Clone {
     /// ```
     fn try_cast(syntax: SyntaxNode<Self::Language>) -> Result<Self, SyntaxNode<Self::Language>> {
         if Self::can_cast(syntax.kind()) {
-            Ok(Self::unwrap_cast(syntax))
+            Ok(Self::cast(syntax).expect("Expected casted node because 'can_cast' returned true."))
         } else {
             Err(syntax)
         }
@@ -188,7 +202,8 @@ pub trait AstNode: Clone {
     /// ```
     fn try_cast_node<T: AstNode<Language = Self::Language>>(node: T) -> Result<Self, T> {
         if Self::can_cast(node.syntax().kind()) {
-            Ok(Self::unwrap_cast(node.into_syntax()))
+            Ok(Self::cast(node.into_syntax())
+                .expect("Expected casted node because 'can_cast' returned true."))
         } else {
             Err(node)
         }


### PR DESCRIPTION
This PR introduces a new `AstNode::cast_ref` method that takes a node by reference and only clones it if it can be cast into the `AstNode`.

Being able to pass a reference instead of the owned value can be useful if it's necessary to test against multiple nodes

```
if let Some(if_statement) = JsIfStatement::cast(node.clone()) {
  ..
} else if let Some(expression_stmt) = JsExpressionStatement::cast(node.clone()) {
  ..
} else if let Some(switch_statement) = JsSwitchStatement::cast(node) {
  ..
}
```

As you can see here, the `node` must be cloned `n-1` times where `n` is the number of branches (Rust may be able to optimize them away but doesn't hurt to help the compiler). Using `cast_ref` reduces the clones to at most one in the case the node matches one branch.

This PR further introduces a `match_ast` macro that allows matching a syntax node against AST nodes. This removes the need to match on `JsSyntaxKind` directly and use `unwrap_cast` all over the code base.

```rust
    match_ast! {
        match parent {
            // Only allows expression in the `object` child.
            JsStaticMemberExpression(_) => true,
            JsStaticMemberAssignment(_) => true,
            JsComputedMemberExpression(member_expression) => {
                 member_expression
                    .object()
                    .map(ExpressionNode::into_resolved_syntax)
                    .as_ref()
                    == Ok(node)
            },
            JsComputedMemberAssignment(assignment) => {
                assignment
                    .object()
                    .map(ExpressionNode::into_resolved_syntax)
                    .as_ref()
                    == Ok(node)
            },
            _ => false,
        }
    }
```

## Tests

I added a doc test to the new macro.


## Credit

All credit for the macro goes to [rust-analyzer](https://github.com/rust-lang/rust-analyzer/blob/c6c0ac26456093b71837e20b0ff51655e0c230f7/crates/syntax/src/lib.rs#L173-L198) 