### PR TITLE
chore(xtask): Part 8: Add line breaks before doc comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,6 +2812,7 @@ name = "xtask_bench"
 version = "0.0.0"
 dependencies = [
  "ansi_rgb",
+ "countme",
  "criterion",
  "dhat",
  "humansize",

--- a/crates/rome_service/src/workspace_types.rs
+++ b/crates/rome_service/src/workspace_types.rs
@@ -65,6 +65,7 @@ fn instance_type<'a>(
                     if let Some(description) = description {
                         let comment = format!("/**\n\t* {} \n\t */", description);
                         let trivia = vec![
+                            (TriviaPieceKind::Newline, "\n"),
                             (TriviaPieceKind::MultiLineComment, comment.as_str()),
                             (TriviaPieceKind::Newline, "\n"),
                         ];
@@ -337,6 +338,7 @@ pub fn generate_type<'a>(
                 if let Some(description) = description {
                     let comment = format!("/**\n\t* {} \n\t */", description);
                     let trivia = vec![
+                        (TriviaPieceKind::Newline, "\n"),
                         (TriviaPieceKind::MultiLineComment, comment.as_str()),
                         (TriviaPieceKind::Newline, "\n"),
                     ];

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -23,6 +23,8 @@ url = "2.2.2"
 itertools = "0.10.3"
 ansi_rgb = "0.2.0"
 
+countme = "3.0.1"
+
 # dhat-on
 dhat = { version = "0.3.0", optional = true }
 humansize = {version = "1.1.1", optional = true }
@@ -32,3 +34,4 @@ mimalloc = "0.1.29"
 
 [features]
 dhat-heap = ["dhat", "humansize"]
+count = ["countme/print_at_exit"]

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -357,18 +357,13 @@ pub fn generate_formatter() {
             }
             NodeKind::Unknown => {
                 quote! {
-                    use crate::prelude::*;
-                    use crate::{FormatNodeFields};
-                    use rome_rowan::AstNode;
+                    use crate::FormatUnknownNodeRule;
                     use rome_js_syntax::#node_id;
 
                     #[derive(Debug, Clone, Default)]
                     pub struct #format_id;
 
-                    impl FormatNodeRule<#node_id> for #format_id {
-                        fn fmt_fields(&self, node: &#node_id, f: &mut JsFormatter) -> FormatResult<()> {
-                            format_unknown_node(node.syntax()).fmt(f)
-                        }
+                    impl FormatUnknownNodeRule<#node_id> for #format_id {
                     }
                 }
             }

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -194,6 +194,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
         if let Some(description) = description {
             let comment = format!("/**\n\t* {} \n\t */\n", description);
             let trivia = vec![
+                (TriviaPieceKind::Newline, "\n"),
                 (TriviaPieceKind::MultiLineComment, comment.as_str()),
                 (TriviaPieceKind::Newline, "\n"),
             ];


### PR DESCRIPTION
This PR is part of the comments refactoring #3227.

## Summary

This PR changes the binding code gen to emit leading line breaks before doc comments.

It contains a few more changes but I hope that's ok:

* The codegen changes so that `cargo codegen formatter` generates files that use the `FormatUnknownNodeRule` for unknown nodes. 
* Adds a `count` feature to `xtask bench` to easily get the counts of any type using `countme`

## Test Plan


Generated the bindings and formatted them with the new formatter. 