### PR TITLE
refactor(rome_diagnostics): change FileId from a type alias to a newtype struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "indexmap",
  "parking_lot 0.12.1",
  "rayon",
+ "rome_diagnostics",
  "schemars",
  "serde",
  "tracing",

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -156,7 +156,7 @@ where
 #[cfg(test)]
 mod tests {
     use rome_console::codespan::Severity;
-    use rome_diagnostics::Diagnostic;
+    use rome_diagnostics::{file::FileId, Diagnostic};
     use rome_rowan::{
         raw_language::{RawLanguage, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
         AstNode, TextRange, TextSize, TriviaPiece, TriviaPieceKind,
@@ -207,7 +207,7 @@ mod tests {
             params.signal_queue.push(SignalEntry {
                 signal: Box::new(DiagnosticSignal::new(move || {
                     AnalyzerDiagnostic::from_diagnostic(
-                        Diagnostic::warning(0, "test_suppression", "test_suppression")
+                        Diagnostic::warning(FileId::zero(), "test_suppression", "test_suppression")
                             .primary(span, ""),
                     )
                 })),
@@ -338,7 +338,7 @@ mod tests {
         analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
 
         let ctx: AnalyzerContext<RawLanguage> = AnalyzerContext {
-            file_id: 0,
+            file_id: FileId::zero(),
             root,
             range: None,
             services: ServiceBag::default(),

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -49,6 +49,7 @@ impl<L: Language> Visitor for SyntaxVisitor<L> {
 #[cfg(test)]
 mod tests {
 
+    use rome_diagnostics::file::FileId;
     use rome_rowan::{
         raw_language::{RawLanguage, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
         AstNode,
@@ -117,7 +118,7 @@ mod tests {
         analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
 
         let ctx: AnalyzerContext<RawLanguage> = AnalyzerContext {
-            file_id: 0,
+            file_id: FileId::zero(),
             root,
             range: None,
             services: ServiceBag::default(),

--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -1,6 +1,7 @@
 use crate::traversal::traverse;
 use crate::{CliSession, Termination};
 use rome_console::{markup, ConsoleExt};
+use rome_diagnostics::file::FileId;
 use rome_fs::RomePath;
 use rome_service::workspace::{
     FeatureName, FixFileMode, FormatFileParams, Language, OpenFileParams, SupportsFeatureParams,
@@ -125,7 +126,7 @@ pub(crate) fn execute_mode(mode: Execution, mut session: CliSession) -> Result<(
     if let Some((path, content)) = mode.as_stdin_file() {
         let workspace = &*session.app.workspace;
         let console = &mut *session.app.console;
-        let rome_path = RomePath::new(path, 0);
+        let rome_path = RomePath::new(path, FileId::zero());
 
         if mode.is_format() {
             let unsupported_format_reason = workspace

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -196,7 +196,7 @@ struct ProcessMessagesOptions<'ctx> {
     /// Mutable reference to the [console](Console)
     console: &'ctx mut dyn Console,
     /// Receiver channel that expects info when a file is processed
-    recv_files: Receiver<(usize, PathBuf)>,
+    recv_files: Receiver<(FileId, PathBuf)>,
     /// Receiver channel that expects info when a message is sent
     recv_msgs: Receiver<Message>,
     /// Sender of reports

--- a/crates/rome_diagnostics/src/emit.rs
+++ b/crates/rome_diagnostics/src/emit.rs
@@ -296,7 +296,10 @@ mod tests {
     use rome_console::{codespan::Severity, markup, BufferConsole, ConsoleExt, Markup};
     use rome_rowan::{TextRange, TextSize};
 
-    use crate::{file::SimpleFile, Applicability, Diagnostic};
+    use crate::{
+        file::{FileId, SimpleFile},
+        Applicability, Diagnostic,
+    };
 
     #[test]
     fn test_error_diagnostic() {
@@ -328,7 +331,7 @@ labore et dolore magna aliqua";
 
         let files = SimpleFile::new(String::from("file_name"), SOURCE.into());
 
-        let diag = Diagnostic::error(0, "CODE", "message")
+        let diag = Diagnostic::error(FileId::zero(), "CODE", "message")
             .label(
                 Severity::Error,
                 TextRange::new(TextSize::from(40u32), TextSize::from(55u32)),

--- a/crates/rome_diagnostics/src/file.rs
+++ b/crates/rome_diagnostics/src/file.rs
@@ -107,8 +107,28 @@ impl Span for TextRange {
     }
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+)]
 /// An id that points into a file database.
-pub type FileId = usize;
+pub struct FileId(usize);
+impl FileId {
+    pub const fn zero() -> Self {
+        Self(0)
+    }
+}
+impl From<usize> for FileId {
+    fn from(input: usize) -> Self {
+        Self(input)
+    }
+}
+impl From<FileId> for usize {
+    fn from(input: FileId) -> Self {
+        input.0
+    }
+}
 
 /// A range that is indexed in a specific file.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -187,7 +207,7 @@ impl SimpleFiles {
 
     /// Adds a file to this database and returns the id for the new file.
     pub fn add(&mut self, name: String, source: String) -> FileId {
-        let id = self.id;
+        let id = FileId::from(self.id);
         self.id += 1;
         self.files.insert(id, SimpleFile::new(name, source));
         id

--- a/crates/rome_fs/Cargo.toml
+++ b/crates/rome_fs/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rome_diagnostics = { path = "../rome_diagnostics" }
 indexmap = "1.8.0"
 parking_lot = { version = "0.12.0", features = ["arc_lock"] }
 rayon = "1.5.1"

--- a/crates/rome_fs/src/fs.rs
+++ b/crates/rome_fs/src/fs.rs
@@ -5,7 +5,8 @@ use std::{
     sync::Arc,
 };
 
-use crate::{interner::FileId, PathInterner, RomePath};
+use crate::{PathInterner, RomePath};
+use rome_diagnostics::file::FileId;
 
 mod memory;
 mod os;

--- a/crates/rome_fs/src/fs/memory.rs
+++ b/crates/rome_fs/src/fs/memory.rs
@@ -158,9 +158,9 @@ mod tests {
 
     use crate::fs::FileSystemExt;
     use crate::{
-        interner::FileId, AtomicInterner, FileSystem, MemoryFileSystem, PathInterner, RomePath,
-        TraversalContext,
+        AtomicInterner, FileSystem, MemoryFileSystem, PathInterner, RomePath, TraversalContext,
     };
+    use rome_diagnostics::file::FileId;
 
     #[test]
     fn file_read_write() {
@@ -226,7 +226,7 @@ mod tests {
             }
 
             fn push_diagnostic(&self, file_id: FileId, code: &'static str, message: String) {
-                panic!("unexpected error {code:?} in file {file_id}: {message}")
+                panic!("unexpected error {code:?} in file {file_id:?}: {message}")
             }
 
             fn can_handle(&self, _: &RomePath) -> bool {

--- a/crates/rome_fs/src/fs/os.rs
+++ b/crates/rome_fs/src/fs/os.rs
@@ -3,10 +3,10 @@ use super::{BoxedTraversal, File};
 use crate::fs::{FileSystemExt, OpenOptions};
 use crate::{
     fs::{TraversalContext, TraversalScope},
-    interner::FileId,
     FileSystem, RomePath,
 };
 use rayon::{scope, Scope};
+use rome_diagnostics::file::FileId;
 use std::{
     ffi::OsStr,
     fs,

--- a/crates/rome_fs/src/interner.rs
+++ b/crates/rome_fs/src/interner.rs
@@ -9,9 +9,8 @@ use std::{
 
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use indexmap::IndexSet;
+use rome_diagnostics::file::FileId;
 use std::sync::RwLock;
-
-pub type FileId = usize;
 
 pub trait PathInterner {
     fn intern_path(&self, path: PathBuf) -> FileId;
@@ -24,7 +23,7 @@ pub struct IndexSetInterner {
 impl PathInterner for IndexSetInterner {
     fn intern_path(&self, path: PathBuf) -> FileId {
         let (index, _) = self.storage.write().unwrap().insert_full(path);
-        index
+        FileId::from(index)
     }
 }
 
@@ -53,7 +52,7 @@ impl AtomicInterner {
 
 impl PathInterner for AtomicInterner {
     fn intern_path(&self, path: PathBuf) -> FileId {
-        let id = self.counter.fetch_add(1, Ordering::Relaxed);
+        let id = FileId::from(self.counter.fetch_add(1, Ordering::Relaxed));
         self.storage.send((id, path)).ok();
         id
     }

--- a/crates/rome_fs/src/path.rs
+++ b/crates/rome_fs/src/path.rs
@@ -7,6 +7,8 @@ use std::fs::read_to_string;
 use std::io::Read;
 use std::{fs::File, io, io::Write, ops::Deref, path::PathBuf};
 
+use rome_diagnostics::file::FileId;
+
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 #[cfg_attr(
     feature = "serde",
@@ -14,7 +16,7 @@ use std::{fs::File, io, io::Write, ops::Deref, path::PathBuf};
 )]
 pub struct RomePath {
     path: PathBuf,
-    id: usize,
+    id: FileId,
 }
 
 impl Deref for RomePath {
@@ -26,7 +28,7 @@ impl Deref for RomePath {
 }
 
 impl RomePath {
-    pub fn new(path_to_file: impl Into<PathBuf>, id: usize) -> Self {
+    pub fn new(path_to_file: impl Into<PathBuf>, id: FileId) -> Self {
         Self {
             path: path_to_file.into(),
             id,
@@ -64,7 +66,7 @@ impl RomePath {
     }
 
     /// Retrieves the ID assigned to the file
-    pub fn file_id(&self) -> usize {
+    pub fn file_id(&self) -> FileId {
         self.id
     }
 

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -101,6 +101,7 @@ mod tests {
 
     use rome_analyze::Never;
     use rome_console::codespan::Severity;
+    use rome_diagnostics::file::FileId;
     use rome_js_parser::parse;
     use rome_js_syntax::{SourceType, TextRange, TextSize};
 
@@ -113,21 +114,26 @@ mod tests {
         foo.bar && foo.bar?.();
         ";
 
-        let parsed = parse(SOURCE, 0, SourceType::js_module());
+        let parsed = parse(SOURCE, FileId::zero(), SourceType::js_module());
 
         let mut error_ranges = Vec::new();
-        analyze(0, &parsed.tree(), AnalysisFilter::default(), |signal| {
-            if let Some(diag) = signal.diagnostic() {
-                let diag = diag.into_diagnostic(Severity::Warning);
-                let primary = diag.primary.as_ref().unwrap();
+        analyze(
+            FileId::zero(),
+            &parsed.tree(),
+            AnalysisFilter::default(),
+            |signal| {
+                if let Some(diag) = signal.diagnostic() {
+                    let diag = diag.into_diagnostic(Severity::Warning);
+                    let primary = diag.primary.as_ref().unwrap();
 
-                error_ranges.push(primary.span.range);
-            }
+                    error_ranges.push(primary.span.range);
+                }
 
-            dbg!(signal.action());
+                dbg!(signal.action());
 
-            ControlFlow::<Never>::Continue(())
-        });
+                ControlFlow::<Never>::Continue(())
+            },
+        );
 
         assert_eq!(error_ranges.as_slice(), &[]);
     }
@@ -155,22 +161,27 @@ mod tests {
             }
         ";
 
-        let parsed = parse(SOURCE, 0, SourceType::js_module());
+        let parsed = parse(SOURCE, FileId::zero(), SourceType::js_module());
 
         let mut error_ranges = Vec::new();
-        analyze(0, &parsed.tree(), AnalysisFilter::default(), |signal| {
-            if let Some(diag) = signal.diagnostic() {
-                let diag = diag.into_diagnostic(Severity::Warning);
-                let code = diag.code.as_deref().unwrap();
-                let primary = diag.primary.as_ref().unwrap();
+        analyze(
+            FileId::zero(),
+            &parsed.tree(),
+            AnalysisFilter::default(),
+            |signal| {
+                if let Some(diag) = signal.diagnostic() {
+                    let diag = diag.into_diagnostic(Severity::Warning);
+                    let code = diag.code.as_deref().unwrap();
+                    let primary = diag.primary.as_ref().unwrap();
 
-                if code == "correctness/noDoubleEquals" {
-                    error_ranges.push(primary.span.range);
+                    if code == "correctness/noDoubleEquals" {
+                        error_ranges.push(primary.span.range);
+                    }
                 }
-            }
 
-            ControlFlow::<Never>::Continue(())
-        });
+                ControlFlow::<Never>::Continue(())
+            },
+        );
 
         assert_eq!(
             error_ranges.as_slice(),

--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -1,6 +1,7 @@
 use crate::utils::batch::JsBatchMutation;
 
 use super::rename::*;
+use rome_diagnostics::file::FileId;
 use rome_js_semantic::semantic_model;
 use rome_js_syntax::{JsFormalParameter, JsIdentifierBinding, JsVariableDeclarator, SourceType};
 use rome_rowan::{AstNode, BatchMutationExt, SyntaxNodeCast};
@@ -8,7 +9,7 @@ use rome_rowan::{AstNode, BatchMutationExt, SyntaxNodeCast};
 /// Search and renames a binding named "a" to "b".
 /// Asserts the renaming worked.
 pub fn assert_rename_ok(before: &str, expected: &str) {
-    let r = rome_js_parser::parse(before, 0, SourceType::js_module());
+    let r = rome_js_parser::parse(before, FileId::zero(), SourceType::js_module());
     let model = semantic_model(&r.tree());
 
     let binding_a = r
@@ -29,7 +30,7 @@ pub fn assert_rename_ok(before: &str, expected: &str) {
 /// Search and renames a binding named "a" to "b".
 /// Asserts the renaming to fail.
 pub fn assert_rename_nok(before: &str) {
-    let r = rome_js_parser::parse(before, 0, SourceType::js_module());
+    let r = rome_js_parser::parse(before, FileId::zero(), SourceType::js_module());
     let model = semantic_model(&r.tree());
 
     let binding_a = r
@@ -46,7 +47,7 @@ pub fn assert_rename_nok(before: &str) {
 /// Search a binding named "a" and remove it.
 /// Asserts the removal worked.
 pub fn assert_remove_ok(before: &str, expected: &str) {
-    let r = rome_js_parser::parse(before, 0, SourceType::js_module());
+    let r = rome_js_parser::parse(before, FileId::zero(), SourceType::js_module());
 
     let binding_a = r
         .syntax()

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -9,6 +9,7 @@ use rome_console::{
     fmt::{Formatter, Termcolor},
     markup, Markup,
 };
+use rome_diagnostics::file::FileId;
 use rome_diagnostics::{file::SimpleFile, termcolor::NoColor, Diagnostic};
 use rome_js_parser::{
     parse,
@@ -28,7 +29,7 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
         .unwrap_or_else(|err| panic!("failed to read {:?}: {:?}", input_file, err));
 
     let source_type = input_file.try_into().unwrap();
-    let parsed = parse(&input_code, 0, source_type);
+    let parsed = parse(&input_code, FileId::zero(), source_type);
     let root = parsed.tree();
 
     let (group, rule) = parse_test_path(input_file);
@@ -42,7 +43,7 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     let mut diagnostics = Vec::new();
     let mut code_fixes = Vec::new();
 
-    rome_js_analyze::analyze(0, &root, filter, |event| {
+    rome_js_analyze::analyze(FileId::zero(), &root, filter, |event| {
         if let Some(diag) = event.diagnostic() {
             let mut diag = diag.into_diagnostic(Severity::Warning);
             if let Some(action) = event.action() {
@@ -165,7 +166,7 @@ fn check_code_action(
     }
 
     // Re-parse the modified code and panic if the resulting tree has syntax errors
-    let re_parse = parse(&output, 0, source_type);
+    let re_parse = parse(&output, FileId::zero(), source_type);
     assert_errors_are_absent(&re_parse, path);
 }
 

--- a/crates/rome_js_formatter/src/check_reformat.rs
+++ b/crates/rome_js_formatter/src/check_reformat.rs
@@ -1,5 +1,5 @@
 use crate::{format_node, JsFormatOptions};
-use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
+use rome_diagnostics::{file::FileId, file::SimpleFiles, termcolor, Emitter};
 use rome_js_parser::parse;
 use rome_js_syntax::{JsSyntaxNode, SourceType};
 
@@ -22,7 +22,7 @@ pub fn check_reformat(params: CheckReformatParams) {
         options,
     } = params;
 
-    let re_parse = parse(text, 0, source_type);
+    let re_parse = parse(text, FileId::zero(), source_type);
 
     // Panic if the result from the formatter has syntax errors
     if re_parse.has_errors() {

--- a/crates/rome_js_formatter/src/comments.rs
+++ b/crates/rome_js_formatter/src/comments.rs
@@ -60,10 +60,11 @@ impl FormatRule<SourceComment<JsLanguage>> for FormatJsLeadingComment {
 /// # use rome_js_parser::parse_module;
 /// # use rome_js_syntax::JsLanguage;
 /// # use rome_rowan::{Direction, SyntaxTriviaPieceComments};
+/// # use rome_diagnostics::file::FileId;
 ///  use rome_js_formatter::comments::is_doc_comment;
 ///
 /// # fn parse_comment(source: &str) -> SyntaxTriviaPieceComments<JsLanguage> {
-/// #     let root = parse_module(source, 0).tree();
+/// #     let root = parse_module(source, FileId::zero()).tree();
 /// #     root
 /// #        .eof_token()
 /// #        .expect("Root to have an EOF token")

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -693,13 +693,14 @@ fn matches_test_call(callee: &JsAnyExpression) -> SyntaxResult<Vec<SyntaxTokenTe
 #[cfg(test)]
 mod test {
     use super::contains_a_test_pattern;
+    use rome_diagnostics::file::FileId;
     use rome_js_parser::parse;
     use rome_js_syntax::{JsCallExpression, SourceType};
     use rome_rowan::AstNodeList;
 
     fn extract_call_expression(src: &str) -> JsCallExpression {
         let source_type = SourceType::js_module();
-        let result = parse(src, 0, source_type);
+        let result = parse(src, FileId::zero(), source_type);
         let module = result
             .tree()
             .as_js_module()

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -592,6 +592,7 @@ mod tests {
     use super::{format_node, format_range};
 
     use crate::context::JsFormatOptions;
+    use rome_diagnostics::file::FileId;
     use rome_formatter::IndentStyle;
     use rome_js_parser::{parse, parse_script};
     use rome_js_syntax::SourceType;
@@ -629,7 +630,7 @@ while(
         let range_start = TextSize::try_from(input.find("let").unwrap() - 2).unwrap();
         let range_end = TextSize::try_from(input.find("const").unwrap()).unwrap();
 
-        let tree = parse_script(input, 0);
+        let tree = parse_script(input, FileId::zero());
         let result = format_range(
             JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
@@ -661,7 +662,7 @@ function() {
         let range_start = TextSize::try_from(input.find("const").unwrap()).unwrap();
         let range_end = TextSize::try_from(input.find('}').unwrap()).unwrap();
 
-        let tree = parse_script(input, 0);
+        let tree = parse_script(input, FileId::zero());
         let result = format_range(
             JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
@@ -692,7 +693,7 @@ function() {
         let range_start = TextSize::try_from(input.find("statement_2").unwrap()).unwrap();
         let range_end = range_start + TextSize::of("statement_2()");
 
-        let tree = parse_script(input, 0);
+        let tree = parse_script(input, FileId::zero());
         let result = format_range(
             JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
@@ -711,7 +712,7 @@ function() {
         let range_start = TextSize::try_from(input.find("3 + 4").unwrap()).unwrap();
         let range_end = range_start + TextSize::of("3 + 4");
 
-        let tree = parse_script(input, 0);
+        let tree = parse_script(input, FileId::zero());
         let result = format_range(
             JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
@@ -733,7 +734,7 @@ function() {
         let range_start = TextSize::from(5);
         let range_end = TextSize::from(5);
 
-        let tree = parse_script(input, 0);
+        let tree = parse_script(input, FileId::zero());
         let result = format_range(
             JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
@@ -754,7 +755,7 @@ function() {
 
 "#;
         let syntax = SourceType::tsx();
-        let tree = parse(src, 0, syntax);
+        let tree = parse(src, FileId::zero(), syntax);
         let options = JsFormatOptions::new(syntax);
 
         let result = format_node(options.clone(), &tree.syntax())
@@ -778,7 +779,7 @@ function() {
         let src = "statement();";
 
         let syntax = SourceType::js_module();
-        let tree = parse(src, 0, syntax);
+        let tree = parse(src, FileId::zero(), syntax);
 
         let result = format_range(
             JsFormatOptions::new(syntax),

--- a/crates/rome_js_formatter/src/parentheses.rs
+++ b/crates/rome_js_formatter/src/parentheses.rs
@@ -890,6 +890,7 @@ pub(crate) fn debug_assert_is_parent(node: &JsSyntaxNode, parent: &JsSyntaxNode)
 pub(crate) mod tests {
     use super::NeedsParentheses;
     use crate::transform;
+    use rome_diagnostics::file::FileId;
     use rome_js_syntax::{JsLanguage, SourceType};
     use rome_rowan::AstNode;
 
@@ -900,7 +901,7 @@ pub(crate) mod tests {
         index: Option<usize>,
         source_type: SourceType,
     ) {
-        let parse = rome_js_parser::parse(input, 0, source_type);
+        let parse = rome_js_parser::parse(input, FileId::zero(), source_type);
 
         let diagnostics = parse.diagnostics();
         assert!(
@@ -941,7 +942,7 @@ pub(crate) mod tests {
         index: Option<usize>,
         source_type: SourceType,
     ) {
-        let parse = rome_js_parser::parse(input, 0, source_type);
+        let parse = rome_js_parser::parse(input, FileId::zero(), source_type);
 
         let diagnostics = parse.diagnostics();
         assert!(

--- a/crates/rome_js_formatter/src/syntax_rewriter.rs
+++ b/crates/rome_js_formatter/src/syntax_rewriter.rs
@@ -500,6 +500,7 @@ where
 mod tests {
     use super::JsFormatSyntaxRewriter;
     use crate::{format_node, JsFormatOptions};
+    use rome_diagnostics::file::FileId;
     use rome_formatter::{SourceMarker, TransformSourceMap};
     use rome_js_parser::parse_module;
     use rome_js_syntax::{
@@ -511,7 +512,7 @@ mod tests {
 
     #[test]
     fn rebalances_logical_expressions() {
-        let root = parse_module("a && (b && c)", 0).syntax();
+        let root = parse_module("a && (b && c)", FileId::zero()).syntax();
 
         let transformed = JsFormatSyntaxRewriter::default().transform(root.clone());
 
@@ -540,7 +541,7 @@ mod tests {
 
     #[test]
     fn only_rebalances_logical_expressions_with_same_operator() {
-        let root = parse_module("a && (b || c)", 0).syntax();
+        let root = parse_module("a && (b || c)", FileId::zero()).syntax();
         let transformed = JsFormatSyntaxRewriter::default().transform(root);
 
         // Removes parentheses
@@ -760,7 +761,7 @@ mod tests {
     }
 
     fn source_map_test(input: &str) -> (JsSyntaxNode, TransformSourceMap) {
-        let tree = parse_module(input, 0).syntax();
+        let tree = parse_module(input, FileId::zero()).syntax();
 
         let mut rewriter = JsFormatSyntaxRewriter::default();
         let transformed = rewriter.transform(tree);

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -886,13 +886,14 @@ impl FusedIterator for BinaryLikePreorder {}
 mod tests {
     use crate::utils::binary_like_expression::{BinaryLikePreorder, VisitEvent};
     use crate::utils::JsAnyBinaryLikeExpression;
+    use rome_diagnostics::file::FileId;
     use rome_js_parser::parse_module;
     use rome_js_syntax::JsLogicalExpression;
     use rome_rowan::AstNode;
 
     #[test]
     fn in_order_visits_every_binary_like_expression() {
-        let parse = parse_module("a && b && c || d", 0);
+        let parse = parse_module("a && b && c || d", FileId::zero());
         let root = parse
             .syntax()
             .descendants()
@@ -940,7 +941,7 @@ mod tests {
 
     #[test]
     fn in_order_skip_subtree() {
-        let parse = parse_module("a && b && c || d", 0);
+        let parse = parse_module("a && b && c || d", FileId::zero());
         let root = parse
             .syntax()
             .descendants()

--- a/crates/rome_js_formatter/src/utils/jsx.rs
+++ b/crates/rome_js_formatter/src/utils/jsx.rs
@@ -402,12 +402,17 @@ impl FusedIterator for JsxSplitChunksIterator<'_> {}
 #[cfg(test)]
 mod tests {
     use crate::utils::jsx::{jsx_split_children, JsxChild, JsxSplitChunksIterator, JsxTextChunk};
+    use rome_diagnostics::file::FileId;
     use rome_js_parser::parse;
     use rome_js_syntax::{JsxChildList, JsxText, SourceType};
     use rome_rowan::{AstNode, TextSize};
 
     fn assert_jsx_text_chunks(text: &str, expected_chunks: Vec<(TextSize, JsxTextChunk)>) {
-        let parse = parse(&std::format!("<>{text}</>"), 0, SourceType::jsx());
+        let parse = parse(
+            &std::format!("<>{text}</>"),
+            FileId::zero(),
+            SourceType::jsx(),
+        );
         assert!(
             !parse.has_errors(),
             "Source should not have any errors {:?}",
@@ -478,7 +483,11 @@ mod tests {
     }
 
     fn parse_jsx_children(children: &str) -> JsxChildList {
-        let parse = parse(&std::format!("<div>{children}</div>"), 0, SourceType::jsx());
+        let parse = parse(
+            &std::format!("<div>{children}</div>"),
+            FileId::zero(),
+            SourceType::jsx(),
+        );
 
         assert!(
             !parse.has_errors(),

--- a/crates/rome_js_formatter/tests/check_reformat.rs
+++ b/crates/rome_js_formatter/tests/check_reformat.rs
@@ -1,4 +1,4 @@
-use rome_diagnostics::{file::SimpleFiles, termcolor, Emitter};
+use rome_diagnostics::{file::FileId, file::SimpleFiles, termcolor, Emitter};
 use rome_js_formatter::context::JsFormatOptions;
 use rome_js_formatter::format_node;
 use rome_js_parser::parse;
@@ -23,7 +23,7 @@ pub fn check_reformat(params: CheckReformatParams) {
         options,
     } = params;
 
-    let re_parse = parse(text, 0, source_type);
+    let re_parse = parse(text, FileId::zero(), source_type);
 
     // Panic if the result from the formatter has syntax errors
     if re_parse.has_errors() {

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -1,3 +1,4 @@
+use rome_diagnostics::file::FileId;
 use rome_rowan::{TextRange, TextSize};
 use similar::{utils::diff_lines, Algorithm, ChangeTag, TextDiff};
 use std::fs::remove_file;
@@ -61,7 +62,7 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
         input_file.try_into().unwrap()
     };
 
-    let parsed = parse(&parse_input, 0, source_type);
+    let parsed = parse(&parse_input, FileId::zero(), source_type);
 
     let has_errors = parsed.has_errors();
     let syntax = parsed.syntax();

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -1,3 +1,4 @@
+use rome_diagnostics::file::FileId;
 use rome_formatter::{FormatOptions, LineWidth};
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
@@ -204,7 +205,7 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
         spec_input_file.display()
     );
 
-    let mut rome_path = RomePath::new(file_path, 0);
+    let mut rome_path = RomePath::new(file_path, FileId::zero());
     let can_format = app
         .workspace
         .supports_feature(SupportsFeatureParams {
@@ -224,7 +225,7 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
         let input = fs::read_to_string(file_path).unwrap();
         snapshot_content.set_input(input.as_str());
 
-        let parsed = parse(buffer.as_str(), 0, source_type);
+        let parsed = parse(buffer.as_str(), FileId::zero(), source_type);
         let has_errors = parsed.has_errors();
         let root = parsed.syntax();
 
@@ -250,7 +251,7 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
         let options_path = test_directory.join("options.json");
         if options_path.exists() {
             {
-                let mut options_path = RomePath::new(&options_path, 0);
+                let mut options_path = RomePath::new(&options_path, FileId::zero());
                 // SAFETY: we checked its existence already, we assume we have rights to read it
                 let options: TestOptions =
                     serde_json::from_str(options_path.get_buffer_from_file().as_str()).unwrap();

--- a/crates/rome_js_parser/src/lexer/buffered_lexer.rs
+++ b/crates/rome_js_parser/src/lexer/buffered_lexer.rs
@@ -283,12 +283,13 @@ impl From<&LexerCheckpoint> for LookaheadToken {
 mod tests {
     use super::BufferedLexer;
     use crate::lexer::{LexContext, Lexer, TextRange, TextSize};
+    use rome_diagnostics::file::FileId;
     use rome_js_syntax::JsSyntaxKind::{JS_NUMBER_LITERAL, NEWLINE, WHITESPACE};
     use rome_js_syntax::T;
 
     #[test]
     fn without_lookahead() {
-        let lexer = Lexer::from_str("let a\n = 5", 0);
+        let lexer = Lexer::from_str("let a\n = 5", FileId::zero());
         let mut buffered = BufferedLexer::new(lexer);
 
         buffered.next_token(LexContext::default());
@@ -315,7 +316,7 @@ mod tests {
 
     #[test]
     fn lookahead() {
-        let lexer = Lexer::from_str("let a\n = 5", 0);
+        let lexer = Lexer::from_str("let a\n = 5", FileId::zero());
         let mut buffered = BufferedLexer::new(lexer);
 
         buffered.next_token(LexContext::default());

--- a/crates/rome_js_parser/src/lexer/tests.rs
+++ b/crates/rome_js_parser/src/lexer/tests.rs
@@ -3,6 +3,7 @@
 
 use super::{LexContext, Lexer, TextSize};
 use quickcheck_macros::quickcheck;
+use rome_diagnostics::file::FileId;
 use rome_diagnostics::Span;
 use rome_js_syntax::JsSyntaxKind::{self, EOF};
 use std::sync::mpsc::channel;
@@ -13,7 +14,7 @@ use std::time::Duration;
 // and make sure the tokens yielded are fully lossless and the source can be reconstructed from only the tokens
 macro_rules! assert_lex {
     ($src:expr, $($kind:ident:$len:expr $(,)?)*) => {{
-        let mut lexer = Lexer::from_str($src, 0);
+        let mut lexer = Lexer::from_str($src, FileId::zero());
         let mut idx = 0;
         let mut tok_idx = TextSize::default();
 
@@ -72,7 +73,7 @@ fn losslessness(string: String) -> bool {
     let cloned = string.clone();
     let (sender, receiver) = channel();
     thread::spawn(move || {
-        let mut lexer = Lexer::from_str(&cloned, 0);
+        let mut lexer = Lexer::from_str(&cloned, FileId::zero());
         let mut tokens = vec![];
 
         while lexer.next_token(LexContext::default()) != EOF {
@@ -1348,7 +1349,7 @@ fn keywords() {
             "Expected `JsSyntaxKind::from_keyword` to return a kind for keyword {keyword}.",
         );
 
-        let mut lexer = Lexer::from_str(keyword, 0);
+        let mut lexer = Lexer::from_str(keyword, FileId::zero());
         lexer.next_token(LexContext::default());
 
         let lexed_kind = lexer.current();

--- a/crates/rome_js_parser/src/parser.rs
+++ b/crates/rome_js_parser/src/parser.rs
@@ -11,6 +11,7 @@ pub(crate) mod rewrite_parser;
 pub(crate) mod single_token_parse_recovery;
 
 use drop_bomb::DebugDropBomb;
+use rome_diagnostics::file::FileId;
 use rome_js_syntax::{
     JsSyntaxKind::{self},
     SourceType, TextRange,
@@ -68,7 +69,7 @@ impl ParserProgress {
 /// The Parser yields lower level events instead of nodes.
 /// These events are then processed into a syntax tree through a [`TreeSink`] implementation.
 pub(crate) struct Parser<'s> {
-    file_id: usize,
+    file_id: FileId,
     pub(super) tokens: TokenSource<'s>,
     pub(super) events: Vec<Event>,
     pub(super) state: ParserState,
@@ -80,7 +81,7 @@ pub(crate) struct Parser<'s> {
 
 impl<'s> Parser<'s> {
     /// Creates a new parser that parses the `source`.
-    pub fn new(source: &'s str, file_id: usize, source_type: SourceType) -> Parser<'s> {
+    pub fn new(source: &'s str, file_id: FileId, source_type: SourceType) -> Parser<'s> {
         let token_source = TokenSource::from_str(source, file_id);
 
         Parser {
@@ -611,6 +612,7 @@ pub struct Checkpoint {
 #[cfg(test)]
 mod tests {
     use crate::Parser;
+    use rome_diagnostics::file::FileId;
     use rome_js_syntax::{JsSyntaxKind, SourceType};
     use rome_rowan::AstNode;
 
@@ -624,7 +626,7 @@ mod tests {
 
         // File id is used for the labels inside parser errors to report them, the file id
         // is used to look up a file's source code and path inside of a codespan `Files` implementation.
-        let mut parser = Parser::new(source, 0, SourceType::default());
+        let mut parser = Parser::new(source, FileId::zero(), SourceType::default());
 
         // Use one of the syntax parsing functions to parse an expression.
         // This adds node and token events to the parser which are then used to make a node.
@@ -669,7 +671,7 @@ mod tests {
         expected = "Marker must either be `completed` or `abandoned` to avoid that children are implicitly attached to a marker's parent."
     )]
     fn uncompleted_markers_panic() {
-        let mut parser = Parser::new("'use strict'", 0, SourceType::default());
+        let mut parser = Parser::new("'use strict'", FileId::zero(), SourceType::default());
 
         let _ = parser.start();
         // drop the marker without calling complete or abandon
@@ -677,7 +679,7 @@ mod tests {
 
     #[test]
     fn completed_marker_doesnt_panic() {
-        let mut p = Parser::new("'use strict'", 0, SourceType::default());
+        let mut p = Parser::new("'use strict'", FileId::zero(), SourceType::default());
 
         let m = p.start();
         p.expect(JsSyntaxKind::JS_STRING_LITERAL);
@@ -686,7 +688,7 @@ mod tests {
 
     #[test]
     fn abandoned_marker_doesnt_panic() {
-        let mut p = Parser::new("'use strict'", 0, SourceType::default());
+        let mut p = Parser::new("'use strict'", FileId::zero(), SourceType::default());
 
         let m = p.start();
         m.abandon(&mut p);

--- a/crates/rome_js_parser/src/tests.rs
+++ b/crates/rome_js_parser/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{parse, parse_module, test_utils::assert_errors_are_absent, Parse};
 use expect_test::expect_file;
+use rome_diagnostics::file::FileId;
 use rome_diagnostics::{file::SimpleFiles, Emitter};
 use rome_js_syntax::{JsAnyRoot, JsSyntaxKind, SourceType};
 use rome_js_syntax::{JsCallArguments, JsLogicalExpression, JsSyntaxToken};
@@ -16,7 +17,7 @@ let
 a;
 "#;
 
-    let module = parse(src, 0, SourceType::tsx());
+    let module = parse(src, FileId::zero(), SourceType::tsx());
     assert_errors_are_absent(&module, Path::new("parser_smoke_test"));
 }
 
@@ -26,7 +27,7 @@ fn parser_missing_smoke_test() {
         console.log("Hello world";
     "#;
 
-    let module = parse_module(src, 0);
+    let module = parse_module(src, FileId::zero());
 
     let arg_list = module
         .syntax()
@@ -57,7 +58,7 @@ fn try_parse(path: &str, text: &str) -> Parse<JsAnyRoot> {
             path.try_into().unwrap()
         };
 
-        let parse = parse(text, 0, source_type);
+        let parse = parse(text, FileId::zero(), source_type);
 
         assert_eq!(
             parse.syntax().to_string(),
@@ -159,7 +160,7 @@ fn assert_errors_are_present(program: &Parse<JsAnyRoot>, path: &Path) {
 #[test]
 pub fn test_trivia_attached_to_tokens() {
     let text = "/**/let a = 1; // nice variable \n /*hey*/ let \t b = 2; // another nice variable";
-    let m = parse_module(text, 0);
+    let m = parse_module(text, FileId::zero());
     let mut tokens = m.syntax().descendants_tokens(Direction::Next);
 
     let is_let = |x: &JsSyntaxToken| x.text_trimmed() == "let";
@@ -193,7 +194,7 @@ pub fn test_trivia_attached_to_tokens() {
 #[test]
 pub fn jsroot_display_text_and_trimmed() {
     let code = " let a = 1; \n ";
-    let root = parse_module(code, 0);
+    let root = parse_module(code, FileId::zero());
     let syntax = root.syntax();
 
     assert_eq!(format!("{}", syntax), code);
@@ -209,7 +210,7 @@ pub fn jsroot_display_text_and_trimmed() {
 pub fn jsroot_ranges() {
     //               0123456789A
     let code = " let a = 1;";
-    let root = parse_module(code, 0);
+    let root = parse_module(code, FileId::zero());
     let syntax = root.syntax();
 
     let first_let = syntax.first_token().unwrap();
@@ -238,7 +239,7 @@ pub fn jsroot_ranges() {
 pub fn node_range_must_be_correct() {
     //               0123456789A123456789B123456789
     let text = " function foo() { let a = 1; }";
-    let root = parse_module(text, 0);
+    let root = parse_module(text, FileId::zero());
 
     let var_decl = root
         .syntax()
@@ -259,7 +260,7 @@ pub fn node_range_must_be_correct() {
 pub fn last_trivia_must_be_appended_to_eof() {
     //               0123456789A123456789B123456789CC
     let text = " function foo() { let a = 1; }\n";
-    let root = parse_module(text, 0);
+    let root = parse_module(text, FileId::zero());
     let syntax = root.syntax();
 
     let range = syntax.text_range();
@@ -274,7 +275,7 @@ pub fn last_trivia_must_be_appended_to_eof() {
 pub fn just_trivia_must_be_appended_to_eof() {
     //               0123456789A123456789B123456789C123
     let text = "// just trivia... nothing else....";
-    let root = parse_module(text, 0);
+    let root = parse_module(text, FileId::zero());
     let syntax = root.syntax();
 
     let range = syntax.text_range();
@@ -288,7 +289,7 @@ pub fn just_trivia_must_be_appended_to_eof() {
 #[test]
 pub fn node_contains_comments() {
     let text = "true && true // comment";
-    let root = parse_module(text, 0);
+    let root = parse_module(text, FileId::zero());
     let syntax = root.syntax();
 
     assert!(syntax.has_comments_descendants());
@@ -297,7 +298,7 @@ pub fn node_contains_comments() {
 #[test]
 fn parser_regexp_after_operator() {
     fn assert_no_errors(src: &str) {
-        let module = parse(src, 0, SourceType::js_script());
+        let module = parse(src, FileId::zero(), SourceType::js_script());
         assert_errors_are_absent(&module, Path::new("parser_regexp_after_operator"));
     }
     assert_no_errors(r#"a=/a/"#);
@@ -310,7 +311,7 @@ fn parser_regexp_after_operator() {
 #[test]
 pub fn node_contains_trailing_comments() {
     let text = "true && (3 - 2 == 0) // comment";
-    let root = parse_module(text, 0);
+    let root = parse_module(text, FileId::zero());
     let syntax = root.syntax();
     let node = syntax
         .descendants()
@@ -329,7 +330,7 @@ pub fn node_contains_leading_comments() {
     let text = r"true &&
 // comment
 (3 - 2 == 0)";
-    let root = parse_module(text, 0);
+    let root = parse_module(text, FileId::zero());
     let syntax = root.syntax();
     let node = syntax
         .descendants()
@@ -348,7 +349,7 @@ pub fn node_has_comments() {
     let text = r"true &&
 // comment
 (3 - 2 == 0)";
-    let root = parse_module(text, 0);
+    let root = parse_module(text, FileId::zero());
     let syntax = root.syntax();
     let node = syntax
         .descendants()

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -134,7 +134,8 @@ impl SemanticEvent {
 /// use rome_js_parser::*;
 /// use rome_js_syntax::*;
 /// use rome_js_semantic::*;
-/// let tree = parse("let a = 1", 0, SourceType::js_script());
+/// use rome_diagnostics::file::FileId;
+/// let tree = parse("let a = 1", FileId::zero(), SourceType::js_script());
 /// let mut extractor = SemanticEventExtractor::new();
 /// for e in tree.syntax().preorder() {
 ///     match e {
@@ -959,7 +960,8 @@ impl Iterator for SemanticEventIterator {
 /// use rome_js_parser::*;
 /// use rome_js_syntax::*;
 /// use rome_js_semantic::*;
-/// let tree = parse("let a = 1", 0, SourceType::js_script());
+/// use rome_diagnostics::file::FileId;
+/// let tree = parse("let a = 1", FileId::zero(), SourceType::js_script());
 /// for e in semantic_events(tree.syntax()) {
 ///     dbg!(e);
 /// }

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -461,8 +461,9 @@ impl SemanticModel {
     /// use rome_rowan::{AstNode, SyntaxNodeCast};
     /// use rome_js_syntax::{SourceType, JsReferenceIdentifier};
     /// use rome_js_semantic::{semantic_model, SemanticScopeExtensions};
+    /// use rome_diagnostics::file::FileId;
     ///
-    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", 0, SourceType::js_module());
+    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", FileId::zero(), SourceType::js_module());
     /// let model = semantic_model(&r.tree());
     ///
     /// let arguments_reference = r
@@ -503,8 +504,9 @@ impl SemanticModel {
     /// use rome_rowan::{AstNode, SyntaxNodeCast};
     /// use rome_js_syntax::{SourceType, JsReferenceIdentifier};
     /// use rome_js_semantic::{semantic_model, DeclarationExtensions};
+    /// use rome_diagnostics::file::FileId;
     ///
-    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", 0, SourceType::js_module());
+    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", FileId::zero(), SourceType::js_module());
     /// let model = semantic_model(&r.tree());
     ///
     /// let arguments_reference = r
@@ -536,8 +538,9 @@ impl SemanticModel {
     /// use rome_rowan::{AstNode, SyntaxNodeCast};
     /// use rome_js_syntax::{SourceType, JsIdentifierBinding};
     /// use rome_js_semantic::{semantic_model, AllReferencesExtensions};
+    /// use rome_diagnostics::file::FileId;
     ///
-    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", 0, SourceType::js_module());
+    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", FileId::zero(), SourceType::js_module());
     /// let model = semantic_model(&r.tree());
     ///
     /// let a_binding = r
@@ -878,6 +881,7 @@ pub fn semantic_model(root: &JsAnyRoot) -> SemanticModel {
 #[cfg(test)]
 mod test {
     use super::*;
+    use rome_diagnostics::file::FileId;
     use rome_js_syntax::{JsReferenceIdentifier, JsSyntaxKind, SourceType, TsIdentifierBinding};
     use rome_rowan::SyntaxNodeCast;
 
@@ -885,7 +889,7 @@ mod test {
     pub fn ok_semantic_model() {
         let r = rome_js_parser::parse(
             "function f(){let a = arguments[0]; let b = a + 1; b = 2; console.log(b)}",
-            0,
+            FileId::zero(),
             SourceType::js_module(),
         );
         let model = semantic_model(&r.tree());
@@ -989,7 +993,7 @@ mod test {
     pub fn ok_semantic_model_function_scope() {
         let r = rome_js_parser::parse(
             "function f() {} function g() {}",
-            0,
+            FileId::zero(),
             SourceType::js_module(),
         );
         let model = semantic_model(&r.tree());
@@ -1029,7 +1033,7 @@ mod test {
 
     /// Finds the last time a token named "name" is used and see if its node is marked as exported
     fn assert_is_exported(is_exported: bool, name: &str, code: &str) {
-        let r = rome_js_parser::parse(code, 0, SourceType::tsx());
+        let r = rome_js_parser::parse(code, FileId::zero(), SourceType::tsx());
         let model = semantic_model(&r.tree());
 
         let node = r

--- a/crates/rome_js_semantic/src/tests/assertions.rs
+++ b/crates/rome_js_semantic/src/tests/assertions.rs
@@ -1,6 +1,6 @@
 use crate::{semantic_events, SemanticEvent};
 use rome_console::{markup, ConsoleExt, EnvConsole};
-use rome_diagnostics::{file::SimpleFile, Diagnostic};
+use rome_diagnostics::{file::FileId, file::SimpleFile, Diagnostic};
 use rome_js_syntax::{JsAnyRoot, JsSyntaxToken, SourceType, TextRange, TextSize, WalkEvent};
 use rome_rowan::{AstNode, NodeOrToken};
 use std::collections::{BTreeMap, HashMap};
@@ -101,7 +101,7 @@ use std::collections::{BTreeMap, HashMap};
 /// if(true) ;/*NOEVENT*/;
 /// ```
 pub fn assert(code: &str, test_name: &str) {
-    let r = rome_js_parser::parse(code, 0, SourceType::tsx());
+    let r = rome_js_parser::parse(code, FileId::zero(), SourceType::tsx());
 
     if r.has_errors() {
         let files = SimpleFile::new(test_name.to_string(), code.into());
@@ -714,7 +714,7 @@ fn error_assertion_not_attached_to_a_declaration(
 ) {
     let files = SimpleFile::new(test_name.to_string(), code.into());
     let d = Diagnostic::error(
-        0,
+        FileId::zero(),
         "",
         "This assertion must be attached to a SemanticEvent::DeclarationFound.",
     )
@@ -734,7 +734,7 @@ fn error_declaration_pointing_to_unknown_scope(
 ) {
     let files = SimpleFile::new(test_name.to_string(), code.into());
     let d = Diagnostic::error(
-        0,
+        FileId::zero(),
         "",
         "Declaration assertions is pointing to the wrong scope",
     )
@@ -755,7 +755,7 @@ fn error_assertion_name_clash(
     // If there is already an assertion with the same name. Suggest a rename
 
     let files = SimpleFile::new(test_name.to_string(), code.into());
-    let d = Diagnostic::error(0, "", "Assertion label conflict.")
+    let d = Diagnostic::error(FileId::zero(), "", "Assertion label conflict.")
         .primary(
             token.text_range(),
             "There is already a assertion with the same name. Consider renaming this one.",
@@ -776,7 +776,7 @@ fn error_scope_end_assertion_points_to_non_existing_scope_start_assertion(
     file_name: &str,
 ) {
     let files = SimpleFile::new(file_name.to_string(), code.into());
-    let d = Diagnostic::error(0, "", "Scope start assertion not found.").primary(
+    let d = Diagnostic::error(FileId::zero(), "", "Scope start assertion not found.").primary(
         range,
         "This scope end assertion points to a non-existing scope start assertion.",
     );
@@ -795,7 +795,7 @@ fn error_scope_end_assertion_points_to_the_wrong_scope_start(
     file_name: &str,
 ) {
     let files = SimpleFile::new(file_name.to_string(), code.into());
-    let d = Diagnostic::error(0, "", "Wrong scope start")
+    let d = Diagnostic::error(FileId::zero(), "", "Wrong scope start")
         .primary(
             range,
             "This scope end assertion points to the wrong scope start.",

--- a/crates/rome_lsp/src/url_interner.rs
+++ b/crates/rome_lsp/src/url_interner.rs
@@ -18,7 +18,7 @@ impl UrlInterner {
     /// If `path` does not exists in `self`, returns [`None`].
     #[allow(unused)]
     pub(crate) fn get(&self, path: &Url) -> Option<FileId> {
-        self.map.get_index_of(path)
+        self.map.get_index_of(path).map(FileId::from)
     }
 
     /// Insert `path` in `self`.
@@ -28,7 +28,7 @@ impl UrlInterner {
     pub(crate) fn intern(&mut self, path: Url) -> FileId {
         let (id, _added) = self.map.insert_full(path);
         assert!(id < usize::MAX);
-        id
+        FileId::from(id)
     }
 
     /// Returns the path corresponding to `id`.
@@ -38,6 +38,6 @@ impl UrlInterner {
     /// Panics if `id` does not exists in `self`.
     #[allow(dead_code)]
     pub(crate) fn lookup(&self, id: FileId) -> &Url {
-        self.map.get_index(id).unwrap()
+        self.map.get_index(id.into()).unwrap()
     }
 }

--- a/xtask/bench/src/features/analyzer.rs
+++ b/xtask/bench/src/features/analyzer.rs
@@ -1,6 +1,7 @@
 use crate::BenchmarkSummary;
 use criterion::black_box;
 use rome_analyze::{AnalysisFilter, ControlFlow, Never, RuleCategories};
+use rome_diagnostics::file::FileId;
 use rome_js_analyze::analyze;
 use rome_js_syntax::JsAnyRoot;
 use std::fmt::{Display, Formatter};
@@ -28,7 +29,7 @@ pub fn run_analyzer(root: &JsAnyRoot) {
         ..AnalysisFilter::default()
     };
 
-    analyze(0, root, filter, |event| {
+    analyze(FileId::zero(), root, filter, |event| {
         black_box(event.diagnostic());
         black_box(event.action());
         ControlFlow::<Never>::Continue(())

--- a/xtask/bench/src/features/parser.rs
+++ b/xtask/bench/src/features/parser.rs
@@ -2,6 +2,7 @@
 use crate::features::print_diff;
 use crate::BenchmarkSummary;
 use itertools::Itertools;
+use rome_diagnostics::file::FileId;
 use rome_diagnostics::file::SimpleFile;
 use rome_diagnostics::{Diagnostic, Emitter, Severity};
 use rome_js_parser::{parse_common, Parse};
@@ -26,7 +27,7 @@ pub fn benchmark_parse_lib(id: &str, code: &str, source_type: SourceType) -> Ben
     let stats = dhat::HeapStats::get();
 
     let parser_timer = timing::start();
-    let (events, diagnostics, trivia) = parse_common(code, 0, source_type);
+    let (events, diagnostics, trivia) = parse_common(code, FileId::zero(), source_type);
     let parse_duration = parser_timer.stop();
 
     #[cfg(feature = "dhat-heap")]
@@ -55,7 +56,7 @@ pub fn benchmark_parse_lib(id: &str, code: &str, source_type: SourceType) -> Ben
 }
 
 pub fn run_parse(code: &str, source_type: SourceType) -> Parse<JsAnyRoot> {
-    rome_js_parser::parse(code, 0, source_type)
+    rome_js_parser::parse(code, FileId::zero(), source_type)
 }
 
 impl ParseMeasurement {

--- a/xtask/bench/src/lib.rs
+++ b/xtask/bench/src/lib.rs
@@ -1,6 +1,7 @@
 mod features;
 mod utils;
 
+use rome_diagnostics::file::FileId;
 use rome_js_parser::parse;
 use rome_js_syntax::SourceType;
 use std::collections::HashMap;
@@ -151,13 +152,13 @@ pub fn run(args: RunArgs) {
                             criterion::black_box(run_parse(code, source_type));
                         }),
                         FeatureToBenchmark::Formatter => {
-                            let root = parse(code, 0, source_type).syntax();
+                            let root = parse(code, FileId::zero(), source_type).syntax();
                             b.iter(|| {
                                 criterion::black_box(run_format(&root, source_type));
                             })
                         }
                         FeatureToBenchmark::Analyzer => {
-                            let root = parse(code, 0, source_type).tree();
+                            let root = parse(code, FileId::zero(), source_type).tree();
                             b.iter(|| {
                                 run_analyzer(&root);
                             })
@@ -169,11 +170,11 @@ pub fn run(args: RunArgs) {
                 let result = match args.feature {
                     FeatureToBenchmark::Parser => benchmark_parse_lib(&id, code, source_type),
                     FeatureToBenchmark::Formatter => {
-                        let root = parse(code, 0, source_type).syntax();
+                        let root = parse(code, FileId::zero(), source_type).syntax();
                         benchmark_format_lib(&id, &root, source_type)
                     }
                     FeatureToBenchmark::Analyzer => {
-                        let root = parse(code, 0, source_type).tree();
+                        let root = parse(code, FileId::zero(), source_type).tree();
                         benchmark_analyze_lib(&id, &root)
                     }
                 };

--- a/xtask/coverage/src/js/test262.rs
+++ b/xtask/coverage/src/js/test262.rs
@@ -2,6 +2,7 @@ use crate::runner::{
     create_unknown_node_in_tree_diagnostic, TestCase, TestCaseFiles, TestRunOutcome, TestSuite,
 };
 use regex::Regex;
+use rome_diagnostics::file::FileId;
 use rome_js_parser::parse;
 use rome_js_syntax::SourceType;
 use rome_rowan::syntax::SyntaxKind;
@@ -99,7 +100,7 @@ impl Test262TestCase {
 
         let files = TestCaseFiles::single(self.name.clone(), self.code.clone(), source_type);
 
-        match parse(&code, 0, source_type).ok() {
+        match parse(&code, FileId::zero(), source_type).ok() {
             Ok(root) if !should_fail => {
                 if let Some(unknown) = root
                     .syntax()
@@ -107,7 +108,10 @@ impl Test262TestCase {
                     .find(|descendant| descendant.kind().is_unknown())
                 {
                     TestRunOutcome::IncorrectlyErrored {
-                        errors: vec![create_unknown_node_in_tree_diagnostic(0, unknown)],
+                        errors: vec![create_unknown_node_in_tree_diagnostic(
+                            FileId::zero(),
+                            unknown,
+                        )],
                         files,
                     }
                 } else {

--- a/xtask/coverage/src/jsx/jsx_babel.rs
+++ b/xtask/coverage/src/jsx/jsx_babel.rs
@@ -3,6 +3,7 @@ use crate::{
     check_file_encoding,
     runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite},
 };
+use rome_diagnostics::file::FileId;
 use rome_js_parser::parse;
 use rome_js_syntax::{ModuleKind, SourceType};
 use rome_rowan::SyntaxKind;
@@ -37,7 +38,7 @@ impl TestCase for BabelJsxTestCase {
     fn run(&self) -> TestRunOutcome {
         let source_type = SourceType::jsx().with_module_kind(ModuleKind::Script);
         let files = TestCaseFiles::single(self.name().to_string(), self.code.clone(), source_type);
-        let result = parse(&self.code, 0, source_type);
+        let result = parse(&self.code, FileId::zero(), source_type);
 
         if result.diagnostics().is_empty() {
             if let Some(unknown) = result
@@ -47,7 +48,10 @@ impl TestCase for BabelJsxTestCase {
             {
                 TestRunOutcome::IncorrectlyErrored {
                     files,
-                    errors: vec![create_unknown_node_in_tree_diagnostic(0, unknown)],
+                    errors: vec![create_unknown_node_in_tree_diagnostic(
+                        FileId::zero(),
+                        unknown,
+                    )],
                 }
             } else {
                 TestRunOutcome::Passed(files)

--- a/xtask/coverage/src/runner.rs
+++ b/xtask/coverage/src/runner.rs
@@ -119,7 +119,7 @@ impl TestCaseFiles {
                 name,
                 code,
                 source_type,
-                id: 0,
+                id: FileId::zero(),
             }],
         }
     }
@@ -133,7 +133,7 @@ impl TestCaseFiles {
             name,
             code,
             source_type,
-            id: self.files.len(),
+            id: FileId::from(self.files.len()),
         })
     }
 

--- a/xtask/coverage/src/symbols/msts.rs
+++ b/xtask/coverage/src/symbols/msts.rs
@@ -1,3 +1,4 @@
+use rome_diagnostics::file::FileId;
 use rome_js_semantic::SemanticEvent;
 use rome_js_syntax::SourceType;
 
@@ -71,7 +72,7 @@ impl TestCase for SymbolsMicrosoftTestCase {
 
         let t = TestCaseFiles::single(self.name.clone(), code.clone(), SourceType::tsx());
 
-        let r = rome_js_parser::parse(&code, 0, SourceType::tsx());
+        let r = rome_js_parser::parse(&code, FileId::zero(), SourceType::tsx());
         let mut actual: Vec<_> = rome_js_semantic::semantic_events(r.syntax())
             .into_iter()
             .filter(|x| {

--- a/xtask/coverage/src/ts/ts_babel.rs
+++ b/xtask/coverage/src/ts/ts_babel.rs
@@ -3,6 +3,7 @@ use crate::{
     check_file_encoding,
     runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite},
 };
+use rome_diagnostics::file::FileId;
 use rome_js_syntax::{LanguageVariant, SourceType};
 use rome_rowan::SyntaxKind;
 use std::path::Path;
@@ -44,7 +45,7 @@ impl TestCase for BabelTypescriptTestCase {
         let source_type = SourceType::ts().with_variant(self.variant);
         let files = TestCaseFiles::single(self.name().to_string(), self.code.clone(), source_type);
 
-        let result = rome_js_parser::parse(&self.code, 0, source_type);
+        let result = rome_js_parser::parse(&self.code, FileId::zero(), source_type);
 
         if self.expected_to_fail && result.diagnostics().is_empty() {
             TestRunOutcome::IncorrectlyPassed(files)
@@ -62,7 +63,10 @@ impl TestCase for BabelTypescriptTestCase {
         {
             TestRunOutcome::IncorrectlyErrored {
                 files,
-                errors: vec![create_unknown_node_in_tree_diagnostic(0, unknown)],
+                errors: vec![create_unknown_node_in_tree_diagnostic(
+                    FileId::zero(),
+                    unknown,
+                )],
             }
         } else {
             TestRunOutcome::Passed(files)

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -4,7 +4,7 @@ use rome_console::{
     fmt::{Formatter, HTML},
     markup, Markup,
 };
-use rome_diagnostics::{file::SimpleFile, Diagnostic};
+use rome_diagnostics::{file::FileId, file::SimpleFile, Diagnostic};
 use rome_js_analyze::{analyze, metadata};
 use rome_js_syntax::{Language, LanguageVariant, ModuleKind, SourceType};
 use rome_service::settings::WorkspaceSettings;
@@ -459,7 +459,7 @@ fn assert_lint(
         Ok(())
     };
 
-    let parse = rome_js_parser::parse(code, 0, test.source_type);
+    let parse = rome_js_parser::parse(code, FileId::zero(), test.source_type);
 
     if parse.has_errors() {
         for diag in parse.into_diagnostics() {
@@ -476,7 +476,7 @@ fn assert_lint(
             ..AnalysisFilter::default()
         };
 
-        let result = analyze(0, &root, filter, |signal| {
+        let result = analyze(FileId::zero(), &root, filter, |signal| {
             if let Some(diag) = signal.diagnostic() {
                 let code = format!("{group}/{rule}");
                 let severity = settings.get_severity_from_rule_code(&code).unwrap();


### PR DESCRIPTION
## Summary

This is a change I extracted from #3222 to make the larger change easier to review. This PR changes the `FileId` type in `rome_diagnostics` from an alias of `usize` to a proper newtype struct. This makes is easier to implement specific behaviors and traits on that type, and could eventually allow us to change the internal representation of File IDs transparently for consumers of the type.

## Test Plan

This is purely a type-level change, it should not impact the functionality of the code (for the most part the machine code generated by the compile should not change and the `FileId` struct should have the same memory layout as a raw `usize`)
