### PR TITLE
test(rome_cli): snap termination error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,6 +1479,7 @@ name = "rome_cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "cfg-if",
  "crossbeam",
  "dashmap",
  "hdrhistogram",

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0.133", features = ["derive"] }
 serde_json = { version = "1.0.74" }
 tokio = { version = "1.15.0", features = ["io-std", "io-util", "net", "time", "rt", "rt-multi-thread", "macros"] }
 anyhow = "1.0.52"
+cfg-if = "1.0.0"
 dashmap = "5.2.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rome_cli/src/termination.rs
+++ b/crates/rome_cli/src/termination.rs
@@ -70,10 +70,17 @@ pub enum Termination {
 }
 
 fn command_name() -> String {
-    current_exe()
+    #[allow(unused_assignments)]
+    let mut command = current_exe()
         .ok()
         .and_then(|path| Some(path.file_name()?.to_str()?.to_string()))
-        .unwrap_or_else(|| String::from("rome"))
+        .unwrap_or_else(|| String::from("rome"));
+    cfg_if::cfg_if! {
+        if #[cfg(debug_assertions)] {
+             command = String::from("rome")
+        }
+    }
+    command
 }
 
 // Termination implements Debug by redirecting to Display instead of deriving

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -109,6 +109,7 @@ mod check {
         CONFIG_LINTER_DISABLED, CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC, CONFIG_LINTER_SUPPRESSED_GROUP,
         CONFIG_LINTER_SUPPRESSED_RULE, CONFIG_LINTER_UPGRADE_DIAGNOSTIC,
     };
+    use crate::snap_test::SnapshotPayload;
     use rome_console::LogLevel;
     use rome_fs::FileSystemExt;
 
@@ -148,7 +149,13 @@ mod check {
             _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
         }
 
-        assert_cli_snapshot(module_path!(), "parse_error", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "parse_error",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -170,7 +177,13 @@ mod check {
             _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
         }
 
-        assert_cli_snapshot(module_path!(), "lint_error", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "lint_error",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -208,7 +221,13 @@ mod check {
                     && content.contains("76")
             }));
 
-        assert_cli_snapshot(module_path!(), "maximum_diagnostics", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "maximum_diagnostics",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -239,7 +258,13 @@ mod check {
 
         assert_eq!(buffer, FIX_AFTER);
 
-        assert_cli_snapshot(module_path!(), "apply_ok", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "apply_ok",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -264,7 +289,13 @@ mod check {
 
         assert!(result.is_ok(), "run_cli returned {result:?}");
 
-        assert_cli_snapshot(module_path!(), "apply_noop", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "apply_noop",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -288,7 +319,7 @@ mod check {
 
         assert!(result.is_err(), "run_cli returned {result:?}");
 
-        match result {
+        match &result {
             Err(error) => {
                 assert!(error
                     .to_string()
@@ -297,7 +328,13 @@ mod check {
             _ => panic!("expected an error, but found none"),
         }
 
-        assert_cli_snapshot(module_path!(), "apply_suggested_error", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "apply_suggested_error",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -328,7 +365,13 @@ mod check {
 
         assert_eq!(buffer, APPLY_SUGGESTED_AFTER);
 
-        assert_cli_snapshot(module_path!(), "apply_suggested", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "apply_suggested",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -362,12 +405,13 @@ mod check {
 
         assert_eq!(buffer, FIX_BEFORE);
 
-        assert_cli_snapshot(
+        assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "no_lint_if_linter_is_disabled_when_run_apply",
             fs,
             console,
-        );
+            result,
+        ));
     }
 
     #[test]
@@ -397,7 +441,13 @@ mod check {
 
         assert_eq!(buffer, FIX_BEFORE);
 
-        assert_cli_snapshot(module_path!(), "no_lint_if_linter_is_disabled", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "no_lint_if_linter_is_disabled",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -431,7 +481,13 @@ mod check {
 
         assert_eq!(buffer, NO_DEBUGGER_AFTER);
 
-        assert_cli_snapshot(module_path!(), "should_disable_a_rule", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "should_disable_a_rule",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -468,7 +524,13 @@ mod check {
 
         assert_eq!(buffer, JS_ERRORS_AFTER);
 
-        assert_cli_snapshot(module_path!(), "should_disable_a_rule_group", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "should_disable_a_rule_group",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -506,7 +568,13 @@ mod check {
             1
         );
 
-        assert_cli_snapshot(module_path!(), "downgrade_severity", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "downgrade_severity",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -555,13 +623,20 @@ mod check {
             1
         );
 
-        assert_cli_snapshot(module_path!(), "upgrade_severity", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "upgrade_severity",
+            fs,
+            console,
+            result,
+        ));
     }
 }
 
 mod ci {
     use super::*;
     use crate::configs::{CONFIG_DISABLED_FORMATTER, CONFIG_LINTER_DISABLED};
+    use crate::snap_test::SnapshotPayload;
     use rome_fs::FileSystemExt;
 
     #[test]
@@ -596,7 +671,13 @@ mod ci {
 
         drop(file);
 
-        assert_cli_snapshot(module_path!(), "ci_ok", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "ci_ok",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -618,7 +699,13 @@ mod ci {
             _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
         }
 
-        assert_cli_snapshot(module_path!(), "formatting_error", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "formatting_error",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -635,12 +722,18 @@ mod ci {
             Arguments::from_vec(vec![OsString::from("ci"), file_path.as_os_str().into()]),
         );
 
-        match result {
+        match &result {
             Err(Termination::CheckError) => {}
             _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
         }
 
-        assert_cli_snapshot(module_path!(), "ci_parse_error", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "ci_parse_error",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -657,12 +750,18 @@ mod ci {
             Arguments::from_vec(vec![OsString::from("ci"), file_path.as_os_str().into()]),
         );
 
-        match result {
+        match &result {
             Err(Termination::CheckError) => {}
             _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
         }
 
-        assert_cli_snapshot(module_path!(), "ci_lint_error", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "ci_lint_error",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -695,7 +794,13 @@ mod ci {
         assert_eq!(content, UNFORMATTED);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "ci_does_not_run_formatter", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "ci_does_not_run_formatter",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -728,7 +833,13 @@ mod ci {
         assert_eq!(content, CUSTOM_FORMAT_BEFORE);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "ci_does_not_run_linter", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "ci_does_not_run_linter",
+            fs,
+            console,
+            result,
+        ));
     }
 }
 
@@ -737,7 +848,7 @@ mod format {
     use crate::configs::{
         CONFIG_DISABLED_FORMATTER, CONFIG_FORMAT, CONFIG_ISSUE_3175_1, CONFIG_ISSUE_3175_2,
     };
-    use crate::snap_test::markup_to_string;
+    use crate::snap_test::{markup_to_string, SnapshotPayload};
     use rome_console::markup;
     use rome_fs::FileSystemExt;
 
@@ -768,7 +879,13 @@ mod format {
         assert_eq!(content, UNFORMATTED);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "formatter_print", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "formatter_print",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -804,7 +921,13 @@ mod format {
         assert_eq!(console.out_buffer.len(), 1);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "formatter_write", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "formatter_write",
+            fs,
+            console,
+            result,
+        ));
     }
 
     // Ensures lint warnings are not printed in format mode
@@ -845,7 +968,13 @@ mod format {
         );
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "formatter_lint_warning", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "formatter_lint_warning",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -885,7 +1014,13 @@ mod format {
         assert_eq!(content, CUSTOM_CONFIGURATION_AFTER);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "applies_custom_configuration", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "applies_custom_configuration",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -928,12 +1063,13 @@ mod format {
         assert_eq!(content, CUSTOM_CONFIGURATION_AFTER);
 
         drop(file);
-        assert_cli_snapshot(
+        assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "applies_custom_configuration_over_config_file",
             fs,
             console,
-        );
+            result,
+        ));
     }
 
     #[test]
@@ -1062,7 +1198,13 @@ mod format {
         assert_eq!(content, APPLY_QUOTE_STYLE_AFTER);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "applies_custom_quote_style", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "applies_custom_quote_style",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1088,7 +1230,13 @@ mod format {
             ),
         }
 
-        assert_cli_snapshot(module_path!(), "indent_style_parse_errors", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "indent_style_parse_errors",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1114,12 +1262,13 @@ mod format {
             ),
         }
 
-        assert_cli_snapshot(
+        assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "indent_size_parse_errors_negative",
             fs,
             console,
-        );
+            result,
+        ));
     }
 
     #[test]
@@ -1145,12 +1294,13 @@ mod format {
             ),
         }
 
-        assert_cli_snapshot(
+        assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "indent_size_parse_errors_overflow",
             fs,
             console,
-        );
+            result,
+        ));
     }
 
     #[test]
@@ -1169,19 +1319,20 @@ mod format {
             ]),
         );
 
-        match result {
-            Err(Termination::ParseError { argument, .. }) => assert_eq!(argument, "--line-width"),
+        match &result {
+            Err(Termination::ParseError { argument, .. }) => assert_eq!(*argument, "--line-width"),
             _ => panic!(
                 "run_cli returned {result:?} for an invalid argument value, expected an error"
             ),
         }
 
-        assert_cli_snapshot(
+        assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "line_width_parse_errors_negative",
             fs,
             console,
-        );
+            result,
+        ));
     }
 
     #[test]
@@ -1200,19 +1351,20 @@ mod format {
             ]),
         );
 
-        match result {
-            Err(Termination::ParseError { argument, .. }) => assert_eq!(argument, "--line-width"),
+        match &result {
+            Err(Termination::ParseError { argument, .. }) => assert_eq!(*argument, "--line-width"),
             _ => panic!(
                 "run_cli returned {result:?} for an invalid argument value, expected an error"
             ),
         }
 
-        assert_cli_snapshot(
+        assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "line_width_parse_errors_overflow",
             fs,
             console,
-        );
+            result,
+        ));
     }
 
     #[test]
@@ -1231,21 +1383,22 @@ mod format {
             ]),
         );
 
-        match result {
+        match &result {
             Err(Termination::ParseError { argument, .. }) => {
-                assert_eq!(argument, "--quote-properties")
+                assert_eq!(*argument, "--quote-properties")
             }
             _ => panic!(
                 "run_cli returned {result:?} for an invalid argument value, expected an error"
             ),
         }
 
-        assert_cli_snapshot(
+        assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "quote_properties_parse_errors_letter_case",
             fs,
             console,
-        );
+            result,
+        ));
     }
 
     #[test]
@@ -1281,7 +1434,13 @@ mod format {
         assert_eq!(content, CUSTOM_FORMAT_AFTER);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "format_with_configuration", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "format_with_configuration",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1317,7 +1476,13 @@ mod format {
         assert_eq!(content, CUSTOM_FORMAT_BEFORE);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "format_is_disabled", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "format_is_disabled",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1352,7 +1517,13 @@ mod format {
 
         assert_eq!(content, "function f() {\n\treturn {};\n}\n");
 
-        assert_cli_snapshot(module_path!(), "format_stdin_successfully", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "format_stdin_successfully",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1379,7 +1550,13 @@ mod format {
             }
         }
 
-        assert_cli_snapshot(module_path!(), "format_stdin_with_errors", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "format_stdin_with_errors",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1417,7 +1594,13 @@ mod format {
 
         assert_eq!(content, "function f() {return{}}".to_string());
 
-        assert_cli_snapshot(module_path!(), "does_not_format_if_disabled", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "does_not_format_if_disabled",
+            fs,
+            console,
+            result,
+        ));
     }
 }
 
@@ -1571,6 +1754,7 @@ mod main {
 mod init {
     use super::*;
     use crate::configs::CONFIG_INIT_DEFAULT;
+    use crate::snap_test::SnapshotPayload;
     use pico_args::Arguments;
     use rome_console::BufferConsole;
     use rome_fs::{FileSystemExt, MemoryFileSystem};
@@ -1603,7 +1787,13 @@ mod init {
 
         drop(file);
 
-        assert_cli_snapshot(module_path!(), "creates_config_file", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "creates_config_file",
+            fs,
+            console,
+            result,
+        ));
     }
 }
 
@@ -1613,6 +1803,7 @@ mod configuration {
         CONFIG_ALL_FIELDS, CONFIG_BAD_LINE_WIDTH, CONFIG_INCORRECT_GLOBALS,
         CONFIG_INCORRECT_GLOBALS_V2, CONFIG_LINTER_WRONG_RULE,
     };
+    use crate::snap_test::SnapshotPayload;
     use pico_args::Arguments;
     use rome_console::BufferConsole;
     use rome_fs::MemoryFileSystem;
@@ -1635,7 +1826,13 @@ mod configuration {
 
         assert!(result.is_ok(), "run_cli returned {result:?}");
 
-        assert_cli_snapshot(module_path!(), "correct_root", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "correct_root",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1654,7 +1851,13 @@ mod configuration {
 
         assert!(result.is_err(), "run_cli returned {result:?}");
 
-        assert_cli_snapshot(module_path!(), "line_width_error", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "line_width_error",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1673,7 +1876,13 @@ mod configuration {
 
         assert!(result.is_err(), "run_cli returned {result:?}");
 
-        assert_cli_snapshot(module_path!(), "incorrect_rule_name", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "incorrect_rule_name",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1692,7 +1901,13 @@ mod configuration {
 
         assert!(result.is_err(), "run_cli returned {result:?}");
 
-        assert_cli_snapshot(module_path!(), "incorrect_globals", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "incorrect_globals",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1715,6 +1930,7 @@ mod configuration {
 
 mod reporter_json {
     use super::*;
+    use crate::snap_test::SnapshotPayload;
     use crate::UNFORMATTED;
     use pico_args::Arguments;
     use rome_fs::FileSystemExt;
@@ -1754,7 +1970,13 @@ mod reporter_json {
         assert_eq!(console.out_buffer.len(), 1);
 
         drop(file);
-        assert_cli_snapshot(module_path!(), "reports_formatter_check_mode", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "reports_formatter_check_mode",
+            fs,
+            console,
+            result,
+        ));
     }
 
     #[test]
@@ -1792,7 +2014,13 @@ mod reporter_json {
 
         drop(file);
 
-        assert_cli_snapshot(module_path!(), "reports_formatter_write", fs, console);
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "reports_formatter_write",
+            fs,
+            console,
+            result,
+        ));
     }
 }
 

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -1107,12 +1107,13 @@ mod format {
         assert_eq!(content, "import React from 'react';\n");
 
         drop(file);
-        assert_cli_snapshot(
+        assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "applies_custom_configuration_over_config_file_issue_3175_v1",
             fs,
             console,
-        );
+            result,
+        ));
     }
 
     #[test]
@@ -1155,12 +1156,13 @@ mod format {
         assert_eq!(content, source);
 
         drop(file);
-        assert_cli_snapshot(
+        assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "applies_custom_configuration_over_config_file_issue_3175_v2",
             fs,
             console,
-        );
+            result,
+        ));
     }
 
     #[test]

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -26,7 +26,7 @@ struct CliSnapshot {
 }
 
 impl CliSnapshot {
-    pub fn form_result(result: Result<(), Termination>) -> Self {
+    pub fn from_result(result: Result<(), Termination>) -> Self {
         Self {
             in_messages: InMessages::default(),
             configuration: None,
@@ -153,7 +153,7 @@ pub fn assert_cli_snapshot(payload: SnapshotPayload<'_>) {
         test_name,
         module_path,
     } = payload;
-    let mut cli_snapshot = CliSnapshot::form_result(result);
+    let mut cli_snapshot = CliSnapshot::from_result(result);
     let config_path = PathBuf::from("rome.json");
     let configuration = fs.read(&config_path).ok();
     if let Some(mut configuration) = configuration {

--- a/crates/rome_cli/tests/snapshots/main_check/apply_suggested_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/apply_suggested_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `fix.js`
@@ -10,6 +9,12 @@ let a = 4;
 debugger;
 console.log(a);
 
+```
+
+# Termination Message
+
+```block
+incompatible arguments '--apply' and '--apply-suggested'
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_check/lint_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/lint_error.snap
@@ -9,6 +9,12 @@ for(;true;);
 
 ```
 
+# Termination Message
+
+```block
+errors where emitted while running checks
+```
+
 # Emitted Messages
 
 ```block

--- a/crates/rome_cli/tests/snapshots/main_check/maximum_diagnostics.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/maximum_diagnostics.snap
@@ -17,6 +17,12 @@ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 
 ```
 
+# Termination Message
+
+```block
+errors where emitted while running checks
+```
+
 # Emitted Messages
 
 ```block

--- a/crates/rome_cli/tests/snapshots/main_check/parse_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/parse_error.snap
@@ -9,6 +9,12 @@ if
 
 ```
 
+# Termination Message
+
+```block
+errors where emitted while running checks
+```
+
 # Emitted Messages
 
 ```block

--- a/crates/rome_cli/tests/snapshots/main_check/upgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/upgrade_severity.snap
@@ -29,6 +29,12 @@ function f() {
 
 ```
 
+# Termination Message
+
+```block
+errors where emitted while running checks
+```
+
 # Emitted Messages
 
 ```block

--- a/crates/rome_cli/tests/snapshots/main_ci/ci_does_not_run_linter.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/ci_does_not_run_linter.snap
@@ -22,6 +22,12 @@ return { something }
 
 ```
 
+# Termination Message
+
+```block
+errors where emitted while running checks
+```
+
 # Emitted Messages
 
 ```block

--- a/crates/rome_cli/tests/snapshots/main_ci/ci_lint_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/ci_lint_error.snap
@@ -9,6 +9,12 @@ for(;true;);
 
 ```
 
+# Termination Message
+
+```block
+errors where emitted while running checks
+```
+
 # Emitted Messages
 
 ```block

--- a/crates/rome_cli/tests/snapshots/main_ci/ci_parse_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/ci_parse_error.snap
@@ -9,6 +9,12 @@ if
 
 ```
 
+# Termination Message
+
+```block
+errors where emitted while running checks
+```
+
 # Emitted Messages
 
 ```block

--- a/crates/rome_cli/tests/snapshots/main_ci/formatting_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/formatting_error.snap
@@ -8,6 +8,12 @@ expression: content
   statement(  )  
 ```
 
+# Termination Message
+
+```block
+errors where emitted while running checks
+```
+
 # Emitted Messages
 
 ```block

--- a/crates/rome_cli/tests/snapshots/main_configuration/incorrect_globals.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/incorrect_globals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `rome.json`
@@ -14,6 +13,13 @@ expression: content
     "globals": [false]
   }
 }
+```
+
+# Termination Message
+
+```block
+Rome couldn't load the configuration file, here's why: 
+invalid type: boolean `false`, expected a string at line 6 column 21
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `rome.json`
@@ -19,6 +18,13 @@ expression: content
     }
   }
 }
+```
+
+# Termination Message
+
+```block
+Rome couldn't load the configuration file, here's why: 
+invalid rule name `foo_rule` at line 7 column 9
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_configuration/line_width_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/line_width_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
 ## `rome.json`
@@ -11,6 +10,14 @@ expression: content
     "lineWidth": 500
   }
 }
+```
+
+# Termination Message
+
+```block
+Rome couldn't load the configuration file, here's why: 
+The line width exceeds the maximum value (320)
+ at line 4 column 3
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_format/format_stdin_with_errors.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/format_stdin_with_errors.snap
@@ -5,7 +5,7 @@ expression: content
 # Termination Message
 
 ```block
-missing argument 'stdin'. Type 'main-ce5f6749bdca01ce format --help' for more information.
+missing argument 'stdin'. Type 'rome format --help' for more information.
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_format/format_stdin_with_errors.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/format_stdin_with_errors.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
+# Termination Message
+
+```block
+missing argument 'stdin'. Type 'main-ce5f6749bdca01ce format --help' for more information.
+```
+
 

--- a/crates/rome_cli/tests/snapshots/main_format/indent_size_parse_errors_negative.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/indent_size_parse_errors_negative.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
+# Termination Message
+
+```block
+failed to parse argument '--indent-size': failed to parse '-1': invalid digit found in string
+```
+
 

--- a/crates/rome_cli/tests/snapshots/main_format/indent_size_parse_errors_overflow.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/indent_size_parse_errors_overflow.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
+# Termination Message
+
+```block
+failed to parse argument '--indent-size': failed to parse '257': number too large to fit in target type
+```
+
 

--- a/crates/rome_cli/tests/snapshots/main_format/indent_style_parse_errors.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/indent_style_parse_errors.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
+# Termination Message
+
+```block
+failed to parse argument '--indent-style': failed to parse 'invalid': Value not supported for IndentStyle
+```
+
 

--- a/crates/rome_cli/tests/snapshots/main_format/line_width_parse_errors_negative.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/line_width_parse_errors_negative.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
+# Termination Message
+
+```block
+failed to parse argument '--line-width': failed to parse '-1': ParseError(ParseIntError { kind: InvalidDigit })
+```
+
 

--- a/crates/rome_cli/tests/snapshots/main_format/line_width_parse_errors_overflow.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/line_width_parse_errors_overflow.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
+# Termination Message
+
+```block
+failed to parse argument '--line-width': failed to parse '321': TryFromIntError(LineWidthFromIntError(321))
+```
+
 

--- a/crates/rome_cli/tests/snapshots/main_format/quote_properties_parse_errors_letter_case.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/quote_properties_parse_errors_letter_case.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 147
 expression: content
 ---
+# Termination Message
+
+```block
+failed to parse argument '--quote-properties': failed to parse 'As-needed': Value not supported for QuoteProperties
+```
+
 

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -351,7 +351,7 @@ where
     for rule_name in value.keys() {
         if !Js::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::UnknownRule("{rule_name}".to_string()),
+                ConfigurationError::UnknownRule(rule_name.to_string()),
             )));
         }
     }
@@ -428,7 +428,7 @@ where
     for rule_name in value.keys() {
         if !Jsx::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::UnknownRule("{rule_name}".to_string()),
+                ConfigurationError::UnknownRule(rule_name.to_string()),
             )));
         }
     }
@@ -495,7 +495,7 @@ where
     for rule_name in value.keys() {
         if !Regex::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::UnknownRule("{rule_name}".to_string()),
+                ConfigurationError::UnknownRule(rule_name.to_string()),
             )));
         }
     }
@@ -561,7 +561,7 @@ where
     for rule_name in value.keys() {
         if !Ts::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::UnknownRule("{rule_name}".to_string()),
+                ConfigurationError::UnknownRule(rule_name.to_string()),
             )));
         }
     }

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -351,7 +351,7 @@ where
     for rule_name in value.keys() {
         if !Js::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::UnknownRule(format!("{rule_name}")),
+                ConfigurationError::UnknownRule("{rule_name}".to_string()),
             )));
         }
     }
@@ -428,7 +428,7 @@ where
     for rule_name in value.keys() {
         if !Jsx::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::UnknownRule(format!("{rule_name}")),
+                ConfigurationError::UnknownRule("{rule_name}".to_string()),
             )));
         }
     }
@@ -495,7 +495,7 @@ where
     for rule_name in value.keys() {
         if !Regex::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::UnknownRule(format!("{rule_name}")),
+                ConfigurationError::UnknownRule("{rule_name}".to_string()),
             )));
         }
     }
@@ -561,7 +561,7 @@ where
     for rule_name in value.keys() {
         if !Ts::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::UnknownRule(format!("{rule_name}")),
+                ConfigurationError::UnknownRule("{rule_name}".to_string()),
             )));
         }
     }

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -351,9 +351,7 @@ where
     for rule_name in value.keys() {
         if !Js::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::DeserializationError(format!(
-                    "Invalid rule name `{rule_name}`"
-                )),
+                ConfigurationError::UnknownRule(format!("{rule_name}")),
             )));
         }
     }
@@ -430,9 +428,7 @@ where
     for rule_name in value.keys() {
         if !Jsx::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::DeserializationError(format!(
-                    "Invalid rule name `{rule_name}`"
-                )),
+                ConfigurationError::UnknownRule(format!("{rule_name}")),
             )));
         }
     }
@@ -499,9 +495,7 @@ where
     for rule_name in value.keys() {
         if !Regex::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::DeserializationError(format!(
-                    "Invalid rule name `{rule_name}`"
-                )),
+                ConfigurationError::UnknownRule(format!("{rule_name}")),
             )));
         }
     }
@@ -567,9 +561,7 @@ where
     for rule_name in value.keys() {
         if !Ts::CATEGORY_RULES.contains(&rule_name.as_str()) {
             return Err(serde::de::Error::custom(RomeError::Configuration(
-                ConfigurationError::DeserializationError(format!(
-                    "Invalid rule name `{rule_name}`"
-                )),
+                ConfigurationError::UnknownRule(format!("{rule_name}")),
             )));
         }
     }

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -74,6 +74,9 @@ pub enum ConfigurationError {
     /// - incorrect fields
     /// - incorrect values
     DeserializationError(String),
+
+    /// Thrown when an unknown rule is found
+    UnknownRule(String),
 }
 
 impl Debug for ConfigurationError {
@@ -81,8 +84,8 @@ impl Debug for ConfigurationError {
         match self {
             ConfigurationError::SerializationError => std::fmt::Display::fmt(self, f),
             ConfigurationError::DeserializationError(_) => std::fmt::Display::fmt(self, f),
-
             ConfigurationError::ConfigAlreadyExists => std::fmt::Display::fmt(self, f),
+            ConfigurationError::UnknownRule(_) => std::fmt::Display::fmt(self, f),
         }
     }
 }
@@ -105,6 +108,10 @@ impl Display for ConfigurationError {
             }
             ConfigurationError::ConfigAlreadyExists => {
                 write!(f, "it seems that a configuration file already exists")
+            }
+
+            ConfigurationError::UnknownRule(rule) => {
+                write!(f, "invalid rule name `{rule}`")
             }
         }
     }
@@ -136,6 +143,8 @@ pub fn load_config(
                 .map_err(|_| RomeError::CantReadFile(configuration_path))?;
 
             let configuration: Configuration = serde_json::from_str(&buffer).map_err(|err| {
+                dbg!(&err);
+
                 RomeError::Configuration(ConfigurationError::DeserializationError(err.to_string()))
             })?;
 

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -152,7 +152,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 for rule_name in value.keys() {
                     if !#group_struct_name::CATEGORY_RULES.contains(&rule_name.as_str()) {
                         return Err(serde::de::Error::custom(RomeError::Configuration(
-                            ConfigurationError::UnknownRule("{rule_name}".to_string()),
+                            ConfigurationError::UnknownRule(rule_name.to_string()),
                         )));
                     }
                 }

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -152,7 +152,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 for rule_name in value.keys() {
                     if !#group_struct_name::CATEGORY_RULES.contains(&rule_name.as_str()) {
                         return Err(serde::de::Error::custom(RomeError::Configuration(
-                            ConfigurationError::DeserializationError(format!("Invalid rule name `{rule_name}`")),
+                            ConfigurationError::UnknownRule(format!("{rule_name}")),
                         )));
                     }
                 }

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -152,7 +152,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 for rule_name in value.keys() {
                     if !#group_struct_name::CATEGORY_RULES.contains(&rule_name.as_str()) {
                         return Err(serde::de::Error::custom(RomeError::Configuration(
-                            ConfigurationError::UnknownRule(format!("{rule_name}")),
+                            ConfigurationError::UnknownRule("{rule_name}".to_string()),
                         )));
                     }
                 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR increases the coverage of the snapshots of the CLI tests, by tracking the `Termination` message emitted in case of errors. 

All the snapshots that result in errors are updated. While doing so, I found a bug in how we construct the error message of the rules and fixed it. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Manually checked that the termination messages are printed in the snapshots

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
