### PR TITLE
feature(vscode): add rules to the schema

### DIFF
--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -216,7 +216,48 @@ pub struct Js {
         deserialize_with = "deserialize_js_rules",
         flatten
     )]
+    #[cfg_attr(feature = "schemars", schemars(with = "JsSchema"))]
     pub rules: IndexMap<String, RuleConfiguration>,
+}
+#[cfg_attr(
+    feature = "schemars",
+    derive(JsonSchema),
+    serde(rename_all = "camelCase")
+)]
+#[allow(dead_code)]
+#[doc = r" A list of rules that belong to this group"]
+struct JsSchema {
+    no_arguments: Option<RuleConfiguration>,
+    no_async_promise_executor: Option<RuleConfiguration>,
+    no_catch_assign: Option<RuleConfiguration>,
+    no_compare_neg_zero: Option<RuleConfiguration>,
+    no_dead_code: Option<RuleConfiguration>,
+    no_debugger: Option<RuleConfiguration>,
+    no_delete: Option<RuleConfiguration>,
+    no_double_equals: Option<RuleConfiguration>,
+    no_dupe_args: Option<RuleConfiguration>,
+    no_empty_pattern: Option<RuleConfiguration>,
+    no_extra_boolean_cast: Option<RuleConfiguration>,
+    no_function_assign: Option<RuleConfiguration>,
+    no_import_assign: Option<RuleConfiguration>,
+    no_label_var: Option<RuleConfiguration>,
+    no_negation_else: Option<RuleConfiguration>,
+    no_shadow_restricted_names: Option<RuleConfiguration>,
+    no_shouty_constants: Option<RuleConfiguration>,
+    no_sparse_array: Option<RuleConfiguration>,
+    no_unnecessary_continue: Option<RuleConfiguration>,
+    no_unsafe_negation: Option<RuleConfiguration>,
+    no_unused_template_literal: Option<RuleConfiguration>,
+    no_unused_variables: Option<RuleConfiguration>,
+    use_block_statements: Option<RuleConfiguration>,
+    use_camel_case: Option<RuleConfiguration>,
+    use_optional_chain: Option<RuleConfiguration>,
+    use_simplified_logic_expression: Option<RuleConfiguration>,
+    use_single_case_statement: Option<RuleConfiguration>,
+    use_single_var_declarator: Option<RuleConfiguration>,
+    use_template: Option<RuleConfiguration>,
+    use_valid_typeof: Option<RuleConfiguration>,
+    use_while: Option<RuleConfiguration>,
 }
 impl Js {
     const CATEGORY_NAME: &'static str = "js";
@@ -373,7 +414,20 @@ pub struct Jsx {
         deserialize_with = "deserialize_jsx_rules",
         flatten
     )]
+    #[cfg_attr(feature = "schemars", schemars(with = "JsxSchema"))]
     pub rules: IndexMap<String, RuleConfiguration>,
+}
+#[cfg_attr(
+    feature = "schemars",
+    derive(JsonSchema),
+    serde(rename_all = "camelCase")
+)]
+#[allow(dead_code)]
+#[doc = r" A list of rules that belong to this group"]
+struct JsxSchema {
+    no_comment_text: Option<RuleConfiguration>,
+    no_implicit_boolean: Option<RuleConfiguration>,
+    use_self_closing_elements: Option<RuleConfiguration>,
 }
 impl Jsx {
     const CATEGORY_NAME: &'static str = "jsx";
@@ -450,7 +504,18 @@ pub struct Regex {
         deserialize_with = "deserialize_regex_rules",
         flatten
     )]
+    #[cfg_attr(feature = "schemars", schemars(with = "RegexSchema"))]
     pub rules: IndexMap<String, RuleConfiguration>,
+}
+#[cfg_attr(
+    feature = "schemars",
+    derive(JsonSchema),
+    serde(rename_all = "camelCase")
+)]
+#[allow(dead_code)]
+#[doc = r" A list of rules that belong to this group"]
+struct RegexSchema {
+    no_multiple_spaces_in_regular_expression_literals: Option<RuleConfiguration>,
 }
 impl Regex {
     const CATEGORY_NAME: &'static str = "regex";
@@ -517,7 +582,18 @@ pub struct Ts {
         deserialize_with = "deserialize_ts_rules",
         flatten
     )]
+    #[cfg_attr(feature = "schemars", schemars(with = "TsSchema"))]
     pub rules: IndexMap<String, RuleConfiguration>,
+}
+#[cfg_attr(
+    feature = "schemars",
+    derive(JsonSchema),
+    serde(rename_all = "camelCase")
+)]
+#[allow(dead_code)]
+#[doc = r" A list of rules that belong to this group"]
+struct TsSchema {
+    use_shorthand_array_type: Option<RuleConfiguration>,
 }
 impl Ts {
     const CATEGORY_NAME: &'static str = "ts";

--- a/crates/rome_service/src/workspace_types.rs
+++ b/crates/rome_service/src/workspace_types.rs
@@ -231,7 +231,10 @@ fn schema_object_type<'a>(
                     })))
                 })
         })
-        .unwrap_or_else(|| panic!("unimplemented schema {schema:#?}"));
+        .unwrap_or_else(|| {
+            // this is temporary workaround to fix the `options` field, which is not used at the moment
+            TsType::from(make::ts_any_type(make::token(T![any])))
+        });
 
     // Types are considered "optional" in the serialization protocol if they
     // have the `nullable` OpenAPI extension property, or if they have a default value

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -132,25 +132,367 @@
       "additionalProperties": false
     },
     "Js": {
+      "description": "A list of rules that belong to this group",
       "type": "object",
       "properties": {
+        "noArguments": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noAsyncPromiseExecutor": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noCatchAssign": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noCompareNegZero": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noDeadCode": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noDebugger": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noDelete": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noDoubleEquals": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noDupeArgs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noEmptyPattern": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noExtraBooleanCast": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noFunctionAssign": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noImportAssign": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noLabelVar": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noNegationElse": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noShadowRestrictedNames": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noShoutyConstants": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noSparseArray": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noUnnecessaryContinue": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noUnsafeNegation": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noUnusedTemplateLiteral": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noUnusedVariables": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "recommended": {
           "description": "It enables the recommended rules for this group",
           "type": [
             "boolean",
             "null"
           ]
+        },
+        "useBlockStatements": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "useCamelCase": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "useOptionalChain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "useSimplifiedLogicExpression": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "useSingleCaseStatement": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "useSingleVarDeclarator": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "useTemplate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "useValidTypeof": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "useWhile": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
     "Jsx": {
+      "description": "A list of rules that belong to this group",
       "type": "object",
       "properties": {
+        "noCommentText": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noImplicitBoolean": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "recommended": {
           "description": "It enables the recommended rules for this group",
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "useSelfClosingElements": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       }
@@ -208,8 +550,19 @@
       ]
     },
     "Regex": {
+      "description": "A list of rules that belong to this group",
       "type": "object",
       "properties": {
+        "noMultipleSpacesInRegularExpressionLiterals": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "recommended": {
           "description": "It enables the recommended rules for this group",
           "type": [
@@ -305,6 +658,7 @@
       "additionalProperties": false
     },
     "Ts": {
+      "description": "A list of rules that belong to this group",
       "type": "object",
       "properties": {
         "recommended": {
@@ -312,6 +666,16 @@
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "useShorthandArrayType": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       }

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -96,29 +96,83 @@ export interface Rules {
 }
 export type QuoteProperties = "asNeeded" | "preserve";
 export type QuoteStyle = "double" | "single";
+/**
+ * A list of rules that belong to this group
+ */
 export interface Js {
+	noArguments?: RuleConfiguration;
+	noAsyncPromiseExecutor?: RuleConfiguration;
+	noCatchAssign?: RuleConfiguration;
+	noCompareNegZero?: RuleConfiguration;
+	noDeadCode?: RuleConfiguration;
+	noDebugger?: RuleConfiguration;
+	noDelete?: RuleConfiguration;
+	noDoubleEquals?: RuleConfiguration;
+	noDupeArgs?: RuleConfiguration;
+	noEmptyPattern?: RuleConfiguration;
+	noExtraBooleanCast?: RuleConfiguration;
+	noFunctionAssign?: RuleConfiguration;
+	noImportAssign?: RuleConfiguration;
+	noLabelVar?: RuleConfiguration;
+	noNegationElse?: RuleConfiguration;
+	noShadowRestrictedNames?: RuleConfiguration;
+	noShoutyConstants?: RuleConfiguration;
+	noSparseArray?: RuleConfiguration;
+	noUnnecessaryContinue?: RuleConfiguration;
+	noUnsafeNegation?: RuleConfiguration;
+	noUnusedTemplateLiteral?: RuleConfiguration;
+	noUnusedVariables?: RuleConfiguration;
 	/**
 	 * It enables the recommended rules for this group
 	 */
 	recommended?: boolean;
+	useBlockStatements?: RuleConfiguration;
+	useCamelCase?: RuleConfiguration;
+	useOptionalChain?: RuleConfiguration;
+	useSimplifiedLogicExpression?: RuleConfiguration;
+	useSingleCaseStatement?: RuleConfiguration;
+	useSingleVarDeclarator?: RuleConfiguration;
+	useTemplate?: RuleConfiguration;
+	useValidTypeof?: RuleConfiguration;
+	useWhile?: RuleConfiguration;
 }
+/**
+ * A list of rules that belong to this group
+ */
 export interface Jsx {
+	noCommentText?: RuleConfiguration;
+	noImplicitBoolean?: RuleConfiguration;
 	/**
 	 * It enables the recommended rules for this group
 	 */
 	recommended?: boolean;
+	useSelfClosingElements?: RuleConfiguration;
 }
+/**
+ * A list of rules that belong to this group
+ */
 export interface Regex {
+	noMultipleSpacesInRegularExpressionLiterals?: RuleConfiguration;
 	/**
 	 * It enables the recommended rules for this group
 	 */
 	recommended?: boolean;
 }
+/**
+ * A list of rules that belong to this group
+ */
 export interface Ts {
 	/**
 	 * It enables the recommended rules for this group
 	 */
 	recommended?: boolean;
+	useShorthandArrayType?: RuleConfiguration;
+}
+export type RuleConfiguration = RulePlainConfiguration | RuleWithOptions;
+export type RulePlainConfiguration = "warn" | "error" | "off";
+export interface RuleWithOptions {
+	level: RulePlainConfiguration;
+	options: any;
 }
 export interface OpenFileParams {
 	content: string;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds support for constructing the rules into the JSON schema used by our VSCode extension.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Manually packaged the extension. Here's a couple of screenshots

<img width="524" alt="Screenshot 2022-09-13 at 13 39 04" src="https://user-images.githubusercontent.com/602478/189903320-22f8a5be-a683-4d71-b864-092bbd42c691.png">


<img width="521" alt="Screenshot 2022-09-13 at 13 38 53" src="https://user-images.githubusercontent.com/602478/189903343-872a7276-71a3-49bc-b0d6-7ad2fa583957.png">


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
