### PR TITLE
fix(rome_formatter): Skipped token trivia spacing

### DIFF
--- a/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
@@ -3,7 +3,6 @@ use crate::prelude::*;
 use rome_formatter::write;
 use rome_js_syntax::{
     JsAnyExpression, JsxExpressionAttributeValue, JsxExpressionAttributeValueFields,
-    TriviaPieceKind,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -70,19 +69,7 @@ impl FormatNodeRule<JsxExpressionAttributeValue> for FormatJsxExpressionAttribut
                     write!(f, [soft_block_indent(&expression.format())])?;
                 };
 
-                write!(f, [line_suffix_boundary(),])?;
-
-                // format if `}` has a `Skipped` leading trivia
-                // <div className={asdf asdf} />;
-                let r_curly_token_ref = r_curly_token.as_ref()?;
-                if matches!(
-                    r_curly_token_ref.leading_trivia().first().map(|t| t.kind()),
-                    Some(TriviaPieceKind::Skipped)
-                ) {
-                    write!(f, [space(), r_curly_token.format()])
-                } else {
-                    write!(f, [r_curly_token.format()])
-                }
+                write!(f, [line_suffix_boundary(), r_curly_token.format()])
             }))]
         )
     }


### PR DESCRIPTION
The formatting of `JsxExpressionAttributeValue` used to special handle the case when the `}` token has a skipped token trivia attached.

```javascript
<div className={asdf asdf} />
```

The special handling ensured that the formatter inserts a whitespace between the expression and the skipped token trivia so that the above doesn't become

```javascript
<div className={asdfasdf} />
```

The problem with the old solution is that it doesn't scale. We can't add these checks in every place where some skipped token trivia may be possibler (which, could be any node).

This PR improves the skipped token trivia formatting in rome formatter to account for any trailing whitespace of the previous token and preserves if it is followed by a skipped token trivia.

## Tests

Verified that the test is still passing after removing the special handling in the attribute formatting.

https://github.com/rome/tools/blob/c6d0450c06e7bd357a3a30fab161c5537448fadc/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx.snap#L54-L56