### PR TITLE
feat(rome_Formatter): Assert formatting of comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,6 @@ version = "0.0.0"
 dependencies = [
  "cfg-if",
  "countme",
- "indexmap",
  "rome_diagnostics",
  "rome_js_parser",
  "rome_js_syntax",

--- a/crates/rome_formatter/Cargo.toml
+++ b/crates/rome_formatter/Cargo.toml
@@ -13,7 +13,6 @@ rome_rowan = { path = "../rome_rowan" }
 tracing = { version = "0.1.31", default-features = false, features = ["std"] }
 serde = { version = "1.0.136", features = ["derive"], optional = true }
 cfg-if = "1.0.0"
-indexmap = "1.8.2"
 schemars = { version = "0.8.10", optional = true }
 rustc-hash = "1.1.0"
 countme = "3.0.1"

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -882,10 +882,12 @@ pub fn format_node<L: FormatLanguage>(
         let document = buffer.into_element();
 
         state.assert_formatted_all_tokens(&root);
-        state
-            .context()
-            .comments()
-            .assert_checked_all_suppressions(&root);
+        {
+            let comments = state.context().comments();
+
+            comments.assert_checked_all_suppressions(&root);
+            comments.assert_formatted_all_comments();
+        }
 
         Ok(Formatted::new(document, state.into_context()))
     })

--- a/crates/rome_formatter/src/trivia.rs
+++ b/crates/rome_formatter/src/trivia.rs
@@ -7,6 +7,8 @@ use crate::{
     TextRange, VecBuffer,
 };
 use rome_rowan::{Language, SyntaxNode, SyntaxToken};
+#[cfg(debug_assertions)]
+use std::cell::Cell;
 
 /// Formats the leading comments of `node`
 pub const fn format_leading_comments<L: Language>(
@@ -57,6 +59,8 @@ where
                     _ => write!(f, [empty_line()])?,
                 },
             }
+
+            comment.mark_formatted()
         }
 
         Ok(())
@@ -129,6 +133,8 @@ where
                     write!(f, [content])?;
                 }
             }
+
+            comment.mark_formatted();
         }
 
         Ok(())
@@ -247,6 +253,8 @@ where
                 let format_comment =
                     FormatRefWithRule::new(comment, Context::CommentRule::default());
                 join.entry(&format_comment);
+
+                comment.mark_formatted();
             }
 
             join.finish()?;
@@ -484,6 +492,8 @@ impl<L: Language> FormatSkippedTokenTrivia<'_, L> {
                     lines_before: lines,
                     lines_after: 0,
                     piece: comment,
+                    #[cfg(debug_assertions)]
+                    formatted: Cell::new(true),
                 };
 
                 dangling_comments.push(source_comment);

--- a/crates/rome_formatter/src/verbatim.rs
+++ b/crates/rome_formatter/src/verbatim.rs
@@ -84,7 +84,7 @@ where
                     let (outside_trimmed_range, in_trimmed_range) =
                         leading_comments.split_at(outside_trimmed_range);
 
-                    write!(f, [FormatLeadingComments::Comments(&outside_trimmed_range)])?;
+                    write!(f, [FormatLeadingComments::Comments(outside_trimmed_range)])?;
 
                     for comment in in_trimmed_range {
                         comment.mark_formatted();

--- a/crates/rome_formatter/src/verbatim.rs
+++ b/crates/rome_formatter/src/verbatim.rs
@@ -40,7 +40,12 @@ where
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
                 SyntaxElement::Node(node) => {
-                    f.context().comments().mark_suppression_checked(&node);
+                    let comments = f.context().comments();
+                    comments.mark_suppression_checked(&node);
+
+                    for comment in comments.leading_dangling_trailing_comments(&node) {
+                        comment.mark_formatted();
+                    }
                 }
             }
         }
@@ -76,12 +81,14 @@ where
                         comment.piece().text_range().end() <= trimmed_source_range.start()
                     });
 
-                    write!(
-                        f,
-                        [FormatLeadingComments::Comments(
-                            &leading_comments[..outside_trimmed_range]
-                        )]
-                    )?;
+                    let (outside_trimmed_range, in_trimmed_range) =
+                        leading_comments.split_at(outside_trimmed_range);
+
+                    write!(f, [FormatLeadingComments::Comments(&outside_trimmed_range)])?;
+
+                    for comment in in_trimmed_range {
+                        comment.mark_formatted();
+                    }
                 }
 
                 // Find the first skipped token trivia, if any, and include it in the verbatim range because
@@ -111,6 +118,10 @@ where
                 )
                 .fmt(f)?;
 
+                for comment in f.context().comments().dangling_comments(self.node) {
+                    comment.mark_formatted();
+                }
+
                 // Format all trailing comments that are outside of the trimmed range.
                 if self.format_comments {
                     let comments = f.context().comments().clone();
@@ -123,12 +134,14 @@ where
                                 <= trimmed_source_range.end()
                         });
 
-                    write!(
-                        f,
-                        [FormatTrailingComments::Comments(
-                            &trailing_comments[outside_trimmed_range_start..]
-                        )]
-                    )?;
+                    let (in_trimmed_range, outside_trimmed_range) =
+                        trailing_comments.split_at(outside_trimmed_range_start);
+
+                    for comment in in_trimmed_range {
+                        comment.mark_formatted();
+                    }
+
+                    write!(f, [FormatTrailingComments::Comments(outside_trimmed_range)])?;
                 }
 
                 Ok(())


### PR DESCRIPTION

## Summary

This PR adds a debug assertion to verify if all comments in a program have been formatted to prevent accidental "dropping" of comments.

## Test Plan

I removed some comments formatting to verify that the panic is triggered.
