### PR TITLE
chore: Replace `num_cpus` crate with `std` call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2843,7 +2843,6 @@ dependencies = [
  "backtrace",
  "colored",
  "indicatif",
- "num_cpus",
  "once_cell",
  "pico-args",
  "regex",

--- a/xtask/coverage/Cargo.toml
+++ b/xtask/coverage/Cargo.toml
@@ -22,7 +22,6 @@ serde_yaml = "0.9.9"
 regex = "1.5.5"
 once_cell = "1.9.0"
 walkdir = "2.3.2"
-num_cpus = "1.13.1"
 atty = "0.2.14"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "std"] }

--- a/xtask/coverage/src/lib.rs
+++ b/xtask/coverage/src/lib.rs
@@ -140,7 +140,7 @@ pub fn run(
         reporter: &mut reporters,
         pool: &yastl::Pool::new(
             std::thread::available_parallelism()
-                .map_or(2, |num| usize::from(num))
+                .map_or(2, usize::from)
                 .max(2),
         ),
     };

--- a/xtask/coverage/src/lib.rs
+++ b/xtask/coverage/src/lib.rs
@@ -138,7 +138,11 @@ pub fn run(
     let mut context = TestRunContext {
         filter: filter.map(|s| s.to_string()),
         reporter: &mut reporters,
-        pool: &yastl::Pool::new(num_cpus::get().max(2)),
+        pool: &yastl::Pool::new(
+            std::thread::available_parallelism()
+                .map_or(2, |num| usize::from(num))
+                .max(2),
+        ),
     };
 
     let mut ran_any_tests = false;


### PR DESCRIPTION
Use `std::thread::available_parallelism()` over `num_cpus` in `xtask coverage`

## Test Plan

`xtask coverage`
