### PR TITLE
fix(rome_lsp, vscode): load config from custom base path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -7,7 +7,7 @@ use rome_service::workspace::{FixFileMode, UpdateSettingsParams};
 
 /// Handler for the "check" command of the Rome CLI
 pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
-    let configuration = load_config(&session.app.fs)?;
+    let configuration = load_config(&session.app.fs, None)?;
     let mut workspace_settings = WorkspaceSettings::default();
 
     let max_diagnostics: Option<u16> = session

--- a/crates/rome_cli/src/commands/ci.rs
+++ b/crates/rome_cli/src/commands/ci.rs
@@ -7,7 +7,7 @@ use super::format::apply_format_settings_from_cli;
 
 /// Handler for the "ci" command of the Rome CLI
 pub(crate) fn ci(mut session: CliSession) -> Result<(), Termination> {
-    let configuration = load_config(&session.app.fs)?;
+    let configuration = load_config(&session.app.fs, None)?;
     let mut workspace_settings = WorkspaceSettings::default();
 
     if let Some(configuration) = configuration {

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -7,7 +7,7 @@ use crate::{execute_mode, CliSession, Execution, Termination, TraversalMode};
 
 /// Handler for the "format" command of the Rome CLI
 pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
-    let configuration = load_config(&session.app.fs)?;
+    let configuration = load_config(&session.app.fs, None)?;
     let mut workspace_settings = WorkspaceSettings::default();
 
     if let Some(configuration) = configuration {

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -27,6 +27,7 @@ rome_rowan = { path = "../rome_rowan", features = ["serde"] }
 rome_text_edit = { path = "../rome_text_edit", features = ["serde"] }
 indexmap = { version = "1.9.1", features = ["serde"] }
 schemars = { version = "0.8.10", features = ["indexmap1"], optional = true }
+tracing = { version = "0.1.31", default-features = false, features = ["std"] }
 
 [features]
 schemars = ["dep:schemars", "rome_formatter/serde", "rome_js_factory"]

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -121,7 +121,7 @@ pub fn load_config(
 ) -> Result<Option<Configuration>, RomeError> {
     let config_name = file_system.config_name();
     let configuration_path = if let Some(base_path) = base_path {
-        PathBuf::from(base_path).join(config_name)
+        base_path.join(config_name)
     } else {
         PathBuf::from(config_name)
     };

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,23 +1,23 @@
 {
 	"name": "rome",
-	"version": "0.10.0",
+	"version": "0.13.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rome",
-			"version": "0.10.0",
+			"version": "0.13.0",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-languageclient": "^8.0.2"
 			},
 			"devDependencies": {
 				"@types/node": "^18.0.0",
-				"@types/vscode": "^1.68.1",
+				"@types/vscode": "^1.70.0",
 				"esbuild": "^0.14.47",
 				"rome": "next",
 				"typescript": "^4.5.2",
-				"vsce": "^2.10.0"
+				"vsce": "^2.11.0"
 			},
 			"engines": {
 				"npm": "^8",
@@ -109,9 +109,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.68.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.1.tgz",
-			"integrity": "sha512-fXlaq13NT5yHh6yZ3c+UxXloTSk34mIvsNFYyQCeO5Po2BLFAwz7EZT4kQ43B64/aPcnAenyWy3QasrTofBOnQ==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.70.0.tgz",
+			"integrity": "sha512-3/9Fz0F2eBgwciazc94Ien+9u1elnjFg9YAhvAb3qDy/WeFWD9VrOPU7CIytryOVUdbxus8uzL4VZYONA0gDtA==",
 			"dev": true
 		},
 		"node_modules/ansi-regex": {
@@ -1787,9 +1787,9 @@
 			"dev": true
 		},
 		"node_modules/vsce": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.0.tgz",
-			"integrity": "sha512-b+wB3XMapEi368g64klSM6uylllZdNutseqbNY+tUoHYSy6g2NwnlWuAGKDQTYc0IqfDUjUFRQBpPgA89Q+Fyw==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.11.0.tgz",
+			"integrity": "sha512-pr9Y0va/HCer0tTifeqaUrK24JJSpRd6oLeF/PY6FtrY41e+lwxiAq6jfMXx4ShAZglYg2rFKoKROwa7E7SEqQ==",
 			"dev": true,
 			"dependencies": {
 				"azure-devops-node-api": "^11.0.1",
@@ -1981,9 +1981,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.68.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.1.tgz",
-			"integrity": "sha512-fXlaq13NT5yHh6yZ3c+UxXloTSk34mIvsNFYyQCeO5Po2BLFAwz7EZT4kQ43B64/aPcnAenyWy3QasrTofBOnQ==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.70.0.tgz",
+			"integrity": "sha512-3/9Fz0F2eBgwciazc94Ien+9u1elnjFg9YAhvAb3qDy/WeFWD9VrOPU7CIytryOVUdbxus8uzL4VZYONA0gDtA==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -3172,9 +3172,9 @@
 			"dev": true
 		},
 		"vsce": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.0.tgz",
-			"integrity": "sha512-b+wB3XMapEi368g64klSM6uylllZdNutseqbNY+tUoHYSy6g2NwnlWuAGKDQTYc0IqfDUjUFRQBpPgA89Q+Fyw==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.11.0.tgz",
+			"integrity": "sha512-pr9Y0va/HCer0tTifeqaUrK24JJSpRd6oLeF/PY6FtrY41e+lwxiAq6jfMXx4ShAZglYg2rFKoKROwa7E7SEqQ==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^11.0.1",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/rome/tools/issues"
 	},
 	"engines": {
-		"vscode": "^1.68.1",
+		"vscode": "^1.70.0",
 		"npm": "^8"
 	},
 	"contributes": {
@@ -117,9 +117,9 @@
 	},
 	"devDependencies": {
 		"@types/node": "^18.0.0",
-		"@types/vscode": "^1.68.1",
+		"@types/vscode": "^1.70.0",
 		"typescript": "^4.5.2",
-		"vsce": "^2.10.0",
+		"vsce": "^2.11.0",
 		"esbuild": "^0.14.47",
 		"rome": "next"
 	}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #3088 
Fixes https://github.com/rome/tools/issues/3128

This PR is partial fix, where it allows the LSP to load the configuration from a `base_path`, which is provided by the client during the initialization of the server. The base path is provided via `root_uri`. (`root_path` is deprecated).

The reason why this is a partial fix, is because loading the configuration file from a custom base path diverges from how our file system works. Basically the resolution of the files should be kept in sync. 

Although this fix can be accepted because our LSP doesn't use the file system, other than when resolving the configuration.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I manually created a project with custom configuration, and checked that it's correctly loaded:

```json
{
  "formatter": {
    "enabled": true
  },
  "linter": {
    "enabled": true,
    "rules": {
      "recommended": true
    }
  },
  "javascript": {
    "formatter": {
      "quoteStyle": "single"
    }
  }
}

```

From the LSP logs:

```
├─10ms TRACE rome_lsp::session The LSP will now use the following configuration: 
│  Configuration { formatter: Some(FormatterConfiguration { enabled: true, format_with_errors: false, indent_style: Tab, indent_size: 2, line_width: LineWidth(80) }), linter: Some(LinterConfiguration { enabled: true, rules: Some(Rules { recommended: Some(true), js: None, jsx: None, regex: None, ts: None }) }), javascript: Some(JavascriptConfiguration { formatter: Some(JavascriptFormatter { quote_style: Single, quote_properties: AsNeeded }), globals: None }) }

```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
