### PR TITLE
feat(rome_js_analyze): useCamelCase accepts function when they are used in new or exported

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_camel_case.rs
@@ -85,9 +85,8 @@ fn is_non_camel_ok(binding: &JsIdentifierBinding, model: &SemanticModel) -> Opti
 
             for reference in binding.all_reads(model) {
                 let greatparent = reference.node().grand_parent()?;
-                match greatparent.kind() {
-                    JS_NEW_EXPRESSION => return Some(true),
-                    _ => {}
+                if let JS_NEW_EXPRESSION = greatparent.kind() {
+                    return Some(true);
                 }
             }
 

--- a/crates/rome_js_analyze/tests/specs/nursery/useCamelCase.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/useCamelCase.js
@@ -35,3 +35,12 @@ let [ UPPER_CASE ] = env;
 const THIS_IS_OK = 1;
 const { THIS_IS_OK } = env;
 const [ THIS_IS_OK ] = env;
+
+function PascalCaseOkBecauseNew() { }
+console.log(new PascalCaseOkBecauseNew());
+
+function PascalCaseOkBecauseExport() { }
+export default PascalCaseOkBecauseExport;
+
+function PascalCaseNOk() { }
+console.log(PascalCaseNOk());

--- a/crates/rome_js_analyze/tests/specs/nursery/useCamelCase.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useCamelCase.js.snap
@@ -209,7 +209,7 @@ Safe fix: Rename this symbol to camel case
 ```
 
 ```
-warning[js/useCamelCase]: Prefer functions names in camel case.
+warning[nursery/useCamelCase]: Prefer functions names in camel case.
    ┌─ useCamelCase.js:45:10
    │
 45 │ function PascalCaseNOk() { }

--- a/crates/rome_js_analyze/tests/specs/nursery/useCamelCase.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useCamelCase.js.snap
@@ -42,6 +42,15 @@ const THIS_IS_OK = 1;
 const { THIS_IS_OK } = env;
 const [ THIS_IS_OK ] = env;
 
+function PascalCaseOkBecauseNew() { }
+console.log(new PascalCaseOkBecauseNew());
+
+function PascalCaseOkBecauseExport() { }
+export default PascalCaseOkBecauseExport;
+
+function PascalCaseNOk() { }
+console.log(PascalCaseNOk());
+
 ```
 
 # Diagnostics
@@ -195,6 +204,26 @@ Safe fix: Rename this symbol to camel case
 31 31 |   let { UPPER_CASE } = env;
 32 32 |   let [ UPPER_CASE ] = env;
 33 33 |   
+
+
+```
+
+```
+warning[js/useCamelCase]: Prefer functions names in camel case.
+   ┌─ useCamelCase.js:45:10
+   │
+45 │ function PascalCaseNOk() { }
+   │          -------------
+
+Safe fix: Rename this symbol to camel case
+      | @@ -42,5 +42,5 @@
+41 41 |   function PascalCaseOkBecauseExport() { }
+42 42 |   export default PascalCaseOkBecauseExport;
+43 43 |   
+44    | - function PascalCaseNOk() { }
+45    | - console.log(PascalCaseNOk());
+   44 | + function pascalCaseNOk() { }
+   45 | + console.log(pascalCaseNOk());
 
 
 ```


### PR DESCRIPTION
## Summary

This PR add support for non camel case function when:  
1 - They are used inside a new expression;
2 - They are exported.

## Test Plan

```
> cargo test -p rome_js_analyze -- camel_case
```
