### PR TITLE
feat(rome_diagnostics): refactor some existing diagnostics to use the new Diagnostic trait

### DIFF
--- a/crates/rome_cli/src/reports/mod.rs
+++ b/crates/rome_cli/src/reports/mod.rs
@@ -2,7 +2,7 @@ pub mod formatter;
 
 use crate::reports::formatter::{FormatterReportFileDetail, FormatterReportSummary};
 use formatter::FormatterReport;
-use rome_diagnostics::{v2::Category, Severity};
+use rome_diagnostics::v2::{Category, Severity};
 use rome_service::RomeError;
 use serde::Serialize;
 use std::collections::HashMap;

--- a/crates/rome_diagnostics/src/emit.rs
+++ b/crates/rome_diagnostics/src/emit.rs
@@ -136,7 +136,7 @@ impl<'a> Display for DiagnosticPrinter<'a> {
 }
 
 impl v2::Diagnostic for DiagnosticPrinter<'_> {
-    fn category(&self) -> Option<&Category> {
+    fn category(&self) -> Option<&'static Category> {
         self.d.code
     }
 

--- a/crates/rome_diagnostics/src/v2/adapters.rs
+++ b/crates/rome_diagnostics/src/v2/adapters.rs
@@ -53,7 +53,7 @@ impl From<io::Error> for IoError {
 }
 
 impl Diagnostic for IoError {
-    fn category(&self) -> Option<&Category> {
+    fn category(&self) -> Option<&'static Category> {
         Some(category!("internalError/io"))
     }
 

--- a/crates/rome_diagnostics/src/v2/context.rs
+++ b/crates/rome_diagnostics/src/v2/context.rs
@@ -182,7 +182,7 @@ mod internal {
     }
 
     impl<M: fmt::Display + 'static, E: AsDiagnostic> Diagnostic for ContextDiagnostic<M, E> {
-        fn category(&self) -> Option<&Category> {
+        fn category(&self) -> Option<&'static Category> {
             self.source.as_diagnostic().category()
         }
 
@@ -280,7 +280,7 @@ mod internal {
     }
 
     impl<E: AsDiagnostic> Diagnostic for CategoryDiagnostic<E> {
-        fn category(&self) -> Option<&Category> {
+        fn category(&self) -> Option<&'static Category> {
             Some(
                 self.source
                     .as_diagnostic()
@@ -335,7 +335,7 @@ mod internal {
     }
 
     impl<E: AsDiagnostic> Diagnostic for FilePathDiagnostic<E> {
-        fn category(&self) -> Option<&Category> {
+        fn category(&self) -> Option<&'static Category> {
             self.source.as_diagnostic().category()
         }
 
@@ -410,7 +410,7 @@ mod internal {
     }
 
     impl<E: AsDiagnostic> Diagnostic for FileSourceCodeDiagnostic<E> {
-        fn category(&self) -> Option<&Category> {
+        fn category(&self) -> Option<&'static Category> {
             self.source.as_diagnostic().category()
         }
 

--- a/crates/rome_diagnostics/src/v2/diagnostic.rs
+++ b/crates/rome_diagnostics/src/v2/diagnostic.rs
@@ -29,7 +29,7 @@ pub trait Diagnostic: Debug {
     /// The category of a diagnostic uniquely identifying this
     /// diagnostic type, such as `lint/correctness/noArguments`, `args/invalid`
     /// or `format/disabled`.
-    fn category(&self) -> Option<&Category> {
+    fn category(&self) -> Option<&'static Category> {
         None
     }
 

--- a/crates/rome_diagnostics/src/v2/display.rs
+++ b/crates/rome_diagnostics/src/v2/display.rs
@@ -589,7 +589,7 @@ mod tests {
     }
 
     impl<A: Advices + std::fmt::Debug> Diagnostic for TestDiagnostic<A> {
-        fn category(&self) -> Option<&Category> {
+        fn category(&self) -> Option<&'static Category> {
             Some(category!("internalError/io"))
         }
 

--- a/crates/rome_diagnostics/src/v2/serde.rs
+++ b/crates/rome_diagnostics/src/v2/serde.rs
@@ -18,7 +18,7 @@ use super::{
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct Diagnostic {
-    category: Option<String>,
+    category: Option<&'static Category>,
     severity: Severity,
     description: String,
     message: MarkupBuf,
@@ -35,7 +35,7 @@ impl Diagnostic {
     }
 
     fn new_impl<D: super::Diagnostic + ?Sized>(diag: &D) -> Self {
-        let category = diag.category().map(|category| category.name().to_string());
+        let category = diag.category();
 
         let severity = diag.severity();
 
@@ -75,15 +75,8 @@ impl Diagnostic {
 }
 
 impl super::Diagnostic for Diagnostic {
-    fn category(&self) -> Option<&Category> {
-        self.category.as_deref().and_then(|name| {
-            let category: Option<&Category> = name.parse().ok();
-            debug_assert!(
-                category.is_some(),
-                "diagnostic category {name:?} does not exist in the static registry"
-            );
-            category
-        })
+    fn category(&self) -> Option<&'static Category> {
+        self.category
     }
 
     fn severity(&self) -> Severity {

--- a/crates/rome_diagnostics_macros/src/generate.rs
+++ b/crates/rome_diagnostics_macros/src/generate.rs
@@ -54,7 +54,7 @@ fn generate_category(input: &DeriveInput) -> TokenStream {
     };
 
     quote! {
-        fn category(&self) -> Option<&rome_diagnostics::v2::Category> {
+        fn category(&self) -> Option<&'static rome_diagnostics::v2::Category> {
             Some(#category)
         }
     }

--- a/crates/rome_fs/src/fs.rs
+++ b/crates/rome_fs/src/fs.rs
@@ -6,13 +6,14 @@ use std::{
 };
 
 use crate::{PathInterner, RomePath};
-use rome_diagnostics::{file::FileId, v2::Category};
+use rome_diagnostics::file::FileId;
 
 mod memory;
 mod os;
 
 pub use memory::MemoryFileSystem;
 pub use os::OsFileSystem;
+use rome_diagnostics::v2::Error;
 pub const CONFIG_NAME: &str = "rome.json";
 
 pub trait FileSystem: Send + Sync + RefUnwindSafe {
@@ -127,7 +128,7 @@ pub trait TraversalContext: Sync {
 
     /// Called by the traversal process to emit an error diagnostic associated
     /// with a particular file ID when an IO error happens
-    fn push_diagnostic(&self, file_id: FileId, code: &'static Category, message: String);
+    fn push_diagnostic(&self, error: Error);
 
     /// Checks if the traversal context can handle a particular path, used as
     /// an optimization to bail out of scheduling a file handler if it wouldn't

--- a/crates/rome_fs/src/fs/memory.rs
+++ b/crates/rome_fs/src/fs/memory.rs
@@ -155,12 +155,13 @@ mod tests {
     };
 
     use parking_lot::Mutex;
+    use rome_diagnostics::v2::Error;
 
     use crate::fs::FileSystemExt;
     use crate::{
         AtomicInterner, FileSystem, MemoryFileSystem, PathInterner, RomePath, TraversalContext,
     };
-    use rome_diagnostics::{file::FileId, v2::Category};
+    use rome_diagnostics::file::FileId;
 
     #[test]
     fn file_read_write() {
@@ -225,11 +226,8 @@ mod tests {
                 &self.interner
             }
 
-            fn push_diagnostic(&self, file_id: FileId, code: &'static Category, message: String) {
-                panic!(
-                    "unexpected error {:?} in file {file_id:?}: {message}",
-                    code.name()
-                )
+            fn push_diagnostic(&self, err: Error) {
+                panic!("unexpected error {err:?}")
             }
 
             fn can_handle(&self, _: &RomePath) -> bool {

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -216,6 +216,9 @@ impl Server {
     }
 }
 
+/// Number of notifications buffered by the server-to-client channel before it starts blocking the current task
+const CHANNEL_BUFFER_SIZE: usize = 8;
+
 #[derive(Debug, PartialEq, Eq)]
 enum ServerNotification {
     PublishDiagnostics(PublishDiagnosticsParams),
@@ -276,7 +279,7 @@ async fn basic_lifecycle() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let (sender, _) = channel(8);
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
     let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
@@ -295,7 +298,7 @@ async fn document_lifecycle() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let (sender, _) = channel(8);
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
     let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
@@ -317,7 +320,7 @@ async fn document_no_extension() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let (sender, _) = channel(8);
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
     let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
@@ -388,7 +391,7 @@ async fn pull_diagnostics() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let (sender, mut receiver) = channel(8);
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
     let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
@@ -467,7 +470,7 @@ async fn pull_quick_fixes() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let (sender, _) = channel(8);
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
     let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
@@ -533,7 +536,7 @@ async fn pull_refactors() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let (sender, _) = channel(8);
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
     let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
@@ -601,7 +604,7 @@ async fn format_with_syntax_errors() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let (sender, _) = channel(8);
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
     let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
@@ -650,7 +653,7 @@ async fn server_shutdown() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let (sender, _) = channel(8);
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
     let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -2,6 +2,7 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
+use futures::channel::mpsc::{channel, Sender};
 use futures::Sink;
 use futures::SinkExt;
 use futures::Stream;
@@ -17,6 +18,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::slice;
 use std::time::Duration;
+use tokio::time::sleep;
 use tower::timeout::Timeout;
 use tower::{Service, ServiceExt};
 use tower_lsp::jsonrpc;
@@ -27,14 +29,20 @@ use tower_lsp::lsp_types::CodeActionKind;
 use tower_lsp::lsp_types::CodeActionOrCommand;
 use tower_lsp::lsp_types::CodeActionParams;
 use tower_lsp::lsp_types::CodeActionResponse;
+use tower_lsp::lsp_types::Diagnostic;
+use tower_lsp::lsp_types::DiagnosticRelatedInformation;
+use tower_lsp::lsp_types::DiagnosticSeverity;
 use tower_lsp::lsp_types::DidCloseTextDocumentParams;
 use tower_lsp::lsp_types::DidOpenTextDocumentParams;
 use tower_lsp::lsp_types::DocumentFormattingParams;
 use tower_lsp::lsp_types::FormattingOptions;
 use tower_lsp::lsp_types::InitializeResult;
 use tower_lsp::lsp_types::InitializedParams;
+use tower_lsp::lsp_types::Location;
+use tower_lsp::lsp_types::NumberOrString;
 use tower_lsp::lsp_types::PartialResultParams;
 use tower_lsp::lsp_types::Position;
+use tower_lsp::lsp_types::PublishDiagnosticsParams;
 use tower_lsp::lsp_types::Range;
 use tower_lsp::lsp_types::TextDocumentIdentifier;
 use tower_lsp::lsp_types::TextDocumentItem;
@@ -208,8 +216,17 @@ impl Server {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum ServerNotification {
+    PublishDiagnostics(PublishDiagnosticsParams),
+}
+
 /// Basic handler for requests and notifications coming from the server for tests
-async fn client_handler<I, O>(mut stream: I, mut sink: O) -> Result<()>
+async fn client_handler<I, O>(
+    mut stream: I,
+    mut sink: O,
+    mut notify: Sender<ServerNotification>,
+) -> Result<()>
 where
     // This function has to be generic as `RequestStream` and `ResponseSink`
     // are not exported from `tower_lsp` and cannot be named in the signature
@@ -217,6 +234,16 @@ where
     O: Sink<Response> + Unpin,
 {
     while let Some(req) = stream.next().await {
+        if req.method() == "textDocument/publishDiagnostics" {
+            let params = req.params().expect("invalid request");
+            let diagnostics = from_value(params.clone()).expect("invalid params");
+            let notification = ServerNotification::PublishDiagnostics(diagnostics);
+            match notify.send(notification).await {
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+
         let id = match req.id() {
             Some(id) => id,
             None => continue,
@@ -249,7 +276,8 @@ async fn basic_lifecycle() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let reader = tokio::spawn(client_handler(stream, sink));
+    let (sender, _) = channel(8);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
     server.initialized().await?;
@@ -267,7 +295,8 @@ async fn document_lifecycle() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let reader = tokio::spawn(client_handler(stream, sink));
+    let (sender, _) = channel(8);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
     server.initialized().await?;
@@ -288,7 +317,8 @@ async fn document_no_extension() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let reader = tokio::spawn(client_handler(stream, sink));
+    let (sender, _) = channel(8);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
     server.initialized().await?;
@@ -352,13 +382,93 @@ async fn document_no_extension() -> Result<()> {
 }
 
 #[tokio::test]
+async fn pull_diagnostics() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(8);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server.open_document("if(a == b) {}").await?;
+
+    let notification = tokio::select! {
+        msg = receiver.next() => msg,
+        _ = sleep(Duration::from_secs(1)) => {
+            panic!("timed out waiting for the server to send diagnostics")
+        }
+    };
+
+    assert_eq!(
+        notification,
+        Some(ServerNotification::PublishDiagnostics(
+            PublishDiagnosticsParams {
+                uri: Url::parse("test://workspace/document.js")?,
+                version: Some(0),
+                diagnostics: vec![Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: 0,
+                            character: 5
+                        },
+                        end: Position {
+                            line: 0,
+                            character: 7
+                        }
+                    },
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: Some(NumberOrString::String(String::from(
+                        "lint/correctness/noDoubleEquals"
+                    ))),
+                    code_description: None,
+                    source: Some(String::from("rome")),
+                    message: String::from(
+                        "Use === instead of ==.\n== is only allowed when comparing against `null`"
+                    ),
+                    related_information: Some(vec![DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: Url::parse("test://workspace/document.js")?,
+                            range: Range {
+                                start: Position {
+                                    line: 0,
+                                    character: 5
+                                },
+                                end: Position {
+                                    line: 0,
+                                    character: 7
+                                }
+                            }
+                        },
+                        message: String::new()
+                    }]),
+                    tags: None,
+                    data: None
+                }],
+            }
+        ))
+    );
+
+    server.close_document().await?;
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn pull_quick_fixes() -> Result<()> {
     let factory = ServerFactory::default();
     let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let reader = tokio::spawn(client_handler(stream, sink));
+    let (sender, _) = channel(8);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
     server.initialized().await?;
@@ -423,7 +533,8 @@ async fn pull_refactors() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let reader = tokio::spawn(client_handler(stream, sink));
+    let (sender, _) = channel(8);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
     server.initialized().await?;
@@ -490,7 +601,8 @@ async fn format_with_syntax_errors() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let reader = tokio::spawn(client_handler(stream, sink));
+    let (sender, _) = channel(8);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
     server.initialized().await?;
@@ -538,7 +650,8 @@ async fn server_shutdown() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let reader = tokio::spawn(client_handler(stream, sink));
+    let (sender, _) = channel(8);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
 
     server.initialize().await?;
     server.initialized().await?;

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -54,7 +54,7 @@
 use crate::{Configuration, RomeError};
 use rome_analyze::ActionCategory;
 pub use rome_analyze::RuleCategories;
-use rome_diagnostics::{CodeSuggestion, Diagnostic};
+use rome_diagnostics::{v2, CodeSuggestion};
 use rome_formatter::Printed;
 use rome_fs::RomePath;
 use rome_js_syntax::{TextRange, TextSize};
@@ -181,7 +181,7 @@ pub struct PullDiagnosticsParams {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PullDiagnosticsResult {
-    pub diagnostics: Vec<Diagnostic>,
+    pub diagnostics: Vec<v2::serde::Diagnostic>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/npm/rome/tests/daemon/__snapshots__/formatContent.test.mjs.snap
+++ b/npm/rome/tests/daemon/__snapshots__/formatContent.test.mjs.snap
@@ -3,36 +3,56 @@
 exports[`Rome Deamon formatter > should not format and have diagnostics > syntax error 1`] = `
 [
   {
-    "children": [],
-    "code": "parse",
-    "file_id": 0,
-    "footers": [],
-    "primary": {
-      "msg": [
+    "advices": {
+      "advices": [
         {
-          "content": "",
-          "elements": [],
+          "Frame": {
+            "path": {
+              "File": {
+                "PathAndId": {
+                  "file_id": 0,
+                  "path": "example.js",
+                },
+              },
+            },
+            "source_code": null,
+            "span": [
+              11,
+              12,
+            ],
+          },
         },
       ],
-      "severity": "Error",
-      "span": {
-        "file": 0,
-        "range": [
-          11,
-          12,
-        ],
-      },
     },
-    "severity": "Error",
-    "suggestions": [],
-    "summary": null,
-    "tag": null,
-    "title": [
+    "category": "parse",
+    "description": "expected a name for the function in a function declaration, but found none",
+    "location": {
+      "path": {
+        "File": {
+          "PathAndId": {
+            "file_id": 0,
+            "path": "example.js",
+          },
+        },
+      },
+      "source_code": null,
+      "span": [
+        11,
+        12,
+      ],
+    },
+    "message": [
       {
         "content": "expected a name for the function in a function declaration, but found none",
         "elements": [],
       },
     ],
+    "severity": "Error",
+    "source": null,
+    "tags": [],
+    "verbose_advices": {
+      "advices": [],
+    },
   },
 ]
 `;

--- a/npm/rome/tests/daemon/formatContent.test.mjs
+++ b/npm/rome/tests/daemon/formatContent.test.mjs
@@ -34,7 +34,7 @@ describe("Rome Deamon formatter", async () => {
 
 		expect(result.content).toEqual(content);
 		expect(result.diagnostics).toHaveLength(1);
-		expect(result.diagnostics[0].title[0].content).toContain(
+		expect(result.diagnostics[0].description).toContain(
 			"expected a name for the function in a function declaration, but found none",
 		);
 		expect(result.diagnostics).toMatchSnapshot("syntax error");

--- a/npm/rome/tests/wasm/__snapshots__/formatContent.test.mjs.snap
+++ b/npm/rome/tests/wasm/__snapshots__/formatContent.test.mjs.snap
@@ -3,36 +3,56 @@
 exports[`Rome WebAssembly formatContent > should not format and have diagnostics > syntax error 1`] = `
 [
   {
-    "children": [],
-    "code": "parse",
-    "file_id": 0,
-    "footers": [],
-    "primary": {
-      "msg": [
+    "advices": {
+      "advices": [
         {
-          "content": "",
-          "elements": [],
+          "Frame": {
+            "path": {
+              "File": {
+                "PathAndId": {
+                  "file_id": 0,
+                  "path": "example.js",
+                },
+              },
+            },
+            "source_code": null,
+            "span": [
+              11,
+              12,
+            ],
+          },
         },
       ],
-      "severity": "Error",
-      "span": {
-        "file": 0,
-        "range": [
-          11,
-          12,
-        ],
-      },
     },
-    "severity": "Error",
-    "suggestions": [],
-    "summary": null,
-    "tag": null,
-    "title": [
+    "category": "parse",
+    "description": "expected a name for the function in a function declaration, but found none",
+    "location": {
+      "path": {
+        "File": {
+          "PathAndId": {
+            "file_id": 0,
+            "path": "example.js",
+          },
+        },
+      },
+      "source_code": null,
+      "span": [
+        11,
+        12,
+      ],
+    },
+    "message": [
       {
         "content": "expected a name for the function in a function declaration, but found none",
         "elements": [],
       },
     ],
+    "severity": "Error",
+    "source": null,
+    "tags": [],
+    "verbose_advices": {
+      "advices": [],
+    },
   },
 ]
 `;

--- a/npm/rome/tests/wasm/formatContent.test.mjs
+++ b/npm/rome/tests/wasm/formatContent.test.mjs
@@ -27,7 +27,7 @@ describe("Rome WebAssembly formatContent", () => {
 
 		expect(result.content).toEqual(content);
 		expect(result.diagnostics).toHaveLength(1);
-		expect(result.diagnostics[0].title[0].content).toContain(
+		expect(result.diagnostics[0].description).toContain(
 			"expected a name for the function in a function declaration, but found none",
 		);
 		expect(result.diagnostics).toMatchSnapshot("syntax error");


### PR DESCRIPTION
## Summary

This PR holds a number of miscellaneous changes related to exposing the new diagnostic system to the node.js API.
The central change to enable this is replacing the `rome_diagnostics::Diagnostic` type in the result of the `pull_diagnostics` Workspace method with the new `rome_diagnostics::v2::serde::Diagnostic` type, the serializable form of the new `Diagnostic` trait.
In order to make this work I had to fix a few bugs around the serialization and lifetime of diagnostic categories.
I also updated the logic that turns Rome diagnostics into LSP diagnostics to be generic over the Diagnostic trait, and changed the error reporting in the CLI filesystem traversal logic to use the new `Error` type provided by `rome_diagnostics` instead of declaring its own `TraversalError`.

## Test Plan

The changes in the filesystem traversal should be covered by the CLI snapshot tests, and I've added an additional test to check how diagnostics are encoded to the LSP