### PR TITLE
feat(rome_js_semantic): Semantic Model support for closures

### DIFF
--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -35,6 +35,7 @@ pub enum SemanticEvent {
     Read {
         range: TextRange,
         declared_at: TextRange,
+        scope_id: usize
     },
 
     /// Tracks where a symbol is read, but only if its declaration
@@ -43,6 +44,7 @@ pub enum SemanticEvent {
     HoistedRead {
         range: TextRange,
         declared_at: TextRange,
+        scope_id: usize
     },
 
     /// Tracks where a symbol is written, but only if its declaration
@@ -52,6 +54,7 @@ pub enum SemanticEvent {
     Write {
         range: TextRange,
         declared_at: TextRange,
+        scope_id: usize
     },
 
     /// Tracks where a symbol is written, but only if its declaration
@@ -61,6 +64,7 @@ pub enum SemanticEvent {
     HoistedWrite {
         range: TextRange,
         declared_at: TextRange,
+        scope_id: usize
     },
 
     /// Tracks references that do no have any matching binding
@@ -453,6 +457,7 @@ impl SemanticEventExtractor {
                 self.stash.push_back(SemanticEvent::Read {
                     range,
                     declared_at: id.syntax().text_range(),
+                    scope_id: self.scopes.last().unwrap().scope_id
                 });
             }
         }
@@ -546,18 +551,22 @@ impl SemanticEventExtractor {
                             (true, Reference::Read { range, .. }) => SemanticEvent::Read {
                                 range: *range,
                                 declared_at: *declaration_at,
+                                scope_id: scope.scope_id
                             },
                             (false, Reference::Read { range, .. }) => SemanticEvent::HoistedRead {
                                 range: *range,
                                 declared_at: *declaration_at,
+                                scope_id: scope.scope_id
                             },
                             (true, Reference::Write { range }) => SemanticEvent::Write {
                                 range: *range,
                                 declared_at: *declaration_at,
+                                scope_id: scope.scope_id
                             },
                             (false, Reference::Write { range }) => SemanticEvent::HoistedWrite {
                                 range: *range,
                                 declared_at: *declaration_at,
+                                scope_id: scope.scope_id
                             },
                         };
                         self.stash.push_back(e);

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -35,7 +35,7 @@ pub enum SemanticEvent {
     Read {
         range: TextRange,
         declared_at: TextRange,
-        scope_id: usize
+        scope_id: usize,
     },
 
     /// Tracks where a symbol is read, but only if its declaration
@@ -44,7 +44,7 @@ pub enum SemanticEvent {
     HoistedRead {
         range: TextRange,
         declared_at: TextRange,
-        scope_id: usize
+        scope_id: usize,
     },
 
     /// Tracks where a symbol is written, but only if its declaration
@@ -54,7 +54,7 @@ pub enum SemanticEvent {
     Write {
         range: TextRange,
         declared_at: TextRange,
-        scope_id: usize
+        scope_id: usize,
     },
 
     /// Tracks where a symbol is written, but only if its declaration
@@ -64,7 +64,7 @@ pub enum SemanticEvent {
     HoistedWrite {
         range: TextRange,
         declared_at: TextRange,
-        scope_id: usize
+        scope_id: usize,
     },
 
     /// Tracks references that do no have any matching binding
@@ -457,7 +457,7 @@ impl SemanticEventExtractor {
                 self.stash.push_back(SemanticEvent::Read {
                     range,
                     declared_at: id.syntax().text_range(),
-                    scope_id: self.scopes.last().unwrap().scope_id
+                    scope_id: self.scopes.last().unwrap().scope_id,
                 });
             }
         }
@@ -551,22 +551,22 @@ impl SemanticEventExtractor {
                             (true, Reference::Read { range, .. }) => SemanticEvent::Read {
                                 range: *range,
                                 declared_at: *declaration_at,
-                                scope_id: scope.scope_id
+                                scope_id: scope.scope_id,
                             },
                             (false, Reference::Read { range, .. }) => SemanticEvent::HoistedRead {
                                 range: *range,
                                 declared_at: *declaration_at,
-                                scope_id: scope.scope_id
+                                scope_id: scope.scope_id,
                             },
                             (true, Reference::Write { range }) => SemanticEvent::Write {
                                 range: *range,
                                 declared_at: *declaration_at,
-                                scope_id: scope.scope_id
+                                scope_id: scope.scope_id,
                             },
                             (false, Reference::Write { range }) => SemanticEvent::HoistedWrite {
                                 range: *range,
                                 declared_at: *declaration_at,
-                                scope_id: scope.scope_id
+                                scope_id: scope.scope_id,
                             },
                         };
                         self.stash.push_back(e);

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -1279,5 +1279,4 @@ mod test {
         assert_is_exported(true, "A", "enum A {}; exports = A");
         assert_is_exported(true, "A", "enum A {}; exports.A = A");
     }
-
 }

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -70,33 +70,27 @@ impl<T: HasDeclarationAstNode> IsExportedCanBeQueried for T {
     }
 }
 
-#[derive(Clone, Debug)]
+/// Represents a refererence inside a scope.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct ScopeReference {
     range: TextRange,
 }
 
-impl std::hash::Hash for ScopeReference {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.range.hash(state);
-    }
-}
-
-impl PartialEq for ScopeReference {
-    fn eq(&self, other: &Self) -> bool {
-        self.range == other.range
-    }
-}
-
-impl Eq for ScopeReference {}
-
 #[derive(Debug)]
 struct SemanticModelScopeData {
+    // The scope range
     range: TextRange,
+    // The parent scope of this scope
     parent: Option<usize>,
+    // All children scope of this scope
     children: Vec<usize>,
+    // All bindings of this scope
     bindings: Vec<TextRange>,
+    // Map pointing to the [bindings] vec  of each bindings by its name
     bindings_by_name: HashMap<SyntaxTokenText, usize>,
+    // All read references of a scope
     read_references: Vec<ScopeReference>,
+    // All write references of a scope
     write_references: Vec<ScopeReference>,
 }
 
@@ -107,10 +101,12 @@ struct SemanticModelScopeData {
 #[derive(Debug)]
 struct SemanticModelData {
     root: JsAnyRoot,
+    // All scopes of this model
     scopes: Vec<SemanticModelScopeData>,
     scope_by_range: rust_lapper::Lapper<usize, usize>,
     // Maps the start of a node range to a scope id
     scope_hoisted_to_by_range: HashMap<TextSize, usize>,
+    // Map to each by its range
     node_by_range: HashMap<TextRange, JsSyntaxNode>,
     // Maps any range in the code to its declaration
     declared_at_by_range: HashMap<TextRange, TextRange>,

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -1,7 +1,9 @@
 mod closure;
 
+use crate::{SemanticEvent, SemanticEventExtractor};
+pub use closure::*;
 use rome_js_syntax::{
-    JsAnyRoot, JsArrowFunctionExpression, JsFunctionDeclaration, JsIdentifierAssignment,
+    JsAnyRoot, JsIdentifierAssignment,
     JsIdentifierBinding, JsLanguage, JsReferenceIdentifier, JsSyntaxKind, JsSyntaxNode,
     JsxReferenceIdentifier, TextRange, TextSize, TsIdentifierBinding,
 };
@@ -12,8 +14,6 @@ use std::{
     iter::FusedIterator,
     sync::Arc,
 };
-use crate::{SemanticEvent, SemanticEventExtractor};
-pub use closure::*;
 
 /// Marker trait that groups all "AstNode" that are declarations
 pub trait IsDeclarationAstNode: AstNode<Language = JsLanguage> {
@@ -70,7 +70,6 @@ impl<T: HasDeclarationAstNode> IsExportedCanBeQueried for T {
         Some(model.data.is_exported(range))
     }
 }
-
 
 #[derive(Clone, Debug)]
 struct ScopeReference {
@@ -679,7 +678,6 @@ impl SemanticModel {
         Closure::from_node(self.data.clone(), node)
     }
 }
-
 
 // Extensions
 

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -304,7 +304,8 @@ impl Scope {
     }
 
     /// Return the [Closure] associated with this scope if
-    /// this scope comes from a function or arrow function.
+    /// it has one, otherwise returns None.  
+    /// See [HasClosureAstNode] for nodes that have closure.
     pub fn closure(&self) -> Option<Closure> {
         Closure::from_scope(self.data.clone(), self.id, self.range())
     }

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -3,9 +3,8 @@ mod closure;
 use crate::{SemanticEvent, SemanticEventExtractor};
 pub use closure::*;
 use rome_js_syntax::{
-    JsAnyRoot, JsIdentifierAssignment,
-    JsIdentifierBinding, JsLanguage, JsReferenceIdentifier, JsSyntaxKind, JsSyntaxNode,
-    JsxReferenceIdentifier, TextRange, TextSize, TsIdentifierBinding,
+    JsAnyRoot, JsIdentifierAssignment, JsIdentifierBinding, JsLanguage, JsReferenceIdentifier,
+    JsSyntaxKind, JsSyntaxNode, JsxReferenceIdentifier, TextRange, TextSize, TsIdentifierBinding,
 };
 use rome_rowan::{AstNode, SyntaxTokenText};
 use rust_lapper::{Interval, Lapper};

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -73,7 +73,6 @@ impl<T: HasDeclarationAstNode> IsExportedCanBeQueried for T {
 #[derive(Clone, Debug)]
 struct ScopeReference {
     range: TextRange,
-    ty: ReferenceType,
 }
 
 impl std::hash::Hash for ScopeReference {
@@ -871,10 +870,7 @@ impl SemanticModelBuilder {
                     .push((ReferenceType::Read { hoisted: false }, range));
 
                 let scope = &mut self.scopes[scope_id];
-                scope.read_references.push(ScopeReference {
-                    range,
-                    ty: ReferenceType::Read { hoisted: false },
-                });
+                scope.read_references.push(ScopeReference { range });
             }
             HoistedRead {
                 range,
@@ -892,10 +888,7 @@ impl SemanticModelBuilder {
                     .push((ReferenceType::Read { hoisted: true }, range));
 
                 let scope = &mut self.scopes[scope_id];
-                scope.read_references.push(ScopeReference {
-                    range,
-                    ty: ReferenceType::Read { hoisted: true },
-                });
+                scope.read_references.push(ScopeReference { range });
             }
             Write {
                 range,
@@ -913,10 +906,7 @@ impl SemanticModelBuilder {
                     .push((ReferenceType::Write { hoisted: false }, range));
 
                 let scope = &mut self.scopes[scope_id];
-                scope.write_references.push(ScopeReference {
-                    range,
-                    ty: ReferenceType::Write { hoisted: false },
-                });
+                scope.write_references.push(ScopeReference { range });
             }
             HoistedWrite {
                 range,
@@ -934,10 +924,7 @@ impl SemanticModelBuilder {
                     .push((ReferenceType::Write { hoisted: true }, range));
 
                 let scope = &mut self.scopes[scope_id];
-                scope.write_references.push(ScopeReference {
-                    range,
-                    ty: ReferenceType::Write { hoisted: true },
-                });
+                scope.write_references.push(ScopeReference { range });
             }
             UnresolvedReference { .. } => {}
             Exported { range } => {

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -1355,7 +1355,7 @@ mod test {
             model.closure(&f)
         };
 
-        closure.children()
+        closure.children().collect()
     }
 
     #[test]

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -22,7 +22,7 @@ pub struct AllCapturesIter {
     data: Arc<SemanticModelData>,
     closure_range: TextRange,
     scopes: Vec<usize>,
-    references: Vec<ScopeReference>
+    references: Vec<ScopeReference>,
 }
 
 impl Iterator for AllCapturesIter {
@@ -36,7 +36,7 @@ impl Iterator for AllCapturesIter {
                     return Some(Reference {
                         data: self.data.clone(),
                         node: self.data.node_by_range[&reference.range].clone(),
-                        range: reference.range.clone(),
+                        range: reference.range,
                         ty: reference.ty,
                     });
                 }
@@ -54,20 +54,20 @@ impl Iterator for AllCapturesIter {
                     }
                     _ => {
                         self.references.clear();
-                        self.references.extend(scope.read_references.iter().cloned());
-                        self.references.extend(scope.write_references.iter().cloned());
+                        self.references
+                            .extend(scope.read_references.iter().cloned());
+                        self.references
+                            .extend(scope.write_references.iter().cloned());
                         self.scopes.extend(scope.children.iter());
                         continue 'references;
                     }
                 }
             }
-               
+
             return None;
         }
     }
-
 }
-
 
 pub struct ChildrenIter {
     data: Arc<SemanticModelData>,
@@ -100,7 +100,6 @@ impl Iterator for ChildrenIter {
 
         None
     }
-
 }
 
 /// Provides all information regarding a specific closure.
@@ -151,13 +150,13 @@ impl Closure {
         let mut scopes = Vec::with_capacity(128);
         scopes.extend(scope.children.iter().cloned());
 
-        let mut references =  Vec::with_capacity(128);
+        let mut references = Vec::with_capacity(128);
         references.extend(scope.read_references.iter().cloned());
         references.extend(scope.write_references.iter().cloned());
 
         AllCapturesIter {
             data: self.data.clone(),
-            closure_range: self.closure_range.clone(),
+            closure_range: self.closure_range,
             scopes,
             references,
         }

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use super::*;
 use rome_js_syntax::{
-    JsArrowFunctionExpression, JsFunctionDeclaration, JsFunctionExpression, JsLanguage, JsConstructorClassMember, JsMethodClassMember, JsGetterClassMember, JsSetterClassMember,
+    JsArrowFunctionExpression, JsConstructorClassMember, JsFunctionDeclaration,
+    JsFunctionExpression, JsGetterClassMember, JsLanguage, JsMethodClassMember,
+    JsSetterClassMember,
 };
 use rome_rowan::{AstNode, SyntaxNode, SyntaxNodeCast};
 
@@ -73,14 +75,35 @@ pub enum AnyHasClosureNode {
 impl AnyHasClosureNode {
     pub fn from_node(node: &SyntaxNode<JsLanguage>) -> Option<AnyHasClosureNode> {
         match node.kind() {
-            JsSyntaxKind::JS_FUNCTION_DECLARATION => node.clone().cast::<JsFunctionDeclaration>().map(AnyHasClosureNode::JsFunctionDeclaration),
-            JsSyntaxKind::JS_FUNCTION_EXPRESSION => node.clone().cast::<JsFunctionExpression>().map(AnyHasClosureNode::JsFunctionExpression),
-            JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => node.clone().cast::<JsArrowFunctionExpression>().map(AnyHasClosureNode::JsArrowFunctionExpression),
-            JsSyntaxKind::JS_CONSTRUCTOR_CLASS_MEMBER => node.clone().cast::<JsConstructorClassMember>().map(AnyHasClosureNode::JsConstructorClassMember),
-            JsSyntaxKind::JS_METHOD_CLASS_MEMBER => node.clone().cast::<JsMethodClassMember>().map(AnyHasClosureNode::JsMethodClassMember),
-            JsSyntaxKind::JS_GETTER_CLASS_MEMBER => node.clone().cast::<JsGetterClassMember>().map(AnyHasClosureNode::JsGetterClassMember),
-            JsSyntaxKind::JS_SETTER_CLASS_MEMBER => node.clone().cast::<JsSetterClassMember>().map(AnyHasClosureNode::JsSetterClassMember),
-            _ => None
+            JsSyntaxKind::JS_FUNCTION_DECLARATION => node
+                .clone()
+                .cast::<JsFunctionDeclaration>()
+                .map(AnyHasClosureNode::JsFunctionDeclaration),
+            JsSyntaxKind::JS_FUNCTION_EXPRESSION => node
+                .clone()
+                .cast::<JsFunctionExpression>()
+                .map(AnyHasClosureNode::JsFunctionExpression),
+            JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => node
+                .clone()
+                .cast::<JsArrowFunctionExpression>()
+                .map(AnyHasClosureNode::JsArrowFunctionExpression),
+            JsSyntaxKind::JS_CONSTRUCTOR_CLASS_MEMBER => node
+                .clone()
+                .cast::<JsConstructorClassMember>()
+                .map(AnyHasClosureNode::JsConstructorClassMember),
+            JsSyntaxKind::JS_METHOD_CLASS_MEMBER => node
+                .clone()
+                .cast::<JsMethodClassMember>()
+                .map(AnyHasClosureNode::JsMethodClassMember),
+            JsSyntaxKind::JS_GETTER_CLASS_MEMBER => node
+                .clone()
+                .cast::<JsGetterClassMember>()
+                .map(AnyHasClosureNode::JsGetterClassMember),
+            JsSyntaxKind::JS_SETTER_CLASS_MEMBER => node
+                .clone()
+                .cast::<JsSetterClassMember>()
+                .map(AnyHasClosureNode::JsSetterClassMember),
+            _ => None,
         }
     }
 }
@@ -258,7 +281,6 @@ impl Closure {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -281,7 +303,7 @@ mod test {
                 .parent()
                 .and_then(|node| AnyHasClosureNode::from_node(&node))
                 .unwrap();
-            model.closure(&node)            
+            model.closure(&node)
         } else {
             let node = r
                 .syntax()
@@ -323,7 +345,7 @@ mod test {
                 .parent()
                 .and_then(|node| AnyHasClosureNode::from_node(&node))
                 .unwrap();
-            model.closure(&node) 
+            model.closure(&node)
         } else {
             let node = r
                 .syntax()

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -215,7 +215,19 @@ impl Closure {
         }
     }
 
-    /// Return all [Reference] this closure captures
+    /// Return all [Reference] this closure captures, not taking into
+    /// consideration any capture of children closures
+    /// 
+    /// ```rust,ignore
+    /// let inner_function = "let a, b;
+    /// function f(c) {
+    ///     console.log(a);
+    ///     function g() {
+    ///         console.log(b, c);
+    ///     }
+    /// }";
+    /// assert!(model.closure(function_f).all_captures(), &["a"]);
+    /// ```
     pub fn all_captures(&self) -> impl Iterator<Item = Capture> {
         let scope = &self.data.scopes[self.scope_id];
 
@@ -234,7 +246,18 @@ impl Closure {
         }
     }
 
-    /// Return all immediate children closures of this closure
+    /// Return all immediate children closures of this closure.
+    /// 
+    /// ```rust,ignore
+    /// let inner_function = "let a, b;
+    /// function f(c) {
+    ///     console.log(a);
+    ///     function g() {
+    ///         console.log(b, c);
+    ///     }
+    /// }";
+    /// assert!(model.closure(function_f).children(), &["g"]);
+    /// ```
     pub fn children(&self) -> impl Iterator<Item = Closure> {
         let scope = &self.data.scopes[self.scope_id];
 

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -2,21 +2,103 @@ use std::sync::Arc;
 
 use super::*;
 use rome_js_syntax::{
-    JsArrowFunctionExpression, JsFunctionDeclaration, JsFunctionExpression, JsLanguage,
+    JsArrowFunctionExpression, JsFunctionDeclaration, JsFunctionExpression, JsLanguage, JsConstructorClassMember, JsMethodClassMember, JsGetterClassMember, JsSetterClassMember,
 };
-use rome_rowan::AstNode;
+use rome_rowan::{AstNode, SyntaxNode, SyntaxNodeCast};
 
 /// Marker trait that groups all "AstNode" that have closure
-pub trait HasClosureAstNode: AstNode<Language = JsLanguage> {
+pub trait HasClosureAstNode {
+    fn node_text_range(&self) -> TextRange;
+}
+
+impl HasClosureAstNode for JsFunctionDeclaration {
     #[inline(always)]
-    fn node(&self) -> &Self {
-        self
+    fn node_text_range(&self) -> TextRange {
+        self.syntax().text_range()
     }
 }
 
-impl HasClosureAstNode for JsFunctionDeclaration {}
-impl HasClosureAstNode for JsFunctionExpression {}
-impl HasClosureAstNode for JsArrowFunctionExpression {}
+impl HasClosureAstNode for JsFunctionExpression {
+    #[inline(always)]
+    fn node_text_range(&self) -> TextRange {
+        self.syntax().text_range()
+    }
+}
+
+impl HasClosureAstNode for JsArrowFunctionExpression {
+    #[inline(always)]
+    fn node_text_range(&self) -> TextRange {
+        self.syntax().text_range()
+    }
+}
+
+impl HasClosureAstNode for JsConstructorClassMember {
+    #[inline(always)]
+    fn node_text_range(&self) -> TextRange {
+        self.syntax().text_range()
+    }
+}
+
+impl HasClosureAstNode for JsMethodClassMember {
+    #[inline(always)]
+    fn node_text_range(&self) -> TextRange {
+        self.syntax().text_range()
+    }
+}
+
+impl HasClosureAstNode for JsGetterClassMember {
+    #[inline(always)]
+    fn node_text_range(&self) -> TextRange {
+        self.syntax().text_range()
+    }
+}
+
+impl HasClosureAstNode for JsSetterClassMember {
+    #[inline(always)]
+    fn node_text_range(&self) -> TextRange {
+        self.syntax().text_range()
+    }
+}
+
+pub enum AnyHasClosureNode {
+    JsFunctionDeclaration(JsFunctionDeclaration),
+    JsFunctionExpression(JsFunctionExpression),
+    JsArrowFunctionExpression(JsArrowFunctionExpression),
+    JsConstructorClassMember(JsConstructorClassMember),
+    JsMethodClassMember(JsMethodClassMember),
+    JsGetterClassMember(JsGetterClassMember),
+    JsSetterClassMember(JsSetterClassMember),
+}
+
+impl AnyHasClosureNode {
+    pub fn from_node(node: &SyntaxNode<JsLanguage>) -> Option<AnyHasClosureNode> {
+        match node.kind() {
+            JsSyntaxKind::JS_FUNCTION_DECLARATION => node.clone().cast::<JsFunctionDeclaration>().map(AnyHasClosureNode::JsFunctionDeclaration),
+            JsSyntaxKind::JS_FUNCTION_EXPRESSION => node.clone().cast::<JsFunctionExpression>().map(AnyHasClosureNode::JsFunctionExpression),
+            JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => node.clone().cast::<JsArrowFunctionExpression>().map(AnyHasClosureNode::JsArrowFunctionExpression),
+            JsSyntaxKind::JS_CONSTRUCTOR_CLASS_MEMBER => node.clone().cast::<JsConstructorClassMember>().map(AnyHasClosureNode::JsConstructorClassMember),
+            JsSyntaxKind::JS_METHOD_CLASS_MEMBER => node.clone().cast::<JsMethodClassMember>().map(AnyHasClosureNode::JsMethodClassMember),
+            JsSyntaxKind::JS_GETTER_CLASS_MEMBER => node.clone().cast::<JsGetterClassMember>().map(AnyHasClosureNode::JsGetterClassMember),
+            JsSyntaxKind::JS_SETTER_CLASS_MEMBER => node.clone().cast::<JsSetterClassMember>().map(AnyHasClosureNode::JsSetterClassMember),
+            _ => None
+        }
+    }
+}
+
+impl HasClosureAstNode for AnyHasClosureNode {
+    #[inline(always)]
+    fn node_text_range(&self) -> TextRange {
+        match self {
+            AnyHasClosureNode::JsFunctionDeclaration(node) => node.syntax().text_range(),
+            AnyHasClosureNode::JsFunctionExpression(node) => node.syntax().text_range(),
+            AnyHasClosureNode::JsArrowFunctionExpression(node) => node.syntax().text_range(),
+            AnyHasClosureNode::JsConstructorClassMember(node) => node.syntax().text_range(),
+            AnyHasClosureNode::JsMethodClassMember(node) => node.syntax().text_range(),
+            AnyHasClosureNode::JsGetterClassMember(node) => node.syntax().text_range(),
+            AnyHasClosureNode::JsSetterClassMember(node) => node.syntax().text_range(),
+        }
+    }
+}
 
 pub struct AllCapturesIter {
     data: Arc<SemanticModelData>,
@@ -114,8 +196,7 @@ impl Closure {
         data: Arc<SemanticModelData>,
         node: &impl HasClosureAstNode,
     ) -> Closure {
-        let node = node.node();
-        let closure_range = node.syntax().text_range();
+        let closure_range = node.node_text_range();
         let scope_id = data.scope(&closure_range);
 
         Closure {
@@ -174,5 +255,140 @@ impl Closure {
             closure_range: self.closure_range,
             scopes,
         }
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rome_diagnostics::file::FileId;
+    use rome_js_syntax::{JsArrowFunctionExpression, JsSyntaxKind, SourceType};
+    use rome_rowan::SyntaxNodeCast;
+
+    fn assert_closure(code: &str, name: &str, captures: &[&str]) {
+        let r = rome_js_parser::parse(code, FileId::zero(), SourceType::tsx());
+        let model = semantic_model(&r.tree());
+
+        let closure = if name != "ARROWFUNCTION" {
+            let node = r
+                .syntax()
+                .descendants()
+                .filter(|x| x.text_trimmed() == name)
+                .last()
+                .unwrap();
+            let node = node
+                .parent()
+                .and_then(|node| AnyHasClosureNode::from_node(&node))
+                .unwrap();
+            model.closure(&node)            
+        } else {
+            let node = r
+                .syntax()
+                .descendants()
+                .filter(|x| x.kind() == JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION)
+                .last()
+                .unwrap()
+                .cast::<JsArrowFunctionExpression>()
+                .unwrap();
+            model.closure(&node)
+        };
+
+        let expected_captures: BTreeSet<String> = captures.iter().map(|x| x.to_string()).collect();
+
+        let all_captures: BTreeSet<String> = closure
+            .all_captures()
+            .map(|x| x.node().text_trimmed().to_string())
+            .collect();
+
+        let intersection = expected_captures.intersection(&all_captures);
+        let intersection_count = intersection.count();
+
+        assert_eq!(intersection_count, expected_captures.len());
+        assert_eq!(intersection_count, all_captures.len());
+    }
+
+    fn get_closure_children(code: &str, name: &str) -> Vec<Closure> {
+        let r = rome_js_parser::parse(code, FileId::zero(), SourceType::tsx());
+        let model = semantic_model(&r.tree());
+
+        let closure = if name != "ARROWFUNCTION" {
+            let node = r
+                .syntax()
+                .descendants()
+                .filter(|x| x.text_trimmed() == name)
+                .last()
+                .unwrap();
+            let node = node
+                .parent()
+                .and_then(|node| AnyHasClosureNode::from_node(&node))
+                .unwrap();
+            model.closure(&node) 
+        } else {
+            let node = r
+                .syntax()
+                .descendants()
+                .filter(|x| x.kind() == JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION)
+                .last()
+                .unwrap()
+                .cast::<JsArrowFunctionExpression>()
+                .unwrap();
+            model.closure(&node)
+        };
+
+        closure.children().collect()
+    }
+
+    #[test]
+    pub fn ok_semantic_model_closure() {
+        assert_closure("function f() {}", "f", &[]);
+
+        let two_captures = "let a, b; function f(c) {console.log(a, b, c)}";
+        assert_closure(two_captures, "f", &["a", "b"]);
+        assert_eq!(get_closure_children(two_captures, "f").len(), 0);
+
+        let inner_function = "let a, b;
+        function f(c) {
+            console.log(a);
+            function g() {
+                console.log(b, c);
+            }
+        }";
+        assert_closure(inner_function, "f", &["a"]);
+        assert_closure(inner_function, "g", &["b", "c"]);
+        assert_eq!(get_closure_children(inner_function, "f").len(), 1);
+        assert_eq!(get_closure_children(inner_function, "g").len(), 0);
+
+        let arrow_function = "let a, b;
+        function f(c) {
+            console.log(a);
+            c.map(x => x + b + c);
+        }";
+        assert_closure(arrow_function, "f", &["a"]);
+        assert_closure(arrow_function, "ARROWFUNCTION", &["b", "c"]);
+        assert_eq!(get_closure_children(arrow_function, "f").len(), 1);
+        assert_eq!(
+            get_closure_children(arrow_function, "ARROWFUNCTION").len(),
+            0
+        );
+
+        let writes = "let a;
+        function f(c) {
+            a = 1
+        }";
+        assert_closure(writes, "f", &["a"]);
+
+        let class_callables = "let a;
+        class A {
+            constructor() { console.log(a); }
+            f() { console.log(a); }
+
+            get getValue() { console.log(a); }
+            set setValue(v) { console.log(a); }
+        }";
+        assert_closure(class_callables, "constructor", &["a"]);
+        assert_closure(class_callables, "f", &["a"]);
+        assert_closure(class_callables, "getValue", &["a"]);
+        assert_closure(class_callables, "setValue", &["a"]);
     }
 }

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -24,6 +24,8 @@ macro_rules! SyntaxTextRangeHasClosureAstNode {
             }
         )*
 
+        /// All nodes that have an associated closure
+        /// and can be used by the [SemanticModel].
         pub enum AnyHasClosureNode {
             $(
                 $node($node),
@@ -142,6 +144,8 @@ impl Iterator for AllCapturesIter {
     }
 }
 
+impl FusedIterator for AllCapturesIter {}
+
 pub struct ChildrenIter {
     data: Arc<SemanticModelData>,
     closure_range: TextRange,
@@ -217,7 +221,7 @@ impl Closure {
 
     /// Return all [Reference] this closure captures, not taking into
     /// consideration any capture of children closures
-    /// 
+    ///
     /// ```rust,ignore
     /// let inner_function = "let a, b;
     /// function f(c) {
@@ -247,7 +251,7 @@ impl Closure {
     }
 
     /// Return all immediate children closures of this closure.
-    /// 
+    ///
     /// ```rust,ignore
     /// let inner_function = "let a, b;
     /// function f(c) {

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -4,7 +4,7 @@ use super::*;
 use rome_js_syntax::{
     JsArrowFunctionExpression, JsConstructorClassMember, JsFunctionDeclaration,
     JsFunctionExpression, JsGetterClassMember, JsLanguage, JsMethodClassMember,
-    JsSetterClassMember,
+    JsSetterClassMember, JsMethodObjectMember, JsGetterObjectMember, JsSetterObjectMember
 };
 use rome_rowan::{AstNode, SyntaxNode, SyntaxNodeCast};
 
@@ -13,114 +13,61 @@ pub trait HasClosureAstNode {
     fn node_text_range(&self) -> TextRange;
 }
 
-impl HasClosureAstNode for JsFunctionDeclaration {
-    #[inline(always)]
-    fn node_text_range(&self) -> TextRange {
-        self.syntax().text_range()
-    }
-}
+macro_rules! SyntaxTextRangeHasClosureAstNode {
+    ($($kind:tt => $node:tt,)*) => {
+        $(
+            impl HasClosureAstNode for $node {
+                #[inline(always)]
+                fn node_text_range(&self) -> TextRange {
+                    self.syntax().text_range()
+                }
+            }
+        )*
 
-impl HasClosureAstNode for JsFunctionExpression {
-    #[inline(always)]
-    fn node_text_range(&self) -> TextRange {
-        self.syntax().text_range()
-    }
-}
-
-impl HasClosureAstNode for JsArrowFunctionExpression {
-    #[inline(always)]
-    fn node_text_range(&self) -> TextRange {
-        self.syntax().text_range()
-    }
-}
-
-impl HasClosureAstNode for JsConstructorClassMember {
-    #[inline(always)]
-    fn node_text_range(&self) -> TextRange {
-        self.syntax().text_range()
-    }
-}
-
-impl HasClosureAstNode for JsMethodClassMember {
-    #[inline(always)]
-    fn node_text_range(&self) -> TextRange {
-        self.syntax().text_range()
-    }
-}
-
-impl HasClosureAstNode for JsGetterClassMember {
-    #[inline(always)]
-    fn node_text_range(&self) -> TextRange {
-        self.syntax().text_range()
-    }
-}
-
-impl HasClosureAstNode for JsSetterClassMember {
-    #[inline(always)]
-    fn node_text_range(&self) -> TextRange {
-        self.syntax().text_range()
-    }
-}
-
-pub enum AnyHasClosureNode {
-    JsFunctionDeclaration(JsFunctionDeclaration),
-    JsFunctionExpression(JsFunctionExpression),
-    JsArrowFunctionExpression(JsArrowFunctionExpression),
-    JsConstructorClassMember(JsConstructorClassMember),
-    JsMethodClassMember(JsMethodClassMember),
-    JsGetterClassMember(JsGetterClassMember),
-    JsSetterClassMember(JsSetterClassMember),
-}
-
-impl AnyHasClosureNode {
-    pub fn from_node(node: &SyntaxNode<JsLanguage>) -> Option<AnyHasClosureNode> {
-        match node.kind() {
-            JsSyntaxKind::JS_FUNCTION_DECLARATION => node
-                .clone()
-                .cast::<JsFunctionDeclaration>()
-                .map(AnyHasClosureNode::JsFunctionDeclaration),
-            JsSyntaxKind::JS_FUNCTION_EXPRESSION => node
-                .clone()
-                .cast::<JsFunctionExpression>()
-                .map(AnyHasClosureNode::JsFunctionExpression),
-            JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => node
-                .clone()
-                .cast::<JsArrowFunctionExpression>()
-                .map(AnyHasClosureNode::JsArrowFunctionExpression),
-            JsSyntaxKind::JS_CONSTRUCTOR_CLASS_MEMBER => node
-                .clone()
-                .cast::<JsConstructorClassMember>()
-                .map(AnyHasClosureNode::JsConstructorClassMember),
-            JsSyntaxKind::JS_METHOD_CLASS_MEMBER => node
-                .clone()
-                .cast::<JsMethodClassMember>()
-                .map(AnyHasClosureNode::JsMethodClassMember),
-            JsSyntaxKind::JS_GETTER_CLASS_MEMBER => node
-                .clone()
-                .cast::<JsGetterClassMember>()
-                .map(AnyHasClosureNode::JsGetterClassMember),
-            JsSyntaxKind::JS_SETTER_CLASS_MEMBER => node
-                .clone()
-                .cast::<JsSetterClassMember>()
-                .map(AnyHasClosureNode::JsSetterClassMember),
-            _ => None,
+        pub enum AnyHasClosureNode {
+            $(
+                $node($node),
+            )*
         }
-    }
+
+        impl AnyHasClosureNode {
+            pub fn from_node(node: &SyntaxNode<JsLanguage>) -> Option<AnyHasClosureNode> {
+                match node.kind() {
+                    $(
+                    JsSyntaxKind::$kind => node
+                        .clone()
+                        .cast::<$node>()
+                        .map(AnyHasClosureNode::$node),
+                    )*
+                    _ => None,
+                }
+            }
+        }
+        
+        impl HasClosureAstNode for AnyHasClosureNode {
+            #[inline(always)]
+            fn node_text_range(&self) -> TextRange {
+                match self {
+                    $(
+                        AnyHasClosureNode::$node(node) => node.syntax().text_range(),
+                    )*
+                }
+            }
+        }
+    };
 }
 
-impl HasClosureAstNode for AnyHasClosureNode {
-    #[inline(always)]
-    fn node_text_range(&self) -> TextRange {
-        match self {
-            AnyHasClosureNode::JsFunctionDeclaration(node) => node.syntax().text_range(),
-            AnyHasClosureNode::JsFunctionExpression(node) => node.syntax().text_range(),
-            AnyHasClosureNode::JsArrowFunctionExpression(node) => node.syntax().text_range(),
-            AnyHasClosureNode::JsConstructorClassMember(node) => node.syntax().text_range(),
-            AnyHasClosureNode::JsMethodClassMember(node) => node.syntax().text_range(),
-            AnyHasClosureNode::JsGetterClassMember(node) => node.syntax().text_range(),
-            AnyHasClosureNode::JsSetterClassMember(node) => node.syntax().text_range(),
-        }
-    }
+SyntaxTextRangeHasClosureAstNode! {
+    JS_FUNCTION_DECLARATION => JsFunctionDeclaration,
+    JS_FUNCTION_EXPRESSION => JsFunctionExpression,
+    JS_ARROW_FUNCTION_EXPRESSION => JsArrowFunctionExpression,
+    JS_CONSTRUCTOR_CLASS_MEMBER => JsConstructorClassMember,
+    JS_METHOD_CLASS_MEMBER => JsMethodClassMember,
+    JS_GETTER_CLASS_MEMBER => JsGetterClassMember,
+    JS_SETTER_CLASS_MEMBER => JsSetterClassMember,
+    JS_METHOD_OBJECT_MEMBER => JsMethodObjectMember,
+    JS_GETTER_OBJECT_MEMBER => JsGetterObjectMember,
+    JS_SETTER_OBJECT_MEMBER => JsSetterObjectMember,
 }
 
 pub struct AllCapturesIter {
@@ -412,5 +359,16 @@ mod test {
         assert_closure(class_callables, "f", &["a"]);
         assert_closure(class_callables, "getValue", &["a"]);
         assert_closure(class_callables, "setValue", &["a"]);
+
+        let object_callables = "let a;
+        let a = {
+            f() { console.log(a); }
+
+            get getValue() { console.log(a); }
+            set setValue(v) { console.log(a); }
+        }";
+        assert_closure(object_callables, "f", &["a"]);
+        assert_closure(object_callables, "getValue", &["a"]);
+        assert_closure(object_callables, "setValue", &["a"]);
     }
 }

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+
+use rome_js_syntax::{JsLanguage, JsFunctionDeclaration, JsArrowFunctionExpression, JsFunctionExpression};
+use rome_rowan::AstNode;
+use super::*;
+
+/// Marker trait that groups all "AstNode" that have closure
+pub trait HasClosureAstNode: AstNode<Language = JsLanguage> {
+    #[inline(always)]
+    fn node(&self) -> &Self {
+        self
+    }
+}
+
+impl HasClosureAstNode for JsFunctionDeclaration {}
+impl HasClosureAstNode for JsFunctionExpression {}
+impl HasClosureAstNode for JsArrowFunctionExpression {}
+
+/// Provides all information regarding a specific closure.
+pub struct Closure {
+    data: Arc<SemanticModelData>,
+    scope_id: usize,
+    closure_range: TextRange,
+}
+
+impl Closure {
+    pub(super) fn from_node(data: Arc<SemanticModelData>, node: &impl HasClosureAstNode) -> Closure {
+        let node = node.node();
+        let closure_range = node.syntax().text_range();
+        let scope_id = data.scope(&closure_range);
+
+        Closure {
+            data,
+            scope_id,
+            closure_range,
+        }
+    }
+
+    pub(super) fn from_scope(data: Arc<SemanticModelData>, scope_id: usize, range: &TextRange) -> Option<Closure> {
+        let node = &data.node_by_range[range];
+        match node.kind() {
+            JsSyntaxKind::JS_FUNCTION_DECLARATION
+            | JsSyntaxKind::JS_FUNCTION_EXPRESSION
+            | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => {
+                Some(Closure {
+                    data,
+                    scope_id,
+                    closure_range: range.clone(),
+                })
+            }
+            _ => None
+        }
+    }
+
+    // Returns all scopes which captures are considered capture of
+    // the current closure
+    fn capture_scopes(&self) -> Vec<usize> {
+        let scope = &self.data.scopes[self.scope_id];
+
+        let mut scopes = VecDeque::from_iter(scope.children.iter().cloned());
+        let mut result = vec![self.scope_id];
+
+        while let Some(id) = scopes.pop_front() {
+            let scope = &self.data.scopes[id];
+            let node = &self.data.node_by_range[&scope.range];
+            match node.kind() {
+                JsSyntaxKind::JS_FUNCTION_DECLARATION
+                | JsSyntaxKind::JS_FUNCTION_EXPRESSION
+                | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => {}
+                _ => {
+                    result.push(id);
+                    scopes.extend(scope.children.iter());
+                }
+            }
+        }
+
+        result
+    }
+
+    // Visit all relevant captures and find references which declarations
+    // live outside the scope of the closure
+    fn captures(&self) -> HashSet<ScopeReference> {
+        let mut captures = HashSet::new();
+
+        for id in self.capture_scopes() {
+            for reference in self.data.scopes[id].read_references.iter() {
+                let declaration = self.data.declared_at_by_range[&reference.range];
+                if self.closure_range.intersect(declaration).is_none() {
+                    captures.insert(reference.clone());
+                }
+            }
+        }
+
+        captures
+    }
+
+    // Return all [Reference] this closure captures
+    pub fn all_captures(&self) -> impl Iterator<Item = Reference> {
+        self.captures()
+            .drain()
+            .map(|x| Reference {
+                data: self.data.clone(),
+                node: self.data.node_by_range[&x.range].clone(),
+                range: x.range,
+                ty: x.ty,
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    // Returns all scopes which are immediate children closures of
+    // the current closure
+    fn children_scopes(&self) -> Vec<usize> {
+        let scope = &self.data.scopes[self.scope_id];
+        
+        let mut scopes = VecDeque::from_iter(scope.children.iter().cloned());
+        let mut result = vec![];
+
+        while let Some(id) = scopes.pop_front() {
+            let scope = &self.data.scopes[id];
+            let node = &self.data.node_by_range[&scope.range];
+            match node.kind() {
+                JsSyntaxKind::JS_FUNCTION_DECLARATION
+                | JsSyntaxKind::JS_FUNCTION_EXPRESSION
+                | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => {
+                    result.push(id);
+                }
+                _ => {
+                    scopes.extend(scope.children.iter());
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Return all immediate children closures of this closure
+    pub fn children(&self) -> Vec<Closure> {
+        let mut closures = vec![];
+
+        for scope_id in self.children_scopes() {
+            let scope = &self.data.scopes[scope_id];
+            closures.push(Closure {
+                data: self.data.clone(),
+                scope_id,
+                closure_range: scope.range,
+            })
+        }
+
+        closures
+    }
+}

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use super::*;
 use rome_js_syntax::{
     JsArrowFunctionExpression, JsConstructorClassMember, JsFunctionDeclaration,
-    JsFunctionExpression, JsGetterClassMember, JsLanguage, JsMethodClassMember,
-    JsSetterClassMember, JsMethodObjectMember, JsGetterObjectMember, JsSetterObjectMember
+    JsFunctionExpression, JsGetterClassMember, JsGetterObjectMember, JsLanguage,
+    JsMethodClassMember, JsMethodObjectMember, JsSetterClassMember, JsSetterObjectMember,
 };
 use rome_rowan::{AstNode, SyntaxNode, SyntaxNodeCast};
 
@@ -43,7 +43,7 @@ macro_rules! SyntaxTextRangeHasClosureAstNode {
                 }
             }
         }
-        
+
         impl HasClosureAstNode for AnyHasClosureNode {
             #[inline(always)]
             fn node_text_range(&self) -> TextRange {


### PR DESCRIPTION
## Summary

This PR introduces closures in the semantic model.
One interesting decision is what to do with:

```js
function f(c) {
    console.log(a);
    function g() {
        console.log(b, c);
    }
}
```

The implementations is returning that ```f``` captures ```a```, and it has a inner closure that captures ```b``` and ```c```. Which is closer to the code.


## Test Plan

```
cargo test -p rome_js_semantic -- ok_semantic_model_closure
```
