### PR TITLE
fix(rome_js_analyze): accept const as non camel case

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
@@ -59,8 +59,8 @@ fn check_is_camel(name: &str) -> Option<State> {
     }
 }
 
-// It is ok to be non camel case when:
-// 1 - is a const variable (eg: const THIS_IS_OK)
+// It is OK to be non camel case when:
+// 1. it's a const variable (eg: const THIS_IS_OK)
 fn is_non_camel_ok(binding: &JsIdentifierBinding) -> Option<bool> {
     use JsSyntaxKind::*;
     let declarator = binding.parent::<JsVariableDeclarator>()?;

--- a/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/js/use_camel_case.rs
@@ -59,6 +59,8 @@ fn check_is_camel(name: &str) -> Option<State> {
     }
 }
 
+// It is ok to be non camel case when:
+// 1 - is a const variable (eg: const THIS_IS_OK)
 fn is_non_camel_ok(binding: &JsIdentifierBinding) -> Option<bool> {
     use JsSyntaxKind::*;
     let declarator = binding.parent::<JsVariableDeclarator>()?;

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -236,9 +236,4 @@ fn ok_to_camel_case() {
         to_camel_case("long_camel_case"),
         Cow::Owned(s) if s.as_str() == "longCamelCase"
     ));
-
-    assert!(matches!(
-        to_camel_case("UPPER_CASE"),
-        Cow::Owned(s) if s.as_str() == "upperCase"
-    ));
 }

--- a/crates/rome_js_analyze/src/utils.rs
+++ b/crates/rome_js_analyze/src/utils.rs
@@ -236,4 +236,9 @@ fn ok_to_camel_case() {
         to_camel_case("long_camel_case"),
         Cow::Owned(s) if s.as_str() == "longCamelCase"
     ));
+
+    assert!(matches!(
+        to_camel_case("UPPER_CASE"),
+        Cow::Owned(s) if s.as_str() == "upperCase"
+    ));
 }

--- a/crates/rome_js_analyze/tests/specs/js/useCamelCase.js
+++ b/crates/rome_js_analyze/tests/specs/js/useCamelCase.js
@@ -27,3 +27,5 @@ console.log({
 
 let camelCase;
 let longCamelCase;
+
+const THIS_IS_OK = 1;

--- a/crates/rome_js_analyze/tests/specs/js/useCamelCase.js
+++ b/crates/rome_js_analyze/tests/specs/js/useCamelCase.js
@@ -28,4 +28,10 @@ console.log({
 let camelCase;
 let longCamelCase;
 
+let UPPER_CASE = 1;
+let { UPPER_CASE } = env;
+let [ UPPER_CASE ] = env;
+
 const THIS_IS_OK = 1;
+const { THIS_IS_OK } = env;
+const [ THIS_IS_OK ] = env;

--- a/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
@@ -35,8 +35,8 @@ let camelCase;
 let longCamelCase;
 
 let UPPER_CASE = 1;
-let { UPPER_CASE } = 1;
-let [ UPPER_CASE ] = 1;
+let { UPPER_CASE } = env;
+let [ UPPER_CASE ] = env;
 
 const THIS_IS_OK = 1;
 const { THIS_IS_OK } = env;
@@ -192,8 +192,8 @@ Safe fix: Rename this symbol to camel case
 29 29 |   
 30    | - let UPPER_CASE = 1;
    30 | + let uPPERCASE = 1;
-31 31 |   let { UPPER_CASE } = 1;
-32 32 |   let [ UPPER_CASE ] = 1;
+31 31 |   let { UPPER_CASE } = env;
+32 32 |   let [ UPPER_CASE ] = env;
 33 33 |   
 
 

--- a/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
@@ -34,7 +34,13 @@ console.log({
 let camelCase;
 let longCamelCase;
 
+let UPPER_CASE = 1;
+let { UPPER_CASE } = 1;
+let [ UPPER_CASE ] = 1;
+
 const THIS_IS_OK = 1;
+const { THIS_IS_OK } = env;
+const [ THIS_IS_OK ] = env;
 
 ```
 
@@ -168,6 +174,27 @@ warning[js/useCamelCase]: Prefer methods names in camel case.
    │
 15 │     set snake_setter(v) {
    │         ------------
+
+
+```
+
+```
+warning[js/useCamelCase]: Prefer variables names in camel case.
+   ┌─ useCamelCase.js:31:5
+   │
+31 │ let UPPER_CASE = 1;
+   │     ----------
+
+Safe fix: Rename this symbol to camel case
+      | @@ -28,7 +28,7 @@
+27 27 |   let camelCase;
+28 28 |   let longCamelCase;
+29 29 |   
+30    | - let UPPER_CASE = 1;
+   30 | + let uPPERCASE = 1;
+31 31 |   let { UPPER_CASE } = 1;
+32 32 |   let [ UPPER_CASE ] = 1;
+33 33 |   
 
 
 ```

--- a/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
+++ b/crates/rome_js_analyze/tests/specs/js/useCamelCase.js.snap
@@ -34,6 +34,8 @@ console.log({
 let camelCase;
 let longCamelCase;
 
+const THIS_IS_OK = 1;
+
 ```
 
 # Diagnostics

--- a/rome.json
+++ b/rome.json
@@ -3,8 +3,7 @@
 		"rules": {
 			"recommended": true,
 			"js": {
-				"noDeadCode": "error",
-				"useCamelCase": "off"
+				"noDeadCode": "error"
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This PR fixes a false flag of all uppercase const as an invalid non-camel case.
Fixes a lot of issues here: https://github.com/rome/tools/runs/8188485278

## Test Plan

```
> cargo test -p rome_js_analyze -- camel_case
```
