### PR TITLE
fix(website): incorrect IR for jsx input

### DIFF
--- a/website/playground/src/utils.ts
+++ b/website/playground/src/utils.ts
@@ -146,14 +146,16 @@ export function formatWithPrettier(
 		// @ts-ignore
 		let debug = prettier.__debug;
 		const document = debug.printToDoc(code, prettierOptions);
-		const formattedCode = debug.printDocToString(
-			document,
-			prettierOptions,
-		).formatted;
+
+		// formatDoc must be before printDocToString because printDocToString mutates the document and breaks the ir
 		const ir = debug.formatDoc(document, {
 			parser: "babel",
 			plugins: [parserBabel],
 		});
+		const formattedCode = debug.printDocToString(
+			document,
+			prettierOptions,
+		).formatted;
 		return { code: formattedCode, ir };
 	} catch (err: any) {
 		console.error(err);


### PR DESCRIPTION


## Summary

Prettier IR tab has an incorrect IR for jsx input.
[Playground](https://play.rome.tools/?code=++%3Cdiv%3E%0A++++ENddddDS+IN+%3Cdiv%3E%0A++++++text+text+text+text+text+text+text+text+text+text+text%0A++++%3C%2Fdiv%3E%7B%27+%27%7D%0A++++HRS%0A++%3C%2Fdiv%3E&lineWidth=80&indentStyle=tab&quoteStyle=double&quoteProperties=as-needed&indentWidth=2&sourceType=module&enabledNurseryRules=true&typescript=true&jsx=true#IAAgADwAZABpAHYAPgAKACAAIAAgACAARQBOAGQAZABkAGQARABTACAASQBOACAAPABkAGkAdgA+AAoAIAAgACAAIAAgACAAdABlAHgAdAAgAHQAZQB4AHQAIAB0AGUAeAB0ACAAdABlAHgAdAAgAHQAZQB4AHQAIAB0AGUAeAB0ACAAdABlAHgAdAAgAHQAZQB4AHQAIAB0AGUAeAB0ACAAdABlAHgAdAAgAHQAZQB4AHQACgAgACAAIAAgADwALwBkAGkAdgA+AHsAJwAgACcAfQAKACAAIAAgACAASABSAFMACgAgACAAPAAvAGQAaQB2AD4A)

It seems that `printDocToString` mutates the document.


## Test Plan
<img width="1565" alt="Screenshot 2022-10-01 at 3 55 55 PM" src="https://user-images.githubusercontent.com/6227442/193410591-856ea719-4e9a-4223-b976-f9fd2e18ef8f.png">

