### PR TITLE
test(rome_js_formatter): Remove `JsFormatOptions` `Default` implementation

### DIFF
--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 use std::rc::Rc;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct JsFormatContext {
     options: JsFormatOptions,
 
@@ -25,7 +25,7 @@ impl JsFormatContext {
         Self {
             options,
             comments: Rc::new(comments),
-            ..JsFormatContext::default()
+            source_map: None,
         }
     }
 
@@ -76,7 +76,7 @@ impl CstFormatContext for JsFormatContext {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct JsFormatOptions {
     /// The indent style.
     indent_style: IndentStyle,
@@ -98,7 +98,10 @@ impl JsFormatOptions {
     pub fn new(source_type: SourceType) -> Self {
         Self {
             source_type,
-            ..JsFormatOptions::default()
+            indent_style: IndentStyle::default(),
+            line_width: LineWidth::default(),
+            quote_style: QuoteStyle::default(),
+            quote_properties: QuoteProperties::default(),
         }
     }
 
@@ -119,11 +122,6 @@ impl JsFormatOptions {
 
     pub fn with_quote_properties(mut self, quote_properties: QuoteProperties) -> Self {
         self.quote_properties = quote_properties;
-        self
-    }
-
-    pub fn with_source_type(mut self, source_type: SourceType) -> Self {
-        self.source_type = source_type;
         self
     }
 

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -631,7 +631,7 @@ while(
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions::default().with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -663,7 +663,7 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions::default().with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -694,7 +694,7 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions::default().with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -713,7 +713,7 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions::default().with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -735,7 +735,7 @@ function() {
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            JsFormatOptions::default().with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -750,13 +750,13 @@ function() {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-const getIconEngagementTypeFrom = (engagementTypes: Array<EngagementType>) =>
-	(iconEngagementType) =>
-		engagementTypes.includes(iconEngagementType);
+const obj1 = conditionIsTruthy
+           ? { some: "long", object: "with", lots: "of", stuff }
+           : shortThing;
 "#;
         let syntax = SourceType::tsx();
         let tree = parse(src, 0, syntax);
-        let options = JsFormatOptions::default();
+        let options = JsFormatOptions::new(syntax);
 
         let result = format_node(options.clone(), &tree.syntax())
             .unwrap()
@@ -782,7 +782,7 @@ const getIconEngagementTypeFrom = (engagementTypes: Array<EngagementType>) =>
         let tree = parse(src, 0, syntax);
 
         let result = format_range(
-            JsFormatOptions::default(),
+            JsFormatOptions::new(syntax),
             &tree.syntax(),
             TextRange::new(TextSize::from(0), TextSize::of(src) + TextSize::from(5)),
         );

--- a/crates/rome_js_formatter/src/syntax_rewriter.rs
+++ b/crates/rome_js_formatter/src/syntax_rewriter.rs
@@ -499,6 +499,7 @@ mod tests {
     use rome_js_syntax::{
         JsArrayExpression, JsBinaryExpression, JsExpressionStatement, JsIdentifierExpression,
         JsLogicalExpression, JsSequenceExpression, JsStringLiteralExpression, JsSyntaxNode,
+        SourceType,
     };
     use rome_rowan::{AstNode, SyntaxRewriter, TextSize};
 
@@ -766,7 +767,8 @@ mod tests {
     fn mappings() {
         let (transformed, source_map) = source_map_test("(((a * b) * c)) / 3");
 
-        let formatted = format_node(JsFormatOptions::default(), &transformed).unwrap();
+        let formatted =
+            format_node(JsFormatOptions::new(SourceType::default()), &transformed).unwrap();
         let printed = formatted.print();
 
         assert_eq!(printed.as_code(), "(a * b * c) / 3;\n");

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -66,7 +66,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
     let has_errors = parsed.has_errors();
     let syntax = parsed.syntax();
 
-    let options = JsFormatOptions::default().with_indent_style(IndentStyle::Space(2));
+    let options = JsFormatOptions::new(source_type).with_indent_style(IndentStyle::Space(2));
 
     let result = match (range_start_index, range_end_index) {
         (Some(start), Some(end)) => {

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -226,7 +226,7 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
         let root = parsed.syntax();
 
         // we ignore the error for now
-        let options = JsFormatOptions::default();
+        let options = JsFormatOptions::new(source_type);
         let formatted = format_node(options.clone(), &root).unwrap();
         let printed = formatted.print();
         let file_name = spec_input_file.file_name().unwrap().to_str().unwrap();
@@ -237,11 +237,11 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
                 text: printed.as_code(),
                 source_type,
                 file_name,
-                options,
+                options: options.clone(),
             });
         }
 
-        snapshot_content.add_output(printed, JsFormatOptions::default());
+        snapshot_content.add_output(printed, options);
 
         let test_directory = PathBuf::from(test_directory);
         let options_path = test_directory.join("options.json");
@@ -253,10 +253,9 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
                     serde_json::from_str(options_path.get_buffer_from_file().as_str()).unwrap();
 
                 for test_case in options.cases {
-                    let mut format_options: JsFormatOptions = test_case.into();
+                    let format_options: JsFormatOptions = test_case.into();
                     // we don't track the source type inside the serializable structs, so we
                     // inject it here
-                    format_options = format_options.with_source_type(source_type);
                     let formatted = format_node(format_options.clone(), &root).unwrap();
                     let printed = formatted.print();
 

--- a/crates/rome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
@@ -54,9 +54,9 @@ type X = {
 	member: string;
 	// you stay like this
 	"member-member": number;
-	4: number;
+	"4": number;
 	with_underscore: number;
-	0197: number;
+	"0197": number;
 	"3n": number;
 	"3p": number;
 	p9: number;
@@ -68,9 +68,9 @@ interface Y {
 	member: string;
 	// you stay like this
 	"member-member": number;
-	4: number;
+	"4": number;
 	with_underscore: number;
-	0197: number;
+	"0197": number;
 	"3n": number;
 	"3p": number;
 	p9: number;
@@ -79,7 +79,7 @@ interface Y {
 }
 
 const Y = {
-	123: false,
+	"123": false,
 	"3n": false,
 	12334: false,
 };
@@ -96,9 +96,9 @@ type X = {
 	member: string;
 	// you stay like this
 	'member-member': number;
-	'4': number;
+	4: number;
 	with_underscore: number;
-	'0197': number;
+	0197: number;
 	'3n': number;
 	'3p': number;
 	p9: number;
@@ -110,9 +110,9 @@ interface Y {
 	member: string;
 	// you stay like this
 	'member-member': number;
-	'4': number;
+	4: number;
 	with_underscore: number;
-	'0197': number;
+	0197: number;
 	'3n': number;
 	'3p': number;
 	p9: number;
@@ -121,7 +121,7 @@ interface Y {
 }
 
 const Y = {
-	'123': false,
+	123: false,
 	'3n': false,
 	12334: false,
 };

--- a/crates/rome_js_parser/src/lexer/tables.rs
+++ b/crates/rome_js_parser/src/lexer/tables.rs
@@ -775,7 +775,9 @@ pub mod derived_property {
         ('𰀀', '𱍊'),
         ('\u{e0100}', '\u{e01ef}'),
     ];
-    pub fn ID_Continue(c: char) -> bool { super::bsearch_range_table(c, ID_Continue_table) }
+    pub fn ID_Continue(c: char) -> bool {
+        super::bsearch_range_table(c, ID_Continue_table)
+    }
     pub const ID_Start_table: &[(char, char)] = &[
         ('A', 'Z'),
         ('a', 'z'),
@@ -1426,5 +1428,7 @@ pub mod derived_property {
         ('丽', '𪘀'),
         ('𰀀', '𱍊'),
     ];
-    pub fn ID_Start(c: char) -> bool { super::bsearch_range_table(c, ID_Start_table) }
+    pub fn ID_Start(c: char) -> bool {
+        super::bsearch_range_table(c, ID_Start_table)
+    }
 }

--- a/crates/rome_js_parser/src/lexer/tables.rs
+++ b/crates/rome_js_parser/src/lexer/tables.rs
@@ -775,9 +775,7 @@ pub mod derived_property {
         ('𰀀', '𱍊'),
         ('\u{e0100}', '\u{e01ef}'),
     ];
-    pub fn ID_Continue(c: char) -> bool {
-        super::bsearch_range_table(c, ID_Continue_table)
-    }
+    pub fn ID_Continue(c: char) -> bool { super::bsearch_range_table(c, ID_Continue_table) }
     pub const ID_Start_table: &[(char, char)] = &[
         ('A', 'Z'),
         ('a', 'z'),
@@ -1428,7 +1426,5 @@ pub mod derived_property {
         ('丽', '𪘀'),
         ('𰀀', '𱍊'),
     ];
-    pub fn ID_Start(c: char) -> bool {
-        super::bsearch_range_table(c, ID_Start_table)
-    }
+    pub fn ID_Start(c: char) -> bool { super::bsearch_range_table(c, ID_Start_table) }
 }

--- a/crates/rome_wasm/build.rs
+++ b/crates/rome_wasm/build.rs
@@ -2,6 +2,7 @@ use std::{env, fs, io, path::PathBuf};
 
 use quote::{format_ident, quote};
 
+use rome_js_factory::syntax::SourceType;
 use rome_js_factory::{
     make,
     syntax::{JsAnyDeclaration, JsAnyModuleItem, JsAnyStatement},
@@ -66,7 +67,7 @@ fn main() -> io::Result<()> {
 
     // Wasm-bindgen will paste the generated TS code as-is into the final .d.ts file,
     // ensure it looks good by running it through the formatter
-    let formatted = format_node(JsFormatOptions::default(), module.syntax()).unwrap();
+    let formatted = format_node(JsFormatOptions::new(SourceType::ts()), module.syntax()).unwrap();
     let printed = formatted.print();
     let definitions = printed.into_code();
 

--- a/xtask/bench/src/features/formatter.rs
+++ b/xtask/bench/src/features/formatter.rs
@@ -4,7 +4,7 @@ use crate::BenchmarkSummary;
 use rome_formatter::Printed;
 use rome_js_formatter::context::JsFormatOptions;
 use rome_js_formatter::format_node;
-use rome_js_syntax::JsSyntaxNode;
+use rome_js_syntax::{JsSyntaxNode, SourceType};
 use std::fmt::{Display, Formatter};
 use std::time::Duration;
 
@@ -13,9 +13,13 @@ pub struct FormatterMeasurement {
     id: String,
     formatting: Duration,
 }
-pub fn benchmark_format_lib(id: &str, root: &JsSyntaxNode) -> BenchmarkSummary {
+pub fn benchmark_format_lib(
+    id: &str,
+    root: &JsSyntaxNode,
+    source_type: SourceType,
+) -> BenchmarkSummary {
     let formatter_timer = timing::start();
-    run_format(root);
+    run_format(root, source_type);
     let formatter_duration = formatter_timer.stop();
 
     BenchmarkSummary::Formatter(FormatterMeasurement {
@@ -24,14 +28,14 @@ pub fn benchmark_format_lib(id: &str, root: &JsSyntaxNode) -> BenchmarkSummary {
     })
 }
 
-pub fn run_format(root: &JsSyntaxNode) -> Printed {
+pub fn run_format(root: &JsSyntaxNode, source_type: SourceType) -> Printed {
     #[cfg(feature = "dhat-on")]
     let stats = {
         println!("Start");
         dhat::get_stats().unwrap()
     };
 
-    let formatted = format_node(JsFormatOptions::default(), root).unwrap();
+    let formatted = format_node(JsFormatOptions::new(source_type), root).unwrap();
 
     #[cfg(feature = "dhat-on")]
     let stats = {

--- a/xtask/bench/src/lib.rs
+++ b/xtask/bench/src/lib.rs
@@ -153,7 +153,7 @@ pub fn run(args: RunArgs) {
                         FeatureToBenchmark::Formatter => {
                             let root = parse(code, 0, source_type).syntax();
                             b.iter(|| {
-                                criterion::black_box(run_format(&root));
+                                criterion::black_box(run_format(&root, source_type));
                             })
                         }
                         FeatureToBenchmark::Analyzer => {
@@ -170,7 +170,7 @@ pub fn run(args: RunArgs) {
                     FeatureToBenchmark::Parser => benchmark_parse_lib(&id, code, source_type),
                     FeatureToBenchmark::Formatter => {
                         let root = parse(code, 0, source_type).syntax();
-                        benchmark_format_lib(&id, &root)
+                        benchmark_format_lib(&id, &root, source_type)
                     }
                     FeatureToBenchmark::Analyzer => {
                         let root = parse(code, 0, source_type).tree();

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -5,7 +5,8 @@ use rome_js_syntax::{
     JsAnyExportClause, JsAnyExpression, JsAnyFormalParameter, JsAnyImportClause,
     JsAnyLiteralExpression, JsAnyModuleItem, JsAnyName, JsAnyNamedImport,
     JsAnyNamedImportSpecifier, JsAnyObjectMember, JsAnyObjectMemberName, JsAnyParameter,
-    JsAnyStatement, TriviaPieceKind, TsAnyName, TsAnyReturnType, TsAnyTypeMember, TsType, T,
+    JsAnyStatement, SourceType, TriviaPieceKind, TsAnyName, TsAnyReturnType, TsAnyTypeMember,
+    TsType, T,
 };
 use rome_rowan::AstNode;
 use rome_service::workspace_types::{generate_type, methods, ModuleQueue};
@@ -393,7 +394,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
     )
     .build();
 
-    let formatted = format_node(JsFormatOptions::default(), module.syntax()).unwrap();
+    let formatted = format_node(JsFormatOptions::new(SourceType::ts()), module.syntax()).unwrap();
     let printed = formatted.print();
     let code = printed.into_code();
 


### PR DESCRIPTION
This PR removes the `Default` implementation from `JsFormatOptions` because passing a `SourceType` that matches with the type of the AST is mandatory to get correct formatting results. Assuming a default isn't safe because the formatting may depend on the correct source type.

I noticed that we aren't always passing in the right source type when adding another test to only apply some expensive logic if the source type is JSX and it never took that branch.

## Tests

See now changed prettier tests
