### PR TITLE
feat(rome_service): allow workspace clients to provide a language hint

### DIFF
--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -3,7 +3,7 @@ use crate::{CliSession, Termination};
 use rome_console::{markup, ConsoleExt};
 use rome_fs::RomePath;
 use rome_service::workspace::{
-    FeatureName, FixFileMode, FormatFileParams, OpenFileParams, SupportsFeatureParams,
+    FeatureName, FixFileMode, FormatFileParams, Language, OpenFileParams, SupportsFeatureParams,
 };
 use std::path::PathBuf;
 
@@ -137,6 +137,7 @@ pub(crate) fn execute_mode(mode: Execution, mut session: CliSession) -> Result<(
                     path: rome_path.clone(),
                     version: 0,
                     content: content.into(),
+                    language_hint: Language::default(),
                 })?;
                 let printed = workspace.format_file(FormatFileParams { path: rome_path })?;
 

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -15,7 +15,9 @@ use rome_diagnostics::{
 use rome_fs::{AtomicInterner, FileSystem, OpenOptions, PathInterner, RomePath};
 use rome_fs::{TraversalContext, TraversalScope};
 use rome_service::{
-    workspace::{FeatureName, FileGuard, OpenFileParams, RuleCategories, SupportsFeatureParams},
+    workspace::{
+        FeatureName, FileGuard, Language, OpenFileParams, RuleCategories, SupportsFeatureParams,
+    },
     Workspace,
 };
 use std::{
@@ -571,6 +573,7 @@ fn process_file(ctx: &TraversalOptions, path: &Path, file_id: FileId) -> FileRes
                 path: rome_path,
                 version: 0,
                 content: input.clone(),
+                language_hint: Language::default(),
             },
         )
         .with_file_id_and_code(file_id, "IO")?;

--- a/crates/rome_lsp/src/documents.rs
+++ b/crates/rome_lsp/src/documents.rs
@@ -1,31 +1,4 @@
-use anyhow::bail;
-
 use crate::line_index::LineIndex;
-
-/// Internal representation of supported [language identifiers]
-///
-/// [language identifiers]: https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum EditorLanguage {
-    JavaScript,
-    JavaScriptReact,
-    TypeScript,
-    TypeScriptReact,
-}
-
-impl TryFrom<&str> for EditorLanguage {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "javascript" => Ok(EditorLanguage::JavaScript),
-            "javascriptreact" => Ok(EditorLanguage::JavaScriptReact),
-            "typescript" => Ok(EditorLanguage::TypeScript),
-            "typescriptreact" => Ok(EditorLanguage::TypeScriptReact),
-            _ => bail!("Unsupported language: {}", value),
-        }
-    }
-}
 
 /// Represents an open [`textDocument`]. Can be cheaply cloned.
 ///

--- a/crates/rome_lsp/src/handlers/text_document.rs
+++ b/crates/rome_lsp/src/handlers/text_document.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use rome_service::workspace::{ChangeFileParams, CloseFileParams, OpenFileParams};
+use rome_service::workspace::{ChangeFileParams, CloseFileParams, Language, OpenFileParams};
 use tower_lsp::lsp_types;
 use tracing::error;
 
@@ -14,6 +14,7 @@ pub(crate) async fn did_open(
     let url = params.text_document.uri;
     let version = params.text_document.version;
     let content = params.text_document.text;
+    let language_hint = Language::from_language_id(&params.text_document.language_id);
 
     let rome_path = session.file_path(&url);
     let doc = Document::new(version, &content);
@@ -22,6 +23,7 @@ pub(crate) async fn did_open(
         path: rome_path,
         version,
         content,
+        language_hint,
     })?;
 
     session.insert_document(url.clone(), doc);

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -64,6 +64,7 @@ use rome_text_edit::Indel;
 use std::{borrow::Cow, panic::RefUnwindSafe, sync::Arc};
 
 pub use self::client::WorkspaceTransport;
+pub use crate::file_handlers::Language;
 
 mod client;
 pub(crate) mod server;
@@ -94,6 +95,7 @@ pub struct OpenFileParams {
     pub path: RomePath,
     pub content: String,
     pub version: i32,
+    pub language_hint: Language,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -95,6 +95,7 @@ pub struct OpenFileParams {
     pub path: RomePath,
     pub content: String,
     pub version: i32,
+    #[serde(default)]
     pub language_hint: Language,
 }
 

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -122,7 +122,7 @@ impl WorkspaceServer {
         self.features.get_capabilities(path, language)
     }
 
-    /// Return an error ffactory function for unsupported features at a given path
+    /// Return an error factory function for unsupported features at a given path
     fn build_capability_error<'a>(&'a self, path: &'a RomePath) -> impl FnOnce() -> RomeError + 'a {
         move || {
             let language_hint = self

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -5,7 +5,7 @@ use super::{
     PullDiagnosticsParams, PullDiagnosticsResult, RenameResult, SupportsFeatureParams,
     UpdateSettingsParams,
 };
-use crate::file_handlers::FixAllParams;
+use crate::file_handlers::{Capabilities, FixAllParams, Language};
 use crate::{
     file_handlers::Features,
     settings::{SettingsHandle, WorkspaceSettings},
@@ -43,6 +43,7 @@ impl RefUnwindSafe for WorkspaceServer {}
 pub(crate) struct Document {
     pub(crate) content: String,
     pub(crate) version: i32,
+    pub(crate) language_hint: Language,
 }
 
 /// Language-independent cache entry for a parsed file
@@ -110,6 +111,31 @@ impl WorkspaceServer {
         SettingsHandle::new(&self.settings)
     }
 
+    /// Get the supported capabilities for a given file path
+    fn get_capabilities(&self, path: &RomePath) -> Capabilities {
+        let language = self
+            .documents
+            .get(path)
+            .map(|doc| doc.language_hint)
+            .unwrap_or_default();
+
+        self.features.get_capabilities(path, language)
+    }
+
+    /// Return an error ffactory function for unsupported features at a given path
+    fn build_capability_error<'a>(&'a self, path: &'a RomePath) -> impl FnOnce() -> RomeError + 'a {
+        move || {
+            let language_hint = self
+                .documents
+                .get(path)
+                .map(|doc| doc.language_hint)
+                .unwrap_or_default();
+
+            let language = Features::get_language(path).or(language_hint);
+            RomeError::SourceFileNotSupported(language, path.clone())
+        }
+    }
+
     /// Get the parser result for a given file
     ///
     /// Returns and error if no file exists in the workspace with this path or
@@ -121,13 +147,13 @@ impl WorkspaceServer {
                 let rome_path = entry.key();
                 let document = self.documents.get(rome_path).ok_or(RomeError::NotFound)?;
 
-                let capabilities = self.features.get_capabilities(rome_path);
+                let capabilities = self.get_capabilities(rome_path);
                 let parse = capabilities
                     .parser
                     .parse
-                    .ok_or_else(|| RomeError::SourceFileNotSupported(rome_path.clone()))?;
+                    .ok_or_else(self.build_capability_error(rome_path))?;
 
-                let parsed = parse(rome_path, &document.content);
+                let parsed = parse(rome_path, document.language_hint, &document.content);
 
                 Ok(entry.insert(parsed).clone())
             }
@@ -137,7 +163,7 @@ impl WorkspaceServer {
 
 impl Workspace for WorkspaceServer {
     fn supports_feature(&self, params: SupportsFeatureParams) -> bool {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let settings = self.settings.read().unwrap();
         match params.feature {
             FeatureName::Format => {
@@ -166,6 +192,7 @@ impl Workspace for WorkspaceServer {
             Document {
                 content: params.content,
                 version: params.version,
+                language_hint: params.language_hint,
             },
         );
         Ok(())
@@ -175,11 +202,11 @@ impl Workspace for WorkspaceServer {
         &self,
         params: GetSyntaxTreeParams,
     ) -> Result<GetSyntaxTreeResult, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let debug_syntax_tree = capabilities
             .debug
             .debug_syntax_tree
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
         let printed = debug_syntax_tree(&params.path, parse);
@@ -191,11 +218,11 @@ impl Workspace for WorkspaceServer {
         &self,
         params: GetControlFlowGraphParams,
     ) -> Result<String, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let debug_control_flow = capabilities
             .debug
             .debug_control_flow
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
         let printed = debug_control_flow(&params.path, parse, params.cursor);
@@ -204,11 +231,11 @@ impl Workspace for WorkspaceServer {
     }
 
     fn get_formatter_ir(&self, params: GetFormatterIRParams) -> Result<String, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let debug_formatter_ir = capabilities
             .debug
             .debug_formatter_ir
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
@@ -250,11 +277,11 @@ impl Workspace for WorkspaceServer {
         &self,
         params: PullDiagnosticsParams,
     ) -> Result<PullDiagnosticsResult, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let lint = capabilities
             .analyzer
             .lint
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings.read().unwrap();
@@ -280,11 +307,11 @@ impl Workspace for WorkspaceServer {
     /// Retrieves the list of code actions available for a given cursor
     /// position within a file
     fn pull_actions(&self, params: PullActionsParams) -> Result<PullActionsResult, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let code_actions = capabilities
             .analyzer
             .code_actions
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
 
@@ -297,11 +324,11 @@ impl Workspace for WorkspaceServer {
     /// Runs the given file through the formatter using the provided options
     /// and returns the resulting source code
     fn format_file(&self, params: FormatFileParams) -> Result<Printed, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let format = capabilities
             .formatter
             .format
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
@@ -314,11 +341,11 @@ impl Workspace for WorkspaceServer {
     }
 
     fn format_range(&self, params: FormatRangeParams) -> Result<Printed, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let format_range = capabilities
             .formatter
             .format_range
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
@@ -331,11 +358,11 @@ impl Workspace for WorkspaceServer {
     }
 
     fn format_on_type(&self, params: FormatOnTypeParams) -> Result<Printed, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let format_on_type = capabilities
             .formatter
             .format_on_type
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
@@ -348,11 +375,11 @@ impl Workspace for WorkspaceServer {
     }
 
     fn fix_file(&self, params: super::FixFileParams) -> Result<FixFileResult, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let fix_all = capabilities
             .analyzer
             .fix_all
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings.read().unwrap();
@@ -366,11 +393,11 @@ impl Workspace for WorkspaceServer {
     }
 
     fn rename(&self, params: super::RenameParams) -> Result<RenameResult, RomeError> {
-        let capabilities = self.features.get_capabilities(&params.path);
+        let capabilities = self.get_capabilities(&params.path);
         let rename = capabilities
             .analyzer
             .rename
-            .ok_or_else(|| RomeError::SourceFileNotSupported(params.path.clone()))?;
+            .ok_or_else(self.build_capability_error(&params.path))?;
 
         let parse = self.get_parse(params.path.clone())?;
         let result = rename(&params.path, parse, params.symbol_at, params.new_name)?;

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -1,2 +1,5 @@
 // list of commands available in the VS Code extension
-export enum Commands { SyntaxTree = "rome.syntaxTree" }
+export enum Commands {
+	SyntaxTree = "rome.syntaxTree",
+	ServerStatus = "rome.serverStatus",
+}

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -1,7 +1,15 @@
 import { spawn } from "child_process";
 import { connect } from "net";
-import { ExtensionContext, Uri, window, workspace } from "vscode";
 import {
+	ExtensionContext,
+	languages,
+	TextEditor,
+	Uri,
+	window,
+	workspace,
+} from "vscode";
+import {
+	DocumentFilter,
 	LanguageClient,
 	LanguageClientOptions,
 	ServerOptions,
@@ -11,6 +19,7 @@ import { setContextValue } from "./utils";
 import { Session } from "./session";
 import { syntaxTree } from "./commands/syntaxTree";
 import { Commands } from "./commands";
+import { StatusBar } from "./status_bar";
 
 let client: LanguageClient;
 
@@ -19,6 +28,7 @@ const IN_ROME_PROJECT = "inRomeProject";
 export async function activate(context: ExtensionContext) {
 	const command =
 		process.env.DEBUG_SERVER_PATH || (await getServerPath(context));
+
 	if (!command) {
 		await window.showErrorMessage(
 			"The Rome extensions doesn't ship with prebuilt binaries for your platform yet. " +
@@ -28,6 +38,8 @@ export async function activate(context: ExtensionContext) {
 		return;
 	}
 
+	const statusBar = new StatusBar();
+
 	const serverOptions: ServerOptions = createMessageTransports.bind(
 		undefined,
 		command,
@@ -35,13 +47,15 @@ export async function activate(context: ExtensionContext) {
 
 	const traceOutputChannel = window.createOutputChannel("Rome Trace");
 
+	const documentSelector: DocumentFilter[] = [
+		{ scheme: "file", language: "javascript" },
+		{ scheme: "file", language: "typescript" },
+		{ scheme: "file", language: "javascriptreact" },
+		{ scheme: "file", language: "typescriptreact" },
+	];
+
 	const clientOptions: LanguageClientOptions = {
-		documentSelector: [
-			{ scheme: "file", language: "javascript" },
-			{ scheme: "file", language: "typescript" },
-			{ scheme: "file", language: "javascriptreact" },
-			{ scheme: "file", language: "typescriptreact" },
-		],
+		documentSelector,
 		traceOutputChannel,
 	};
 
@@ -49,10 +63,37 @@ export async function activate(context: ExtensionContext) {
 
 	const session = new Session(context, client);
 
+	const codeDocumentSelector =
+		client.protocol2CodeConverter.asDocumentSelector(documentSelector);
+
 	// we are now in a rome project
 	setContextValue(IN_ROME_PROJECT, true);
 
 	session.registerCommand(Commands.SyntaxTree, syntaxTree(session));
+	session.registerCommand(Commands.ServerStatus, () => {
+		traceOutputChannel.show();
+	});
+
+	context.subscriptions.push(
+		client.onDidChangeState((evt) => {
+			statusBar.setServerState(evt.newState);
+		}),
+	);
+
+	const handleActiveTextEditorChanged = (textEditor?: TextEditor) => {
+		if (!textEditor) {
+			statusBar.setActive(false);
+		}
+
+		const { document } = textEditor;
+		statusBar.setActive(languages.match(codeDocumentSelector, document) > 0);
+	};
+
+	context.subscriptions.push(
+		window.onDidChangeActiveTextEditor(handleActiveTextEditorChanged),
+	);
+
+	handleActiveTextEditorChanged(window.activeTextEditor);
 
 	client.start();
 }

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -48,10 +48,10 @@ export async function activate(context: ExtensionContext) {
 	const traceOutputChannel = window.createOutputChannel("Rome Trace");
 
 	const documentSelector: DocumentFilter[] = [
-		{ scheme: "file", language: "javascript" },
-		{ scheme: "file", language: "typescript" },
-		{ scheme: "file", language: "javascriptreact" },
-		{ scheme: "file", language: "typescriptreact" },
+		{ language: "javascript" },
+		{ language: "typescript" },
+		{ language: "javascriptreact" },
+		{ language: "typescriptreact" },
 	];
 
 	const clientOptions: LanguageClientOptions = {

--- a/editors/vscode/src/status_bar.ts
+++ b/editors/vscode/src/status_bar.ts
@@ -1,0 +1,115 @@
+import { StatusBarAlignment, StatusBarItem, ThemeColor, window } from "vscode";
+import { State } from "vscode-languageclient";
+import { Commands } from "./commands";
+
+enum Status {
+	Pending = "refresh",
+	Ready = "check",
+	Inactive = "eye-closed",
+	Warning = "warning",
+	Error = "error",
+}
+
+export class StatusBar {
+	private statusBarItem: StatusBarItem;
+
+	private serverState: State = State.Starting;
+	private isActive: boolean = false;
+
+	constructor() {
+		this.statusBarItem = window.createStatusBarItem(
+			"rome.status",
+			StatusBarAlignment.Right,
+			-1,
+		);
+
+		this.statusBarItem.name = "Rome";
+		this.statusBarItem.command = Commands.ServerStatus;
+		this.update();
+	}
+
+	public setServerState(state: State) {
+		this.serverState = state;
+		this.update();
+	}
+
+	public setActive(isActive: boolean) {
+		this.isActive = isActive;
+		this.update();
+	}
+
+	private update() {
+		let status: Status;
+		if (this.serverState === State.Running) {
+			if (this.isActive) {
+				status = Status.Ready;
+			} else {
+				status = Status.Inactive;
+			}
+		} else if (this.serverState === State.Starting) {
+			status = Status.Pending;
+		} else {
+			status = Status.Error;
+		}
+
+		this.statusBarItem.text = `$(${status}) Rome`;
+
+		switch (status) {
+			case Status.Pending: {
+				this.statusBarItem.tooltip = "Rome is initializing ...";
+				break;
+			}
+			case Status.Ready: {
+				this.statusBarItem.tooltip = "Rome is active";
+				break;
+			}
+			case Status.Inactive: {
+				this.statusBarItem.tooltip =
+					"The current file is not supported or ignored by Rome";
+				break;
+			}
+			// @ts-expect-error Reserved for future use
+			case Status.Warning: {
+				this.statusBarItem.tooltip = undefined;
+				break;
+			}
+			case Status.Error: {
+				this.statusBarItem.tooltip = "Rome encountered a fatal error";
+				break;
+			}
+		}
+
+		switch (status) {
+			case Status.Error: {
+				this.statusBarItem.color = new ThemeColor(
+					"statusBarItem.errorForeground",
+				);
+				this.statusBarItem.backgroundColor = new ThemeColor(
+					"statusBarItem.errorBackground",
+				);
+				break;
+			}
+			// @ts-expect-error Reserved for future use
+			case Status.Warning: {
+				this.statusBarItem.color = new ThemeColor(
+					"statusBarItem.warningForeground",
+				);
+				this.statusBarItem.backgroundColor = new ThemeColor(
+					"statusBarItem.warningBackground",
+				);
+				break;
+			}
+			default: {
+				this.statusBarItem.color = undefined;
+				this.statusBarItem.backgroundColor = undefined;
+				break;
+			}
+		}
+
+		this.statusBarItem.show();
+	}
+
+	public hide() {
+		this.statusBarItem.hide();
+	}
+}

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -122,9 +122,20 @@ export interface Ts {
 }
 export interface OpenFileParams {
 	content: string;
+	language_hint?: Language;
 	path: RomePath;
 	version: number;
 }
+/**
+ * Supported languages by Rome
+ */
+export type Language =
+	| "JavaScript"
+	| "JavaScriptReact"
+	| "TypeScript"
+	| "TypeScriptReact"
+	| "Json"
+	| "Unknown";
 export interface ChangeFileParams {
 	content: string;
 	path: RomePath;


### PR DESCRIPTION
## Summary

Fixes #3006

This PR adds a new `language_hint` field to the parameters of the `open_file` Workspace method. It lets clients specify a language ID as a hint for the file type resolver, for instance for files that do not have a file extension yet in the editor. To support this I've merged the `EditorLanguage` enum in `rome_lsp` into the `Language` enum in `rome_service`, and refactored error handling across the code base to make the lack of a file extension a non-fatal error in file type determination.

## Test Plan

I've added an additional test for the LSP to verify we can correctly format files without an extension
