### PR TITLE
perf(rome_js_formatter): Remove unnecessary memoize

### DIFF
--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -927,7 +927,7 @@ impl Format<JsFormatContext> for JsAnyAssignmentLike {
             let layout = self.layout(is_left_short, f)?;
 
             let left = format_once(|f| f.write_element(formatted_left));
-            let right = format_with(|f| self.write_right(f, layout)).memoized();
+            let right = format_with(|f| self.write_right(f, layout));
 
             let inner_content = format_with(|f| {
                 if matches!(


### PR DESCRIPTION



## Summary

The memoize of right is no longer necessary as it is now using the `indent_if_group_breaks` IR element

## Test Plan

`cargo test`
