### PR TITLE
feat(rome_service): ignore files

### DIFF
--- a/crates/rome_analyze/src/categories.rs
+++ b/crates/rome_analyze/src/categories.rs
@@ -44,6 +44,12 @@ impl Default for RuleCategories {
     }
 }
 
+impl RuleCategories {
+    pub fn is_syntax(&self) -> bool {
+        *self == RuleCategories::SYNTAX
+    }
+}
+
 impl From<RuleCategory> for RuleCategories {
     fn from(input: RuleCategory) -> Self {
         match input {

--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -128,11 +128,13 @@ pub(crate) fn execute_mode(mode: Execution, mut session: CliSession) -> Result<(
         let rome_path = RomePath::new(path, 0);
 
         if mode.is_format() {
-            let can_format = workspace.supports_feature(SupportsFeatureParams {
-                path: rome_path.clone(),
-                feature: FeatureName::Format,
-            })?;
-            if can_format {
+            let unsupported_format_reason = workspace
+                .supports_feature(SupportsFeatureParams {
+                    path: rome_path.clone(),
+                    feature: FeatureName::Format,
+                })?
+                .reason;
+            if unsupported_format_reason.is_none() {
                 workspace.open_file(OpenFileParams {
                     path: rome_path.clone(),
                     version: 0,

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -14,6 +14,7 @@ use rome_diagnostics::{
 };
 use rome_fs::{AtomicInterner, FileSystem, OpenOptions, PathInterner, RomePath};
 use rome_fs::{TraversalContext, TraversalScope};
+use rome_service::workspace::UnsupportedReason;
 use rome_service::{
     workspace::{
         FeatureName, FileGuard, Language, OpenFileParams, RuleCategories, SupportsFeatureParams,
@@ -434,11 +435,13 @@ impl<'ctx, 'app> TraversalOptions<'ctx, 'app> {
         self.messages.send(msg.into()).ok();
     }
 
-    fn can_format(&self, rome_path: &RomePath) -> Result<bool, RomeError> {
-        self.workspace.supports_feature(SupportsFeatureParams {
-            path: rome_path.clone(),
-            feature: FeatureName::Format,
-        })
+    fn can_format(&self, rome_path: &RomePath) -> Option<UnsupportedReason> {
+        self.workspace
+            .supports_feature(SupportsFeatureParams {
+                path: rome_path.clone(),
+                feature: FeatureName::Format,
+            })
+            .reason
     }
 
     fn push_format_stat(&self, path: String, stat: FormatterReportFileDetail) {
@@ -447,11 +450,13 @@ impl<'ctx, 'app> TraversalOptions<'ctx, 'app> {
             .ok();
     }
 
-    fn can_lint(&self, rome_path: &RomePath) -> Result<bool, RomeError> {
-        self.workspace.supports_feature(SupportsFeatureParams {
-            path: rome_path.clone(),
-            feature: FeatureName::Lint,
-        })
+    fn can_lint(&self, rome_path: &RomePath) -> Option<UnsupportedReason> {
+        self.workspace
+            .supports_feature(SupportsFeatureParams {
+                path: rome_path.clone(),
+                feature: FeatureName::Lint,
+            })
+            .reason
     }
 }
 
@@ -475,6 +480,10 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
             TraversalMode::CI { .. } => self
                 .can_lint(rome_path)
                 .and_then(|can_lint| Ok(can_lint || self.can_format(rome_path)?)),
+            // TraversalMode::CI { .. } => self
+            //     .can_lint(rome_path)
+            //     .or_else(|| self.can_format(rome_path)),
+
             TraversalMode::Format { .. } => self.can_format(rome_path),
         };
 
@@ -485,6 +494,7 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
                 false
             }
         }
+        .is_none()
     }
 
     fn handle_file(&self, path: &Path, file_id: FileId) {
@@ -563,15 +573,28 @@ fn process_file(ctx: &TraversalOptions, path: &Path, file_id: FileId) -> FileRes
             TraversalMode::Check { .. } => can_lint,
             TraversalMode::CI { .. } => can_lint || can_format,
             TraversalMode::Format { .. } => can_format,
-        };
+        // let unsupported_format = ctx.can_format(&rome_path);
+        // let unsupported_lint = ctx.can_lint(&rome_path);
+        // let unsupported_file = match ctx.execution.traversal_mode() {
+        //     TraversalMode::Check { .. } => unsupported_lint.as_ref(),
+        //     TraversalMode::CI { .. } => unsupported_lint.as_ref().or(unsupported_format.as_ref()),
+        //     TraversalMode::Format { .. } => unsupported_format.as_ref(),
+        // };
 
-        if !can_handle {
-            return Err(Message::from(TraversalError {
-                severity: Severity::Error,
-                file_id,
-                code: "IO",
-                message: String::from("unhandled file type"),
-            }));
+        if let Some(reason) = unsupported_file {
+            match reason {
+                UnsupportedReason::FileNotSupported => {
+                    return Err(Message::from(TraversalError {
+                        severity: Severity::Error,
+                        file_id,
+                        code: "IO",
+                        message: String::from("unhandled file type"),
+                    }));
+                }
+                UnsupportedReason::FeatureNotEnabled | UnsupportedReason::Ignored => {
+                    return Ok(FileStatus::Ignored)
+                }
+            }
         }
         let open_options = OpenOptions::default().read(true).write(true);
         let mut file = ctx
@@ -673,7 +696,7 @@ fn process_file(ctx: &TraversalOptions, path: &Path, file_id: FileId) -> FileRes
             return Ok(result);
         }
 
-        if can_format {
+        if unsupported_format.is_none() {
             let write = match ctx.execution.traversal_mode() {
                 // In check mode do not run the formatter and return the result immediately,
                 // but only if the argument `--apply` is not passed.

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -160,3 +160,19 @@ pub const CONFIG_ISSUE_3175_2: &str = r#"{
     }
   }
 }"#;
+
+pub const CONFIG_FORMATTER_IGNORED_FILES: &str = r#"{
+  "formatter": {
+    "enabled": true,
+    "ignore": ["test.js"]
+  }
+}
+"#;
+
+pub const CONFIG_LINTER_IGNORED_FILES: &str = r#"{
+  "linter": {
+    "enabled": true,
+    "ignore": ["test.js"]
+  }
+}
+"#;

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -106,8 +106,9 @@ const CUSTOM_CONFIGURATION_AFTER: &str = "function f() {
 mod check {
     use super::*;
     use crate::configs::{
-        CONFIG_LINTER_DISABLED, CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC, CONFIG_LINTER_SUPPRESSED_GROUP,
-        CONFIG_LINTER_SUPPRESSED_RULE, CONFIG_LINTER_UPGRADE_DIAGNOSTIC,
+        CONFIG_LINTER_DISABLED, CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC, CONFIG_LINTER_IGNORED_FILES,
+        CONFIG_LINTER_SUPPRESSED_GROUP, CONFIG_LINTER_SUPPRESSED_RULE,
+        CONFIG_LINTER_UPGRADE_DIAGNOSTIC,
     };
     use crate::snap_test::SnapshotPayload;
     use rome_console::LogLevel;
@@ -630,6 +631,40 @@ mod check {
             console,
             result,
         ));
+    }
+
+    #[test]
+    fn no_lint_when_file_is_ignored() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("rome.json");
+        fs.insert(file_path.into(), CONFIG_LINTER_IGNORED_FILES.as_bytes());
+
+        let file_path = Path::new("test.js");
+        fs.insert(file_path.into(), FIX_BEFORE.as_bytes());
+
+        let result = run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![
+                OsString::from("check"),
+                OsString::from("--apply"),
+                file_path.as_os_str().into(),
+            ]),
+        );
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        let mut buffer = String::new();
+        fs.open(file_path)
+            .unwrap()
+            .read_to_string(&mut buffer)
+            .unwrap();
+
+        assert_eq!(buffer, FIX_BEFORE);
+
+        assert_cli_snapshot(module_path!(), "no_lint_when_file_is_ignored", fs, console);
     }
 }
 
@@ -1603,6 +1638,42 @@ mod format {
             console,
             result,
         ));
+    }
+
+    #[test]
+    fn does_not_format_ignored_files() {
+        let mut console = BufferConsole::default();
+        let mut fs = MemoryFileSystem::default();
+        let file_path = Path::new("rome.json");
+        fs.insert(file_path.into(), CONFIG_FORMATTER_IGNORED_FILES.as_bytes());
+
+        let file_path = Path::new("test.js");
+        fs.insert(file_path.into(), UNFORMATTED.as_bytes());
+
+        let result = run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![
+                OsString::from("format"),
+                OsString::from("test.js"),
+                OsString::from("--write"),
+            ]),
+        );
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        let mut file = fs
+            .open(file_path)
+            .expect("formatting target file was removed by the CLI");
+
+        let mut content = String::new();
+        file.read_to_string(&mut content)
+            .expect("failed to read file from memory FS");
+
+        assert_eq!(content, UNFORMATTED);
+
+        drop(file);
+        assert_cli_snapshot(module_path!(), "does_not_format_ignored_files", fs, console);
     }
 }
 

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -664,7 +664,13 @@ mod check {
 
         assert_eq!(buffer, FIX_BEFORE);
 
-        assert_cli_snapshot(module_path!(), "no_lint_when_file_is_ignored", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "no_lint_when_file_is_ignored",
+            fs,
+            console,
+            result,
+        ));
     }
 }
 
@@ -881,7 +887,8 @@ mod ci {
 mod format {
     use super::*;
     use crate::configs::{
-        CONFIG_DISABLED_FORMATTER, CONFIG_FORMAT, CONFIG_ISSUE_3175_1, CONFIG_ISSUE_3175_2,
+        CONFIG_DISABLED_FORMATTER, CONFIG_FORMAT, CONFIG_FORMATTER_IGNORED_FILES,
+        CONFIG_ISSUE_3175_1, CONFIG_ISSUE_3175_2,
     };
     use crate::snap_test::{markup_to_string, SnapshotPayload};
     use rome_console::markup;
@@ -1673,7 +1680,13 @@ mod format {
         assert_eq!(content, UNFORMATTED);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "does_not_format_ignored_files", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "does_not_format_ignored_files",
+            fs,
+            console,
+            result,
+        ));
     }
 }
 

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -200,7 +200,7 @@ mod check {
             Arguments::from_vec(vec![OsString::from("check"), file_path.as_os_str().into()]),
         );
 
-        assert!(result.is_err());
+        assert!(result.is_err(), "run_cli returned {result:?}");
 
         let messages = &console.out_buffer;
 

--- a/crates/rome_cli/tests/snapshots/main_check/no_lint_if_linter_is_disabled.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/no_lint_if_linter_is_disabled.snap
@@ -22,12 +22,4 @@ if(a != -0) {}
 
 # Emitted Messages
 
-```block
-fix.js: error[IO]: unhandled file type
-```
-
-```block
-Skipped 1 files
-```
-
 

--- a/crates/rome_cli/tests/snapshots/main_check/no_lint_if_linter_is_disabled_when_run_apply.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/no_lint_if_linter_is_disabled_when_run_apply.snap
@@ -22,12 +22,4 @@ if(a != -0) {}
 
 # Emitted Messages
 
-```block
-fix.js: error[IO]: unhandled file type
-```
-
-```block
-Skipped 1 files
-```
-
 

--- a/crates/rome_cli/tests/snapshots/main_check/no_lint_when_file_is_ignored.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/no_lint_when_file_is_ignored.snap
@@ -6,20 +6,19 @@ expression: content
 
 ```json
 {
-  "formatter": {
-    "enabled": false
+  "linter": {
+    "enabled": true,
+    "ignore": ["test.js"]
   }
 }
 
 ```
 
-## `file.js`
+## `test.js`
 
 ```js
 
-function f() {
-return { something }
-}
+if(a != -0) {}
 
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_format/does_not_format_ignored_files.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/does_not_format_ignored_files.snap
@@ -7,20 +7,17 @@ expression: content
 ```json
 {
   "formatter": {
-    "enabled": false
+    "enabled": true,
+    "ignore": ["test.js"]
   }
 }
 
 ```
 
-## `file.js`
+## `test.js`
 
 ```js
-
-function f() {
-return { something }
-}
-
+  statement(  )  
 ```
 
 # Emitted Messages

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -213,7 +213,7 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
         })
         .unwrap();
 
-    if can_format {
+    if can_format.reason.is_none() {
         let mut snapshot_content = SnapshotContent::default();
         let buffer = rome_path.get_buffer_from_file();
         let mut source_type: SourceType = rome_path.as_path().try_into().unwrap();

--- a/crates/rome_lsp/src/handlers/analysis.rs
+++ b/crates/rome_lsp/src/handlers/analysis.rs
@@ -28,11 +28,11 @@ pub(crate) fn code_actions(
     let url = params.text_document.uri.clone();
     let rome_path = session.file_path(&url);
 
-    let linter_enabled = &session.workspace.supports_feature(SupportsFeatureParams {
+    let unsupported_lint = &session.workspace.supports_feature(SupportsFeatureParams {
         path: rome_path,
         feature: FeatureName::Lint,
     })?;
-    if !linter_enabled {
+    if unsupported_lint.reason.is_some() {
         return Ok(Some(Vec::new()));
     }
 

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -26,7 +26,9 @@ pub(crate) fn format(
 
     let printed = match result {
         Ok(printed) => printed,
-        Err(RomeError::FormatWithErrorsDisabled) => return Ok(None),
+        Err(RomeError::FormatWithErrorsDisabled) | Err(RomeError::FileIgnored(_)) => {
+            return Ok(None)
+        }
         Err(err) => return Err(Error::from(err)),
     };
 
@@ -78,7 +80,9 @@ pub(crate) fn format_range(
 
     let formatted = match result {
         Ok(formatted) => formatted,
-        Err(RomeError::FormatWithErrorsDisabled) => return Ok(None),
+        Err(RomeError::FormatWithErrorsDisabled) | Err(RomeError::FileIgnored(_)) => {
+            return Ok(None)
+        }
         Err(err) => return Err(Error::from(err)),
     };
 
@@ -134,7 +138,9 @@ pub(crate) fn format_on_type(
 
     let formatted = match result {
         Ok(formatted) => formatted,
-        Err(RomeError::FormatWithErrorsDisabled) => return Ok(None),
+        Err(RomeError::FormatWithErrorsDisabled) | Err(RomeError::FileIgnored(_)) => {
+            return Ok(None)
+        }
         Err(err) => return Err(Error::from(err)),
     };
 

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -115,12 +115,12 @@ impl Session {
     pub(crate) async fn update_diagnostics(&self, url: lsp_types::Url) -> anyhow::Result<()> {
         let rome_path = self.file_path(&url);
         let doc = self.document(&url)?;
-        let lint_enabled = self.workspace.supports_feature(SupportsFeatureParams {
+        let unsupported_lint = self.workspace.supports_feature(SupportsFeatureParams {
             feature: FeatureName::Lint,
             path: rome_path.clone(),
         })?;
 
-        let diagnostics = if lint_enabled {
+        let diagnostics = if unsupported_lint.reason.is_none() {
             let result = self.workspace.pull_diagnostics(PullDiagnosticsParams {
                 path: rome_path,
                 categories: RuleCategories::SYNTAX | RuleCategories::LINT,

--- a/crates/rome_service/src/configuration/formatter.rs
+++ b/crates/rome_service/src/configuration/formatter.rs
@@ -1,4 +1,5 @@
 use crate::settings::FormatSettings;
+use indexmap::IndexSet;
 use rome_formatter::{IndentStyle, LineWidth};
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +26,15 @@ pub struct FormatterConfiguration {
         serialize_with = "serialize_line_width"
     )]
     pub line_width: LineWidth,
+
+    /// A list of Unix shell style patterns. The formatter will ignore files/folders that will
+    /// match these patterns.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::deserialize_set_of_strings",
+        serialize_with = "crate::serialize_set_of_strings"
+    )]
+    pub ignore: Option<IndexSet<String>>,
 }
 
 impl Default for FormatterConfiguration {
@@ -35,6 +45,7 @@ impl Default for FormatterConfiguration {
             indent_size: 2,
             indent_style: PlainIndentStyle::default(),
             line_width: LineWidth::default(),
+            ignore: None,
         }
     }
 }
@@ -50,6 +61,7 @@ impl From<FormatterConfiguration> for FormatSettings {
             indent_style: Some(indent_style),
             line_width: Some(conf.line_width),
             format_with_errors: conf.format_with_errors,
+            ignored_files: conf.ignore.unwrap_or_default(),
         }
     }
 }

--- a/crates/rome_service/src/configuration/javascript.rs
+++ b/crates/rome_service/src/configuration/javascript.rs
@@ -1,9 +1,6 @@
 use indexmap::IndexSet;
 use rome_js_formatter::context::{QuoteProperties, QuoteStyle};
-use serde::de::{SeqAccess, Visitor};
-use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
 
 #[derive(Default, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -17,8 +14,8 @@ pub struct JavascriptConfiguration {
     /// If defined here, they should not emit diagnostics.
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_globals",
-        serialize_with = "serialize_globals"
+        deserialize_with = "crate::deserialize_set_of_strings",
+        serialize_with = "crate::serialize_set_of_strings"
     )]
     pub globals: Option<IndexSet<String>>,
 }
@@ -29,69 +26,6 @@ impl JavascriptConfiguration {
             formatter: Some(JavascriptFormatter::default()),
             ..JavascriptConfiguration::default()
         }
-    }
-}
-
-pub(crate) fn deserialize_globals<'de, D>(
-    deserializer: D,
-) -> Result<Option<IndexSet<String>>, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    struct IndexVisitor {
-        marker: PhantomData<fn() -> Option<IndexSet<String>>>,
-    }
-
-    impl IndexVisitor {
-        fn new() -> Self {
-            IndexVisitor {
-                marker: PhantomData,
-            }
-        }
-    }
-
-    impl<'de> Visitor<'de> for IndexVisitor {
-        type Value = Option<IndexSet<String>>;
-
-        // Format a message stating what data this Visitor expects to receive.
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            formatter.write_str("expecting a sequence")
-        }
-
-        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-        where
-            A: SeqAccess<'de>,
-        {
-            let mut index_set = IndexSet::with_capacity(seq.size_hint().unwrap_or(0));
-
-            while let Some(value) = seq.next_element()? {
-                index_set.insert(value);
-            }
-
-            Ok(Some(index_set))
-        }
-    }
-
-    deserializer.deserialize_seq(IndexVisitor::new())
-}
-
-pub(crate) fn serialize_globals<S>(
-    globals: &Option<IndexSet<String>>,
-    s: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: serde::ser::Serializer,
-{
-    if let Some(globals) = globals {
-        let mut sequence = s.serialize_seq(Some(globals.len()))?;
-        let iter = globals.into_iter();
-        for global in iter {
-            sequence.serialize_element(global)?;
-        }
-
-        sequence.end()
-    } else {
-        s.serialize_none()
     }
 }
 

--- a/crates/rome_service/src/configuration/linter/mod.rs
+++ b/crates/rome_service/src/configuration/linter/mod.rs
@@ -3,6 +3,7 @@ mod rules;
 
 pub use crate::configuration::linter::rules::Rules;
 use crate::settings::LinterSettings;
+use indexmap::IndexSet;
 use rome_console::codespan::Severity;
 pub use rules::*;
 #[cfg(feature = "schemars")]
@@ -19,6 +20,15 @@ pub struct LinterConfiguration {
     /// List of rules
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rules: Option<Rules>,
+
+    /// A list of Unix shell style patterns. The formatter will ignore files/folders that will
+    /// match these patterns.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::deserialize_set_of_strings",
+        serialize_with = "crate::serialize_set_of_strings"
+    )]
+    pub ignore: Option<IndexSet<String>>,
 }
 
 impl Default for LinterConfiguration {
@@ -26,6 +36,7 @@ impl Default for LinterConfiguration {
         Self {
             enabled: true,
             rules: Some(Rules::default()),
+            ignore: None,
         }
     }
 }
@@ -35,6 +46,7 @@ impl From<LinterConfiguration> for LinterSettings {
         Self {
             enabled: conf.enabled,
             rules: conf.rules,
+            ignored_files: conf.ignore.unwrap_or_default(),
         }
     }
 }

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -80,6 +80,9 @@ pub enum ConfigurationError {
 
     /// Thrown when an unknown rule is found
     UnknownRule(String),
+
+    /// Thrown when the pattern inside the `ignore` field errors
+    InvalidIgnorePattern(String, String),
 }
 
 impl Debug for ConfigurationError {
@@ -89,6 +92,7 @@ impl Debug for ConfigurationError {
             ConfigurationError::DeserializationError(_) => std::fmt::Display::fmt(self, f),
             ConfigurationError::ConfigAlreadyExists => std::fmt::Display::fmt(self, f),
             ConfigurationError::UnknownRule(_) => std::fmt::Display::fmt(self, f),
+            ConfigurationError::InvalidIgnorePattern(_, _) => std::fmt::Display::fmt(self, f),
         }
     }
 }
@@ -115,6 +119,9 @@ impl Display for ConfigurationError {
 
             ConfigurationError::UnknownRule(rule) => {
                 write!(f, "invalid rule name `{rule}`")
+            }
+            ConfigurationError::InvalidIgnorePattern(pattern, reason) => {
+                write!(f, "couldn't parse the pattern {pattern}, reason: {reason}")
             }
         }
     }

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -4,17 +4,20 @@
 //! by language. The language might further options divided by tool.
 
 use crate::{DynRef, RomeError};
+use indexmap::IndexSet;
 use rome_fs::{FileSystem, OpenOptions};
+use serde::de::{SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 use std::io::ErrorKind;
+use std::marker::PhantomData;
 use std::path::PathBuf;
 use tracing::{error, info};
 
 mod formatter;
 mod javascript;
 pub mod linter;
-
 pub use formatter::{FormatterConfiguration, PlainIndentStyle};
 pub use javascript::{JavascriptConfiguration, JavascriptFormatter};
 pub use linter::{LinterConfiguration, RuleConfiguration, Rules};
@@ -198,4 +201,68 @@ pub fn create_config(
         .map_err(|_| RomeError::CantReadFile(path))?;
 
     Ok(())
+}
+
+/// Some documentation
+pub fn deserialize_set_of_strings<'de, D>(
+    deserializer: D,
+) -> Result<Option<IndexSet<String>>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    struct IndexVisitor {
+        marker: PhantomData<fn() -> Option<IndexSet<String>>>,
+    }
+
+    impl IndexVisitor {
+        fn new() -> Self {
+            IndexVisitor {
+                marker: PhantomData,
+            }
+        }
+    }
+
+    impl<'de> Visitor<'de> for IndexVisitor {
+        type Value = Option<IndexSet<String>>;
+
+        // Format a message stating what data this Visitor expects to receive.
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("expecting a sequence")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut index_set = IndexSet::with_capacity(seq.size_hint().unwrap_or(0));
+
+            while let Some(value) = seq.next_element()? {
+                index_set.insert(value);
+            }
+
+            Ok(Some(index_set))
+        }
+    }
+
+    deserializer.deserialize_seq(IndexVisitor::new())
+}
+
+pub fn serialize_set_of_strings<S>(
+    globals: &Option<IndexSet<String>>,
+    s: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    if let Some(globals) = globals {
+        let mut sequence = s.serialize_seq(Some(globals.len()))?;
+        let iter = globals.into_iter();
+        for global in iter {
+            sequence.serialize_element(global)?;
+        }
+
+        sequence.end()
+    } else {
+        s.serialize_none()
+    }
 }

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -56,8 +56,10 @@ impl Language {
 
     /// Returns the language corresponding to this language ID
     ///
-    /// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+    /// See the [microsoft spec] https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
     /// for a list of language identifiers
+    ///
+    /// [microsoft spec]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
     pub fn from_language_id(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "javascript" => Language::JavaScript,

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -15,15 +15,22 @@ mod file_handlers;
 pub mod settings;
 pub mod workspace;
 
+pub mod matcher;
+
 #[cfg(feature = "schemars")]
 pub mod workspace_types;
 
 pub use crate::configuration::{
     create_config, load_config, Configuration, ConfigurationError, RuleConfiguration, Rules,
 };
+pub use crate::matcher::{MatchOptions, Matcher, Pattern};
+
 pub use crate::file_handlers::JsFormatSettings;
 use crate::file_handlers::Language;
 pub use crate::workspace::Workspace;
+
+/// Exports only for this crate
+pub(crate) use crate::configuration::{deserialize_set_of_strings, serialize_set_of_strings};
 
 /// This is the main entrypoint of the application.
 pub struct App<'app> {
@@ -62,6 +69,8 @@ pub enum RomeError {
     RenameError(RenameError),
     /// Error emitted by the underlying transport layer for a remote Workspace
     TransportError(TransportError),
+    /// Emitted when the file is ignored and should not be processed
+    FileIgnored(PathBuf),
 }
 
 impl Debug for RomeError {
@@ -150,6 +159,9 @@ impl Display for RomeError {
 
             RomeError::TransportError(err) => {
                 write!(f, "{err}",)
+            }
+            RomeError::FileIgnored(path) => {
+                write!(f, "The file {} was ignored", path.display())
             }
         }
     }

--- a/crates/rome_service/src/matcher/LICENSE-APACHE
+++ b/crates/rome_service/src/matcher/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/rome_service/src/matcher/LICENSE-MIT
+++ b/crates/rome_service/src/matcher/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/rome_service/src/matcher/mod.rs
+++ b/crates/rome_service/src/matcher/mod.rs
@@ -1,0 +1,135 @@
+pub mod pattern;
+
+pub use pattern::{MatchOptions, Pattern, PatternError};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::RwLock;
+
+/// A data structure to use when there's need to match a string or a path a against
+/// a unix shell style patterns
+pub struct Matcher<'matches> {
+    patterns: Vec<Pattern>,
+    options: MatchOptions,
+    already_ignored: RwLock<HashMap<&'matches str, bool>>,
+}
+
+impl<'matches> Matcher<'matches> {
+    /// Creates a new Matcher with given options.
+    ///
+    /// Check [glob website](https://docs.rs/glob/latest/glob/struct.MatchOptions.html) for [MatchOptions]
+    pub fn new(options: MatchOptions) -> Self {
+        Self {
+            patterns: Vec::new(),
+            options,
+            already_ignored: RwLock::new(HashMap::default()),
+        }
+    }
+
+    /// It adds a unix shell style pattern
+    pub fn add_pattern(&mut self, pattern: &str) -> Result<(), PatternError> {
+        let pattern = Pattern::new(pattern)?;
+        self.patterns.push(pattern);
+        Ok(())
+    }
+
+    /// It matches the given string against the stored patterns.
+    ///
+    /// It returns [true] if there's at least a match
+    pub fn matches(&self, source: &'matches str) -> bool {
+        let mut already_ignored = self.already_ignored.write().unwrap();
+        if let Some(matches) = already_ignored.get(source) {
+            return *matches;
+        }
+        for pattern in &self.patterns {
+            if pattern.matches_with(source, self.options) || source.contains(pattern.as_str()) {
+                already_ignored.insert(source, true);
+                return true;
+            }
+        }
+        already_ignored.insert(source, false);
+        false
+    }
+
+    /// It matches the given path against the stored patterns
+    ///
+    /// It returns [true] if there's a lest a match
+    pub fn matches_path(&self, source: &'matches Path) -> bool {
+        let mut already_ignored = self.already_ignored.write().unwrap();
+        let source_as_string = source.to_str();
+        if let Some(source_as_string) = source_as_string {
+            if let Some(matches) = already_ignored.get(source_as_string) {
+                return *matches;
+            }
+        }
+        let matches = {
+            for pattern in &self.patterns {
+                let matches = if pattern.matches_path_with(source, self.options) {
+                    true
+                } else {
+                    // Here we cover cases where the user specifies single files inside the patterns.
+                    // The pattern library doesn't support single files, we here we just do a check
+                    // on contains
+                    source_as_string.map_or(false, |source| source.contains(pattern.as_str()))
+                };
+
+                if matches {
+                    return true;
+                }
+            }
+
+            false
+        };
+
+        if let Some(source_as_string) = source_as_string {
+            already_ignored.insert(source_as_string, matches);
+        }
+
+        matches
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::matcher::pattern::MatchOptions;
+    use crate::matcher::Matcher;
+    use std::env;
+
+    #[test]
+    fn matches() {
+        let current = env::current_dir().unwrap();
+        let dir = format!("{}/**/*.rs", current.display());
+        let mut ignore = Matcher::new(MatchOptions::default());
+        ignore.add_pattern(&dir).unwrap();
+        let path = env::current_dir().unwrap().join("src/workspace.rs");
+        let result = ignore.matches(path.to_str().unwrap());
+
+        assert!(result);
+    }
+
+    #[test]
+    fn matches_path() {
+        let current = env::current_dir().unwrap();
+        let dir = format!("{}/**/*.rs", current.display());
+        let mut ignore = Matcher::new(MatchOptions::default());
+        ignore.add_pattern(&dir).unwrap();
+        let path = env::current_dir().unwrap().join("src/workspace.rs");
+        let result = ignore.matches_path(path.as_path());
+
+        assert!(result);
+    }
+
+    #[test]
+    fn matches_single_path() {
+        let dir = "workspace.rs";
+        let mut ignore = Matcher::new(MatchOptions {
+            require_literal_separator: true,
+            case_sensitive: true,
+            require_literal_leading_dot: true,
+        });
+        ignore.add_pattern(dir).unwrap();
+        let path = env::current_dir().unwrap().join("src/workspace.rs");
+        let result = ignore.matches(path.to_str().unwrap());
+
+        assert!(result);
+    }
+}

--- a/crates/rome_service/src/matcher/mod.rs
+++ b/crates/rome_service/src/matcher/mod.rs
@@ -7,13 +7,14 @@ use std::sync::RwLock;
 
 /// A data structure to use when there's need to match a string or a path a against
 /// a unix shell style patterns
-pub struct Matcher<'matches> {
+#[derive(Debug)]
+pub struct Matcher {
     patterns: Vec<Pattern>,
     options: MatchOptions,
-    already_ignored: RwLock<HashMap<&'matches str, bool>>,
+    already_ignored: RwLock<HashMap<String, bool>>,
 }
 
-impl<'matches> Matcher<'matches> {
+impl Matcher {
     /// Creates a new Matcher with given options.
     ///
     /// Check [glob website](https://docs.rs/glob/latest/glob/struct.MatchOptions.html) for [MatchOptions]
@@ -35,25 +36,25 @@ impl<'matches> Matcher<'matches> {
     /// It matches the given string against the stored patterns.
     ///
     /// It returns [true] if there's at least a match
-    pub fn matches(&self, source: &'matches str) -> bool {
+    pub fn matches(&self, source: &str) -> bool {
         let mut already_ignored = self.already_ignored.write().unwrap();
         if let Some(matches) = already_ignored.get(source) {
             return *matches;
         }
         for pattern in &self.patterns {
             if pattern.matches_with(source, self.options) || source.contains(pattern.as_str()) {
-                already_ignored.insert(source, true);
+                already_ignored.insert(source.to_string(), true);
                 return true;
             }
         }
-        already_ignored.insert(source, false);
+        already_ignored.insert(source.to_string(), false);
         false
     }
 
     /// It matches the given path against the stored patterns
     ///
     /// It returns [true] if there's a lest a match
-    pub fn matches_path(&self, source: &'matches Path) -> bool {
+    pub fn matches_path(&self, source: &Path) -> bool {
         let mut already_ignored = self.already_ignored.write().unwrap();
         let source_as_string = source.to_str();
         if let Some(source_as_string) = source_as_string {
@@ -81,7 +82,7 @@ impl<'matches> Matcher<'matches> {
         };
 
         if let Some(source_as_string) = source_as_string {
-            already_ignored.insert(source_as_string, matches);
+            already_ignored.insert(source_as_string.to_string(), matches);
         }
 
         matches

--- a/crates/rome_service/src/matcher/pattern.rs
+++ b/crates/rome_service/src/matcher/pattern.rs
@@ -1,0 +1,838 @@
+use crate::matcher::pattern::CharSpecifier::{CharRange, SingleChar};
+use crate::matcher::pattern::MatchResult::{
+    EntirePatternDoesntMatch, Match, SubPatternDoesntMatch,
+};
+use crate::matcher::pattern::PatternToken::{
+    AnyChar, AnyExcept, AnyRecursiveSequence, AnySequence, AnyWithin, Char,
+};
+use std::error::Error;
+use std::path::Path;
+use std::str::FromStr;
+use std::{fmt, path};
+
+/// A pattern parsing error.
+#[derive(Debug)]
+#[allow(missing_copy_implementations)]
+pub struct PatternError {
+    /// The approximate character index of where the error occurred.
+    pub pos: usize,
+
+    /// A message describing the error.
+    pub msg: &'static str,
+}
+
+impl Error for PatternError {
+    fn description(&self) -> &str {
+        self.msg
+    }
+}
+
+impl fmt::Display for PatternError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Pattern syntax error near position {}: {}",
+            self.pos, self.msg
+        )
+    }
+}
+
+/// A compiled Unix shell style pattern.
+///
+/// - `?` matches any single character.
+///
+/// - `*` matches any (possibly empty) sequence of characters.
+///
+/// - `**` matches the current directory and arbitrary subdirectories. This
+///   sequence **must** form a single path component, so both `**a` and `b**`
+///   are invalid and will result in an error.  A sequence of more than two
+///   consecutive `*` characters is also invalid.
+///
+/// - `[...]` matches any character inside the brackets.  Character sequences
+///   can also specify ranges of characters, as ordered by Unicode, so e.g.
+///   `[0-9]` specifies any character between 0 and 9 inclusive. An unclosed
+///   bracket is invalid.
+///
+/// - `[!...]` is the negation of `[...]`, i.e. it matches any characters
+///   **not** in the brackets.
+///
+/// - The metacharacters `?`, `*`, `[`, `]` can be matched by using brackets
+///   (e.g. `[?]`).  When a `]` occurs immediately following `[` or `[!` then it
+///   is interpreted as being part of, rather then ending, the character set, so
+///   `]` and NOT `]` can be matched by `[]]` and `[!]]` respectively.  The `-`
+///   character can be specified inside a character sequence pattern by placing
+///   it at the start or the end, e.g. `[abc-]`.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+pub struct Pattern {
+    original: String,
+    tokens: Vec<PatternToken>,
+    is_recursive: bool,
+}
+
+/// Show the original glob pattern.
+impl fmt::Display for Pattern {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.original.fmt(f)
+    }
+}
+
+impl FromStr for Pattern {
+    type Err = PatternError;
+
+    fn from_str(s: &str) -> Result<Self, PatternError> {
+        Self::new(s)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+enum PatternToken {
+    Char(char),
+    AnyChar,
+    AnySequence,
+    AnyRecursiveSequence,
+    AnyWithin(Vec<CharSpecifier>),
+    AnyExcept(Vec<CharSpecifier>),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+enum CharSpecifier {
+    SingleChar(char),
+    CharRange(char, char),
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum MatchResult {
+    Match,
+    SubPatternDoesntMatch,
+    EntirePatternDoesntMatch,
+}
+
+const ERROR_WILDCARDS: &str = "wildcards are either regular `*` or recursive `**`";
+const ERROR_RECURSIVE_WILDCARDS: &str = "recursive wildcards must form a single path \
+                                         component";
+const ERROR_INVALID_RANGE: &str = "invalid range pattern";
+
+impl Pattern {
+    /// This function compiles Unix shell style patterns.
+    ///
+    /// An invalid glob pattern will yield a `PatternError`.
+    pub fn new(pattern: &str) -> Result<Self, PatternError> {
+        let chars = pattern.chars().collect::<Vec<_>>();
+        let mut tokens = Vec::new();
+        let mut is_recursive = false;
+        let mut i = 0;
+
+        while i < chars.len() {
+            match chars[i] {
+                '?' => {
+                    tokens.push(AnyChar);
+                    i += 1;
+                }
+                '*' => {
+                    let old = i;
+
+                    while i < chars.len() && chars[i] == '*' {
+                        i += 1;
+                    }
+
+                    let count = i - old;
+
+                    match count {
+                        count if count > 2 => {
+                            return Err(PatternError {
+                                pos: old + 2,
+                                msg: ERROR_WILDCARDS,
+                            });
+                        }
+                        count if count == 2 => {
+                            // ** can only be an entire path component
+                            // i.e. a/**/b is valid, but a**/b or a/**b is not
+                            // invalid matches are treated literally
+                            let is_valid = if i == 2 || path::is_separator(chars[i - count - 1]) {
+                                // it ends in a '/'
+                                if i < chars.len() && path::is_separator(chars[i]) {
+                                    i += 1;
+                                    true
+                                    // or the pattern ends here
+                                    // this enables the existing globbing mechanism
+                                } else if i == chars.len() {
+                                    true
+                                    // `**` ends in non-separator
+                                } else {
+                                    return Err(PatternError {
+                                        pos: i,
+                                        msg: ERROR_RECURSIVE_WILDCARDS,
+                                    });
+                                }
+                                // `**` begins with non-separator
+                            } else {
+                                return Err(PatternError {
+                                    pos: old - 1,
+                                    msg: ERROR_RECURSIVE_WILDCARDS,
+                                });
+                            };
+
+                            if is_valid {
+                                // collapse consecutive AnyRecursiveSequence to a
+                                // single one
+
+                                let tokens_len = tokens.len();
+
+                                if !(tokens_len > 1
+                                    && tokens[tokens_len - 1] == AnyRecursiveSequence)
+                                {
+                                    is_recursive = true;
+                                    tokens.push(AnyRecursiveSequence);
+                                }
+                            }
+                        }
+                        _ => {
+                            tokens.push(AnySequence);
+                        }
+                    }
+                }
+                '[' => {
+                    if i + 4 <= chars.len() && chars[i + 1] == '!' {
+                        match chars[i + 3..].iter().position(|x| *x == ']') {
+                            None => (),
+                            Some(j) => {
+                                let chars = &chars[i + 2..i + 3 + j];
+                                let cs = parse_char_specifiers(chars);
+                                tokens.push(AnyExcept(cs));
+                                i += j + 4;
+                                continue;
+                            }
+                        }
+                    } else if i + 3 <= chars.len() && chars[i + 1] != '!' {
+                        match chars[i + 2..].iter().position(|x| *x == ']') {
+                            None => (),
+                            Some(j) => {
+                                let cs = parse_char_specifiers(&chars[i + 1..i + 2 + j]);
+                                tokens.push(AnyWithin(cs));
+                                i += j + 3;
+                                continue;
+                            }
+                        }
+                    }
+
+                    // if we get here then this is not a valid range pattern
+                    return Err(PatternError {
+                        pos: i,
+                        msg: ERROR_INVALID_RANGE,
+                    });
+                }
+                c => {
+                    tokens.push(Char(c));
+                    i += 1;
+                }
+            }
+        }
+
+        Ok(Self {
+            tokens,
+            original: pattern.to_string(),
+            is_recursive,
+        })
+    }
+
+    /// Escape metacharacters within the given string by surrounding them in
+    /// brackets. The resulting string will, when compiled into a `Pattern`,
+    /// match the input string and nothing else.
+    pub fn escape(s: &str) -> String {
+        let mut escaped = String::new();
+        for c in s.chars() {
+            match c {
+                // note that ! does not need escaping because it is only special
+                // inside brackets
+                '?' | '*' | '[' | ']' => {
+                    escaped.push('[');
+                    escaped.push(c);
+                    escaped.push(']');
+                }
+                c => {
+                    escaped.push(c);
+                }
+            }
+        }
+        escaped
+    }
+
+    /// Return if the given `str` matches this `Pattern` using the default
+    /// match options (i.e. `MatchOptions::new()`).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use crate::rome_service::Pattern;
+    ///
+    /// assert!(Pattern::new("c?t").unwrap().matches("cat"));
+    /// assert!(Pattern::new("k[!e]tteh").unwrap().matches("kitteh"));
+    /// assert!(Pattern::new("d*g").unwrap().matches("doog"));
+    /// ```
+    pub fn matches(&self, str: &str) -> bool {
+        self.matches_with(str, MatchOptions::new())
+    }
+
+    /// Return if the given `Path`, when converted to a `str`, matches this
+    /// `Pattern` using the default match options (i.e. `MatchOptions::new()`).
+    pub fn matches_path(&self, path: &Path) -> bool {
+        // FIXME (#9639): This needs to handle non-utf8 paths
+        path.to_str().map_or(false, |s| self.matches(s))
+    }
+
+    /// Return if the given `str` matches this `Pattern` using the specified
+    /// match options.
+    pub fn matches_with(&self, str: &str, options: MatchOptions) -> bool {
+        self.matches_from(true, str.chars(), 0, options) == Match
+    }
+
+    /// Return if the given `Path`, when converted to a `str`, matches this
+    /// `Pattern` using the specified match options.
+    pub fn matches_path_with(&self, path: &Path, options: MatchOptions) -> bool {
+        // FIXME (#9639): This needs to handle non-utf8 paths
+        path.to_str()
+            .map_or(false, |s| self.matches_with(s, options))
+    }
+
+    /// Access the original glob pattern.
+    pub fn as_str(&self) -> &str {
+        &self.original
+    }
+
+    fn matches_from(
+        &self,
+        mut follows_separator: bool,
+        mut file: std::str::Chars,
+        i: usize,
+        options: MatchOptions,
+    ) -> MatchResult {
+        for (ti, token) in self.tokens[i..].iter().enumerate() {
+            match *token {
+                AnySequence | AnyRecursiveSequence => {
+                    // ** must be at the start.
+                    debug_assert!(match *token {
+                        AnyRecursiveSequence => follows_separator,
+                        _ => true,
+                    });
+
+                    // Empty match
+                    match self.matches_from(follows_separator, file.clone(), i + ti + 1, options) {
+                        SubPatternDoesntMatch => (), // keep trying
+                        m => return m,
+                    };
+
+                    while let Some(c) = file.next() {
+                        if follows_separator && options.require_literal_leading_dot && c == '.' {
+                            return SubPatternDoesntMatch;
+                        }
+                        follows_separator = path::is_separator(c);
+                        match *token {
+                            AnyRecursiveSequence if !follows_separator => continue,
+                            AnySequence
+                                if options.require_literal_separator && follows_separator =>
+                            {
+                                return SubPatternDoesntMatch
+                            }
+                            _ => (),
+                        }
+                        match self.matches_from(
+                            follows_separator,
+                            file.clone(),
+                            i + ti + 1,
+                            options,
+                        ) {
+                            SubPatternDoesntMatch => (), // keep trying
+                            m => return m,
+                        }
+                    }
+                }
+                _ => {
+                    let c = match file.next() {
+                        Some(c) => c,
+                        None => return EntirePatternDoesntMatch,
+                    };
+
+                    let is_sep = path::is_separator(c);
+
+                    if !match *token {
+                        AnyChar | AnyWithin(..) | AnyExcept(..)
+                            if (options.require_literal_separator && is_sep)
+                                || (follows_separator
+                                    && options.require_literal_leading_dot
+                                    && c == '.') =>
+                        {
+                            false
+                        }
+                        AnyChar => true,
+                        AnyWithin(ref specifiers) => in_char_specifiers(specifiers, c, options),
+                        AnyExcept(ref specifiers) => !in_char_specifiers(specifiers, c, options),
+                        Char(c2) => chars_eq(c, c2, options.case_sensitive),
+                        AnySequence | AnyRecursiveSequence => unreachable!(),
+                    } {
+                        return SubPatternDoesntMatch;
+                    }
+                    follows_separator = is_sep;
+                }
+            }
+        }
+
+        // Iter is fused.
+        if file.next().is_none() {
+            Match
+        } else {
+            SubPatternDoesntMatch
+        }
+    }
+}
+
+fn parse_char_specifiers(s: &[char]) -> Vec<CharSpecifier> {
+    let mut cs = Vec::new();
+    let mut i = 0;
+    while i < s.len() {
+        if i + 3 <= s.len() && s[i + 1] == '-' {
+            cs.push(CharRange(s[i], s[i + 2]));
+            i += 3;
+        } else {
+            cs.push(SingleChar(s[i]));
+            i += 1;
+        }
+    }
+    cs
+}
+
+fn in_char_specifiers(specifiers: &[CharSpecifier], c: char, options: MatchOptions) -> bool {
+    for &specifier in specifiers.iter() {
+        match specifier {
+            SingleChar(sc) => {
+                if chars_eq(c, sc, options.case_sensitive) {
+                    return true;
+                }
+            }
+            CharRange(start, end) => {
+                // FIXME: work with non-ascii chars properly (issue #1347)
+                if !options.case_sensitive && c.is_ascii() && start.is_ascii() && end.is_ascii() {
+                    let start = start.to_ascii_lowercase();
+                    let end = end.to_ascii_lowercase();
+
+                    let start_up = start.to_uppercase().next().unwrap();
+                    let end_up = end.to_uppercase().next().unwrap();
+
+                    // only allow case insensitive matching when
+                    // both start and end are within a-z or A-Z
+                    if start != start_up && end != end_up {
+                        let c = c.to_ascii_lowercase();
+                        if c >= start && c <= end {
+                            return true;
+                        }
+                    }
+                }
+
+                if c >= start && c <= end {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// A helper function to determine if two chars are (possibly case-insensitively) equal.
+fn chars_eq(a: char, b: char, case_sensitive: bool) -> bool {
+    if cfg!(windows) && path::is_separator(a) && path::is_separator(b) {
+        true
+    } else if !case_sensitive && a.is_ascii() && b.is_ascii() {
+        // FIXME: work with non-ascii chars properly (issue #9084)
+        a.to_ascii_lowercase() == b.to_ascii_lowercase()
+    } else {
+        a == b
+    }
+}
+
+/// Configuration options to modify the behaviour of `Pattern::matches_with(..)`.
+#[allow(missing_copy_implementations)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct MatchOptions {
+    /// Whether or not patterns should be matched in a case-sensitive manner.
+    /// This currently only considers upper/lower case relationships between
+    /// ASCII characters, but in future this might be extended to work with
+    /// Unicode.
+    pub case_sensitive: bool,
+
+    /// Whether or not path-component separator characters (e.g. `/` on
+    /// Posix) must be matched by a literal `/`, rather than by `*` or `?` or
+    /// `[...]`.
+    pub require_literal_separator: bool,
+
+    /// Whether or not paths that contain components that start with a `.`
+    /// will require that `.` appears literally in the pattern; `*`, `?`, `**`,
+    /// or `[...]` will not match. This is useful because such files are
+    /// conventionally considered hidden on Unix systems and it might be
+    /// desirable to skip them when listing files.
+    pub require_literal_leading_dot: bool,
+}
+
+impl MatchOptions {
+    /// Constructs a new `MatchOptions` with default field values. This is used
+    /// when calling functions that do not take an explicit `MatchOptions`
+    /// parameter.
+    ///
+    /// This function always returns this value:
+    ///
+    /// ```rust,ignore
+    /// MatchOptions {
+    ///     case_sensitive: true,
+    ///     require_literal_separator: false,
+    ///     require_literal_leading_dot: false
+    /// }
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{MatchOptions, Pattern};
+    use std::path::Path;
+
+    #[test]
+    fn test_pattern_from_str() {
+        assert!("a*b".parse::<Pattern>().unwrap().matches("a_b"));
+        assert!("a/**b".parse::<Pattern>().unwrap_err().pos == 4);
+    }
+
+    #[test]
+    fn test_wildcard_errors() {
+        assert!(Pattern::new("a/**b").unwrap_err().pos == 4);
+        assert!(Pattern::new("a/bc**").unwrap_err().pos == 3);
+        assert!(Pattern::new("a/*****").unwrap_err().pos == 4);
+        assert!(Pattern::new("a/b**c**d").unwrap_err().pos == 2);
+        assert!(Pattern::new("a**b").unwrap_err().pos == 0);
+    }
+
+    #[test]
+    fn test_unclosed_bracket_errors() {
+        assert!(Pattern::new("abc[def").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[!def").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[!").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[d").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[!d").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[]").unwrap_err().pos == 3);
+        assert!(Pattern::new("abc[!]").unwrap_err().pos == 3);
+    }
+
+    #[test]
+    fn test_wildcards() {
+        assert!(Pattern::new("a*b").unwrap().matches("a_b"));
+        assert!(Pattern::new("a*b*c").unwrap().matches("abc"));
+        assert!(!Pattern::new("a*b*c").unwrap().matches("abcd"));
+        assert!(Pattern::new("a*b*c").unwrap().matches("a_b_c"));
+        assert!(Pattern::new("a*b*c").unwrap().matches("a___b___c"));
+        assert!(Pattern::new("abc*abc*abc")
+            .unwrap()
+            .matches("abcabcabcabcabcabcabc"));
+        assert!(!Pattern::new("abc*abc*abc")
+            .unwrap()
+            .matches("abcabcabcabcabcabcabca"));
+        assert!(Pattern::new("a*a*a*a*a*a*a*a*a")
+            .unwrap()
+            .matches("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        assert!(Pattern::new("a*b[xyz]c*d").unwrap().matches("abxcdbxcddd"));
+    }
+
+    #[test]
+    fn test_recursive_wildcards() {
+        let pat = Pattern::new("some/**/needle.txt").unwrap();
+        assert!(pat.matches("some/needle.txt"));
+        assert!(pat.matches("some/one/needle.txt"));
+        assert!(pat.matches("some/one/two/needle.txt"));
+        assert!(pat.matches("some/other/needle.txt"));
+        assert!(!pat.matches("some/other/notthis.txt"));
+
+        // a single ** should be valid, for globs
+        // Should accept anything
+        let pat = Pattern::new("**").unwrap();
+        assert!(pat.is_recursive);
+        assert!(pat.matches("abcde"));
+        assert!(pat.matches(""));
+        assert!(pat.matches(".asdf"));
+        assert!(pat.matches("/x/.asdf"));
+
+        // collapse consecutive wildcards
+        let pat = Pattern::new("some/**/**/needle.txt").unwrap();
+        assert!(pat.matches("some/needle.txt"));
+        assert!(pat.matches("some/one/needle.txt"));
+        assert!(pat.matches("some/one/two/needle.txt"));
+        assert!(pat.matches("some/other/needle.txt"));
+        assert!(!pat.matches("some/other/notthis.txt"));
+
+        // ** can begin the pattern
+        let pat = Pattern::new("**/test").unwrap();
+        assert!(pat.matches("one/two/test"));
+        assert!(pat.matches("one/test"));
+        assert!(pat.matches("test"));
+
+        // /** can begin the pattern
+        let pat = Pattern::new("/**/test").unwrap();
+        assert!(pat.matches("/one/two/test"));
+        assert!(pat.matches("/one/test"));
+        assert!(pat.matches("/test"));
+        assert!(!pat.matches("/one/notthis"));
+        assert!(!pat.matches("/notthis"));
+
+        // Only start sub-patterns on start of path segment.
+        let pat = Pattern::new("**/.*").unwrap();
+        assert!(pat.matches(".abc"));
+        assert!(pat.matches("abc/.abc"));
+        assert!(!pat.matches("ab.c"));
+        assert!(!pat.matches("abc/ab.c"));
+    }
+
+    #[test]
+    fn test_range_pattern() {
+        let pat = Pattern::new("a[0-9]b").unwrap();
+        for i in 0..10 {
+            assert!(pat.matches(&format!("a{}b", i)));
+        }
+        assert!(!pat.matches("a_b"));
+
+        let pat = Pattern::new("a[!0-9]b").unwrap();
+        for i in 0..10 {
+            assert!(!pat.matches(&format!("a{}b", i)));
+        }
+        assert!(pat.matches("a_b"));
+
+        let pats = ["[a-z123]", "[1a-z23]", "[123a-z]"];
+        for &p in pats.iter() {
+            let pat = Pattern::new(p).unwrap();
+            for c in "abcdefghijklmnopqrstuvwxyz".chars() {
+                assert!(pat.matches(&c.to_string()));
+            }
+            for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
+                let options = MatchOptions {
+                    case_sensitive: false,
+                    ..MatchOptions::new()
+                };
+                assert!(pat.matches_with(&c.to_string(), options));
+            }
+            assert!(pat.matches("1"));
+            assert!(pat.matches("2"));
+            assert!(pat.matches("3"));
+        }
+
+        let pats = ["[abc-]", "[-abc]", "[a-c-]"];
+        for &p in pats.iter() {
+            let pat = Pattern::new(p).unwrap();
+            assert!(pat.matches("a"));
+            assert!(pat.matches("b"));
+            assert!(pat.matches("c"));
+            assert!(pat.matches("-"));
+            assert!(!pat.matches("d"));
+        }
+
+        let pat = Pattern::new("[2-1]").unwrap();
+        assert!(!pat.matches("1"));
+        assert!(!pat.matches("2"));
+
+        assert!(Pattern::new("[-]").unwrap().matches("-"));
+        assert!(!Pattern::new("[!-]").unwrap().matches("-"));
+    }
+
+    #[test]
+    fn test_pattern_matches() {
+        let txt_pat = Pattern::new("*hello.txt").unwrap();
+        assert!(txt_pat.matches("hello.txt"));
+        assert!(txt_pat.matches("gareth_says_hello.txt"));
+        assert!(txt_pat.matches("some/path/to/hello.txt"));
+        assert!(txt_pat.matches("some\\path\\to\\hello.txt"));
+        assert!(txt_pat.matches("/an/absolute/path/to/hello.txt"));
+        assert!(!txt_pat.matches("hello.txt-and-then-some"));
+        assert!(!txt_pat.matches("goodbye.txt"));
+
+        let dir_pat = Pattern::new("*some/path/to/hello.txt").unwrap();
+        assert!(dir_pat.matches("some/path/to/hello.txt"));
+        assert!(dir_pat.matches("a/bigger/some/path/to/hello.txt"));
+        assert!(!dir_pat.matches("some/path/to/hello.txt-and-then-some"));
+        assert!(!dir_pat.matches("some/other/path/to/hello.txt"));
+    }
+
+    #[test]
+    fn test_pattern_escape() {
+        let s = "_[_]_?_*_!_";
+        assert_eq!(Pattern::escape(s), "_[[]_[]]_[?]_[*]_!_".to_string());
+        assert!(Pattern::new(&Pattern::escape(s)).unwrap().matches(s));
+    }
+
+    #[test]
+    fn test_pattern_matches_case_insensitive() {
+        let pat = Pattern::new("aBcDeFg").unwrap();
+        let options = MatchOptions {
+            case_sensitive: false,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+
+        assert!(pat.matches_with("aBcDeFg", options));
+        assert!(pat.matches_with("abcdefg", options));
+        assert!(pat.matches_with("ABCDEFG", options));
+        assert!(pat.matches_with("AbCdEfG", options));
+    }
+
+    #[test]
+    fn test_pattern_matches_case_insensitive_range() {
+        let pat_within = Pattern::new("[a]").unwrap();
+        let pat_except = Pattern::new("[!a]").unwrap();
+
+        let options_case_insensitive = MatchOptions {
+            case_sensitive: false,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+        let options_case_sensitive = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+
+        assert!(pat_within.matches_with("a", options_case_insensitive));
+        assert!(pat_within.matches_with("A", options_case_insensitive));
+        assert!(!pat_within.matches_with("A", options_case_sensitive));
+
+        assert!(!pat_except.matches_with("a", options_case_insensitive));
+        assert!(!pat_except.matches_with("A", options_case_insensitive));
+        assert!(pat_except.matches_with("A", options_case_sensitive));
+    }
+
+    #[test]
+    fn test_pattern_matches_require_literal_separator() {
+        let options_require_literal = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: true,
+            require_literal_leading_dot: false,
+        };
+        let options_not_require_literal = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+
+        assert!(Pattern::new("abc/def")
+            .unwrap()
+            .matches_with("abc/def", options_require_literal));
+        assert!(!Pattern::new("abc?def")
+            .unwrap()
+            .matches_with("abc/def", options_require_literal));
+        assert!(!Pattern::new("abc*def")
+            .unwrap()
+            .matches_with("abc/def", options_require_literal));
+        assert!(!Pattern::new("abc[/]def")
+            .unwrap()
+            .matches_with("abc/def", options_require_literal));
+
+        assert!(Pattern::new("abc/def")
+            .unwrap()
+            .matches_with("abc/def", options_not_require_literal));
+        assert!(Pattern::new("abc?def")
+            .unwrap()
+            .matches_with("abc/def", options_not_require_literal));
+        assert!(Pattern::new("abc*def")
+            .unwrap()
+            .matches_with("abc/def", options_not_require_literal));
+        assert!(Pattern::new("abc[/]def")
+            .unwrap()
+            .matches_with("abc/def", options_not_require_literal));
+    }
+
+    #[test]
+    fn test_pattern_matches_require_literal_leading_dot() {
+        let options_require_literal_leading_dot = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: true,
+        };
+        let options_not_require_literal_leading_dot = MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        };
+
+        let f = |options| {
+            Pattern::new("*.txt")
+                .unwrap()
+                .matches_with(".hello.txt", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new(".*.*")
+                .unwrap()
+                .matches_with(".hello.txt", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/bbb/*")
+                .unwrap()
+                .matches_with("aaa/bbb/.ccc", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/bbb/*")
+                .unwrap()
+                .matches_with("aaa/bbb/c.c.c.", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/bbb/.*")
+                .unwrap()
+                .matches_with("aaa/bbb/.ccc", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/?bbb")
+                .unwrap()
+                .matches_with("aaa/.bbb", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+
+        let f = |options| {
+            Pattern::new("aaa/[.]bbb")
+                .unwrap()
+                .matches_with("aaa/.bbb", options)
+        };
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+
+        let f = |options| Pattern::new("**/*").unwrap().matches_with(".bbb", options);
+        assert!(f(options_not_require_literal_leading_dot));
+        assert!(!f(options_require_literal_leading_dot));
+    }
+
+    #[test]
+    fn test_matches_path() {
+        // on windows, (Path::new("a/b").as_str().unwrap() == "a\\b"), so this
+        // tests that / and \ are considered equivalent on windows
+        assert!(Pattern::new("a/b").unwrap().matches_path(Path::new("a/b")));
+    }
+
+    #[test]
+    fn test_path_join() {
+        let pattern = Path::new("one").join(Path::new("**/*.rs"));
+        assert!(Pattern::new(pattern.to_str().unwrap()).is_ok());
+    }
+}

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -77,6 +77,8 @@ pub struct FormatSettings {
     pub format_with_errors: bool,
     pub indent_style: Option<IndentStyle>,
     pub line_width: Option<LineWidth>,
+    /// List of paths/files to matcher
+    pub ignored_files: IndexSet<String>,
 }
 
 impl Default for FormatSettings {
@@ -86,6 +88,7 @@ impl Default for FormatSettings {
             format_with_errors: false,
             indent_style: Some(IndentStyle::default()),
             line_width: Some(LineWidth::default()),
+            ignored_files: IndexSet::default(),
         }
     }
 }
@@ -98,6 +101,9 @@ pub struct LinterSettings {
 
     /// List of rules
     pub rules: Option<Rules>,
+
+    /// List of paths/files to matcher
+    pub ignored_files: IndexSet<String>,
 }
 
 impl Default for LinterSettings {
@@ -105,6 +111,7 @@ impl Default for LinterSettings {
         Self {
             enabled: true,
             rules: Some(Rules::default()),
+            ignored_files: IndexSet::default(),
         }
     }
 }

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -1,4 +1,4 @@
-use crate::{Configuration, Rules};
+use crate::{Configuration, MatchOptions, Matcher, RomeError, Rules};
 use indexmap::IndexSet;
 use rome_console::codespan::Severity;
 use rome_formatter::{IndentStyle, LineWidth};
@@ -29,10 +29,13 @@ impl WorkspaceSettings {
     }
 
     /// The (configuration)[Configuration] is merged into the workspace
-    pub fn merge_with_configuration(&mut self, configuration: Configuration) {
+    pub fn merge_with_configuration(
+        &mut self,
+        configuration: Configuration,
+    ) -> Result<(), RomeError> {
         // formatter part
         if let Some(formatter) = configuration.formatter {
-            self.formatter = FormatSettings::from(formatter);
+            self.formatter = FormatSettings::try_from(formatter)?;
         }
         let formatter = configuration
             .javascript
@@ -45,11 +48,13 @@ impl WorkspaceSettings {
 
         // linter part
         if let Some(linter) = configuration.linter {
-            self.linter = LinterSettings::from(linter)
+            self.linter = LinterSettings::try_from(linter)?;
         }
 
         let globals = configuration.javascript.and_then(|j| j.globals);
         self.languages.javascript.globals = globals;
+
+        Ok(())
     }
 
     /// It retrieves the severity based on the `code` of the rule and the current configuration.
@@ -78,7 +83,7 @@ pub struct FormatSettings {
     pub indent_style: Option<IndentStyle>,
     pub line_width: Option<LineWidth>,
     /// List of paths/files to matcher
-    pub ignored_files: IndexSet<String>,
+    pub ignored_files: Matcher,
 }
 
 impl Default for FormatSettings {
@@ -88,7 +93,11 @@ impl Default for FormatSettings {
             format_with_errors: false,
             indent_style: Some(IndentStyle::default()),
             line_width: Some(LineWidth::default()),
-            ignored_files: IndexSet::default(),
+            ignored_files: Matcher::new(MatchOptions {
+                case_sensitive: true,
+                require_literal_leading_dot: false,
+                require_literal_separator: false,
+            }),
         }
     }
 }
@@ -103,7 +112,7 @@ pub struct LinterSettings {
     pub rules: Option<Rules>,
 
     /// List of paths/files to matcher
-    pub ignored_files: IndexSet<String>,
+    pub ignored_files: Matcher,
 }
 
 impl Default for LinterSettings {
@@ -111,7 +120,11 @@ impl Default for LinterSettings {
         Self {
             enabled: true,
             rules: Some(Rules::default()),
-            ignored_files: IndexSet::default(),
+            ignored_files: Matcher::new(MatchOptions {
+                case_sensitive: true,
+                require_literal_leading_dot: false,
+                require_literal_separator: false,
+            }),
         }
     }
 }

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -83,26 +83,26 @@ pub struct SupportsFeatureResult {
 }
 
 impl SupportsFeatureResult {
-    fn ignored() -> Self {
+    const fn ignored() -> Self {
         Self {
             reason: Some(UnsupportedReason::Ignored),
         }
     }
 
-    fn disabled() -> Self {
+    const fn disabled() -> Self {
         Self {
             reason: Some(UnsupportedReason::FeatureNotEnabled),
         }
     }
 
-    fn incapable() -> Self {
+    const fn file_not_supported() -> Self {
         Self {
             reason: Some(UnsupportedReason::FileNotSupported),
         }
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum UnsupportedReason {
     Ignored,
@@ -110,7 +110,7 @@ pub enum UnsupportedReason {
     FileNotSupported,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum FeatureName {
     Format,

--- a/crates/rome_service/src/workspace/client.rs
+++ b/crates/rome_service/src/workspace/client.rs
@@ -7,6 +7,7 @@ use rome_formatter::Printed;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 
+use crate::workspace::SupportsFeatureResult;
 use crate::{RomeError, TransportError, Workspace};
 
 use super::{
@@ -89,7 +90,10 @@ impl<T> Workspace for WorkspaceClient<T>
 where
     T: WorkspaceTransport + RefUnwindSafe + Send + Sync,
 {
-    fn supports_feature(&self, params: SupportsFeatureParams) -> Result<bool, RomeError> {
+    fn supports_feature(
+        &self,
+        params: SupportsFeatureParams,
+    ) -> Result<SupportsFeatureResult, RomeError> {
         self.request("rome/supports_feature", params)
     }
 

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -10,11 +10,11 @@ use crate::workspace::SupportsFeatureResult;
 use crate::{
     file_handlers::Features,
     settings::{SettingsHandle, WorkspaceSettings},
-    MatchOptions, Matcher, RomeError, Workspace,
+    RomeError, Workspace,
 };
 use dashmap::{mapref::entry::Entry, DashMap};
 use indexmap::IndexSet;
-use rome_analyze::{AnalysisFilter, RuleCategories, RuleFilter};
+use rome_analyze::{AnalysisFilter, RuleFilter};
 use rome_diagnostics::{Diagnostic, Severity};
 use rome_formatter::Printed;
 use rome_fs::RomePath;
@@ -142,7 +142,7 @@ impl WorkspaceServer {
     /// Returns and error if no file exists in the workspace with this path or
     /// if the language associated with the file has no parser capability
     fn get_parse(&self, rome_path: RomePath, feature: FeatureName) -> Result<AnyParse, RomeError> {
-        let ignored = self.is_file_ignored(&rome_path, feature);
+        let ignored = self.is_file_ignored(&rome_path, &feature);
 
         if ignored {
             return Err(RomeError::FileIgnored(rome_path.to_path_buf()));
@@ -171,7 +171,7 @@ impl WorkspaceServer {
     /// a list of paths to match against.
     ///
     /// If the file path matches, than `true` is returned and it should be considered ignored.
-    fn is_file_ignored(&self, rome_path: &RomePath, feature: FeatureName) -> bool {
+    fn is_file_ignored(&self, rome_path: &RomePath, feature: &FeatureName) -> bool {
         let settings = self.settings();
         match feature {
             FeatureName::Format => settings

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -195,15 +195,30 @@ impl Workspace for WorkspaceServer {
     ) -> Result<SupportsFeatureResult, RomeError> {
         let capabilities = self.get_capabilities(&params.path);
         let settings = self.settings.read().unwrap();
-        let is_ignored = matches!(self.is_file_ignored(&params.path, params.feature), true);
-        let result = if is_ignored {
-            SupportsFeatureResult::ignored()
-        } else if capabilities.formatter.format.is_none() {
-            SupportsFeatureResult::file_not_supported()
-        } else if !settings.formatter().enabled {
-            SupportsFeatureResult::disabled()
-        } else {
-            SupportsFeatureResult { reason: None }
+        let is_ignored = matches!(self.is_file_ignored(&params.path, &params.feature), true);
+        let result = match params.feature {
+            FeatureName::Format => {
+                if is_ignored {
+                    SupportsFeatureResult::ignored()
+                } else if capabilities.formatter.format.is_none() {
+                    SupportsFeatureResult::file_not_supported()
+                } else if !settings.formatter().enabled {
+                    SupportsFeatureResult::disabled()
+                } else {
+                    SupportsFeatureResult { reason: None }
+                }
+            }
+            FeatureName::Lint => {
+                if is_ignored {
+                    SupportsFeatureResult::ignored()
+                } else if capabilities.analyzer.lint.is_none() {
+                    SupportsFeatureResult::file_not_supported()
+                } else if !settings.linter().enabled {
+                    SupportsFeatureResult::disabled()
+                } else {
+                    SupportsFeatureResult { reason: None }
+                }
+            }
         };
         Ok(result)
     }

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -195,7 +195,7 @@ impl Workspace for WorkspaceServer {
     ) -> Result<SupportsFeatureResult, RomeError> {
         let capabilities = self.get_capabilities(&params.path);
         let settings = self.settings.read().unwrap();
-        let is_ignored = matches!(self.is_file_ignored(&params.path, &params.feature), true);
+        let is_ignored = self.is_file_ignored(&params.path, &params.feature);
         let result = match params.feature {
             FeatureName::Format => {
                 if is_ignored {
@@ -334,7 +334,12 @@ impl Workspace for WorkspaceServer {
             .ok_or_else(self.build_capability_error(&params.path))?;
 
         let settings = self.settings.read().unwrap();
-        let parse = self.get_parse(params.path.clone(), FeatureName::Lint)?;
+        let feature = if params.categories.is_syntax() {
+            FeatureName::Format
+        } else {
+            FeatureName::Lint
+        };
+        let parse = self.get_parse(params.path.clone(), feature)?;
         let rules = settings.linter().rules.as_ref();
         let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
             let enabled: IndexSet<RuleFilter> = rules.as_enabled_rules();

--- a/crates/rome_service/src/workspace_types.rs
+++ b/crates/rome_service/src/workspace_types.rs
@@ -428,7 +428,7 @@ macro_rules! workspace_method {
 /// Returns a list of signature for all the methods in the [Workspace] trait
 pub fn methods() -> [WorkspaceMethod; 15] {
     [
-        WorkspaceMethod::of::<SupportsFeatureParams, bool>("supports_feature"),
+        WorkspaceMethod::of::<SupportsFeatureParams, SupportsFeatureResult>("supports_feature"),
         workspace_method!(update_settings),
         workspace_method!(open_file),
         workspace_method!(change_file),

--- a/crates/rome_wasm/src/lib.rs
+++ b/crates/rome_wasm/src/lib.rs
@@ -36,9 +36,15 @@ impl Workspace {
     }
 
     #[wasm_bindgen(js_name = supportsFeature)]
-    pub fn supports_feature(&self, params: ISupportsFeatureParams) -> Result<bool, Error> {
+    pub fn supports_feature(
+        &self,
+        params: ISupportsFeatureParams,
+    ) -> Result<ISupportsFeatureResult, Error> {
         let params: SupportsFeatureParams = params.into_serde().map_err(into_error)?;
-        self.inner.supports_feature(params).map_err(into_error)
+        let result = self.inner.supports_feature(params).map_err(into_error)?;
+        JsValue::from_serde(&result)
+            .map(ISupportsFeatureResult::from)
+            .map_err(into_error)
     }
 
     #[wasm_bindgen(js_name = updateSettings)]

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -52,6 +52,17 @@
           "default": false,
           "type": "boolean"
         },
+        "ignore": {
+          "description": "A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
         "indentSize": {
           "description": "The size of the indentation, 2 by default",
           "default": 2,
@@ -168,6 +179,17 @@
           "description": "if `false`, it disables the feature and the linter won't be executed. `true` by default",
           "default": true,
           "type": "boolean"
+        },
+        "ignore": {
+          "description": "A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
         },
         "rules": {
           "description": "List of rules",

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -9,6 +9,13 @@ export interface RomePath {
 	id: number;
 	path: string;
 }
+export interface SupportsFeatureResult {
+	reason?: UnsupportedReason;
+}
+export type UnsupportedReason =
+	| "Ignored"
+	| "FeatureNotEnabled"
+	| "FileNotSupported";
 export interface UpdateSettingsParams {
 	configuration: Configuration;
 }
@@ -36,6 +43,10 @@ export interface FormatterConfiguration {
 	 */
 	formatWithErrors?: boolean;
 	/**
+	 * A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.
+	 */
+	ignore?: string[];
+	/**
 	 * The size of the indentation, 2 by default
 	 */
 	indentSize?: number;
@@ -62,6 +73,10 @@ export interface LinterConfiguration {
 	 * if `false`, it disables the feature and the linter won't be executed. `true` by default
 	 */
 	enabled?: boolean;
+	/**
+	 * A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.
+	 */
+	ignore?: string[];
 	/**
 	 * List of rules
 	 */
@@ -361,7 +376,9 @@ export interface RenameResult {
 	range: TextRangeSchema;
 }
 export interface Workspace {
-	supportsFeature(params: SupportsFeatureParams): Promise<boolean>;
+	supportsFeature(
+		params: SupportsFeatureParams,
+	): Promise<SupportsFeatureResult>;
 	updateSettings(params: UpdateSettingsParams): Promise<void>;
 	openFile(params: OpenFileParams): Promise<void>;
 	changeFile(params: ChangeFileParams): Promise<void>;

--- a/website/src/credits.md
+++ b/website/src/credits.md
@@ -443,6 +443,10 @@ substantially rewritten.
 	- **Original**: [`rust-analyzer/rowan`](https://github.com/rust-analyzer/rowan)
 	- **License**: Apache License, Version 2.0
 
-- [`crates/rome_rowan`](https://github.com/rome/tools/tree/main/crates/rome_text_size)
+- [`crates/rome_text_size`](https://github.com/rome/tools/tree/main/crates/rome_text_size)
   - **Original**: [`rust-analyzer/text-size`](https://github.com/rust-analyzer/text-size)
   - **License**: Apache License, Version 2.0 or MIT
+
+- [`crates/rome_service/src/ignore/pattern`](https://github.com/rome/tools/tree/main/crates/rome_service/src/ignore/pattern)
+    - **Original**: [`rust-lang/glob`](https://github.com/rust-lang/glob/blob/master/src/lib.rs)
+    - **License**: Apache License, Version 2.0 or MIT


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #2827 

### Configuration 

This PR adds support for ignoring files via configuration. The new field has been added to the `formatter` and the `linter` sections.

```json
{
	"formatter": {
		"ignore": ["path/to"]
	},
	"linter": {
		"ignore": ["*.ts"]
	}
}
```

- the functions `deserialize_globals` and `serialize_globals` have been renamed to `deserialize_set_of_strings` and `serialize_set_of_strings`, so I could apply the same functions for the fields `globals` and `ignore`;

### Matcher

I forked the create [glob](https://github.com/rust-lang/glob) locally. I just copied the engine (parser) of the unix shell style patterns, as we are not interested in actual `glob` function, which does a traversal of the file system. The only changes that I applied to the crate are merely around clippy - it seems there's low activity on the code - and removed some tests. I won't be able to answer technical questions around this crate.

I added license files and credits to the website.

I created a small wrapper called `Matcher` to add patterns and run the matcher against paths and strings. It also holds a `HashMap` to track the already checked paths/strings. 

**There's a catch with this crate**: the crate doesn't support patterns like `"test.ts"`. I tested it myself and I think it's intentional. I added some basic check in the `Matcher` struct to cover this cases, I figured that users might want to ignore single files.

### Workspace

The check is done in two places inside the workspace:
- inside the function `support_features`
- inside a newly created function called `is_file_ignored`

`support_features` now returns a new struct which olds an optional `reason` that explains why the workspace doesn't support a certain file. Before, we were not distinguish the reason why a file couldn't be supported, and this caused some issue that **are not fixed**. If you check the snapshots, you might notice some deletions of some code that was out of place. 

We now use an enum called `UnsupportedReason` which tells the traversal/LSP why a file is not supported, and based on that they can react accordingly. 

`is_file_ignored` is in the workspace `Workspace`. This new function is now used in most of all functions that act on some files, I am not sure if I should extend the functionality also on `get_syntax_tree` and `get_control_flow_graph`.

The usage of `is_file_ignored` has been placed **before the parsing** starts. There's no need to actually parse a file if it's ignored. 

When a file is ignored, we intentionally return an error. It's up to the clients to decide to ignore the error or deal with it. This is a pattern we already apply in case a file is not supported.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added two new tests for the CLI. 

I manually built the VSCode extension and made sure that I don't see diagnostics if a file is ignored. And also if the file doesn't get formatted.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
