### PR TITLE
feat(rome_js_analyze): no unused starting with underscore; small hack for React and removing suggested fix

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_unused_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_unused_variables.rs
@@ -1,16 +1,13 @@
-use crate::{semantic_services::Semantic, utils::batch::JsBatchMutation, JsRuleAction};
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
-};
+use crate::semantic_services::Semantic;
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleCategory, RuleDiagnostic};
 use rome_console::markup;
-use rome_diagnostics::Applicability;
 use rome_js_semantic::{AllReferencesExtensions, SemanticScopeExtensions};
 use rome_js_syntax::{
-    JsCatchDeclaration, JsConstructorParameterList, JsConstructorParameters, JsFormalParameter,
-    JsFunctionDeclaration, JsIdentifierBinding, JsParameterList, JsParameters, JsSyntaxKind,
+    JsClassExpression, JsConstructorParameterList, JsConstructorParameters, JsFunctionDeclaration,
+    JsFunctionExpression, JsIdentifierBinding, JsParameterList, JsParameters, JsSyntaxKind,
     JsVariableDeclarator,
 };
-use rome_rowan::{AstNode, BatchMutationExt};
+use rome_rowan::AstNode;
 
 declare_rule! {
     /// Disallow unused variables.
@@ -117,12 +114,28 @@ impl Rule for NoUnusedVariables {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let binding = ctx.query();
-        let model = ctx.model();
+        let name = binding.name_token().ok()?;
+        let name = name.token_text_trimmed();
+        let name = name.text();
+
+        // Old code import React but do not used directly
+        // only indirectly after transpiling JSX.
+        if name.starts_with('_') || name == "React" {
+            return None;
+        }
+
+        // Ignore expressions
+        if binding.parent::<JsFunctionExpression>().is_some()
+            || binding.parent::<JsClassExpression>().is_some()
+        {
+            return None;
+        }
 
         if is_typescript_unused_ok(binding).is_some() {
             return None;
         }
 
+        let model = ctx.model();
         if model.is_exported(binding) {
             return None;
         }
@@ -197,44 +210,5 @@ impl Rule for NoUnusedVariables {
         );
 
         Some(diag)
-    }
-
-    fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
-        let root = ctx.root();
-        let binding = ctx.query();
-
-        let mut batch = root.begin();
-
-        // Try to remove node
-        let removed = if let Some(declaration) = binding.parent::<JsFunctionDeclaration>() {
-            batch.remove_node(declaration);
-            true
-        } else if let Some(variable_declarator) = binding.parent::<JsVariableDeclarator>() {
-            batch.remove_js_variable_declarator(&variable_declarator)
-        } else if let Some(formal_parameter) = binding.parent::<JsFormalParameter>() {
-            batch.remove_js_formal_parameter(&formal_parameter)
-        } else if let Some(catch_declaration) = binding.parent::<JsCatchDeclaration>() {
-            batch.remove_node(catch_declaration);
-            true
-        } else {
-            false
-        };
-
-        if removed {
-            let symbol_type = match binding.syntax().parent().unwrap().kind() {
-                JsSyntaxKind::JS_FORMAL_PARAMETER => "parameter",
-                JsSyntaxKind::JS_FUNCTION_DECLARATION => "function",
-                _ => "variable",
-            };
-
-            Some(JsRuleAction {
-                category: ActionCategory::QuickFix,
-                applicability: Applicability::MaybeIncorrect,
-                message: markup! { "Remove this " {symbol_type} "." }.to_owned(),
-                mutation: batch,
-            })
-        } else {
-            None
-        }
     }
 }

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/no_unused_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/no_unused_variables.rs
@@ -62,6 +62,20 @@ declare_rule! {
     /// };
     /// foo();
     /// ```
+    ///
+    /// ```js
+    /// function foo(_unused) {
+    /// };
+    /// foo();
+    /// ```
+    ///
+    /// ```jsx
+    /// import React from 'react';
+    /// function foo() {
+    ///     return <div />;
+    /// };
+    /// foo();
+    /// ```
     pub(crate) NoUnusedVariables {
         version: "0.9.0",
         name: "noUnusedVariables",

--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 const a = 1;
 const b = 2,
 	c = 3;
@@ -47,4 +49,8 @@ let value;
 function Button() {}
 console.log(<Button att={value}/>);
 
-(function f(){})()
+(function f(_a){})()
+
+new (class C {
+
+})

--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.js.snap
@@ -4,6 +4,8 @@ expression: noUnusedVariables.js
 ---
 # Input
 ```js
+import React from 'react';
+
 const a = 1;
 const b = 2,
 	c = 3;
@@ -53,25 +55,20 @@ let value;
 function Button() {}
 console.log(<Button att={value}/>);
 
-(function f(){})()
+(function f(_a){})()
 
+new (class C {
+
+})
 ```
 
 # Diagnostics
 ```
 warning[js/noUnusedVariables]: This variable is unused.
-  ┌─ noUnusedVariables.js:1:7
+  ┌─ noUnusedVariables.js:3:7
   │
-1 │ const a = 1;
+3 │ const a = 1;
   │       -
-
-Suggested fix: Remove this variable.
-    | @@ -1,4 +1,4 @@
-0   | - const a = 1;
-  0 | + 
-1 1 |   const b = 2,
-2 2 |   	c = 3;
-3 3 |   console.log(c);
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -80,42 +77,10 @@ Suggested fix: Remove this variable.
 
 ```
 warning[js/noUnusedVariables]: This variable is unused.
-  ┌─ noUnusedVariables.js:2:7
+  ┌─ noUnusedVariables.js:4:7
   │
-2 │ const b = 2,
+4 │ const b = 2,
   │       -
-
-Suggested fix: Remove this variable.
-    | @@ -1,5 +1,5 @@
-0 0 |   const a = 1;
-1   | - const b = 2,
-  1 | + const
-2 2 |   	c = 3;
-3 3 |   console.log(c);
-4 4 |   
-
-=  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
-
-
-```
-
-```
-warning[js/noUnusedVariables]: This function is unused.
-  ┌─ noUnusedVariables.js:6:10
-  │
-6 │ function f1() {}
-  │          --
-
-Suggested fix: Remove this function.
-    | @@ -3,8 +3,6 @@
-2 2 |   	c = 3;
-3 3 |   console.log(c);
-4 4 |   
-5   | - function f1() {}
-6   | - 
-7 5 |   function f2() {
-8 6 |   	f2();
-9 7 |   }
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -126,21 +91,8 @@ Suggested fix: Remove this function.
 warning[js/noUnusedVariables]: This function is unused.
   ┌─ noUnusedVariables.js:8:10
   │
-8 │ function f2() {
+8 │ function f1() {}
   │          --
-
-Suggested fix: Remove this function.
-    | @@ -5,10 +5,6 @@
-4 4 |   
-5 5 |   function f1() {}
-6 6 |   
-7   | - function f2() {
-8   | - 	f2();
-9   | - }
-10   | - 
-11 7 |   function f3() {
-12 8 |   	function g() {
-13 9 |   		f3();
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -149,26 +101,22 @@ Suggested fix: Remove this function.
 
 ```
 warning[js/noUnusedVariables]: This function is unused.
-   ┌─ noUnusedVariables.js:12:10
+   ┌─ noUnusedVariables.js:10:10
    │
-12 │ function f3() {
+10 │ function f2() {
    │          --
 
-Suggested fix: Remove this function.
-      | @@ -9,13 +9,6 @@
- 8  8 |   	f2();
- 9  9 |   }
-10 10 |   
-11    | - function f3() {
-12    | - 	function g() {
-13    | - 		f3();
-14    | - 	}
-15    | - 	g();
-16    | - }
-17    | - 
-18 11 |   function f41(a) {}
-19 12 |   f41();
-20 13 |   
+=  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+
+
+```
+
+```
+warning[js/noUnusedVariables]: This function is unused.
+   ┌─ noUnusedVariables.js:14:10
+   │
+14 │ function f3() {
+   │          --
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -177,21 +125,22 @@ Suggested fix: Remove this function.
 
 ```
 warning[js/noUnusedVariables]: This parameter is unused.
-   ┌─ noUnusedVariables.js:19:14
+   ┌─ noUnusedVariables.js:21:14
    │
-19 │ function f41(a) {}
+21 │ function f41(a) {}
    │              -
 
-Suggested fix: Remove this parameter.
-      | @@ -16,7 +16,7 @@
-15 15 |   	g();
-16 16 |   }
-17 17 |   
-18    | - function f41(a) {}
-   18 | + function f41() {}
-19 19 |   f41();
-20 20 |   
-21 21 |   function f42(a, b) {
+=  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+
+
+```
+
+```
+warning[js/noUnusedVariables]: This parameter is unused.
+   ┌─ noUnusedVariables.js:24:17
+   │
+24 │ function f42(a, b) {
+   │                 -
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -200,67 +149,10 @@ Suggested fix: Remove this parameter.
 
 ```
 warning[js/noUnusedVariables]: This parameter is unused.
-   ┌─ noUnusedVariables.js:22:17
+   ┌─ noUnusedVariables.js:29:17
    │
-22 │ function f42(a, b) {
+29 │ function f43(a, b) {
    │                 -
-
-Suggested fix: Remove this parameter.
-      | @@ -19,7 +19,7 @@
-18 18 |   function f41(a) {}
-19 19 |   f41();
-20 20 |   
-21    | - function f42(a, b) {
-   21 | + function f42(a) {
-22 22 |   	console.log(a);
-23 23 |   }
-24 24 |   f42();
-
-=  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
-
-
-```
-
-```
-warning[js/noUnusedVariables]: This parameter is unused.
-   ┌─ noUnusedVariables.js:27:17
-   │
-27 │ function f43(a, b) {
-   │                 -
-
-Suggested fix: Remove this parameter.
-      | @@ -24,7 +24,7 @@
-23 23 |   }
-24 24 |   f42();
-25 25 |   
-26    | - function f43(a, b) {
-   26 | + function f43(a) {
-27 27 |   	console.log(a);
-28 28 |   }
-29 29 |   f43();
-
-=  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
-
-
-```
-
-```
-warning[js/noUnusedVariables]: This variable is unused.
-   ┌─ noUnusedVariables.js:32:7
-   │
-32 │ const f5 = () => {};
-   │       --
-
-Suggested fix: Remove this variable.
-      | @@ -29,8 +29,6 @@
-28 28 |   }
-29 29 |   f43();
-30 30 |   
-31    | - const f5 = () => {};
-32    | - 
-33 31 |   const f6 = () => {
-34 32 |   	f6();
-35 33 |   };
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -271,21 +163,8 @@ Suggested fix: Remove this variable.
 warning[js/noUnusedVariables]: This variable is unused.
    ┌─ noUnusedVariables.js:34:7
    │
-34 │ const f6 = () => {
+34 │ const f5 = () => {};
    │       --
-
-Suggested fix: Remove this variable.
-      | @@ -31,10 +31,6 @@
-30 30 |   
-31 31 |   const f5 = () => {};
-32 32 |   
-33    | - const f6 = () => {
-34    | - 	f6();
-35    | - };
-36    | - 
-37 33 |   try {
-38 34 |   } catch (e) {}
-39 35 |   
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -294,21 +173,22 @@ Suggested fix: Remove this variable.
 
 ```
 warning[js/noUnusedVariables]: This variable is unused.
-   ┌─ noUnusedVariables.js:39:10
+   ┌─ noUnusedVariables.js:36:7
    │
-39 │ } catch (e) {}
-   │          -
+36 │ const f6 = () => {
+   │       --
 
-Suggested fix: Remove this variable.
-      | @@ -36,7 +36,7 @@
-35 35 |   };
-36 36 |   
-37 37 |   try {
-38    | - } catch (e) {}
-   38 | + } catch {}
-39 39 |   
-40 40 |   export function exported_function() {}
-41 41 |   
+=  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+
+
+```
+
+```
+warning[js/noUnusedVariables]: This variable is unused.
+   ┌─ noUnusedVariables.js:41:10
+   │
+41 │ } catch (e) {}
+   │          -
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 

--- a/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/js/noUnusedVariables/noUnusedVariables.ts.snap
@@ -52,17 +52,6 @@ warning[js/noUnusedVariables]: This parameter is unused.
 4 │     constructor(a: number) {}
   │                 -
 
-Suggested fix: Remove this parameter.
-    | @@ -1,7 +1,7 @@
-0 0 |   // Invalid
-1 1 |   
-2 2 |   class D {
-3   | - 	constructor(a: number) {}
-  3 | + 	constructor() {}
-4 4 |   	f(a: number) {}
-5 5 |   	set a(a: number) {}
-6 6 |   }
-
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
 
@@ -74,17 +63,6 @@ warning[js/noUnusedVariables]: This parameter is unused.
   │
 5 │     f(a: number) {}
   │       -
-
-Suggested fix: Remove this parameter.
-    | @@ -2,7 +2,7 @@
-1 1 |   
-2 2 |   class D {
-3 3 |   	constructor(a: number) {}
-4   | - 	f(a: number) {}
-  4 | + 	f() {}
-5 5 |   	set a(a: number) {}
-6 6 |   }
-7 7 |   console.log(new D());
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 

--- a/website/src/docs/lint/rules/noUnusedVariables.md
+++ b/website/src/docs/lint/rules/noUnusedVariables.md
@@ -23,11 +23,6 @@ const a = 4;
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> const <span style="color: Tomato;">a</span> = 4;
   <span style="color: rgb(38, 148, 255);">│</span>       <span style="color: Tomato;">^</span>
 
-<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove this variable.</span>
-    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">const a = 4;</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"></span>
-
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
 </code></pre>{% endraw %}
@@ -41,11 +36,6 @@ let a = 4;
   <span style="color: rgb(38, 148, 255);">│</span>
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> let <span style="color: Tomato;">a</span> = 4;
   <span style="color: rgb(38, 148, 255);">│</span>     <span style="color: Tomato;">^</span>
-
-<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove this variable.</span>
-    | <span style="color: rgb(38, 148, 255);">@@ -1 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">let a = 4;</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"></span>
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -61,12 +51,6 @@ function foo() {
   <span style="color: rgb(38, 148, 255);">│</span>
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> function <span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span>() {
   <span style="color: rgb(38, 148, 255);">│</span>          <span style="color: Tomato;">^</span><span style="color: Tomato;">^</span><span style="color: Tomato;">^</span>
-
-<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove this function.</span>
-    | <span style="color: rgb(38, 148, 255);">@@ -1,2 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">function foo() {</span>
-1   | <span style="color: Tomato;">- </span><span style="color: Tomato;">};</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">;</span>
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -85,14 +69,6 @@ foo();
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> function foo(<span style="color: Tomato;">m</span><span style="color: Tomato;">y</span><span style="color: Tomato;">V</span><span style="color: Tomato;">a</span><span style="color: Tomato;">r</span>) {
   <span style="color: rgb(38, 148, 255);">│</span>              <span style="color: Tomato;">^</span><span style="color: Tomato;">^</span><span style="color: Tomato;">^</span><span style="color: Tomato;">^</span><span style="color: Tomato;">^</span>
 
-<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove this parameter.</span>
-    | <span style="color: rgb(38, 148, 255);">@@ -1,4 +1,4 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">function foo(myVar) {</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;">function foo() {</span>
-1 1 |       console.log('foo');
-2 2 |   }
-3 3 |   foo();
-
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
 </code></pre>{% endraw %}
@@ -107,12 +83,6 @@ const foo = () => {
   <span style="color: rgb(38, 148, 255);">│</span>
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> const <span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span> = () =&gt; {
   <span style="color: rgb(38, 148, 255);">│</span>       <span style="color: Tomato;">^</span><span style="color: Tomato;">^</span><span style="color: Tomato;">^</span>
-
-<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove this variable.</span>
-    | <span style="color: rgb(38, 148, 255);">@@ -1,2 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">const foo = () =&gt; {</span>
-1   | <span style="color: Tomato;">- </span><span style="color: Tomato;">};</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"></span>
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -129,13 +99,6 @@ function foo() {
   <span style="color: rgb(38, 148, 255);">│</span>
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> function <span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span>() {
   <span style="color: rgb(38, 148, 255);">│</span>          <span style="color: Tomato;">^</span><span style="color: Tomato;">^</span><span style="color: Tomato;">^</span>
-
-<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove this function.</span>
-    | <span style="color: rgb(38, 148, 255);">@@ -1,3 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">function foo() {</span>
-1   | <span style="color: Tomato;">- </span><span style="color: Tomato;">    foo();</span>
-2   | <span style="color: Tomato;">- </span><span style="color: Tomato;">}</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"></span>
 
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
@@ -154,14 +117,6 @@ const foo = () => {
 <span style="color: rgb(38, 148, 255);">1</span> <span style="color: rgb(38, 148, 255);">│</span> const <span style="color: Tomato;">f</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span> = () =&gt; {
   <span style="color: rgb(38, 148, 255);">│</span>       <span style="color: Tomato;">^</span><span style="color: Tomato;">^</span><span style="color: Tomato;">^</span>
 
-<span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove this variable.</span>
-    | <span style="color: rgb(38, 148, 255);">@@ -1,4 +1 @@</span>
-0   | <span style="color: Tomato;">- </span><span style="color: Tomato;">const foo = () =&gt; {</span>
-1   | <span style="color: Tomato;">- </span><span style="color: Tomato;">    foo();</span>
-2   | <span style="color: Tomato;">- </span><span style="color: Tomato;">    console.log(this);</span>
-3   | <span style="color: Tomato;">- </span><span style="color: Tomato;">};</span>
-  0 | <span style="color: MediumSeaGreen;">+ </span><span style="color: MediumSeaGreen;"></span>
-
 =  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
 </code></pre>{% endraw %}
@@ -171,6 +126,20 @@ const foo = () => {
 ```jsx
 function foo(b) {
     console.log(b)
+};
+foo();
+```
+
+```jsx
+function foo(_unused) {
+};
+foo();
+```
+
+```jsx
+import React from 'react';
+function foo() {
+    return <div />;
 };
 foo();
 ```


### PR DESCRIPTION
## Summary

This improves noUnusedVariables in three ways and removes the suggestion of removing the unused variables:

1 - It does not flag variables starting with "_";
2 - It does not flag React because some old codebases import React and use it only after JSX transpiling;
3 - It ignores function and class expressions (we are going to deal with these in another rule);

The suggestion was removed, because it suggested removing the first parameter of a function, and of course, completely changing the meaning of the other parameters. We need to think a little bit about what we want to suggest.

## Test Plan

```
> cargo test -p rome_js_analuze -- no_unused
```
