### PR TITLE
chore(rome_service): remove constraints from settings

### DIFF
--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -87,10 +87,10 @@ pub(crate) fn apply_format_settings_from_cli(
 
     match indent_style {
         Some(IndentStyle::Tab) => {
-            workspace_settings.format.indent_style = Some(IndentStyle::Tab);
+            workspace_settings.formatter.indent_style = Some(IndentStyle::Tab);
         }
         Some(IndentStyle::Space(default_size)) => {
-            workspace_settings.format.indent_style =
+            workspace_settings.formatter.indent_style =
                 Some(IndentStyle::Space(size.unwrap_or(default_size)));
         }
         None => {}
@@ -133,7 +133,7 @@ pub(crate) fn apply_format_settings_from_cli(
         })?;
 
     if let Some(line_width) = line_width {
-        workspace_settings.format.line_width = Some(line_width);
+        workspace_settings.formatter.line_width = Some(line_width);
     }
 
     Ok(())

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -18,7 +18,6 @@ mod formatter;
 mod javascript;
 pub mod linter;
 
-pub(crate) use javascript::{deserialize_globals, serialize_globals};
 pub use linter::{RuleConfiguration, Rules};
 
 /// The configuration that is contained inside the file `rome.json`

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -167,9 +167,9 @@ impl Workspace for WorkspaceServer {
         let settings = self.settings.read().unwrap();
         match params.feature {
             FeatureName::Format => {
-                capabilities.formatter.format.is_some() && settings.format.enabled
+                capabilities.formatter.format.is_some() && settings.formatter().enabled
             }
-            FeatureName::Lint => capabilities.analyzer.lint.is_some() && settings.linter.enabled,
+            FeatureName::Lint => capabilities.analyzer.lint.is_some() && settings.linter().enabled,
         }
     }
 
@@ -240,7 +240,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
 
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
+        if !settings.as_ref().formatter().format_with_errors && parse.has_errors() {
             return Err(RomeError::FormatWithErrorsDisabled);
         }
 
@@ -285,7 +285,7 @@ impl Workspace for WorkspaceServer {
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings.read().unwrap();
-        let rules = settings.linter.rules.as_ref();
+        let rules = settings.linter().rules.as_ref();
         let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
             let enabled: IndexSet<RuleFilter> = rules.as_enabled_rules();
             Some(enabled.into_iter().collect())
@@ -316,7 +316,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
 
         let settings = self.settings.read().unwrap();
-        let rules = settings.linter.rules.as_ref();
+        let rules = settings.linter().rules.as_ref();
 
         Ok(code_actions(&params.path, parse, params.range, rules))
     }
@@ -333,7 +333,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
 
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
+        if !settings.as_ref().formatter().format_with_errors && parse.has_errors() {
             return Err(RomeError::FormatWithErrorsDisabled);
         }
 
@@ -350,7 +350,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
 
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
+        if !settings.as_ref().formatter().format_with_errors && parse.has_errors() {
             return Err(RomeError::FormatWithErrorsDisabled);
         }
 
@@ -367,7 +367,7 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings();
 
-        if !settings.as_ref().format.format_with_errors && parse.has_errors() {
+        if !settings.as_ref().formatter().format_with_errors && parse.has_errors() {
             return Err(RomeError::FormatWithErrorsDisabled);
         }
 
@@ -383,7 +383,7 @@ impl Workspace for WorkspaceServer {
 
         let parse = self.get_parse(params.path.clone())?;
         let settings = self.settings.read().unwrap();
-        let rules = settings.linter.rules.as_ref();
+        let rules = settings.linter().rules.as_ref();
         fix_all(FixAllParams {
             rome_path: &params.path,
             parse,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR is a follow up of https://github.com/rome/tools/pull/3123

This PR removes all the constraints that we have inside the `WorkspaceSettings`. Now the settings are not publicly exposed anymore, so we can remove all the serde/schemars macros. This will allow to have more choice with the data structures we want to choose.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

This is an internal refactor, so the existing CI should pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
