### PR TITLE
feat(playground): enable nursery lint rules

### DIFF
--- a/website/playground/package.json
+++ b/website/playground/package.json
@@ -36,7 +36,6 @@
 		"@vitejs/plugin-react": "^1.0.7",
 		"autoprefixer": "^10.4.2",
 		"postcss": "^8.4.6",
-		"rome": "next",
 		"tailwindcss": "^3.0.19",
 		"typescript": "^4.8.2",
 		"vite": "2.9.5",

--- a/website/playground/package.json
+++ b/website/playground/package.json
@@ -10,7 +10,7 @@
 		"build:wasm": "wasm-pack build --out-dir ../../npm/wasm-web --target web --release --scope rometools ../../crates/rome_wasm",
 		"build:wasm-dev": "wasm-pack build --out-dir ../../npm/wasm-web --target web --dev --scope rometools ../../crates/rome_wasm",
 		"format": "cargo rome-cli-dev format --write ./src",
-		"check": "cargo rome-cli-dev check ./src",
+		"check": "cd ../../ && cargo rome-cli-dev check ./website/playground/src",
 		"tsc": "tsc"
 	},
 	"dependencies": {

--- a/website/playground/pnpm-lock.yaml
+++ b/website/playground/pnpm-lock.yaml
@@ -21,7 +21,6 @@ specifiers:
   react: ^17.0.2
   react-dom: ^17.0.2
   react-tabs: ^3.2.3
-  rome: next
   tailwindcss: ^3.0.19
   typescript: ^4.8.2
   vite: 2.9.5
@@ -50,7 +49,6 @@ devDependencies:
   '@vitejs/plugin-react': 1.1.4
   autoprefixer: 10.4.2_postcss@8.4.6
   postcss: 8.4.6
-  rome: 0.8.0-next.ff4153b
   tailwindcss: 3.0.19_qm7bagfnbv4vjkuayu3hle4sne
   typescript: 4.8.2
   vite: 2.9.5
@@ -491,54 +489,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
     dev: true
-
-  /@rometools/cli-darwin-arm64/0.8.0-next.ff4153b:
-    resolution: {integrity: sha512-P0BCJyN50Go7U5AG2Ujh8rIwmnaGpOqYqpsmF2J9hRX8zdMiIpYdbmAG6q0B6kibmwYcwS0+JgIdrYn4bl9Hpg==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rometools/cli-darwin-x64/0.8.0-next.ff4153b:
-    resolution: {integrity: sha512-d9PuyMo4Nc16/YrWaskU+2mygYK1+Vg5GjHJswX51fkUsNlVbNFqDtYLce6m1Oe7UAh0GcsViOvF3jw7fDncbQ==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rometools/cli-linux-arm64/0.8.0-next.ff4153b:
-    resolution: {integrity: sha512-evoUPlk5t6LshpGA9bLB1+42sakKZspyAOJP5P5Fp9HQc9Lvg7c3H5dSosSPSsKK3EVk9ClNVNJq9XMKS5qABQ==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rometools/cli-linux-x64/0.8.0-next.ff4153b:
-    resolution: {integrity: sha512-vjMS1l32GC1YZC0ed9Ryr85IDYWKb4gcLgLaGTiaGEgB8tjlWAvB4h8IdomT8bJYSYjgdZOHuV5lTJ5pI2VfKg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rometools/cli-win32-arm64/0.8.0-next.ff4153b:
-    resolution: {integrity: sha512-W5sUoDXuE7+bK/hNtafctYT+lfxlLacqeGsw7apFczXa8c7H+SrcHneveTwzl0iUxY2R+XY9wUe4aDa+v+zYlw==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rometools/cli-win32-x64/0.8.0-next.ff4153b:
-    resolution: {integrity: sha512-zpEhtqM5K3WfxDv2/bgyXOU6R33lfwuDbehM7eMsaRgwMIA7vbLenxX7Y/hpgPqhZ2MpodJhFLuK8m9yIQ7Rxw==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /@svgr/babel-plugin-add-jsx-attribute/6.0.0_@babel+core@7.17.0:
     resolution: {integrity: sha512-MdPdhdWLtQsjd29Wa4pABdhWbaRMACdM1h31BY+c6FghTZqNGT7pEYdBoaGeKtdTOBC/XNFQaKVj+r/Ei2ryWA==}
@@ -1693,20 +1643,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
-
-  /rome/0.8.0-next.ff4153b:
-    resolution: {integrity: sha512-Hf1gx01l+6JRRKK4XSThLC7d7f8QuFTU5OyaSnGdCd0M//uBVBKSt5b9v9TWK6fT98ZjKMvmMOcZItHwLVJx7g==}
-    engines: {node: '>=14.*'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@rometools/cli-darwin-arm64': 0.8.0-next.ff4153b
-      '@rometools/cli-darwin-x64': 0.8.0-next.ff4153b
-      '@rometools/cli-linux-arm64': 0.8.0-next.ff4153b
-      '@rometools/cli-linux-x64': 0.8.0-next.ff4153b
-      '@rometools/cli-win32-arm64': 0.8.0-next.ff4153b
-      '@rometools/cli-win32-x64': 0.8.0-next.ff4153b
     dev: true
 
   /run-parallel/1.2.0:

--- a/website/playground/src/NurseryRules.tsx
+++ b/website/playground/src/NurseryRules.tsx
@@ -8,10 +8,10 @@ export default function NurseryRules({
 	enabledNurseryRules,
 }: Props) {
 	return (
-		<div className="pl-5 pb-5">
+		<div className="pl-5">
 			<fieldset className="flex items-center">
 				<legend className="sr-only">Linter</legend>
-				<div className="relative flex p-5 pl-1 pt-7 pb-0">
+				<div className="relative flex p-5 pt-0 pl-1">
 					<div className="flex items-center h-5">
 						<input
 							id="nursery-rules"

--- a/website/playground/src/NurseryRules.tsx
+++ b/website/playground/src/NurseryRules.tsx
@@ -1,5 +1,3 @@
-import { SourceType } from "./types";
-
 interface Props {
 	setEnabledNurseryRules: (b: boolean) => void;
 	enabledNurseryRules: boolean;

--- a/website/playground/src/NurseryRules.tsx
+++ b/website/playground/src/NurseryRules.tsx
@@ -1,0 +1,42 @@
+import {SourceType} from "./types";
+
+interface Props {
+    setEnabledNurseryRules: (b: boolean) => void,
+    enabledNurseryRules: boolean
+}
+
+export default function NurseryRules({
+    setEnabledNurseryRules,
+    enabledNurseryRules
+
+                                         }: Props) {
+    return (
+        <div className="pl-5 pb-5">
+            <fieldset className="flex items-center">
+                <legend className="sr-only">Linter</legend>
+                <div className="relative flex p-5 pl-1 pt-7 pb-0">
+                    <div className="flex items-center h-5">
+                        <input
+                            id="nursery-rules"
+                            aria-describedby="jsx-description"
+                            name="jsx"
+                            type="checkbox"
+                            checked={enabledNurseryRules}
+                            onChange={(e) => setEnabledNurseryRules(e.target.checked)}
+                            className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded disabled:opacity-30"
+                        />
+                    </div>
+                    <div className="ml-1 text-sm">
+
+                        <label htmlFor="jsx" className="font-medium text-gray-700">
+                            Nursery rules enabled
+                        </label>
+                        <span id="nursery-rules-description" className="text-gray-500">
+							<span className="sr-only">Nursery rules enabled</span>
+						</span>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+    );
+}

--- a/website/playground/src/NurseryRules.tsx
+++ b/website/playground/src/NurseryRules.tsx
@@ -24,7 +24,10 @@ export default function NurseryRules({
 						/>
 					</div>
 					<div className="ml-1 text-sm">
-						<label htmlFor="nursery-rules" className="font-medium text-gray-700">
+						<label
+							htmlFor="nursery-rules"
+							className="font-medium text-gray-700"
+						>
 							Nursery rules
 						</label>
 						<span id="nursery-rules-description" className="text-gray-500">

--- a/website/playground/src/NurseryRules.tsx
+++ b/website/playground/src/NurseryRules.tsx
@@ -1,42 +1,40 @@
-import {SourceType} from "./types";
+import { SourceType } from "./types";
 
 interface Props {
-    setEnabledNurseryRules: (b: boolean) => void,
-    enabledNurseryRules: boolean
+	setEnabledNurseryRules: (b: boolean) => void;
+	enabledNurseryRules: boolean;
 }
 
 export default function NurseryRules({
-    setEnabledNurseryRules,
-    enabledNurseryRules
-
-                                         }: Props) {
-    return (
-        <div className="pl-5 pb-5">
-            <fieldset className="flex items-center">
-                <legend className="sr-only">Linter</legend>
-                <div className="relative flex p-5 pl-1 pt-7 pb-0">
-                    <div className="flex items-center h-5">
-                        <input
-                            id="nursery-rules"
-                            aria-describedby="jsx-description"
-                            name="jsx"
-                            type="checkbox"
-                            checked={enabledNurseryRules}
-                            onChange={(e) => setEnabledNurseryRules(e.target.checked)}
-                            className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded disabled:opacity-30"
-                        />
-                    </div>
-                    <div className="ml-1 text-sm">
-
-                        <label htmlFor="jsx" className="font-medium text-gray-700">
-                            Nursery rules enabled
-                        </label>
-                        <span id="nursery-rules-description" className="text-gray-500">
+	setEnabledNurseryRules,
+	enabledNurseryRules,
+}: Props) {
+	return (
+		<div className="pl-5 pb-5">
+			<fieldset className="flex items-center">
+				<legend className="sr-only">Linter</legend>
+				<div className="relative flex p-5 pl-1 pt-7 pb-0">
+					<div className="flex items-center h-5">
+						<input
+							id="nursery-rules"
+							aria-describedby="jsx-description"
+							name="jsx"
+							type="checkbox"
+							checked={enabledNurseryRules}
+							onChange={(e) => setEnabledNurseryRules(e.target.checked)}
+							className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded disabled:opacity-30"
+						/>
+					</div>
+					<div className="ml-1 text-sm">
+						<label htmlFor="jsx" className="font-medium text-gray-700">
+							Nursery rules enabled
+						</label>
+						<span id="nursery-rules-description" className="text-gray-500">
 							<span className="sr-only">Nursery rules enabled</span>
 						</span>
-                    </div>
-                </div>
-            </fieldset>
-        </div>
-    );
+					</div>
+				</div>
+			</fieldset>
+		</div>
+	);
 }

--- a/website/playground/src/NurseryRules.tsx
+++ b/website/playground/src/NurseryRules.tsx
@@ -15,8 +15,8 @@ export default function NurseryRules({
 					<div className="flex items-center h-5">
 						<input
 							id="nursery-rules"
-							aria-describedby="jsx-description"
-							name="jsx"
+							aria-describedby="nursery-rules-description"
+							name="nursery-rules"
 							type="checkbox"
 							checked={enabledNurseryRules}
 							onChange={(e) => setEnabledNurseryRules(e.target.checked)}
@@ -24,11 +24,11 @@ export default function NurseryRules({
 						/>
 					</div>
 					<div className="ml-1 text-sm">
-						<label htmlFor="jsx" className="font-medium text-gray-700">
-							Nursery rules enabled
+						<label htmlFor="nursery-rules" className="font-medium text-gray-700">
+							Nursery rules
 						</label>
 						<span id="nursery-rules-description" className="text-gray-500">
-							<span className="sr-only">Nursery rules enabled</span>
+							<span className="sr-only">Nursery rules</span>
 						</span>
 					</div>
 				</div>

--- a/website/playground/src/NurseryRules.tsx
+++ b/website/playground/src/NurseryRules.tsx
@@ -28,10 +28,10 @@ export default function NurseryRules({
 							htmlFor="nursery-rules"
 							className="font-medium text-gray-700"
 						>
-							Nursery rules
+							Nursery lint rules
 						</label>
 						<span id="nursery-rules-description" className="text-gray-500">
-							<span className="sr-only">Nursery rules</span>
+							<span className="sr-only">Nursery lint rules</span>
 						</span>
 					</div>
 				</div>

--- a/website/playground/src/SettingsMenu.tsx
+++ b/website/playground/src/SettingsMenu.tsx
@@ -70,7 +70,6 @@ export function SettingsMenu({
 					)}
 					enabledNurseryRules={enabledNurseryRules}
 				/>
-
 			</div>
 		</div>
 	);

--- a/website/playground/src/SettingsMenu.tsx
+++ b/website/playground/src/SettingsMenu.tsx
@@ -24,7 +24,7 @@ export function SettingsMenu({
 		sourceType,
 		isTypeScript,
 		isJsx,
-		enabledNurseryRules
+		enabledNurseryRules,
 	},
 }: Props) {
 	return (
@@ -61,7 +61,13 @@ export function SettingsMenu({
 					sourceType={sourceType}
 					setSourceType={createSetter(setPlaygroundState, "sourceType")}
 				/>
-				<NurseryRules setEnabledNurseryRules={createSetter(setPlaygroundState, "enabledNurseryRules")} enabledNurseryRules={enabledNurseryRules} />
+				<NurseryRules
+					setEnabledNurseryRules={createSetter(
+						setPlaygroundState,
+						"enabledNurseryRules",
+					)}
+					enabledNurseryRules={enabledNurseryRules}
+				/>
 			</div>
 		</div>
 	);

--- a/website/playground/src/SettingsMenu.tsx
+++ b/website/playground/src/SettingsMenu.tsx
@@ -61,6 +61,8 @@ export function SettingsMenu({
 					sourceType={sourceType}
 					setSourceType={createSetter(setPlaygroundState, "sourceType")}
 				/>
+			</div>
+			<div className="flex flex-col sm:flex-row">
 				<NurseryRules
 					setEnabledNurseryRules={createSetter(
 						setPlaygroundState,
@@ -68,6 +70,7 @@ export function SettingsMenu({
 					)}
 					enabledNurseryRules={enabledNurseryRules}
 				/>
+
 			</div>
 		</div>
 	);

--- a/website/playground/src/SettingsMenu.tsx
+++ b/website/playground/src/SettingsMenu.tsx
@@ -6,6 +6,7 @@ import { PlaygroundSettings, PlaygroundState } from "./types";
 import { Dispatch, SetStateAction } from "react";
 import { createSetter } from "./utils";
 import QuotePropertiesSelect from "./QuotePropertiesSelect";
+import NurseryRules from "./NurseryRules";
 
 interface Props {
 	settings: PlaygroundSettings;
@@ -23,6 +24,7 @@ export function SettingsMenu({
 		sourceType,
 		isTypeScript,
 		isJsx,
+		enabledNurseryRules
 	},
 }: Props) {
 	return (
@@ -59,6 +61,7 @@ export function SettingsMenu({
 					sourceType={sourceType}
 					setSourceType={createSetter(setPlaygroundState, "sourceType")}
 				/>
+				<NurseryRules setEnabledNurseryRules={createSetter(setPlaygroundState, "enabledNurseryRules")} enabledNurseryRules={enabledNurseryRules} />
 			</div>
 		</div>
 	);

--- a/website/playground/src/romeWorker.ts
+++ b/website/playground/src/romeWorker.ts
@@ -2,7 +2,6 @@ import init, {
 	DiagnosticPrinter,
 	RomePath,
 	Workspace,
-	Nursery,
 	Configuration,
 } from "@rometools/wasm-web";
 import {

--- a/website/playground/src/romeWorker.ts
+++ b/website/playground/src/romeWorker.ts
@@ -2,6 +2,8 @@ import init, {
 	DiagnosticPrinter,
 	RomePath,
 	Workspace,
+	Nursery,
+	Configuration
 } from "@rometools/wasm-web";
 import {
 	SourceType,
@@ -81,10 +83,10 @@ self.addEventListener("message", async (e) => {
 				isJsx,
 				sourceType,
 				cursorPosition,
+				enabledNurseryRules
 			} = playgroundState;
 
-			workspace.updateSettings({
-				configuration: {
+			const configuration: Configuration = {
 					formatter: {
 						enabled: true,
 						formatWithErrors: true,
@@ -105,7 +107,23 @@ self.addEventListener("message", async (e) => {
 									: "asNeeded",
 						},
 					},
-				},
+			};
+			if (enabledNurseryRules) {
+				configuration.linter = {
+					enabled: true,
+					rules: {
+						nursery: {
+							noNewSymbol: "error",
+							noDangerouslySetInnerHtml: "error",
+							noUnusedVariables: "error",
+							noUnreachable: "error",
+							useCamelCase: "error"
+						}
+					}
+				}
+			}
+			workspace.updateSettings({
+				configuration
 			});
 
 			const path = getPathForType(sourceType, isTypeScript, isJsx);

--- a/website/playground/src/romeWorker.ts
+++ b/website/playground/src/romeWorker.ts
@@ -3,7 +3,7 @@ import init, {
 	RomePath,
 	Workspace,
 	Nursery,
-	Configuration
+	Configuration,
 } from "@rometools/wasm-web";
 import {
 	SourceType,
@@ -83,30 +83,29 @@ self.addEventListener("message", async (e) => {
 				isJsx,
 				sourceType,
 				cursorPosition,
-				enabledNurseryRules
+				enabledNurseryRules,
 			} = playgroundState;
 
 			const configuration: Configuration = {
+				formatter: {
+					enabled: true,
+					formatWithErrors: true,
+					lineWidth: lineWidth,
+					indentStyle: indentStyle === IndentStyle.Tab ? "tab" : "space",
+					indentSize: indentWidth,
+				},
+				linter: {
+					enabled: true,
+				},
+				javascript: {
 					formatter: {
-						enabled: true,
-						formatWithErrors: true,
-						lineWidth: lineWidth,
-						indentStyle: indentStyle === IndentStyle.Tab ? "tab" : "space",
-						indentSize: indentWidth,
+						quoteStyle: quoteStyle === QuoteStyle.Double ? "double" : "single",
+						quoteProperties:
+							quoteProperties === QuoteProperties.Preserve
+								? "preserve"
+								: "asNeeded",
 					},
-					linter: {
-						enabled: true,
-					},
-					javascript: {
-						formatter: {
-							quoteStyle:
-								quoteStyle === QuoteStyle.Double ? "double" : "single",
-							quoteProperties:
-								quoteProperties === QuoteProperties.Preserve
-									? "preserve"
-									: "asNeeded",
-						},
-					},
+				},
 			};
 			if (enabledNurseryRules) {
 				configuration.linter = {
@@ -117,13 +116,13 @@ self.addEventListener("message", async (e) => {
 							noDangerouslySetInnerHtml: "error",
 							noUnusedVariables: "error",
 							noUnreachable: "error",
-							useCamelCase: "error"
-						}
-					}
-				}
+							useCamelCase: "error",
+						},
+					},
+				};
 			}
 			workspace.updateSettings({
-				configuration
+				configuration,
 			});
 
 			const path = getPathForType(sourceType, isTypeScript, isJsx);

--- a/website/playground/src/types.ts
+++ b/website/playground/src/types.ts
@@ -62,7 +62,7 @@ export const defaultRomeConfig: RomeConfiguration = {
 	isTypeScript: false,
 	isJsx: false,
 	cursorPosition: 0,
-	enabledNurseryRules: true
+	enabledNurseryRules: true,
 };
 
 export interface PlaygroundProps {

--- a/website/playground/src/types.ts
+++ b/website/playground/src/types.ts
@@ -43,6 +43,7 @@ export interface PlaygroundState {
 	isTypeScript: boolean;
 	isJsx: boolean;
 	cursorPosition: number;
+	enabledNurseryRules: boolean;
 }
 
 // change `lineWidth` and `indentWidth` to string type, just to fits our `usePlaygroundState` fallback usage
@@ -61,6 +62,7 @@ export const defaultRomeConfig: RomeConfiguration = {
 	isTypeScript: false,
 	isJsx: false,
 	cursorPosition: 0,
+	enabledNurseryRules: true
 };
 
 export interface PlaygroundProps {
@@ -80,6 +82,7 @@ export type PlaygroundSettings = Pick<
 	| "sourceType"
 	| "isTypeScript"
 	| "isJsx"
+	| "enabledNurseryRules"
 >;
 
 export type Tree = ReturnType<typeof parser.parse>;

--- a/website/playground/src/utils.ts
+++ b/website/playground/src/utils.ts
@@ -78,7 +78,9 @@ export function usePlaygroundState(
 			(searchParams.get("sourceType") as SourceType) ??
 			defaultRomeConfig.sourceType,
 		cursorPosition: 0,
-		enabledNurseryRules: searchParams.get("enabledNurseryRules") === "true" || defaultRomeConfig.enabledNurseryRules,
+		enabledNurseryRules:
+			searchParams.get("enabledNurseryRules") === "true" ||
+			defaultRomeConfig.enabledNurseryRules,
 	});
 	const [playgroundState, setPlaygroundState] = useState(initState());
 

--- a/website/playground/src/utils.ts
+++ b/website/playground/src/utils.ts
@@ -78,6 +78,7 @@ export function usePlaygroundState(
 			(searchParams.get("sourceType") as SourceType) ??
 			defaultRomeConfig.sourceType,
 		cursorPosition: 0,
+		enabledNurseryRules: searchParams.get("enabledNurseryRules") === "true" || defaultRomeConfig.enabledNurseryRules,
 	});
 	const [playgroundState, setPlaygroundState] = useState(initState());
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a new checkbox to the playground to enable nursery rules. This allows us to debug these rules that are still in development. 

I didn't bother much about where to put that checkbox... I am sure we would need an overhaul of the UI, in a separate place.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Play with the deployed background

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
