### PR TITLE
Draft: reaft(rome_rowan): improvements to the batch mutation api to support multiple mutations

### DIFF
--- a/crates/rome_cli/tests/snapshots/main_check/lint_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/lint_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `check.js`
@@ -37,7 +36,7 @@ error[js/useWhile]: Use while loops instead of for loops.
 Suggested fix: Use a while loop
     | @@ -1 +1 @@
 0   | - for(;true;);
-  0 | + while (true);
+  0 | +  while (true);
 
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_check/maximum_diagnostics.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/maximum_diagnostics.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `check.js`
@@ -47,13 +46,13 @@ error[js/useWhile]: Use while loops instead of for loops.
   │ ^^^^^^^^^^^
 
 Suggested fix: Use a while loop
-    | @@ -1,5 +1,5 @@
-0 0 |   
+    | @@ -1,5 +1,4 @@
+0   | - 
 1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  1 | + while (true);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  0 | +  while (true);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+2 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
 ```
@@ -88,7 +87,7 @@ Suggested fix: Use a while loop
     | @@ -1,5 +1,5 @@
 0 0 |   
 1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  1 | + for(;true;);while (true);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;); while (true);for(;true;);for(;true;);for(;true;);for(;true;);
 2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
@@ -126,7 +125,7 @@ Suggested fix: Use a while loop
     | @@ -1,5 +1,5 @@
 0 0 |   
 1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  1 | + for(;true;);for(;true;);while (true);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;); while (true);for(;true;);for(;true;);for(;true;);
 2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
@@ -164,7 +163,7 @@ Suggested fix: Use a while loop
     | @@ -1,5 +1,5 @@
 0 0 |   
 1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  1 | + for(;true;);for(;true;);for(;true;);while (true);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;); while (true);for(;true;);for(;true;);
 2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
@@ -202,7 +201,7 @@ Suggested fix: Use a while loop
     | @@ -1,5 +1,5 @@
 0 0 |   
 1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  1 | + for(;true;);for(;true;);for(;true;);for(;true;);while (true);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;);for(;true;); while (true);for(;true;);
 2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
@@ -240,7 +239,7 @@ Suggested fix: Use a while loop
     | @@ -1,5 +1,5 @@
 0 0 |   
 1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  1 | + for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);while (true);
+  1 | + for(;true;);for(;true;);for(;true;);for(;true;);for(;true;); while (true);
 2 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
@@ -276,14 +275,14 @@ error[js/useWhile]: Use while loops instead of for loops.
   │ ^^^^^^^^^^^
 
 Suggested fix: Use a while loop
-    | @@ -1,6 +1,6 @@
+    | @@ -1,6 +1,5 @@
 0 0 |   
-1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+1   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  2 | + while (true);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+  1 | + for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;); while (true);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+3 2 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+4 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
+5 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 
 ```
@@ -320,7 +319,7 @@ Suggested fix: Use a while loop
 0 0 |   
 1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  2 | + for(;true;);while (true);for(;true;);for(;true;);for(;true;);for(;true;);
+  2 | + for(;true;); while (true);for(;true;);for(;true;);for(;true;);for(;true;);
 3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
@@ -360,7 +359,7 @@ Suggested fix: Use a while loop
 0 0 |   
 1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  2 | + for(;true;);for(;true;);while (true);for(;true;);for(;true;);for(;true;);
+  2 | + for(;true;);for(;true;); while (true);for(;true;);for(;true;);for(;true;);
 3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
@@ -400,7 +399,7 @@ Suggested fix: Use a while loop
 0 0 |   
 1 1 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 2   | - for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
-  2 | + for(;true;);for(;true;);for(;true;);while (true);for(;true;);for(;true;);
+  2 | + for(;true;);for(;true;);for(;true;); while (true);for(;true;);for(;true;);
 3 3 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 4 4 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 5 5 |   for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);

--- a/crates/rome_cli/tests/snapshots/main_ci/ci_lint_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/ci_lint_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `ci.js`
@@ -37,7 +36,7 @@ error[js/useWhile]: Use while loops instead of for loops.
 Suggested fix: Use a while loop
     | @@ -1 +1 @@
 0   | - for(;true;);
-  0 | + while (true);
+  0 | +  while (true);
 
 
 ```

--- a/crates/rome_js_analyze/src/utils/batch.rs
+++ b/crates/rome_js_analyze/src/utils/batch.rs
@@ -172,6 +172,11 @@ impl JsBatchMutation for BatchMutation<JsLanguage> {
 
 #[cfg(test)]
 mod tests {
+    use rome_js_factory::make;
+    use rome_js_parser::parse;
+    use rome_js_syntax::{JsAnyExpression, JsLogicalExpression, SourceType, T};
+    use rome_rowan::{BatchMutationExt, SyntaxNodeCast};
+
     use crate::assert_remove_ok;
 
     // Remove JsVariableDeclarator
@@ -229,5 +234,44 @@ mod tests {
         ok_remove_formal_parameter_from_class_constructor_middle,
             "class A { constructor(b, a, c) {} }",
             "class A { constructor(b, c) {} }",
+    }
+
+    #[test]
+    pub fn ok_recursive_batch_mutation() {
+        let r = parse("if (a && a.b && a.b.c) {}", 0, SourceType::js_module());
+
+        let exprs: Vec<JsLogicalExpression> = r
+            .syntax()
+            .descendants()
+            .filter_map(|x| x.cast::<JsLogicalExpression>())
+            .collect();
+
+        let mut batch = r.tree().begin();
+
+        let right = exprs[0].right().ok().unwrap();
+        let right = right.as_js_static_member_expression().unwrap().clone();
+
+        batch.replace_node(
+            JsAnyExpression::JsLogicalExpression(exprs[0].clone()),
+            JsAnyExpression::JsStaticMemberExpression(right.clone()),
+        );
+
+        // batch.replace_token_slot(&right, 1, make::token(T![?.]));
+        // batch.replace_token_slot(&right.object().unwrap(), 1, make::token(T![?.]));
+
+        batch.replace_token(right.operator_token().unwrap(), make::token(T![?.]));
+
+        let obj = right.object().unwrap();
+        batch.replace_token(
+            obj.as_js_static_member_expression()
+                .unwrap()
+                .operator_token()
+                .unwrap(),
+            make::token(T![?.]),
+        );
+
+        let root = batch.commit();
+        let after = root.to_string();
+        assert_eq!("if (a?.b?.c) {}", after.as_str());
     }
 }


### PR DESCRIPTION
## Summary

This PR removes a limitation on the BatchMutation to allow multiple mutations to the same node.
Now we can do something like: 

```rust
let r = parse("if (a && a.b && a.b.c) {}", 0, SourceType::js_module());

let mut batch = r.tree().begin();

        let right = exprs[0].right().ok().unwrap();
        let right = right.as_js_static_member_expression().unwrap().clone();

        batch.replace_node(
            JsAnyExpression::JsLogicalExpression(exprs[0].clone()),
            JsAnyExpression::JsStaticMemberExpression(right.clone()),
        );

        // batch.replace_token_slot(&right, 1, make::token(T![?.]));
        // batch.replace_token_slot(&right.object().unwrap(), 1, make::token(T![?.]));

        batch.replace_token(right.operator_token().unwrap(), make::token(T![?.]));

        let obj = right.object().unwrap();
        batch.replace_token(
            obj.as_js_static_member_expression()
                .unwrap()
                .operator_token()
                .unwrap(),
            make::token(T![?.]),
        );

        let root = batch.commit();
```

I am also planning on leaving as comments the ```println!``` explaining what the mutation is doing.

```
-----------
Before: "a.b"
. -> Some("?.")
After: "a?.b"
-----------
Before: "a.b.c"
a.b -> Some("a?.b")
. -> Some("?.")
After: "a?.b?.c"
Another mutation uses this node. Stashing to use this new version later
-----------
Before: "if (a && a.b && a.b.c) {}"
a && a.b && a.b.c -> Some("a.b.c")
There is a newer version of this node in the stash. Using it: Some("a?.b?.c")
After: "if (a?.b?.c) {}"
-----------
Before: "if (a && a.b && a.b.c) {}"
if (a && a.b && a.b.c) {} -> Some("if (a?.b?.c) {}")
After: "if (a?.b?.c) {}"
-----------
Before: "if (a && a.b && a.b.c) {}"
if (a && a.b && a.b.c) {} -> Some("if (a?.b?.c) {}")
After: "if (a?.b?.c) {}"
-----------
Final: "if (a?.b?.c) {}"
```

## Test Plan

```
> cargo test -p rome_js_analyze -- ok_recursive_batch_mutation --nocapture
```


