### PR TITLE
feat(rome_text_size): implement the JsonSchema trait on TextRange and TextSize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,6 +1797,7 @@ dependencies = [
 name = "rome_text_size"
 version = "0.0.0"
 dependencies = [
+ "schemars",
  "serde",
  "serde_test",
  "static_assertions",

--- a/crates/rome_diagnostics/src/file.rs
+++ b/crates/rome_diagnostics/src/file.rs
@@ -138,7 +138,6 @@ impl From<FileId> for usize {
 )]
 pub struct FileSpan {
     pub file: FileId,
-    #[cfg_attr(feature = "serde", schemars(with = "rome_rowan::TextRangeSchema"))]
     pub range: TextRange,
 }
 

--- a/crates/rome_diagnostics/src/suggestion.rs
+++ b/crates/rome_diagnostics/src/suggestion.rs
@@ -19,7 +19,6 @@ pub struct CodeSuggestion {
     pub applicability: Applicability,
     pub msg: MarkupBuf,
     pub style: SuggestionStyle,
-    #[cfg_attr(feature = "serde", schemars(with = "Vec<rome_rowan::TextRangeSchema>"))]
     pub labels: Vec<TextRange>,
 }
 

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -298,10 +298,8 @@ impl FormatOptions for SimpleFormatOptions {
 )]
 pub struct SourceMarker {
     /// Position of the marker in the original source
-    #[cfg_attr(feature = "serde", schemars(with = "u32"))]
     pub source: TextSize,
     /// Position of the marker in the output code
-    #[cfg_attr(feature = "serde", schemars(with = "u32"))]
     pub dest: TextSize,
 }
 
@@ -358,13 +356,8 @@ where
 )]
 pub struct Printed {
     code: String,
-    #[cfg_attr(
-        feature = "serde",
-        schemars(with = "Option<rome_rowan::TextRangeSchema>")
-    )]
     range: Option<TextRange>,
     sourcemap: Vec<SourceMarker>,
-    #[cfg_attr(feature = "serde", schemars(with = "Vec<rome_rowan::TextRangeSchema>"))]
     verbatim_ranges: Vec<TextRange>,
 }
 

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -34,8 +34,6 @@ mod syntax_token_text;
 mod tree_builder;
 
 pub use rome_text_size::{TextLen, TextRange, TextSize};
-#[cfg(feature = "serde")]
-pub use serde_impls::TextRangeSchema;
 
 pub use crate::{
     ast::*,

--- a/crates/rome_rowan/src/serde_impls.rs
+++ b/crates/rome_rowan/src/serde_impls.rs
@@ -1,4 +1,3 @@
-use schemars::JsonSchema;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::fmt;
 
@@ -6,12 +5,6 @@ use crate::{
     syntax::{Language, SyntaxNode, SyntaxToken},
     NodeOrToken,
 };
-
-#[derive(JsonSchema)]
-pub struct TextRangeSchema {
-    pub start: u32,
-    pub end: u32,
-}
 
 struct SerDisplay<T>(T);
 impl<T: fmt::Display> Serialize for SerDisplay<T> {

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -58,8 +58,6 @@ use rome_diagnostics::{CodeSuggestion, Diagnostic};
 use rome_formatter::Printed;
 use rome_fs::RomePath;
 use rome_js_syntax::{TextRange, TextSize};
-#[cfg(feature = "schemars")]
-use rome_rowan::TextRangeSchema;
 use rome_text_edit::Indel;
 use std::{borrow::Cow, panic::RefUnwindSafe, sync::Arc};
 
@@ -150,7 +148,6 @@ pub struct GetSyntaxTreeResult {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct GetControlFlowGraphParams {
     pub path: RomePath,
-    #[cfg_attr(feature = "schemars", schemars(with = "u32"))]
     pub cursor: TextSize,
 }
 
@@ -191,7 +188,6 @@ pub struct PullDiagnosticsResult {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PullActionsParams {
     pub path: RomePath,
-    #[cfg_attr(feature = "schemars", schemars(with = "TextRangeSchema"))]
     pub range: TextRange,
 }
 
@@ -219,7 +215,6 @@ pub struct FormatFileParams {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct FormatRangeParams {
     pub path: RomePath,
-    #[cfg_attr(feature = "schemars", schemars(with = "TextRangeSchema"))]
     pub range: TextRange,
 }
 
@@ -227,7 +222,6 @@ pub struct FormatRangeParams {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct FormatOnTypeParams {
     pub path: RomePath,
-    #[cfg_attr(feature = "schemars", schemars(with = "u32"))]
     pub offset: TextSize,
 }
 
@@ -266,7 +260,6 @@ pub struct FixAction {
     /// Name of the rule that emitted this code action
     pub rule_name: Cow<'static, str>,
     /// Source range at which this action was applied
-    #[cfg_attr(feature = "schemars", schemars(with = "TextRangeSchema"))]
     pub range: TextRange,
 }
 
@@ -274,7 +267,6 @@ pub struct FixAction {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RenameParams {
     pub path: RomePath,
-    #[cfg_attr(feature = "schemars", schemars(with = "u32"))]
     pub symbol_at: TextSize,
     pub new_name: String,
 }
@@ -283,7 +275,6 @@ pub struct RenameParams {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RenameResult {
     /// Range of source code modified by this rename operation
-    #[cfg_attr(feature = "schemars", schemars(with = "TextRangeSchema"))]
     pub range: TextRange,
     /// List of text edit operations to apply on the source code
     pub indels: Vec<Indel>,

--- a/crates/rome_service/src/workspace_types.rs
+++ b/crates/rome_service/src/workspace_types.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashSet, VecDeque};
 
-use rome_js_syntax::JsAnyDeclaration;
+use rome_js_syntax::{JsAnyDeclaration, TsAnyTupleTypeElement};
 use schemars::{
     gen::{SchemaGenerator, SchemaSettings},
     schema::{InstanceType, RootSchema, Schema, SchemaObject, SingleOrVec},
@@ -97,7 +97,18 @@ fn instance_type<'a>(
                         make::token(T![']']),
                     ))
                 }
-                SingleOrVec::Vec(_) => unimplemented!(),
+                SingleOrVec::Vec(items) => TsType::from(make::ts_tuple_type(
+                    make::token(T!['[']),
+                    make::ts_tuple_type_element_list(
+                        items.iter().map(|schema| {
+                            let (ts_type, optional, _) = schema_type(queue, root_schema, schema);
+                            assert!(!optional, "optional nested types are not supported");
+                            TsAnyTupleTypeElement::TsType(ts_type)
+                        }),
+                        items.iter().map(|_| make::token(T![,])),
+                    ),
+                    make::token(T![']']),
+                )),
             }
         }
 

--- a/crates/rome_text_edit/Cargo.toml
+++ b/crates/rome_text_edit/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "1.0.136", features = ["derive"], optional = true }
 schemars = { version = "0.8.10", optional = true }
 
 [features]
-serde = ["dep:serde", "schemars", "rome_text_size/serde"]
+serde = ["dep:serde", "schemars", "rome_text_size/serde", "rome_text_size/schemars"]

--- a/crates/rome_text_edit/src/lib.rs
+++ b/crates/rome_text_edit/src/lib.rs
@@ -14,15 +14,7 @@ pub use rome_text_size::{TextRange, TextSize};
 pub struct Indel {
     pub insert: String,
     /// Refers to offsets in the original text
-    #[cfg_attr(feature = "serde", schemars(with = "TextRangeSchema"))]
     pub delete: TextRange,
-}
-
-#[cfg(feature = "serde")]
-#[derive(schemars::JsonSchema)]
-pub struct TextRangeSchema {
-    pub start: u32,
-    pub end: u32,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/rome_text_size/Cargo.toml
+++ b/crates/rome_text_size/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/rome/tools"
 
 [dependencies]
 serde = { version = "1.0", optional = true, default_features = false }
+schemars = { version = "0.8.10", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/crates/rome_text_size/src/lib.rs
+++ b/crates/rome_text_size/src/lib.rs
@@ -23,6 +23,8 @@ mod range;
 mod size;
 mod traits;
 
+#[cfg(feature = "schemars")]
+mod schemars_impls;
 #[cfg(feature = "serde")]
 mod serde_impls;
 

--- a/crates/rome_text_size/src/schemars_impls.rs
+++ b/crates/rome_text_size/src/schemars_impls.rs
@@ -1,0 +1,22 @@
+use crate::{TextRange, TextSize};
+use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
+
+impl JsonSchema for TextSize {
+    fn schema_name() -> String {
+        String::from("TextSize")
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        <u32>::json_schema(gen)
+    }
+}
+
+impl JsonSchema for TextRange {
+    fn schema_name() -> String {
+        String::from("TextRange")
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        <(TextSize, TextSize)>::json_schema(gen)
+    }
+}

--- a/crates/rome_text_size/src/schemars_impls.rs
+++ b/crates/rome_text_size/src/schemars_impls.rs
@@ -1,3 +1,10 @@
+//! This module implements the [JsonSchema] trait from the [schemars] crate for
+//! [TextSize] and [TextRange] if the `schemars` feature is enabled. This trait
+//! exposes meta-information on how a given type is serialized and deserialized
+//! using `serde`, and is currently used to generate autocomplete information
+//! for the `rome.json` configuration file and TypeScript types for the node.js
+//! bindings to the Workspace API
+
 use crate::{TextRange, TextSize};
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 
@@ -7,6 +14,8 @@ impl JsonSchema for TextSize {
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        // TextSize is represented as a raw u32, see serde_impls.rs for the
+        // actual implementation
         <u32>::json_schema(gen)
     }
 }
@@ -17,6 +26,8 @@ impl JsonSchema for TextRange {
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        // TextSize is represented as (TextSize, TextSize), see serde_impls.rs
+        // for the actual implementation
         <(TextSize, TextSize)>::json_schema(gen)
     }
 }

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -216,9 +216,10 @@ export interface GetSyntaxTreeResult {
 	cst: string;
 }
 export interface GetControlFlowGraphParams {
-	cursor: number;
+	cursor: TextSize;
 	path: RomePath;
 }
+export type TextSize = number;
 export interface GetFormatterIRParams {
 	path: RomePath;
 }
@@ -273,7 +274,7 @@ export type Severity = "Help" | "Note" | "Warning" | "Error" | "Bug";
  */
 export interface CodeSuggestion {
 	applicability: Applicability;
-	labels: TextRangeSchema[];
+	labels: TextRange[];
 	msg: MarkupBuf;
 	span: FileSpan;
 	style: SuggestionStyle;
@@ -289,7 +290,7 @@ export type MarkupBuf = MarkupNodeBuf[];
  */
 export interface FileSpan {
 	file: FileId;
-	range: TextRangeSchema;
+	range: TextRange;
 }
 /**
  * Indicates how a tool should manage this suggestion.
@@ -299,10 +300,7 @@ export type Applicability =
 	| "MaybeIncorrect"
 	| "HasPlaceholders"
 	| "Unspecified";
-export interface TextRangeSchema {
-	end: number;
-	start: number;
-}
+export type TextRange = [TextSize, TextSize];
 export type SuggestionStyle = "DontShow" | "HideCode" | "Inline" | "Full";
 export type SuggestionChange = { Indels: Indel[] } | { String: string };
 export interface MarkupNodeBuf {
@@ -318,7 +316,7 @@ export interface Indel {
 	/**
 	 * Refers to offsets in the original text
 	 */
-	delete: TextRangeSchema;
+	delete: TextRange;
 	insert: string;
 }
 /**
@@ -336,7 +334,7 @@ export type MarkupElement =
 	| { Hyperlink: { href: string } };
 export interface PullActionsParams {
 	path: RomePath;
-	range: TextRangeSchema;
+	range: TextRange;
 }
 export interface PullActionsResult {
 	actions: CodeAction[];
@@ -352,9 +350,9 @@ export interface FormatFileParams {
 }
 export interface Printed {
 	code: string;
-	range?: TextRangeSchema;
+	range?: TextRange;
 	sourcemap: SourceMarker[];
-	verbatim_ranges: TextRangeSchema[];
+	verbatim_ranges: TextRange[];
 }
 /**
  * Lightweight sourcemap marker between source and output tokens
@@ -363,18 +361,18 @@ export interface SourceMarker {
 	/**
 	 * Position of the marker in the output code
 	 */
-	dest: number;
+	dest: TextSize;
 	/**
 	 * Position of the marker in the original source
 	 */
-	source: number;
+	source: TextSize;
 }
 export interface FormatRangeParams {
 	path: RomePath;
-	range: TextRangeSchema;
+	range: TextRange;
 }
 export interface FormatOnTypeParams {
-	offset: number;
+	offset: TextSize;
 	path: RomePath;
 }
 export interface FixFileParams {
@@ -403,7 +401,7 @@ export interface FixAction {
 	/**
 	 * Source range at which this action was applied
 	 */
-	range: TextRangeSchema;
+	range: TextRange;
 	/**
 	 * Name of the rule that emitted this code action
 	 */
@@ -412,7 +410,7 @@ export interface FixAction {
 export interface RenameParams {
 	new_name: string;
 	path: RomePath;
-	symbol_at: number;
+	symbol_at: TextSize;
 }
 export interface RenameResult {
 	/**
@@ -422,7 +420,7 @@ export interface RenameResult {
 	/**
 	 * Range of source code modified by this rename operation
 	 */
-	range: TextRangeSchema;
+	range: TextRange;
 }
 export interface Workspace {
 	supportsFeature(

--- a/npm/rome/src/index.ts
+++ b/npm/rome/src/index.ts
@@ -246,9 +246,6 @@ export class Rome {
 		if (options.range) {
 			const result = await this.backend.workspace.formatRange({
 				path: file.path,
-				// TODO: investigate following error:
-				// Unknown Error: invalid type: map, expected a tuple of size 2
-				// @ts-ignore The backend fails when passing an object, but it's ok when sending a tuple
 				range: options.range,
 			});
 			code = result.code;


### PR DESCRIPTION
## Summary

This is another change extracted from #3222, this implements the `JsonSchema` trait on the `TextRange` and `TextSize` structs directly in the `rome_text_size` crate since now own it, instead relying on manual `-Schema` implementations that were actually incorrect.

## Test Plan

This PR only change how these types are represented in the `schemars` meta-type system, the only visible side-effect for this is that the `TextRange` type is now correctly declared as `[number, number]` in the generated TypeScript bindings
