### PR TITLE
fix(rome_cli): correctly compute configuration

### DIFF
--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -2,14 +2,11 @@ use crate::commands::format::apply_format_settings_from_cli;
 use crate::{execute_mode, CliSession, Execution, Termination, TraversalMode};
 use rome_diagnostics::MAXIMUM_DISPLAYABLE_DIAGNOSTICS;
 use rome_service::load_config;
-use rome_service::settings::WorkspaceSettings;
 use rome_service::workspace::{FixFileMode, UpdateSettingsParams};
 
 /// Handler for the "check" command of the Rome CLI
 pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
     let configuration = load_config(&session.app.fs, None)?;
-    let mut workspace_settings = WorkspaceSettings::default();
-
     let max_diagnostics: Option<u16> = session
         .args
         .opt_value_from_str("--max-diagnostics")
@@ -31,13 +28,11 @@ pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
         20
     };
 
-    if let Some(configuration) = configuration {
-        session
-            .app
-            .workspace
-            .update_settings(UpdateSettingsParams { configuration })?;
-    }
-    apply_format_settings_from_cli(&mut session, &mut workspace_settings)?;
+    let configuration = apply_format_settings_from_cli(&mut session, configuration)?;
+    session
+        .app
+        .workspace
+        .update_settings(UpdateSettingsParams { configuration })?;
 
     let apply = session.args.contains("--apply");
     let apply_suggested = session.args.contains("--apply-suggested");

--- a/crates/rome_cli/src/commands/ci.rs
+++ b/crates/rome_cli/src/commands/ci.rs
@@ -1,6 +1,5 @@
 use crate::{execute_mode, CliSession, Execution, Termination, TraversalMode};
 use rome_service::load_config;
-use rome_service::settings::WorkspaceSettings;
 use rome_service::workspace::UpdateSettingsParams;
 
 use super::format::apply_format_settings_from_cli;
@@ -8,15 +7,12 @@ use super::format::apply_format_settings_from_cli;
 /// Handler for the "ci" command of the Rome CLI
 pub(crate) fn ci(mut session: CliSession) -> Result<(), Termination> {
     let configuration = load_config(&session.app.fs, None)?;
-    let mut workspace_settings = WorkspaceSettings::default();
+    let configuration = apply_format_settings_from_cli(&mut session, configuration)?;
 
-    if let Some(configuration) = configuration {
-        session
-            .app
-            .workspace
-            .update_settings(UpdateSettingsParams { configuration })?;
-    }
-    apply_format_settings_from_cli(&mut session, &mut workspace_settings)?;
+    session
+        .app
+        .workspace
+        .update_settings(UpdateSettingsParams { configuration })?;
 
     execute_mode(Execution::new(TraversalMode::CI), session)
 }

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -82,6 +82,27 @@ const NO_DEAD_CODE_ERROR: &str = r#"function f() {
 }
 "#;
 
+const APPLY_QUOTE_STYLE_BEFORE: &str = r#"
+let a = "something";
+let b = {
+    "hey": "hello"
+};"#;
+
+const APPLY_QUOTE_STYLE_AFTER: &str = "let a = 'something';
+let b = {\n\t'hey': 'hello',\n};\n";
+
+const CUSTOM_CONFIGURATION_BEFORE: &str = r#"function f() {
+  return { a, b }
+}"#;
+
+const CUSTOM_CONFIGURATION_AFTER: &str = "function f() {
+        return {
+                a,
+                b,
+        };
+}
+";
+
 mod check {
     use super::*;
     use crate::configs::{
@@ -756,6 +777,84 @@ mod format {
 
         drop(file);
         assert_cli_snapshot(module_path!(), "formatter_lint_warning", fs, console);
+    }
+
+    #[test]
+    fn applies_custom_configuration() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("file.js");
+        fs.insert(file_path.into(), CUSTOM_CONFIGURATION_BEFORE.as_bytes());
+
+        let result = run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![
+                OsString::from("format"),
+                OsString::from("--line-width"),
+                OsString::from("10"),
+                OsString::from("--indent-style"),
+                OsString::from("space"),
+                OsString::from("--indent-size"),
+                OsString::from("8"),
+                OsString::from("--write"),
+                file_path.as_os_str().into(),
+            ]),
+        );
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        let mut file = fs
+            .open(file_path)
+            .expect("formatting target file was removed by the CLI");
+
+        let mut content = String::new();
+        file.read_to_string(&mut content)
+            .expect("failed to read file from memory FS");
+
+        assert_eq!(content, CUSTOM_CONFIGURATION_AFTER);
+
+        drop(file);
+        assert_cli_snapshot(module_path!(), "applies_custom_configuration", fs, console);
+    }
+
+    #[test]
+    fn applies_custom_quote_style() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("file.js");
+        fs.insert(file_path.into(), APPLY_QUOTE_STYLE_BEFORE.as_bytes());
+
+        let result = run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![
+                OsString::from("format"),
+                OsString::from("--quote-style"),
+                OsString::from("single"),
+                OsString::from("--quote-properties"),
+                OsString::from("preserve"),
+                OsString::from("--write"),
+                file_path.as_os_str().into(),
+            ]),
+        );
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        let mut file = fs
+            .open(file_path)
+            .expect("formatting target file was removed by the CLI");
+
+        let mut content = String::new();
+        file.read_to_string(&mut content)
+            .expect("failed to read file from memory FS");
+
+        assert_eq!(content, APPLY_QUOTE_STYLE_AFTER);
+
+        drop(file);
+        assert_cli_snapshot(module_path!(), "applies_custom_quote_style", fs, console);
     }
 
     #[test]

--- a/crates/rome_cli/tests/snapshots/main_format/applies_custom_configuration.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/applies_custom_configuration.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+function f() {
+        return {
+                a,
+                b,
+        };
+}
+
+```
+
+# Emitted Messages
+
+

--- a/crates/rome_cli/tests/snapshots/main_format/applies_custom_configuration_over_config_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/applies_custom_configuration_over_config_file.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "formatter": {
+    "enabled": true,
+    "lineWidth": 160,
+    "indentStyle": "space",
+    "indentSize": 6
+  }
+}
+
+```
+
+## `file.js`
+
+```js
+function f() {
+        return {
+                a,
+                b,
+        };
+}
+
+```
+
+# Emitted Messages
+
+

--- a/crates/rome_cli/tests/snapshots/main_format/applies_custom_quote_style.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/applies_custom_quote_style.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+let a = 'something';
+let b = {
+	'hey': 'hello',
+};
+
+```
+
+# Emitted Messages
+
+

--- a/crates/rome_service/src/configuration/formatter.rs
+++ b/crates/rome_service/src/configuration/formatter.rs
@@ -17,7 +17,7 @@ pub struct FormatterConfiguration {
     pub indent_style: PlainIndentStyle,
 
     /// The size of the indentation, 2 by default
-    indent_size: u8,
+    pub indent_size: u8,
 
     /// What's the max width of a line. Defaults to 80.
     #[serde(

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -3,9 +3,6 @@
 //! The configuration is divided by "tool", and then it's possible to further customise it
 //! by language. The language might further options divided by tool.
 
-use crate::configuration::formatter::FormatterConfiguration;
-use crate::configuration::javascript::JavascriptConfiguration;
-use crate::configuration::linter::LinterConfiguration;
 use crate::{DynRef, RomeError};
 use rome_fs::{FileSystem, OpenOptions};
 use serde::{Deserialize, Serialize};
@@ -18,7 +15,9 @@ mod formatter;
 mod javascript;
 pub mod linter;
 
-pub use linter::{RuleConfiguration, Rules};
+pub use formatter::{FormatterConfiguration, PlainIndentStyle};
+pub use javascript::{JavascriptConfiguration, JavascriptFormatter};
+pub use linter::{LinterConfiguration, RuleConfiguration, Rules};
 
 /// The configuration that is contained inside the file `rome.json`
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #3175 

We were incorrectly computing a `WorkspaceSettings`, while now we should change/create a `Configuration` struct instead and then update the settings of the workspace.

This bug went undetected because we don't have tests that check that arguments passed via CLI are correctly applied.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I created two new tests, one that applies the generic configuration of the formatter and one that applies the configuration for the javascript language.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
