### PR TITLE
fix(xtask): Fix dhat build

### DIFF
--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -23,12 +23,12 @@ url = "2.2.2"
 itertools = "0.10.3"
 ansi_rgb = "0.2.0"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = "0.1.29"
-
 # dhat-on
 dhat = { version = "0.3.0", optional = true }
 humansize = {version = "1.1.1", optional = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+mimalloc = "0.1.29"
+
 [features]
-dhat-on = ["dhat", "humansize"]
+dhat-heap = ["dhat", "humansize"]

--- a/xtask/bench/README.md
+++ b/xtask/bench/README.md
@@ -53,5 +53,5 @@ critcmp main pr # (cargo install critcmp)
 ## Heap Profiling using `dhat`
 
 ```bash
-cargo run -p xtask_bench --features dhat-on --release
+cargo run -p xtask_bench --features dhat-heap --release-with-debug
 ```

--- a/xtask/bench/src/features/formatter.rs
+++ b/xtask/bench/src/features/formatter.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "dhat-on")]
+#[cfg(feature = "dhat-heap")]
 use crate::features::print_diff;
 use crate::BenchmarkSummary;
 use rome_formatter::Printed;
@@ -29,27 +29,27 @@ pub fn benchmark_format_lib(
 }
 
 pub fn run_format(root: &JsSyntaxNode, source_type: SourceType) -> Printed {
-    #[cfg(feature = "dhat-on")]
+    #[cfg(feature = "dhat-heap")]
     let stats = {
         println!("Start");
-        dhat::get_stats().unwrap()
+        dhat::HeapStats::get()
     };
 
     let formatted = format_node(JsFormatOptions::new(source_type), root).unwrap();
 
-    #[cfg(feature = "dhat-on")]
+    #[cfg(feature = "dhat-heap")]
     let stats = {
         println!("Formatted");
-        print_diff(stats, dhat::get_stats().unwrap())
+        print_diff(stats, dhat::HeapStats::get())
     };
 
     let printed = formatted.print();
     drop(formatted);
 
-    #[cfg(feature = "dhat-on")]
+    #[cfg(feature = "dhat-heap")]
     {
         println!("Printed");
-        print_diff(stats, dhat::get_stats().unwrap());
+        print_diff(stats, dhat::HeapStats::get());
     }
 
     #[allow(clippy::let_and_return)]

--- a/xtask/bench/src/features/mod.rs
+++ b/xtask/bench/src/features/mod.rs
@@ -2,23 +2,21 @@ pub mod analyzer;
 pub mod formatter;
 pub mod parser;
 
-#[cfg(feature = "dhat-on")]
-fn print_diff(before: dhat::Stats, current: dhat::Stats) -> dhat::Stats {
+#[cfg(feature = "dhat-heap")]
+fn print_diff(before: dhat::HeapStats, current: dhat::HeapStats) -> dhat::HeapStats {
     use humansize::{file_size_opts as options, FileSize};
 
     println!("\tMemory");
-    if let Some(heap) = &current.heap {
-        println!("\t\tCurrent Blocks: {}", heap.curr_blocks);
-        println!(
-            "\t\tCurrent Bytes: {}",
-            heap.curr_bytes.file_size(options::CONVENTIONAL).unwrap()
-        );
-        println!("\t\tMax Blocks: {}", heap.max_blocks);
-        println!(
-            "\t\tMax Bytes: {}",
-            heap.max_bytes.file_size(options::CONVENTIONAL).unwrap()
-        );
-    }
+    println!("\t\tCurrent Blocks: {}", current.curr_blocks);
+    println!(
+        "\t\tCurrent Bytes: {}",
+        current.curr_bytes.file_size(options::CONVENTIONAL).unwrap()
+    );
+    println!("\t\tMax Blocks: {}", current.max_blocks);
+    println!(
+        "\t\tMax Bytes: {}",
+        current.max_bytes.file_size(options::CONVENTIONAL).unwrap()
+    );
 
     println!(
         "\t\tTotal Blocks: {}",

--- a/xtask/bench/src/features/parser.rs
+++ b/xtask/bench/src/features/parser.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "dhat-on")]
+#[cfg(feature = "dhat-heap")]
 use crate::features::print_diff;
 use crate::BenchmarkSummary;
 use itertools::Itertools;
@@ -20,19 +20,19 @@ pub struct ParseMeasurement {
 }
 
 pub fn benchmark_parse_lib(id: &str, code: &str, source_type: SourceType) -> BenchmarkSummary {
-    #[cfg(feature = "dhat-on")]
+    #[cfg(feature = "dhat-heap")]
     println!("Start");
-    #[cfg(feature = "dhat-on")]
-    let stats = dhat::get_stats().unwrap();
+    #[cfg(feature = "dhat-heap")]
+    let stats = dhat::HeapStats::get();
 
     let parser_timer = timing::start();
     let (events, diagnostics, trivia) = parse_common(code, 0, source_type);
     let parse_duration = parser_timer.stop();
 
-    #[cfg(feature = "dhat-on")]
+    #[cfg(feature = "dhat-heap")]
     println!("Parsed");
-    #[cfg(feature = "dhat-on")]
-    let stats = print_diff(stats, dhat::get_stats().unwrap());
+    #[cfg(feature = "dhat-heap")]
+    let stats = print_diff(stats, dhat::HeapStats::get());
 
     let tree_sink_timer = timing::start();
     let mut tree_sink = rome_js_parser::LosslessTreeSink::new(code, &trivia);
@@ -40,10 +40,10 @@ pub fn benchmark_parse_lib(id: &str, code: &str, source_type: SourceType) -> Ben
     let (_green, diagnostics) = tree_sink.finish();
     let tree_sink_duration = tree_sink_timer.stop();
 
-    #[cfg(feature = "dhat-on")]
+    #[cfg(feature = "dhat-heap")]
     println!("Tree-Sink");
-    #[cfg(feature = "dhat-on")]
-    print_diff(stats, dhat::get_stats().unwrap());
+    #[cfg(feature = "dhat-heap")]
+    print_diff(stats, dhat::HeapStats::get());
 
     BenchmarkSummary::Parser(ParseMeasurement {
         id: id.to_string(),

--- a/xtask/bench/src/main.rs
+++ b/xtask/bench/src/main.rs
@@ -2,20 +2,17 @@ use pico_args::Arguments;
 use xtask::{project_root, pushd, Result};
 use xtask_bench::{run, FeatureToBenchmark, RunArgs};
 
-#[cfg(feature = "dhat-on")]
-use dhat::DhatAlloc;
-
-#[cfg(feature = "dhat-on")]
+#[cfg(feature = "dhat-heap")]
 #[global_allocator]
-static ALLOCATOR: DhatAlloc = DhatAlloc;
+static ALLOCATOR: dhat::Alloc = dhat::Alloc;
 
-#[cfg(all(target_os = "windows", not(feature = "dhat-on")))]
+#[cfg(all(target_os = "windows", not(feature = "dhat-heap")))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() -> Result<(), pico_args::Error> {
-    #[cfg(feature = "dhat-on")]
-    let _dhat = dhat::Dhat::start_heap_profiling();
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
 
     let _d = pushd(project_root());
     let mut args = Arguments::from_env();


### PR DESCRIPTION
Fix the dhat build:

* Many symbols have been renamed with the 0.3.0 release and I forgot to test the dhat build when upgrading the dependencies
* The `[target]` must come after the dhat dependencies or the dependencies are only specified on windows

## Test

```bash
cargo run --profile=release-with-debug  --features=dhat-heap -- --feature formatter --filter tex --criterion=false
```

```
[tex-chtml-full.js] - Downloading [https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-chtml-full.js] to [/home/micha/git/rome/target/tex-chtml-full.js]
Start
Formatted
	Memory
		Current Blocks: 532101
		Current Bytes: 47.43 MB
		Max Blocks: 570275
		Max Bytes: 50.15 MB
		Total Blocks: 4473827
		Total Bytes: 302.32 MB
Printed
	Memory
		Current Blocks: 149075
		Current Bytes: 21.56 MB
		Max Blocks: 532106
		Max Bytes: 57.70 MB
		Total Blocks: 68
		Total Bytes: 20.51 MB
Benchmark: https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-chtml-full.js
	Formatting: 12.098187219s
	              ----------
	Total:        12.098187219s

Summary
-------
tex-chtml-full.js, Formatting: 12.098187219s
dhat: Total:     393,113,113 bytes in 4,655,978 blocks
dhat: At t-gmax: 60,502,267 bytes in 532,106 blocks
dhat: At t-end:  117,398 bytes in 303 blocks
dhat: The data has been saved to dhat-heap.json, and is viewable with dhat/dh_view.html

Process finished with exit code 0
```