### PR TITLE
test(rome_js_formatter): Document array-fill comments difference

### DIFF
--- a/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js
@@ -1,0 +1,8 @@
+[
+ 	// Prettier prints the `-2` element on the same line as the `-3`.
+	// This is the case because Prettier doesn't add virtual groups around `fill` elements, making it return `true` when it
+	// encounters the first hard line break. As it happens, this line comment contains a hard line break, making
+	// Prettier believe that the `-3` with this leading comment all fits on the line, which, obviously, isn't the case.
+	-3,
+	-2
+]

--- a/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: fill-array-comments.js
+---
+# Input
+[
+ 	// Prettier prints the `-2` element on the same line as the `-3`.
+	// This is the case because Prettier doesn't add virtual groups around `fill` elements, making it return `true` when it
+	// encounters the first hard line break. As it happens, this line comment contains a hard line break, making
+	// Prettier believe that the `-3` with this leading comment all fits on the line, which, obviously, isn't the case.
+	-3,
+	-2
+]
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+-----
+[
+	// Prettier prints the `-2` element on the same line as the `-3`.
+	// This is the case because Prettier doesn't add virtual groups around `fill` elements, making it return `true` when it
+	// encounters the first hard line break. As it happens, this line comment contains a hard line break, making
+	// Prettier believe that the `-3` with this leading comment all fits on the line, which, obviously, isn't the case.
+	-3,
+	-2,
+];
+
+
+## Lines exceeding width of 80 characters
+
+    3: 	// This is the case because Prettier doesn't add virtual groups around `fill` elements, making it return `true` when it
+    4: 	// encounters the first hard line break. As it happens, this line comment contains a hard line break, making
+    5: 	// Prettier believe that the `-3` with this leading comment all fits on the line, which, obviously, isn't the case.
+


### PR DESCRIPTION
As discussed offline with @ematipico  Add a test that shows why Rome formats array fill elements differently than Prettier.
