### PR TITLE
fix(ci): download the WASM artifacts to the correct directory in the publish job

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -191,6 +191,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: wasm
+          path: npm
 
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rome",
-    "version": "0.9.0-next",
+    "version": "0.9.1-next",
     "bin": "bin/rome",
     "scripts": {
         "postinstall": "node scripts/postinstall.js",


### PR DESCRIPTION
## Summary

The `upload-artifact` action is stripping the `npm/` prefix from the WASM artifacts, this adds an explicit path to the corresponding `download-artifact` so the files get downloaded and unpacked to the correct directory

## Test Plan

Run the CLI release CI workflow again
