### PR TITLE
feat(rome_js_formatter): TS Intersection & Union types

### DIFF
--- a/crates/rome_js_formatter/src/ts/types/union_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/union_type.rs
@@ -25,12 +25,13 @@ impl FormatNodeRule<TsUnionType> for FormatTsUnionType {
         // } | null | void
         // ```
         // should be inlined and not be printed in the multi-line variant
-        if should_hug_type(&node.clone().into()) {
+        let should_hug = should_hug_type(&node.clone().into());
+        if should_hug {
             return write!(
                 f,
                 [
                     FormatTypeMemberSeparator::new(leading_separator_token.as_ref()),
-                    types.format()
+                    types.format().with_options(should_hug)
                 ]
             );
         }


### PR DESCRIPTION


## Summary

Use `FormatRuleWithOptions` instead the parent traversing.

## Test Plan

`cargo test -p rome_js_formatter`
