### PR TITLE
perf(rome_cli): replace global allocator with jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "fst"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1504,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -2172,6 +2179,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.1+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931e876f91fed0827f863a2d153897790da0b24d882c721a79cb3beb0b903261"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2804,6 +2832,7 @@ dependencies = [
  "rome_js_formatter",
  "rome_js_parser",
  "rome_js_syntax",
+ "tikv-jemallocator",
  "timing",
  "ureq",
  "url",

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { version = "1.15.0", features = ["process"] }
 [target.'cfg(windows)'.dependencies]
 mimalloc = "0.1.29"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(not(windows))'.dependencies]
 tikv-jemallocator = "0.5.0"
 
 [dev-dependencies]

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -42,6 +42,9 @@ tokio = { version = "1.15.0", features = ["process"] }
 [target.'cfg(windows)'.dependencies]
 mimalloc = "0.1.29"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+tikv-jemallocator = "0.5.0"
+
 [dev-dependencies]
 insta = "1.18.2"
 tokio = { version = "1.15.0", features = ["io-util"] }

--- a/crates/rome_cli/src/main.rs
+++ b/crates/rome_cli/src/main.rs
@@ -12,7 +12,7 @@ use tokio::runtime::Runtime;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[cfg(target_os = "macos")]
+#[cfg(not(target_os = "windows"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/crates/rome_cli/src/main.rs
+++ b/crates/rome_cli/src/main.rs
@@ -12,6 +12,10 @@ use tokio::runtime::Runtime;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(target_os = "macos")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 fn main() -> Result<(), Termination> {
     setup_panic_handler();
 

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -30,5 +30,8 @@ humansize = {version = "1.1.1", optional = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.29"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+tikv-jemallocator = "0.5.0"
+
 [features]
 dhat-heap = ["dhat", "humansize"]

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -30,7 +30,7 @@ humansize = {version = "1.1.1", optional = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.29"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(not(windows))'.dependencies]
 tikv-jemallocator = "0.5.0"
 
 [features]

--- a/xtask/bench/src/main.rs
+++ b/xtask/bench/src/main.rs
@@ -10,6 +10,10 @@ static ALLOCATOR: dhat::Alloc = dhat::Alloc;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(all(target_os = "macos", not(feature = "dhat-heap")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 fn main() -> Result<(), pico_args::Error> {
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();

--- a/xtask/bench/src/main.rs
+++ b/xtask/bench/src/main.rs
@@ -10,7 +10,7 @@ static ALLOCATOR: dhat::Alloc = dhat::Alloc;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[cfg(all(target_os = "macos", not(feature = "dhat-heap")))]
+#[cfg(all(not(target_os = "windows"), not(feature = "dhat-heap")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR replaces the default global allocator to use `jemallocator` on **all operative systems**, exception for Windows because it's not supported.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Here's some benchmarks from my machine (I use macOS)

### parser

```block
group                                 jamalloc                               main
-----                                 --------                               ----
parser/checker.ts                     1.00     98.9±7.70ms    26.3 MB/sec    1.16    115.2±3.25ms    22.6 MB/sec
parser/compiler.js                    1.00     52.8±1.15ms    19.8 MB/sec    1.49     79.0±1.86ms    13.3 MB/sec
parser/d3.min.js                      1.00     34.2±2.76ms     7.7 MB/sec    1.22     41.9±0.96ms     6.3 MB/sec
parser/dojo.js                        1.00      3.1±0.24ms    22.2 MB/sec    1.16      3.6±0.09ms    19.2 MB/sec
parser/ios.d.ts                       1.00     76.2±3.42ms    24.5 MB/sec    1.33    101.1±5.28ms    18.5 MB/sec
parser/jquery.min.js                  1.00      8.4±0.70ms     9.8 MB/sec    1.40     11.8±0.25ms     7.0 MB/sec
parser/math.js                        1.00     68.2±6.90ms     9.5 MB/sec    1.21     82.7±1.39ms     7.8 MB/sec
parser/parser.ts                      1.00      2.2±0.18ms    22.1 MB/sec    1.13      2.5±0.07ms    19.6 MB/sec
parser/pixi.min.js                    1.00     43.2±1.93ms    10.2 MB/sec    1.33     57.4±1.07ms     7.6 MB/sec
parser/react-dom.production.min.js    1.00     11.4±0.31ms    10.1 MB/sec    1.32     15.1±0.43ms     7.6 MB/sec
parser/react.production.min.js        1.00   618.1±75.15µs    10.0 MB/sec    1.31   810.4±21.71µs     7.6 MB/sec
parser/router.ts                      1.00  1744.8±96.27µs    35.2 MB/sec    1.23      2.1±0.08ms    28.6 MB/sec
parser/tex-chtml-full.js              1.00     92.9±5.44ms     9.8 MB/sec    1.21    112.5±6.80ms     8.1 MB/sec
parser/three.min.js                   1.00     51.7±7.25ms    11.4 MB/sec    1.15     59.4±1.29ms     9.9 MB/sec
parser/typescript.js                  1.00   381.1±29.09ms    24.9 MB/sec    1.25    478.1±8.76ms    19.9 MB/sec
parser/vue.global.prod.js             1.00     13.7±0.39ms     8.8 MB/sec    1.39     19.1±0.48ms     6.3 MB/sec
```

### formatter

```block
group                                    formatter-jamalloc                      formatter-main
-----                                    ------------------                      --------------
formatter/checker.ts                     1.00   360.2±11.12ms     7.2 MB/sec     1.99   718.7±88.40ms     3.6 MB/sec
formatter/compiler.js                    1.00   213.1±24.96ms     4.9 MB/sec     1.94   413.6±32.24ms     2.5 MB/sec
formatter/d3.min.js                      1.00    162.9±6.40ms  1647.7 KB/sec     2.14   348.4±24.40ms   770.3 KB/sec
formatter/dojo.js                        1.00     10.1±0.38ms     6.8 MB/sec     1.83     18.6±0.68ms     3.7 MB/sec
formatter/ios.d.ts                       1.00    224.4±7.34ms     8.3 MB/sec     2.09   469.8±52.19ms     4.0 MB/sec
formatter/jquery.min.js                  1.00     46.2±3.25ms  1830.6 KB/sec     1.88     86.9±4.87ms   973.9 KB/sec
formatter/math.js                        1.00   316.2±16.29ms     2.0 MB/sec     2.07   654.2±44.04ms  1013.5 KB/sec
formatter/parser.ts                      1.00      7.6±0.24ms     6.4 MB/sec     1.78     13.5±0.81ms     3.6 MB/sec
formatter/pixi.min.js                    1.00   182.9±20.46ms     2.4 MB/sec     2.04   372.9±26.13ms  1205.1 KB/sec
formatter/react-dom.production.min.js    1.00     53.6±3.05ms     2.1 MB/sec     2.16   115.6±16.34ms  1019.3 KB/sec
formatter/react.production.min.js        1.00      2.5±0.07ms     2.5 MB/sec     1.82      4.5±0.22ms  1385.1 KB/sec
formatter/router.ts                      1.00      6.0±0.37ms    10.2 MB/sec     1.65      9.9±0.51ms     6.2 MB/sec
formatter/tex-chtml-full.js              1.00   405.0±17.74ms     2.3 MB/sec     2.19   886.4±69.69ms  1052.8 KB/sec
formatter/three.min.js                   1.00   210.4±23.22ms     2.8 MB/sec     1.99   418.5±33.31ms  1436.6 KB/sec
formatter/typescript.js                  1.00  1444.9±154.91ms     6.6 MB/sec    1.67       2.4±0.10s     3.9 MB/sec
formatter/vue.global.prod.js             1.00     70.9±5.05ms  1740.0 KB/sec     2.07   146.9±13.28ms   839.9 KB/sec
```

### analyzer

```block
group                     analyzer-jamalloc                      analyzer-main
-----                     -----------------                      -------------
analyzer/css.js           1.00  1682.7±79.01µs     6.9 MB/sec    2.03      3.4±0.10ms     3.4 MB/sec
analyzer/index.js         1.00      4.5±0.08ms     7.2 MB/sec    2.43     10.9±0.36ms     3.0 MB/sec
analyzer/lint.ts          1.00      2.5±0.20ms    16.8 MB/sec    1.73      4.3±0.12ms     9.7 MB/sec
analyzer/parser.ts        1.00      5.8±0.28ms     8.4 MB/sec    1.84     10.7±0.18ms     4.6 MB/sec
analyzer/router.ts        1.00      4.0±0.14ms    15.4 MB/sec    1.85      7.4±0.10ms     8.3 MB/sec
analyzer/statement.ts     1.00      5.4±0.25ms     6.5 MB/sec    1.99     10.8±0.72ms     3.3 MB/sec
analyzer/typescript.ts    1.00      9.1±0.52ms     6.0 MB/sec    1.67     15.2±0.26ms     3.6 MB/sec
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->


## Memory consumption 

I used `cargo instruments` and I am not an expert at using the trace tool provided by XCode. I share here the screenshots and the trace file in case someone has more knowledge than me.

I run the formatter on the prettier repository, their `src` folder. No `--write`.

### `jemalloc`

![Screenshot 2022-09-21 at 10 32 34](https://user-images.githubusercontent.com/602478/191470025-04eedbbd-f345-403b-bb3f-4c807fd9debb.png)

- [Link to Rome shared drive](https://drive.google.com/drive/folders/1bVrif5ZLVZSmXn1yGHxTgYVMyXfWybAB?usp=sharing)

### `main`

![Screenshot 2022-09-21 at 10 32 29](https://user-images.githubusercontent.com/602478/191470780-f6d0d4b3-883a-415c-93aa-48a72ff21932.png)

- [Link to Rome shared drive](https://drive.google.com/drive/folders/18x6YwQ8t4B6pI2EDb995tS-JWaTkLc1c?usp=sharing)
