### PR TITLE
docs: fix link to download latest asset

### DIFF
--- a/website/src/_includes/docs/getting-started.md
+++ b/website/src/_includes/docs/getting-started.md
@@ -62,7 +62,7 @@ steps:
 You can download and install the binary directly using `curl`:
 
 ```shell
-curl -L https://github.com/rome/tools/releases/download/latest/rome-<OS>-<ARCH> -o rome
+curl -L https://github.com/rome/tools/releases/latest/download/rome-<OS>-<ARCH> -o rome
 chmod +x rome
 ```
 


### PR DESCRIPTION
## Summary

The order of `download` and `latest` was swapped, so the command was not working.
Source: https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases