### PR TITLE
perf(rome_formatter): Make source maps optional

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -790,7 +790,7 @@ impl FormatOptions for IrFormatOptions {
         LineWidth(80)
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
+    fn as_printer_options(&self) -> PrinterOptions {
         PrinterOptions {
             tab_width: 2,
             print_width: self.line_width().into(),

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -156,7 +156,7 @@ impl FormatOptions for JsFormatOptions {
         self.line_width
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
+    fn as_printer_options(&self) -> PrinterOptions {
         PrinterOptions::default()
             .with_indent(self.indent_style)
             .with_print_width(self.line_width.into())

--- a/crates/rome_js_formatter/src/js/expressions/template_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_element.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use rome_formatter::printer::{PrintWidth, Printer};
+use rome_formatter::printer::{PrintOptions, PrintWidth, Printer};
 use rome_formatter::{format_args, write, FormatOptions, FormatRuleWithOptions, VecBuffer};
 
 use crate::context::TabWidth;
@@ -89,11 +89,11 @@ impl Format<JsFormatContext> for FormatTemplateElement {
                 write!(buffer, [format_expression])?;
                 let root = buffer.into_element();
 
-                let print_options = f
+                let printer_options = f
                     .options()
-                    .as_print_options()
+                    .as_printer_options()
                     .with_print_width(PrintWidth::infinite());
-                let printed = Printer::new(print_options).print(&root);
+                let printed = Printer::new(printer_options).print(&root, PrintOptions::default());
 
                 write!(
                     f,

--- a/crates/rome_js_formatter/src/syntax_rewriter.rs
+++ b/crates/rome_js_formatter/src/syntax_rewriter.rs
@@ -494,6 +494,7 @@ where
 mod tests {
     use super::JsFormatSyntaxRewriter;
     use crate::{format_node, JsFormatOptions};
+    use rome_formatter::printer::PrintOptions;
     use rome_formatter::{SourceMarker, TransformSourceMap};
     use rome_js_parser::parse_module;
     use rome_js_syntax::{
@@ -767,7 +768,10 @@ mod tests {
         let (transformed, source_map) = source_map_test("(((a * b) * c)) / 3");
 
         let formatted = format_node(JsFormatOptions::default(), &transformed).unwrap();
-        let printed = formatted.print();
+        let printed = formatted.print_with_options(PrintOptions {
+            generate_source_map: true,
+            ..PrintOptions::default()
+        });
 
         assert_eq!(printed.as_code(), "(a * b * c) / 3;\n");
 

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -1,3 +1,4 @@
+use rome_formatter::printer::PrintOptions;
 use rome_formatter::{FormatOptions, LineWidth};
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
@@ -228,7 +229,10 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
         // we ignore the error for now
         let options = JsFormatOptions::default();
         let formatted = format_node(options.clone(), &root).unwrap();
-        let printed = formatted.print();
+        let printed = formatted.print_with_options(PrintOptions {
+            generate_source_map: true,
+            ..PrintOptions::default()
+        });
         let file_name = spec_input_file.file_name().unwrap().to_str().unwrap();
 
         if !has_errors {
@@ -258,7 +262,10 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
                     // inject it here
                     format_options = format_options.with_source_type(source_type);
                     let formatted = format_node(format_options.clone(), &root).unwrap();
-                    let printed = formatted.print();
+                    let printed = formatted.print_with_options(PrintOptions {
+                        generate_source_map: true,
+                        ..PrintOptions::default()
+                    });
 
                     if !has_errors {
                         check_reformat::check_reformat(check_reformat::CheckReformatParams {

--- a/xtask/bench/src/lib.rs
+++ b/xtask/bench/src/lib.rs
@@ -52,6 +52,15 @@ impl Display for FeatureToBenchmark {
     }
 }
 
+impl FeatureToBenchmark {
+    fn measure_time(&self) -> Duration {
+        match self {
+            FeatureToBenchmark::Formatter => Duration::new(30, 0),
+            _ => Duration::new(10, 0),
+        }
+    }
+}
+
 /// If groups the summary by their category and creates a small interface
 /// where each bench result can create their summary
 pub enum BenchmarkSummary {
@@ -139,7 +148,7 @@ pub fn run(args: RunArgs) {
                 if args.criterion {
                     let mut criterion = criterion::Criterion::default()
                         .without_plots()
-                        .measurement_time(Duration::new(10, 0));
+                        .measurement_time(args.feature.measure_time());
                     if let Some(ref baseline) = args.baseline {
                         criterion = criterion.save_baseline(baseline.to_string());
                     }


### PR DESCRIPTION
The Printer source maps are only needed for range formatting but the Printer used to generate them all the time. This has an even higher cost since we rewrite the source tree because the markers must be mapped back to the original position in the source tree.

This PR requires consumers to explicitly enable source maps if they need the source mapping information.
