### PR TITLE
fix(rome_formatter): Printer fill fits

### DIFF
--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -986,7 +986,7 @@ fn fits_element_on_line<'a, 'rest>(
                 Some(group_id) => state
                     .group_modes
                     .get_print_mode(group_id)
-                    .unwrap_or_else(|| PrintMode::Flat),
+                    .unwrap_or_else(|| args.mode()),
             };
 
             if group_mode != condition.mode {

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -382,7 +382,6 @@ impl<'a> Printer<'a> {
                 // variant.
 
                 // Try to fit only the first variant on a single line
-
                 if !matches!(variant.first(), Some(&FormatElement::Tag(Tag::StartEntry))) {
                     return invalid_start_tag(TagKind::Entry, variant.first());
                 }
@@ -438,6 +437,8 @@ impl<'a> Printer<'a> {
         let mut current_fits =
             self.fits_fill_entry(SingleEntryPredicate::default(), queue, stack)?;
 
+        self.state.measured_group_fits = current_fits;
+
         self.print_entry(
             queue,
             stack,
@@ -457,6 +458,8 @@ impl<'a> Printer<'a> {
             } else {
                 false
             };
+
+            self.state.measured_group_fits = all_fits;
 
             let separator_mode = if all_fits {
                 PrintMode::Flat
@@ -479,6 +482,8 @@ impl<'a> Printer<'a> {
                 // Test if item fits now
                 let next_fits =
                     self.fits_fill_entry(SingleEntryPredicate::default(), queue, stack)?;
+
+                self.state.measured_group_fits = next_fits;
 
                 self.print_entry(
                     queue,
@@ -981,7 +986,7 @@ fn fits_element_on_line<'a, 'rest>(
                 Some(group_id) => state
                     .group_modes
                     .get_print_mode(group_id)
-                    .unwrap_or_else(|| args.mode()),
+                    .unwrap_or_else(|| PrintMode::Flat),
             };
 
             if group_mode != condition.mode {

--- a/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/closing_element.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-use rome_formatter::{format_args, write};
+use rome_formatter::write;
 use rome_js_syntax::{JsxClosingElement, JsxClosingElementFields};
 
 #[derive(Debug, Clone, Default)]
@@ -21,13 +21,13 @@ impl FormatNodeRule<JsxClosingElement> for FormatJsxClosingElement {
 
         write![
             formatter,
-            [group(&format_args![
+            [
                 l_angle_token.format(),
                 slash_token.format(),
                 name.format(),
                 line_suffix_boundary(),
                 r_angle_token.format(),
-            ])]
+            ]
         ]
     }
 }

--- a/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/opening_element.rs
@@ -66,7 +66,7 @@ impl Format<JsFormatContext> for JsxAnyOpeningElement {
                         line_suffix_boundary(),
                         space(),
                         attributes.format(),
-                        line_suffix_boundary(),
+                        (!attributes.is_empty()).then_some(line_suffix_boundary()),
                         attribute_spacing,
                         format_close
                     ]
@@ -82,7 +82,7 @@ impl Format<JsFormatContext> for JsxAnyOpeningElement {
                             type_arguments.format(),
                             line_suffix_boundary(),
                             soft_line_indent_or_space(&attributes.format()),
-                            line_suffix_boundary(),
+                            (!attributes.is_empty()).then_some(line_suffix_boundary()),
                         ]
                     )?;
 


### PR DESCRIPTION
## Summary

This fixes the issue why the test is currently failing in #3251 

The specific snipped triggering the issue is:

```javascript
  <div>
    ENddddDSIIIN <div>
      texttexttexttexttexttexttexttexttexttexttexttextextffg
    </div>{" "}
    HRS
  </div>
```

That generates the following IR

```
[
  group(["<div>"]),
  indent([
    hard_line_break,
    fill([
        ["ENddddDSIIIN"],
        [
          if_group_breaks(["{" "}", soft_line_break]),
          if_group_fits_on_line([" "])
        ],
        [
          best_fitting([
            [
              [
                group(["<div>"]),
                "texttexttexttexttexttexttexttexttexttexttexttextextffg",
                "</div>"
              ]
            ]
            [
              [
                group(["<div>"]),
                indent([
                  hard_line_break,
                  fill([
                      ["texttexttexttexttexttexttexttexttexttexttexttextextffg"]
                  ])
                ]),
                hard_line_break,
                "</div>"
              ]
            ]
          ])
        ],
        [
          if_group_breaks(["{" "}", soft_line_break]),
          if_group_fits_on_line([" "])
        ],
        ["HRS"]
      ]
    ])
  ]),
  hard_line_break,
  "</div>;",
  hard_line_break
]
```

The issue is the combination of `fill` with `best_fitting`. 

* Fill tests if `ENddddDSIIIN` fits on the line -> yes. Print the entry
* Fill tests if the space and the `<div>text...</div>` fits on the line -> yes. Print the entry
* The best fitting now tests if its content up to the first hard line break fits on the line. This is includes the following content: `<div>text...</div> HRS`. Notice how it includes the `HRS` which is from the next `fill` entry.

The measuring if the best fitting should stop at the next separator because `fill` will make that separator expand if it otherwise risks exceeding the line width. Now, stopping at the next separator isn't trivial. However, there's no need for `best_fitting` to even test if it fits because `fill` already tested that. 

That's why the fix is somewhat simple. All that is necessary is to set that we know it will fit and that the printer can simply use the first variant.

## But what about...

if the fill element doesn't fit. Do we not have the same problem then? Not really, because the element gets printed in expanded mode and this also applies for the separator coming right after. Since the separator **must** contain a soft line break the printer either decides that the content fits (for best fitting) or expands (group). 

## Test Plan

Tested that  #3251 now formats correctly