### PR TITLE
fix(rome_js_analyzer): add newline if statement has comments in `useBlockStatements`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/correctness/use_block_statements.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_block_statements.rs
@@ -216,8 +216,16 @@ impl Rule for UseBlockStatements {
 
                     r_curly_token.with_leading_trivia(leading_trivia)
                 } else {
-                    r_curly_token
-                        .with_leading_trivia(iter::once((TriviaPieceKind::Whitespace, " ")))
+                    let has_trailing_comments = stmt.syntax().has_trailing_comments();
+                    // if the node we have to enclose has some leading comments, then we add a new line
+                    // to the leading trivia of the right curly brace
+                    if !has_trailing_comments {
+                        r_curly_token
+                            .with_leading_trivia(iter::once((TriviaPieceKind::Whitespace, " ")))
+                    } else {
+                        r_curly_token
+                            .with_leading_trivia(iter::once((TriviaPieceKind::Newline, "\n")))
+                    }
                 };
 
                 mutation.replace_node_discard_trivia(

--- a/crates/rome_js_analyze/src/analyzers/correctness/use_block_statements.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_block_statements.rs
@@ -216,10 +216,18 @@ impl Rule for UseBlockStatements {
 
                     r_curly_token.with_leading_trivia(leading_trivia)
                 } else {
-                    let has_trailing_comments = stmt.syntax().has_trailing_comments();
-                    // if the node we have to enclose has some leading comments, then we add a new line
+                    let has_trailing_single_line_comments = stmt
+                        .syntax()
+                        .last_trailing_trivia()
+                        .map(|trivia| {
+                            trivia
+                                .pieces()
+                                .any(|trivia| trivia.kind() == TriviaPieceKind::SingleLineComment)
+                        })
+                        .unwrap_or(false);
+                    // if the node we have to enclose has some trailing comments, then we add a new line
                     // to the leading trivia of the right curly brace
-                    if !has_trailing_comments {
+                    if !has_trailing_single_line_comments {
                         r_curly_token
                             .with_leading_trivia(iter::once((TriviaPieceKind::Whitespace, " ")))
                     } else {

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -112,12 +112,10 @@ mod tests {
     #[test]
     fn quick_test() {
         const SOURCE: &str = r#"
-import AwesomeReact, { Fragment as AwesomeFragment } from "react";
-
-<>
-    <AwesomeFragment>foo</AwesomeFragment>
-    <AwesomeReact.Fragment>foo</AwesomeReact.Fragment>
-</>
+if (true) {
+  console.log("true");
+} else
+  console.log("false"); // comment
 
         "#;
 
@@ -131,13 +129,16 @@ import AwesomeReact, { Fragment as AwesomeFragment } from "react";
             |signal| {
                 if let Some(diag) = signal.diagnostic() {
                     let diag = diag.into_diagnostic(Severity::Warning);
-                    dbg!(&diag);
                     let primary = diag.primary.as_ref().unwrap();
 
                     error_ranges.push(primary.span.range);
                 }
 
-                dbg!(signal.action());
+                if let Some(action) = signal.action() {
+                    let new_code = action.mutation.commit();
+
+                    eprintln!("{new_code}");
+                }
 
                 ControlFlow::<Never>::Continue(())
             },

--- a/crates/rome_js_analyze/tests/specs/correctness/useBlockStatements.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/useBlockStatements.js
@@ -38,3 +38,7 @@ else
     bar
   else
     bar
+
+if (test) {
+  correct;
+} else console.log("false") // comment

--- a/crates/rome_js_analyze/tests/specs/correctness/useBlockStatements.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/useBlockStatements.js.snap
@@ -45,6 +45,10 @@ else
   else
     bar
 
+if (test) {
+  correct;
+} else console.log("false") // comment
+
 ```
 
 # Diagnostics
@@ -546,7 +550,7 @@ useBlockStatements.js:37:8 lint/correctness/useBlockStatements  FIXABLE  ━━�
   
   i Suggested fix: Wrap the statement with a `JsBlockStatement`
   
-        | @@ -34,7 +34,8 @@
+        | @@ -34,8 +34,9 @@
   33 33 |   
   34 34 |     if (test)
   35 35 |       bar
@@ -556,6 +560,7 @@ useBlockStatements.js:37:8 lint/correctness/useBlockStatements  FIXABLE  ━━�
      38 | +   }
   38 39 |     else
   39 40 |       bar
+  40 41 |   
   
 
 ```
@@ -573,7 +578,7 @@ useBlockStatements.js:39:3 lint/correctness/useBlockStatements  FIXABLE  ━━�
   
   i Suggested fix: Wrap the statement with a `JsBlockStatement`
   
-        | @@ -36,5 +36,6 @@
+        | @@ -36,8 +36,9 @@
   35 35 |       bar
   36 36 |     else if(test)
   37 37 |       bar
@@ -581,6 +586,32 @@ useBlockStatements.js:39:3 lint/correctness/useBlockStatements  FIXABLE  ━━�
      38 | +   else {
   39 39 |       bar
      40 | +   }
+  40 41 |   
+  41 42 |   if (test) {
+  42 43 |     correct;
+  
+
+```
+
+```
+useBlockStatements.js:44:3 lint/correctness/useBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Block statements are preferred in this position.
+  
+     ┌─ useBlockStatements.js:44:3
+     │
+  44 │ } else console.log("false") // comment
+     │   ^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i Suggested fix: Wrap the statement with a `JsBlockStatement`
+  
+        | @@ -41,4 +41,5 @@
+  40 40 |   
+  41 41 |   if (test) {
+  42 42 |     correct;
+  43    | - } else console.log("false") // comment
+     43 | + } else { console.log("false") // comment
+     44 | + }
   
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes #3199

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test case

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
