### PR TITLE
feat(rome_rowan): Expose `SyntaxElementKey`

### DIFF
--- a/crates/rome_rowan/src/syntax.rs
+++ b/crates/rome_rowan/src/syntax.rs
@@ -11,7 +11,7 @@ pub use trivia::{
     TriviaPieceKind,
 };
 
-pub use element::SyntaxElement;
+pub use element::{SyntaxElement, SyntaxElementKey};
 pub(crate) use node::SyntaxSlots;
 pub use node::{
     Preorder, PreorderWithTokens, SendNode, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren,

--- a/crates/rome_rowan/src/syntax/element.rs
+++ b/crates/rome_rowan/src/syntax/element.rs
@@ -124,7 +124,7 @@ impl<L: Language> From<SyntaxNode<L>> for SyntaxElement<L> {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct SyntaxElementKey {
     node_data: NonNull<()>,
     offset: TextSize,


### PR DESCRIPTION
## Summary

This PR makes the `SyntaxElementKey` public. The `key` methods already have been public but the type itself wasn't, preventing it to e.g. be used as keys in a `HashMap`.

The Comments refactoring uses `SyntaxElementKey` as `HashMap`  keys which is why it is necessary to use the type in other crates. An alternative would have been to use `SyntaxNode` and `SyntaxToken` as keys. However, this has the downside that all keys must be deallocated after formatting a file whereas the compiler may be able to optimize the drop away when using the key.


## Test Plan

`cargo build`
