### PR TITLE
fix(rome_lsp): fix the parsing of the Workspace root URI on Windows

### DIFF
--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -14,7 +14,6 @@ use rome_service::workspace::{FeatureName, PullDiagnosticsParams, SupportsFeatur
 use rome_service::{load_config, Workspace};
 use rome_service::{DynRef, RomeError};
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
 use tokio::sync::Notify;
@@ -176,7 +175,13 @@ impl Session {
     /// This function attempts to read the configuration from the root URI
     pub(crate) async fn update_configuration(&self) {
         let root_uri = self.root_uri.read().unwrap();
-        let base_path = root_uri.as_ref().map(|uri| PathBuf::from(uri.path()));
+        let base_path =  root_uri.as_ref().and_then(|root_uri| match root_uri.to_file_path() {
+            Ok(base_path) => Some(base_path),
+            Err(()) => {
+                error!("The Workspace root URI {root_uri:?} could not be parsed as a filesystem path");
+                None
+            }
+        });
 
         match load_config(&self.fs, base_path) {
             Ok(Some(configuration)) => {


### PR DESCRIPTION
## Summary

Fixes #3182 

In the Language Server Protocol, the path to the workspace root is sent from the editor to the language server as a URI. In order to load the configuration file from the disk we need to parse this URI as a filesystem path, previously this was done by extracting the path segment of the URI which works on Unix systems (the URI `file:///home/user/workspace` becomes the path `/home/user/workspace`) but is not sufficient on Windows where the drive ID needs to be decoded: the URI `file:///c%3A/users/user/workspace` should be parsed as `c:/users/user/workspace` but was previously interpreted as `/c%3A/users/user/workspace`

## Test Plan

Unfortunately this relies on OS-specific code (the implementation of the `Uri::to_file_path` differs depending on the target platform) so it's hard to test automatically as we do not run tests on Windows. Instead I just built and run the language server locally and verified it could parse the workspace path and load the configuration file correctly on Windows
