### PR TITLE
docs: fix line break in `noUnusedVariables` lint rule

### DIFF
--- a/website/src/docs/lint/rules/noUnusedVariables.md
+++ b/website/src/docs/lint/rules/noUnusedVariables.md
@@ -11,6 +11,7 @@ There are two exceptions to this rule:
 
 1. variables that starts with underscore, ex: `let _something;`
 2. the `React` variable;
+
 The pattern of having an underscore as prefix of a name of variable is a very diffuse
 pattern among programmers, and Rome decided to follow it.
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

The docs is missing a line break which resulted in [incorrect rendering](https://rome.tools/docs/lint/rules/nounusedvariables/):

<img width="849" alt="image" src="https://user-images.githubusercontent.com/44045911/190476665-fe107118-e828-4c7b-a7a4-69a555b20969.png">

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
