### PR TITLE
fix(rome_service): correctly compute rules

### DIFF
--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -522,6 +522,17 @@ mod check {
                 .count(),
             1
         );
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|m| m.level == LogLevel::Error)
+                .filter(|m| {
+                    let content = format!("{:?}", m.content);
+                    content.contains("js/noUnusedVariables")
+                })
+                .count(),
+            1
+        );
 
         assert_cli_snapshot(module_path!(), "upgrade_severity", fs, console);
     }

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -128,7 +128,6 @@ pub fn assert_cli_snapshot(
     }
 
     for message in &console.out_buffer {
-        dbg!(&message);
         let content = markup_to_string(markup! {
             {message.content}
         });

--- a/crates/rome_cli/tests/snapshots/main_check/should_disable_a_rule_group.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/should_disable_a_rule_group.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `rome.json`

--- a/crates/rome_cli/tests/snapshots/main_check/upgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/upgrade_severity.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `rome.json`
@@ -39,6 +38,18 @@ error[js/noDeadCode]: This code is unreachable
 3 │ ┌         continue;
 4 │ │         break;
   │ └──────────────^
+
+
+```
+
+```block
+error[js/noUnusedVariables]: This function is unused.
+  ┌─ file.js:1:10
+  │
+1 │ function f() {
+  │          ^
+
+=  note: Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
 
 
 ```

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -312,7 +312,7 @@ impl Js {
         RuleFilter::Rule("js", Self::CATEGORY_RULES[28]),
         RuleFilter::Rule("js", Self::CATEGORY_RULES[29]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -391,7 +391,7 @@ impl Jsx {
         RuleFilter::Rule("jsx", Self::CATEGORY_RULES[1]),
         RuleFilter::Rule("jsx", Self::CATEGORY_RULES[2]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -460,7 +460,7 @@ impl Regex {
     const RECOMMENDED_RULES: [&'static str; 1] = ["noMultipleSpacesInRegularExpressionLiterals"];
     const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 1] =
         [RuleFilter::Rule("regex", Self::CATEGORY_RULES[0])];
-    pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -528,7 +528,7 @@ impl Ts {
     const RECOMMENDED_RULES: [&'static str; 1] = ["useShorthandArrayType"];
     const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 1] =
         [RuleFilter::Rule("ts", Self::CATEGORY_RULES[0])];
-    pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {

--- a/rome.json
+++ b/rome.json
@@ -1,0 +1,12 @@
+{
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"js": {
+				"noDeadCode": "warn",
+				"useCamelCase": "warn"
+			}
+		}
+	}
+}

--- a/rome.json
+++ b/rome.json
@@ -4,7 +4,7 @@
 			"recommended": true,
 			"js": {
 				"noDeadCode": "error",
-				"useCamelCase": "error"
+				"useCamelCase": "off"
 			}
 		}
 	}

--- a/rome.json
+++ b/rome.json
@@ -1,11 +1,10 @@
 {
 	"linter": {
-		"enabled": true,
 		"rules": {
 			"recommended": true,
 			"js": {
-				"noDeadCode": "warn",
-				"useCamelCase": "warn"
+				"noDeadCode": "error",
+				"useCamelCase": "error"
 			}
 		}
 	}

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -103,7 +103,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
 
 
                 pub(crate) fn is_recommended(&self) -> bool {
-                    matches!(self.recommended, Some(true))
+                    !matches!(self.recommended, Some(false))
                 }
 
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR  adds a `rome.json` file to the root of our project and fixes a bug I found.

While I was enabling the non-recommended rules in our codebase, I found out that a certain configuration was not correctly computing the rule to run. This PR applies a fix.

The reason why I added a `rome.json` file to out repository is because at the moment there are some rules that are not run by default, and in order to dogfood rome, we should be enable all the rules if possible. This will help us to find early bugs.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I verified that the updated tests are correct. I also added a new assertion. I manually verified in the VSCode extension that the enabled rules are applied, as well as the recommended rules.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
