### PR TITLE
perf(rome_service): increase the throughput of the remote daemon transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "crossbeam",
+ "dashmap",
  "hdrhistogram",
  "insta",
  "lazy_static",

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0.133", features = ["derive"] }
 serde_json = { version = "1.0.74" }
 tokio = { version = "1.15.0", features = ["io-std", "io-util", "net", "time", "rt", "rt-multi-thread", "macros"] }
 anyhow = "1.0.52"
+dashmap = "5.2.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.127"

--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -131,7 +131,7 @@ pub(crate) fn execute_mode(mode: Execution, mut session: CliSession) -> Result<(
             let can_format = workspace.supports_feature(SupportsFeatureParams {
                 path: rome_path.clone(),
                 feature: FeatureName::Format,
-            });
+            })?;
             if can_format {
                 workspace.open_file(OpenFileParams {
                     path: rome_path.clone(),

--- a/crates/rome_cli/src/service/mod.rs
+++ b/crates/rome_cli/src/service/mod.rs
@@ -113,7 +113,7 @@ impl SocketTransport {
         W: AsyncWrite + Unpin + Send + 'static,
     {
         /// Capacity of the "write channel", once this many requests have been
-        /// queued up calls to `write_send.send` will block the sending task
+        /// queued up, calls to `write_send.send` will block the sending task
         /// until enough capacity is available again
         ///
         /// Note that this does not limit how many requests can be in flight at

--- a/crates/rome_cli/src/service/unix.rs
+++ b/crates/rome_cli/src/service/unix.rs
@@ -8,7 +8,7 @@ use std::{
 
 use rome_lsp::{ServerConnection, ServerFactory};
 use tokio::{
-    io::{split, Interest},
+    io::Interest,
     net::{
         unix::{OwnedReadHalf, OwnedWriteHalf},
         UnixListener, UnixStream,

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -18,7 +18,7 @@ use rome_service::{
     workspace::{
         FeatureName, FileGuard, Language, OpenFileParams, RuleCategories, SupportsFeatureParams,
     },
-    Workspace,
+    RomeError, Workspace,
 };
 use std::{
     collections::HashMap,
@@ -434,7 +434,7 @@ impl<'ctx, 'app> TraversalOptions<'ctx, 'app> {
         self.messages.send(msg.into()).ok();
     }
 
-    fn can_format(&self, rome_path: &RomePath) -> bool {
+    fn can_format(&self, rome_path: &RomePath) -> Result<bool, RomeError> {
         self.workspace.supports_feature(SupportsFeatureParams {
             path: rome_path.clone(),
             feature: FeatureName::Format,
@@ -447,7 +447,7 @@ impl<'ctx, 'app> TraversalOptions<'ctx, 'app> {
             .ok();
     }
 
-    fn can_lint(&self, rome_path: &RomePath) -> bool {
+    fn can_lint(&self, rome_path: &RomePath) -> Result<bool, RomeError> {
         self.workspace.supports_feature(SupportsFeatureParams {
             path: rome_path.clone(),
             feature: FeatureName::Lint,
@@ -470,10 +470,20 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
     }
 
     fn can_handle(&self, rome_path: &RomePath) -> bool {
-        match self.execution.traversal_mode() {
+        let result = match self.execution.traversal_mode() {
             TraversalMode::Check { .. } => self.can_lint(rome_path),
-            TraversalMode::CI { .. } => self.can_lint(rome_path) || self.can_format(rome_path),
+            TraversalMode::CI { .. } => self
+                .can_lint(rome_path)
+                .and_then(|can_lint| Ok(can_lint || self.can_format(rome_path)?)),
             TraversalMode::Format { .. } => self.can_format(rome_path),
+        };
+
+        match result {
+            Ok(result) => result,
+            Err(err) => {
+                self.push_diagnostic(rome_path.file_id(), "IO", err.to_string());
+                false
+            }
         }
     }
 
@@ -543,10 +553,18 @@ type FileResult = Result<FileStatus, Message>;
 fn process_file(ctx: &TraversalOptions, path: &Path, file_id: FileId) -> FileResult {
     tracing::trace_span!("process_file", path = ?path).in_scope(move || {
         let rome_path = RomePath::new(path, file_id);
-        let can_format = ctx.can_format(&rome_path);
+        let can_format = ctx
+            .can_format(&rome_path)
+            .with_file_id_and_code(file_id, "IO")?;
         let can_handle = match ctx.execution.traversal_mode() {
-            TraversalMode::Check { .. } => ctx.can_lint(&rome_path),
-            TraversalMode::CI { .. } => ctx.can_lint(&rome_path) || can_format,
+            TraversalMode::Check { .. } => ctx
+                .can_lint(&rome_path)
+                .with_file_id_and_code(file_id, "IO")?,
+            TraversalMode::CI { .. } => {
+                ctx.can_lint(&rome_path)
+                    .with_file_id_and_code(file_id, "IO")?
+                    || can_format
+            }
             TraversalMode::Format { .. } => can_format,
         };
 

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -1513,7 +1513,8 @@ fn run_cli<'app>(
     let (stdin, stdout) = split(server);
     runtime.spawn(connection.accept(stdin, stdout));
 
-    let transport = SocketTransport::open(runtime, client);
+    let (client_read, client_write) = split(client);
+    let transport = SocketTransport::open(runtime, client_read, client_write);
 
     let workspace = workspace::client(transport).unwrap();
     let app = App::new(fs, console, WorkspaceRef::Owned(workspace));

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -205,10 +205,13 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
     );
 
     let mut rome_path = RomePath::new(file_path, 0);
-    let can_format = app.workspace.supports_feature(SupportsFeatureParams {
-        path: rome_path.clone(),
-        feature: FeatureName::Format,
-    });
+    let can_format = app
+        .workspace
+        .supports_feature(SupportsFeatureParams {
+            path: rome_path.clone(),
+            feature: FeatureName::Format,
+        })
+        .unwrap();
 
     if can_format {
         let mut snapshot_content = SnapshotContent::default();

--- a/crates/rome_lsp/src/handlers/analysis.rs
+++ b/crates/rome_lsp/src/handlers/analysis.rs
@@ -31,7 +31,7 @@ pub(crate) fn code_actions(
     let linter_enabled = &session.workspace.supports_feature(SupportsFeatureParams {
         path: rome_path,
         feature: FeatureName::Lint,
-    });
+    })?;
     if !linter_enabled {
         return Ok(Some(Vec::new()));
     }

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -189,6 +189,10 @@ macro_rules! workspace_method {
                 });
 
                 result.map(move |result| {
+                    // The type of `result` is `Result<Result<R, RomeError>, JoinError>`,
+                    // where the inner result is the return value of `$method` while the
+                    // outer one is added by `spawn_blocking` to catch panics or
+                    // cancellations of the task
                     match result {
                         Ok(Ok(result)) => Ok(result),
                         Ok(Err(err)) => Err(into_lsp_error(err)),

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -6,9 +6,11 @@ use crate::session::Session;
 use crate::utils::{into_lsp_error, panic_to_lsp_error};
 use crate::{handlers, requests};
 use futures::future::ready;
+use futures::FutureExt;
 use rome_service::{workspace, Workspace};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Notify;
+use tokio::task::spawn_blocking;
 use tower_lsp::jsonrpc::Result as LspResult;
 use tower_lsp::{lsp_types::*, ClientSocket};
 use tower_lsp::{Client, LanguageServer, LspService, Server};
@@ -178,13 +180,21 @@ macro_rules! workspace_method {
         $builder = $builder.custom_method(
             concat!("rome/", stringify!($method)),
             |server: &LSPServer, params| {
-                let workspace = &server.session.workspace;
-                let result = catch_unwind(move || workspace.$method(params));
+                let span = tracing::trace_span!(concat!("rome/", stringify!($method)), params = ?params).or_current();
 
-                ready(match result {
-                    Ok(Ok(result)) => Ok(result),
-                    Ok(Err(err)) => Err(into_lsp_error(err)),
-                    Err(err) => Err(panic_to_lsp_error(err)),
+                let workspace = server.session.workspace.clone();
+                let result = spawn_blocking(move || {
+                    let _guard = span.entered();
+                    catch_unwind(move || workspace.$method(params))
+                });
+
+                result.map(move |result| {
+                    match result {
+                        Ok(Ok(Ok(result))) => Ok(result),
+                        Ok(Ok(Err(err))) => Err(into_lsp_error(err)),
+                        Ok(Err(err)) => Err(panic_to_lsp_error(err)),
+                        Err(err) => Err(into_lsp_error(err)),
+                    }
                 })
             },
         );
@@ -212,11 +222,7 @@ impl ServerFactory {
             ready(Ok(Some(())))
         });
 
-        // supports_feature is special because it returns a bool instead of a Result
-        builder = builder.custom_method("rome/supports_feature", |server: &LSPServer, params| {
-            ready(Ok(server.session.workspace.supports_feature(params)))
-        });
-
+        workspace_method!(builder, supports_feature);
         workspace_method!(builder, update_settings);
         workspace_method!(builder, open_file);
         workspace_method!(builder, get_syntax_tree);

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -119,7 +119,7 @@ impl Session {
         let lint_enabled = self.workspace.supports_feature(SupportsFeatureParams {
             feature: FeatureName::Lint,
             path: rome_path.clone(),
-        });
+        })?;
 
         let diagnostics = if lint_enabled {
             let result = self.workspace.pull_diagnostics(PullDiagnosticsParams {

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -174,6 +174,8 @@ impl From<TransportError> for RomeError {
 pub enum TransportError {
     /// Error emitted by the transport layer if the connection was lost due to an I/O error
     ChannelClosed,
+    /// Error emitted by the transport layer if a request timed out
+    Timeout,
     /// Error caused by a serialization or deserialization issue
     SerdeError(String),
     /// Generic error type for RPC errors that can't be deserialized into RomeError
@@ -189,14 +191,11 @@ impl Display for TransportError {
             TransportError::ChannelClosed => fmt.write_str(
                 "a request to the remote workspace failed because the connection was interrupted",
             ),
+            TransportError::Timeout => {
+                fmt.write_str("the request to the remote workspace timed out")
+            }
             TransportError::RPCError(err) => fmt.write_str(err),
         }
-    }
-}
-
-impl From<serde_json::Error> for TransportError {
-    fn from(err: serde_json::Error) -> Self {
-        TransportError::SerdeError(err.to_string())
     }
 }
 

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -63,7 +63,7 @@ use rome_rowan::TextRangeSchema;
 use rome_text_edit::Indel;
 use std::{borrow::Cow, panic::RefUnwindSafe, sync::Arc};
 
-pub use self::client::{WorkspaceClient, WorkspaceTransport};
+pub use self::client::{TransportRequest, WorkspaceClient, WorkspaceTransport};
 pub use crate::file_handlers::Language;
 
 mod client;
@@ -259,7 +259,7 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// Checks whether a certain feature is supported. There are different conditions:
     /// - Rome doesn't recognize a file, so it can provide the feature;
     /// - the feature is disabled inside the configuration;
-    fn supports_feature(&self, params: SupportsFeatureParams) -> bool;
+    fn supports_feature(&self, params: SupportsFeatureParams) -> Result<bool, RomeError>;
 
     /// Update the global settings for this workspace
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), RomeError>;

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -162,15 +162,16 @@ impl WorkspaceServer {
 }
 
 impl Workspace for WorkspaceServer {
-    fn supports_feature(&self, params: SupportsFeatureParams) -> bool {
+    fn supports_feature(&self, params: SupportsFeatureParams) -> Result<bool, RomeError> {
         let capabilities = self.get_capabilities(&params.path);
         let settings = self.settings.read().unwrap();
-        match params.feature {
+        let result = match params.feature {
             FeatureName::Format => {
                 capabilities.formatter.format.is_some() && settings.formatter().enabled
             }
             FeatureName::Lint => capabilities.analyzer.lint.is_some() && settings.linter().enabled,
-        }
+        };
+        Ok(result)
     }
 
     /// Update the global settings for this workspace

--- a/crates/rome_wasm/src/lib.rs
+++ b/crates/rome_wasm/src/lib.rs
@@ -38,7 +38,7 @@ impl Workspace {
     #[wasm_bindgen(js_name = supportsFeature)]
     pub fn supports_feature(&self, params: ISupportsFeatureParams) -> Result<bool, Error> {
         let params: SupportsFeatureParams = params.into_serde().map_err(into_error)?;
-        Ok(self.inner.supports_feature(params))
+        self.inner.supports_feature(params).map_err(into_error)
     }
 
     #[wasm_bindgen(js_name = updateSettings)]


### PR DESCRIPTION
## Summary

This PR improves the performance of the remote daemon transport, primarily by allowing both the client and server to process more requests at the same time. The changes include:
- Refactored the `WorkspaceTransport` trait to make it aware of request IDs. This lets the transport layer send out multiple requests to the remote server at the same time and process the responses out of order (this makes use of the `dashmap` crate to store the handles of pending requests in a thread-safe hashmap)
- Use the `OwnedReadHalf` and `OwnedWriteHalf` types provided by `tokio` on Unix, and manually implemented `<Client|Server>ReadHalf` and `<Client|Server>WriteHalf` types on Windows to support "true" parallel I/O operations on the transport socket, rather than relying on the `split` function provided by `tokio` (that relies on a form of spinlocking internally)
- Run the implementation of all the `rome/*` remote calls in the blocking thread pool of the server. This avoids starving the scheduler if a file takes longer to process

Additionally, I also modified the signature of the `supports_feature` method of the Workspace to return a `Result`, since it may error as any other method if there's an issue with the remote connection. Finally, I added a timeout error to all remote calls as a last-resort measure, currently the timeout is fixed to 15 seconds.

## Test Plan

These are internal-only changes that should not be visible to end users, some of these are covered by the tests for the node.js JSON-RPC bindings but the OS-specific I/O code is still mostly untested.
