### PR TITLE
perf(rome_rowan): `SyntaxNodeText` improvements

### DIFF
--- a/crates/rome_diagnostics/src/file.rs
+++ b/crates/rome_diagnostics/src/file.rs
@@ -39,23 +39,19 @@ pub trait Span {
     }
 
     fn sub_start(&self, amount: TextSize) -> TextRange {
-        let range = self.as_range();
-        TextRange::new(range.start() - amount, range.end())
+        self.as_range().sub_start(amount)
     }
 
     fn add_start(&self, amount: TextSize) -> TextRange {
-        let range = self.as_range();
-        TextRange::new(range.start() + amount, range.end())
+        self.as_range().add_start(amount)
     }
 
     fn sub_end(&self, amount: TextSize) -> TextRange {
-        let range = self.as_range();
-        TextRange::new(range.start(), range.end() - amount)
+        self.as_range().sub_end(amount)
     }
 
     fn add_end(&self, amount: TextSize) -> TextRange {
-        let range = self.as_range();
-        TextRange::new(range.start(), range.end() + amount)
+        self.as_range().add_end(amount)
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
@@ -57,13 +57,14 @@ fn is_id_and_string_literal_inner_text_equal(
 ) -> Option<(JsIdentifierBinding, JsStringLiteralExpression)> {
     let id = declarator.id().ok()?;
     let id = id.as_js_any_binding()?.as_js_identifier_binding()?;
-    let id_text = id.syntax().text_trimmed();
+    let name = id.name_token().ok()?;
+    let id_text = name.text_trimmed();
 
     let expression = declarator.initializer()?.expression().ok()?;
     let literal = expression
         .as_js_any_literal_expression()?
         .as_js_string_literal_expression()?;
-    let literal_text = literal.inner_string_text();
+    let literal_text = literal.inner_string_text().ok()?;
 
     for (from_id, from_literal) in id_text.chars().zip(literal_text.chars()) {
         if from_id != from_literal {

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -31,7 +31,7 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     let parsed = parse(&input_code, 0, source_type);
     let root = parsed.tree();
 
-    let (group, rule) = dbg!(parse_test_path(input_file));
+    let (group, rule) = parse_test_path(input_file);
 
     let rule_filter = RuleFilter::Rule(group, rule);
     let filter = AnalysisFilter {

--- a/crates/rome_rowan/src/cursor/node.rs
+++ b/crates/rome_rowan/src/cursor/node.rs
@@ -335,8 +335,7 @@ impl SyntaxNode {
 
         let mut children = self.children_with_tokens().filter(|child| {
             let child_range = child.text_range();
-            !child_range.is_empty()
-                && (child_range.start() <= offset && offset <= child_range.end())
+            !child_range.is_empty() && child_range.contains_inclusive(offset)
         });
 
         let left = children.next().unwrap();
@@ -602,16 +601,6 @@ impl PreorderWithTokens {
             WalkEvent::Enter(first_child) => WalkEvent::Leave(first_child.parent().unwrap().into()),
             WalkEvent::Leave(parent) => WalkEvent::Leave(parent),
         })
-    }
-
-    pub fn until_next_token(&mut self) -> Option<SyntaxToken> {
-        loop {
-            match self.next() {
-                Some(crate::WalkEvent::Enter(NodeOrToken::Token(t))) => break Some(t),
-                None => break None,
-                _ => continue,
-            }
-        }
     }
 }
 

--- a/crates/rome_rowan/src/syntax_token_text.rs
+++ b/crates/rome_rowan/src/syntax_token_text.rs
@@ -51,6 +51,10 @@ impl SyntaxTokenText {
         self
     }
 
+    pub fn range(&self) -> TextRange {
+        self.range
+    }
+
     pub fn text(&self) -> &str {
         &self.token.text()[self.range]
     }

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -143,8 +143,6 @@ pub fn load_config(
                 .map_err(|_| RomeError::CantReadFile(configuration_path))?;
 
             let configuration: Configuration = serde_json::from_str(&buffer).map_err(|err| {
-                dbg!(&err);
-
                 RomeError::Configuration(ConfigurationError::DeserializationError(err.to_string()))
             })?;
 

--- a/crates/rome_text_size/src/range.rs
+++ b/crates/rome_text_size/src/range.rs
@@ -340,6 +340,81 @@ impl TextRange {
             Ordering::Equal
         }
     }
+
+    /// Subtracts an offset from the start position.
+    ///
+    ///
+    /// ## Panics
+    /// If `start - amount` is less than zero.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rome_text_size::{TextRange, TextSize};
+    ///
+    /// let range = TextRange::new(TextSize::from(5), TextSize::from(10));
+    /// assert_eq!(range.sub_start(TextSize::from(2)), TextRange::new(TextSize::from(3), TextSize::from(10)));
+    /// ```
+    #[inline]
+    pub fn sub_start(&self, amount: TextSize) -> TextRange {
+        TextRange::new(self.start() - amount, self.end())
+    }
+
+    /// Adds an offset to the start position.
+    ///
+    /// ## Panics
+    /// If `start + amount > end`
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rome_text_size::{TextRange, TextSize};
+    ///
+    /// let range = TextRange::new(TextSize::from(5), TextSize::from(10));
+    /// assert_eq!(range.add_start(TextSize::from(3)), TextRange::new(TextSize::from(8), TextSize::from(10)));
+    /// ```
+    #[inline]
+    pub fn add_start(&self, amount: TextSize) -> TextRange {
+        TextRange::new(self.start() + amount, self.end())
+    }
+
+    /// Subtracts an offset from the end position.
+    ///
+    ///
+    /// ## Panics
+    /// If `end - amount < 0` or `end - amount < start`
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rome_text_size::{TextRange, TextSize};
+    ///
+    /// let range = TextRange::new(TextSize::from(5), TextSize::from(10));
+    /// assert_eq!(range.sub_end(TextSize::from(2)), TextRange::new(TextSize::from(5), TextSize::from(8)));
+    /// ```
+    #[inline]
+    pub fn sub_end(&self, amount: TextSize) -> TextRange {
+        TextRange::new(self.start(), self.end() - amount)
+    }
+
+    /// Adds an offset to the end position.
+    ///
+    ///
+    /// ## Panics
+    /// If `end + amount > u32::MAX`
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rome_text_size::{TextRange, TextSize};
+    ///
+    /// let range = TextRange::new(TextSize::from(5), TextSize::from(10));
+    /// assert_eq!(range.add_end(TextSize::from(2)), TextRange::new(TextSize::from(5), TextSize::from(12)));
+    /// ```
+    #[inline]
+    pub fn add_end(&self, amount: TextSize) -> TextRange {
+        TextRange::new(self.start(), self.end() + amount)
+    }
 }
 
 impl Index<TextRange> for str {


### PR DESCRIPTION
This PR improves the performance of `SyntaxNodeText` by using the `token_at_offset` method rather than traversing over all tokens in the tree until it find the first token that has an overlapping range. Using `token_at_offset` has better performance because it only traverses into nodes that have an overlapping range.

Example: Getting the text for `+ e` in ``a + b + c + d + e`

* Old implementation: Traverses through the whole tree until it reaches the `+` token
* New: Finds the `+` on the first level, then traverses into `e`

Doing this improvement I discovered that `noShoutyConstants` uses `SyntaxNodeText` over `SyntaxTokenText`. `SyntaxTokenText` has the better performance because it isn't necessary to find the first token with an overlapping range. So, I refactored the implementation to use `SyntaxTokenText` instead

 ## Performance

 ```
 group                                    main                                    text
 -----                                    ----                                    ----
 analyzer/css.js                          1.06  1238.1±109.59µs     9.4 MB/sec    1.00   1167.7±6.84µs     9.9 MB/sec
 analyzer/index.js                        1.03      3.6±0.36ms     9.2 MB/sec     1.00      3.5±0.30ms     9.4 MB/sec
 analyzer/lint.ts                         1.04      2.1±0.07ms    19.6 MB/sec     1.00      2.0±0.01ms    20.4 MB/sec
 analyzer/parser.ts                       1.05      4.3±0.35ms    11.4 MB/sec     1.00      4.1±0.17ms    12.0 MB/sec
 analyzer/router.ts                       1.00      2.8±0.14ms    21.9 MB/sec     1.02      2.9±0.02ms    21.5 MB/sec
 analyzer/statement.ts                    1.00      3.8±0.17ms     9.3 MB/sec     1.01      3.8±0.12ms     9.3 MB/sec
 analyzer/typescript.ts                   1.22      7.4±1.25ms     7.3 MB/sec     1.00      6.1±0.46ms     9.0 MB/sec
```

## Test Plan

I added new doc tests and integration tests for the changes in `rome_rowan` and `rome_text_size`
