### PR TITLE
fix(rome_cli): do not pull diagnostics if linter is turned off

### DIFF
--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -540,6 +540,7 @@ mod check {
 
 mod ci {
     use super::*;
+    use crate::configs::{CONFIG_DISABLED_FORMATTER, CONFIG_LINTER_DISABLED};
     use rome_fs::FileSystemExt;
 
     #[test]
@@ -641,6 +642,72 @@ mod ci {
         }
 
         assert_cli_snapshot(module_path!(), "ci_lint_error", fs, console);
+    }
+
+    #[test]
+    fn ci_does_not_run_formatter() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("rome.json");
+        fs.insert(file_path.into(), CONFIG_DISABLED_FORMATTER.as_bytes());
+
+        let file_path = Path::new("file.js");
+        fs.insert(file_path.into(), UNFORMATTED.as_bytes());
+
+        let result = run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![OsString::from("ci"), file_path.as_os_str().into()]),
+        );
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        let mut file = fs
+            .open(file_path)
+            .expect("formatting target file was removed by the CLI");
+
+        let mut content = String::new();
+        file.read_to_string(&mut content)
+            .expect("failed to read file from memory FS");
+
+        assert_eq!(content, UNFORMATTED);
+
+        drop(file);
+        assert_cli_snapshot(module_path!(), "ci_does_not_run_formatter", fs, console);
+    }
+
+    #[test]
+    fn ci_does_not_run_linter() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("rome.json");
+        fs.insert(file_path.into(), CONFIG_LINTER_DISABLED.as_bytes());
+
+        let file_path = Path::new("file.js");
+        fs.insert(file_path.into(), CUSTOM_FORMAT_BEFORE.as_bytes());
+
+        let result = run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![OsString::from("ci"), file_path.as_os_str().into()]),
+        );
+
+        assert!(result.is_err(), "run_cli returned {result:?}");
+
+        let mut file = fs
+            .open(file_path)
+            .expect("formatting target file was removed by the CLI");
+
+        let mut content = String::new();
+        file.read_to_string(&mut content)
+            .expect("failed to read file from memory FS");
+
+        assert_eq!(content, CUSTOM_FORMAT_BEFORE);
+
+        drop(file);
+        assert_cli_snapshot(module_path!(), "ci_does_not_run_linter", fs, console);
     }
 }
 

--- a/crates/rome_cli/tests/snapshots/main_check/apply_noop.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/apply_noop.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `fix.js`

--- a/crates/rome_cli/tests/snapshots/main_check/apply_ok.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/apply_ok.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `fix.js`

--- a/crates/rome_cli/tests/snapshots/main_check/downgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/downgrade_severity.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `rome.json`

--- a/crates/rome_cli/tests/snapshots/main_check/lint_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/lint_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `check.js`

--- a/crates/rome_cli/tests/snapshots/main_check/maximum_diagnostics.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/maximum_diagnostics.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `check.js`

--- a/crates/rome_cli/tests/snapshots/main_check/no_lint_if_linter_is_disabled_when_run_apply.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/no_lint_if_linter_is_disabled_when_run_apply.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 148
 expression: content
 ---
 ## `rome.json`

--- a/crates/rome_cli/tests/snapshots/main_check/parse_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/parse_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `check.js`

--- a/crates/rome_cli/tests/snapshots/main_ci/ci_does_not_run_formatter.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/ci_does_not_run_formatter.snap
@@ -6,28 +6,19 @@ expression: content
 
 ```json
 {
-  "linter": {
+  "formatter": {
     "enabled": false
   }
 }
+
 ```
 
-## `fix.js`
+## `file.js`
 
 ```js
-
-if(a != -0) {}
-
+  statement(  )  
 ```
 
 # Emitted Messages
-
-```block
-fix.js: error[IO]: unhandled file type
-```
-
-```block
-Skipped 1 files
-```
 
 

--- a/crates/rome_cli/tests/snapshots/main_ci/ci_does_not_run_linter.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/ci_does_not_run_linter.snap
@@ -6,11 +6,10 @@ expression: content
 
 ```json
 {
-  "formatter": {
+  "linter": {
     "enabled": false
   }
 }
-
 ```
 
 ## `file.js`
@@ -26,11 +25,14 @@ return { something }
 # Emitted Messages
 
 ```block
-file.js: error[IO]: unhandled file type
-```
+file.js: error[CI]: File content differs from formatting output
+    | @@ -1,4 +1,3 @@
+0   | - 
+1 0 |   function f() {
+2   | - return { something }
+  1 | + 	return { something };
+3 2 |   }
 
-```block
-Skipped 1 files
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_ci/ci_lint_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/ci_lint_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `ci.js`

--- a/crates/rome_cli/tests/snapshots/main_ci/ci_parse_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/ci_parse_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `ci.js`

--- a/crates/rome_cli/tests/snapshots/main_ci/formatting_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/formatting_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `ci.js`

--- a/crates/rome_cli/tests/snapshots/main_format/does_not_format_if_disabled.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/does_not_format_if_disabled.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `rome.json`

--- a/crates/rome_cli/tests/snapshots/main_format/format_stdin_successfully.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/format_stdin_successfully.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 # Input messages

--- a/crates/rome_cli/tests/snapshots/main_format/formatter_lint_warning.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/formatter_lint_warning.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `format.js`

--- a/crates/rome_cli/tests/snapshots/main_format/formatter_print.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/formatter_print.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `format.js`

--- a/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `rome.json`

--- a/crates/rome_cli/tests/snapshots/main_reporter_json/reports_formatter_check_mode.snap
+++ b/crates/rome_cli/tests/snapshots/main_reporter_json/reports_formatter_check_mode.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 148
 expression: content
 ---
 ## `format.js`

--- a/crates/rome_cli/tests/snapshots/main_reporter_json/reports_formatter_write.snap
+++ b/crates/rome_cli/tests/snapshots/main_reporter_json/reports_formatter_write.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 148
 expression: content
 ---
 ## `format.js`


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes #3167 


Diagnostics were pulled regardless of the capability of the workspace. I added a small condition before the pulling of diagnostics.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I created two test cases: one where the formatter is enabled and linter disabled, one where the formatter is disabled and the linter enabled

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
