### PR TITLE
ci: stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '00 12 * * 1-5'
 
 jobs:
   stale:
@@ -9,14 +9,10 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          stale-pr-message: 'This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          stale-issue-message: 'This issue is stale because it has been open 14 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 14 days with no activity.'
           days-before-issue-stale: 14
           days-before-pr-stale: 14
-          days-before-issue-close: 5
-          days-before-pr-close: 7
           exempt-pr-labels: 'PR: on hold'
           stale-issue-label: 'S-Stale'
           stale-pr-label: 'S-Stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          days-before-issue-stale: 14
+          days-before-pr-stale: 14
+          days-before-issue-close: 5
+          days-before-pr-close: 7
+          exempt-pr-labels: 'PR: on hold'
+          stale-issue-label: 'S-Stale'
+          stale-pr-label: 'S-Stale'


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR implements a simple cron job to automatically mark PRs/issues in stale state using the 'S-Stable' label. Then, the action proceeds to close them if there's further inactivity.

PRs with the label 'PR: on hold' are exempt. 


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Merge it and wait. The example was copied from the [repository of the action](https://github.com/actions/stale)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
