### PR TITLE
feat(rome_formatter): Custom separator per `Fill` item

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -62,8 +62,9 @@ pub enum FormatElement {
     List(List),
 
     /// Concatenates multiple elements together with a given separator printed in either
-    /// flat or expanded mode to fill the print width. See [crate::Formatter::fill].
-    Fill(Fill),
+    /// flat or expanded mode to fill the print width. Expect that the content is a list of alternating
+    /// [element, separator] See [crate::Formatter::fill].
+    Fill(Content),
 
     /// A text that should be printed as is, see [crate::text] for documentation and examples.
     Text(Text),
@@ -244,26 +245,6 @@ impl Deref for List {
 
     fn deref(&self) -> &Self::Target {
         &self.content
-    }
-}
-
-/// Fill is a list of [FormatElement]s along with a separator.
-///
-/// The printer prints this list delimited by a separator, wrapping the list when it
-/// reaches the specified `line_width`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Fill {
-    pub(super) content: Content,
-    pub(super) separator: Box<FormatElement>,
-}
-
-impl Fill {
-    pub fn content(&self) -> &[FormatElement] {
-        &self.content
-    }
-
-    pub fn separator(&self) -> &FormatElement {
-        &self.separator
     }
 }
 
@@ -669,7 +650,7 @@ impl FormatElement {
             FormatElement::Group(Group { content, .. })
             | FormatElement::ConditionalGroupContent(ConditionalGroupContent { content, .. })
             | FormatElement::Comment(content)
-            | FormatElement::Fill(Fill { content, .. })
+            | FormatElement::Fill(content)
             | FormatElement::Verbatim(Verbatim { content, .. })
             | FormatElement::Label(Label { content, .. })
             | FormatElement::Indent(content)
@@ -933,18 +914,8 @@ impl Format<IrFormatContext> for FormatElement {
                     ]
                 )
             }
-            FormatElement::Fill(fill) => {
-                write!(
-                    f,
-                    [
-                        text("fill("),
-                        fill.separator.as_ref(),
-                        text(","),
-                        space(),
-                        fill.content(),
-                        text(")")
-                    ]
-                )
+            FormatElement::Fill(content) => {
+                write!(f, [text("fill("), content.as_ref(), text(")")])
             }
 
             FormatElement::BestFitting(best_fitting) => {

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -137,11 +137,11 @@ impl<'buf, Context> Formatter<'buf, Context> {
     /// use rome_formatter::{format, format_args};
     ///
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
-    ///     f.fill(soft_line_break_or_space())
-    ///         .entry(&text("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
-    ///         .entry(&text("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
-    ///         .entry(&text("cccccccccccccccccccccccccccccc"))
-    ///         .entry(&text("dddddddddddddddddddddddddddddd"))
+    ///     f.fill()
+    ///         .entry(&text("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), &soft_line_break_or_space())
+    ///         .entry(&text("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), &soft_line_break_or_space())
+    ///         .entry(&text("cccccccccccccccccccccccccccccc"), &soft_line_break_or_space())
+    ///         .entry(&text("dddddddddddddddddddddddddddddd"), &soft_line_break_or_space())
     ///         .finish()
     /// })]).unwrap();
     ///
@@ -163,7 +163,7 @@ impl<'buf, Context> Formatter<'buf, Context> {
     /// ];
     ///
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
-    ///     f.fill(soft_line_break()).entries(entries.iter()).finish()
+    ///     f.fill().entries(entries.iter(), &soft_line_break()).finish()
     /// })]).unwrap();
     ///
     /// assert_eq!(
@@ -171,11 +171,8 @@ impl<'buf, Context> Formatter<'buf, Context> {
     ///     formatted.print().as_code()
     /// )
     /// ```
-    pub fn fill<'a, Separator>(&'a mut self, separator: Separator) -> FillBuilder<'a, 'buf, Context>
-    where
-        Separator: Format<Context>,
-    {
-        FillBuilder::new(self, separator)
+    pub fn fill<'a>(&'a mut self) -> FillBuilder<'a, 'buf, Context> {
+        FillBuilder::new(self)
     }
 
     /// Formats `content` into an interned element without writing it to the formatter's buffer.

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -138,10 +138,10 @@ impl<'buf, Context> Formatter<'buf, Context> {
     ///
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
     ///     f.fill()
-    ///         .entry(&text("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), &soft_line_break_or_space())
-    ///         .entry(&text("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), &soft_line_break_or_space())
-    ///         .entry(&text("cccccccccccccccccccccccccccccc"), &soft_line_break_or_space())
-    ///         .entry(&text("dddddddddddddddddddddddddddddd"), &soft_line_break_or_space())
+    ///         .entry(&soft_line_break_or_space(), &text("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+    ///         .entry(&soft_line_break_or_space(), &text("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+    ///         .entry(&soft_line_break_or_space(), &text("cccccccccccccccccccccccccccccc"))
+    ///         .entry(&soft_line_break_or_space(), &text("dddddddddddddddddddddddddddddd"))
     ///         .finish()
     /// })]).unwrap();
     ///
@@ -163,7 +163,7 @@ impl<'buf, Context> Formatter<'buf, Context> {
     /// ];
     ///
     /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
-    ///     f.fill().entries(entries.iter(), &soft_line_break()).finish()
+    ///     f.fill().entries(&soft_line_break(), entries.iter()).finish()
     /// })]).unwrap();
     ///
     /// assert_eq!(

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -1316,39 +1316,39 @@ two lines`,
             .fill()
             // These all fit on the same line together
             .entry(
+                &soft_line_break_or_space(),
                 &format_args!(text("1"), text(",")),
-                &soft_line_break_or_space(),
             )
             .entry(
+                &soft_line_break_or_space(),
                 &format_args!(text("2"), text(",")),
-                &soft_line_break_or_space(),
             )
             .entry(
-                &format_args!(text("3"), text(",")),
                 &soft_line_break_or_space(),
+                &format_args!(text("3"), text(",")),
             )
             // This one fits on a line by itself,
             .entry(
-                &format_args!(text("723493294"), text(",")),
                 &soft_line_break_or_space(),
+                &format_args!(text("723493294"), text(",")),
             )
             // fits without breaking
             .entry(
+                &soft_line_break_or_space(),
                 &group(&format_args!(
                     text("["),
                     soft_block_indent(&text("5")),
                     text("],")
                 )),
-                &soft_line_break_or_space(),
             )
             // this one must be printed in expanded mode to fit
             .entry(
+                &soft_line_break_or_space(),
                 &group(&format_args!(
                     text("["),
                     soft_block_indent(&text("123456789")),
                     text("]"),
                 )),
-                &soft_line_break_or_space(),
             )
             .finish()
             .unwrap();
@@ -1372,16 +1372,16 @@ two lines`,
                 soft_block_indent(&format_with(|f| {
                     f.fill()
                         .entry(
+                            &soft_line_break_or_space(),
                             &format_args!(text("1"), text(",")),
-                            &soft_line_break_or_space(),
                         )
                         .entry(
+                            &soft_line_break_or_space(),
                             &format_args!(text("2"), text(",")),
-                            &soft_line_break_or_space(),
                         )
                         .entry(
-                            &format_args!(text("3"), if_group_breaks(&text(","))),
                             &soft_line_break_or_space(),
+                            &format_args!(text("3"), if_group_breaks(&text(","))),
                         )
                         .finish()
                 })),

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -29,10 +29,11 @@ impl FormatRule<JsArrayElementList> for FormatJsArrayElementList {
         if !has_formatter_trivia(node.syntax()) && can_print_fill(node) {
             // Using format_separated is valid in this case as can_print_fill does not allow holes
             return f
-                .fill(soft_line_break_or_space())
+                .fill()
                 .entries(
                     node.format_separated(JsSyntaxKind::COMMA)
                         .with_group_id(self.group_id),
+                    &soft_line_break_or_space(),
                 )
                 .finish();
         }

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -31,9 +31,9 @@ impl FormatRule<JsArrayElementList> for FormatJsArrayElementList {
             return f
                 .fill()
                 .entries(
+                    &soft_line_break_or_space(),
                     node.format_separated(JsSyntaxKind::COMMA)
                         .with_group_id(self.group_id),
-                    &soft_line_break_or_space(),
                 )
                 .finish();
         }

--- a/crates/rome_js_formatter/src/jsx/lists/child_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/child_list.rs
@@ -12,8 +12,8 @@ impl FormatRule<JsxChildList> for FormatJsxChildList {
     fn fmt(&self, node: &JsxChildList, formatter: &mut JsFormatter) -> FormatResult<()> {
         if contains_meaningful_jsx_text(node) {
             formatter
-                .fill(soft_line_break())
-                .flatten_entries(node.iter().formatted())
+                .fill()
+                .flatten_entries(node.iter().formatted(), &soft_line_break())
                 .finish()
         } else {
             formatter

--- a/crates/rome_js_formatter/src/jsx/lists/child_list.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/child_list.rs
@@ -13,7 +13,7 @@ impl FormatRule<JsxChildList> for FormatJsxChildList {
         if contains_meaningful_jsx_text(node) {
             formatter
                 .fill()
-                .flatten_entries(node.iter().formatted(), &soft_line_break())
+                .flatten_entries(&soft_line_break(), node.iter().formatted())
                 .finish()
         } else {
             formatter


### PR DESCRIPTION
This PR refactors `Fill` to support different separators for every item rather than one uniform separator that separates all elements in the list.

This is necessary to implement `fill` for array expressions where the separator should be a:

* soft line break or space: if there are 0 - 1 line breaks before the node
* empty line: if there are more than 1 new lines before the node.

Used in #3126
