### PR TITLE
fix(rome_formatter): Best fitting start entry

### DIFF
--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -937,8 +937,7 @@ fn fits_element_on_line<'a, 'rest>(
                 return invalid_start_tag(TagKind::Entry, slice.first());
             }
 
-            stack.push(TagKind::Entry, args.with_print_mode(args.mode()));
-            queue.extend_back(&slice[1..]);
+            queue.extend_back(slice);
         }
 
         FormatElement::Interned(content) => queue.extend_back(content),


### PR DESCRIPTION
I noticed this when investigating how to correctly implement `fill`.

The problem with only pushing the items of the variant after the `StartEntry` is that any `FitsPredicate` that counts the start/end entries won't see the corresponding `StartEntry`.

Manually pushing the `StartEntry` onto the stack isn't even necessary because it uses the same `args` anyway

Why is it important to be fixed. A `FitsPredicate` may return a `PrintError::InvalidDocument` if it believes that it has seen an `EndEntry` without a matching `StartEntry` even for valid documents.

