### PR TITLE
fix(rome_js_analyze): no unused variables accepting ts public/private constructor parameters

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_unused_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_unused_variables.rs
@@ -151,7 +151,7 @@ fn is_typescript_unused_ok(binding: &JsIdentifierBinding) -> Option<()> {
                         }
                     }
 
-                    return None;
+                    None
                 }
                 _ => None,
             }

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/noUnusedVariables.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/noUnusedVariables.ts
@@ -42,6 +42,8 @@ f();
 
 export type Command = (...args: any[]) => unknown;
 
+declare function notUsedParameters(a);
+
 function used_overloaded(): number;
 function used_overloaded(s: string): string;
 function used_overloaded(s?: string) {

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/noUnusedVariables.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/noUnusedVariables.ts.snap
@@ -48,6 +48,8 @@ f();
 
 export type Command = (...args: any[]) => unknown;
 
+declare function notUsedParameters(a);
+
 function used_overloaded(): number;
 function used_overloaded(s: string): string;
 function used_overloaded(s?: string) {

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts
@@ -2,4 +2,5 @@ class A {
     constructor(a, private b, public c) {
     }
 }
+
 console.log(new A(1, 2, 3));

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts
@@ -1,6 +1,5 @@
 class A {
     constructor(a, private b, public c) {
-
     }
 }
 console.log(new A(1, 2, 3));

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts
@@ -1,0 +1,6 @@
+class A {
+    constructor(a, private b, public c) {
+
+    }
+}
+console.log(new A(1, 2, 3));

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts.snap
@@ -8,6 +8,7 @@ class A {
     constructor(a, private b, public c) {
     }
 }
+
 console.log(new A(1, 2, 3));
 
 ```

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts.snap
@@ -19,10 +19,11 @@ privateOrPublicConstructorParameters.ts:2:17 lint/nursery/noUnusedVariables ━�
 
   ! This parameter is unused.
   
-    ┌─ privateOrPublicConstructorParameters.ts:2:17
-    │
-  2 │     constructor(a, private b, public c) {
-    │                 ^
+    1 │ class A {
+  > 2 │     constructor(a, private b, public c) {
+      │                 ^
+    3 │     }
+    4 │ }
   
   i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
   

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: privateOrPublicConstructorParameters.ts
+---
+# Input
+```js
+class A {
+    constructor(a, private b, public c) {
+
+    }
+}
+console.log(new A(1, 2, 3));
+```
+
+# Diagnostics
+```
+privateOrPublicConstructorParameters.ts:2:17 lint/nursery/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This parameter is unused.
+  
+    ┌─ privateOrPublicConstructorParameters.ts:2:17
+    │
+  2 │     constructor(a, private b, public c) {
+    │                 ^
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnusedVariables/privateOrPublicConstructorParameters.ts.snap
@@ -6,10 +6,10 @@ expression: privateOrPublicConstructorParameters.ts
 ```js
 class A {
     constructor(a, private b, public c) {
-
     }
 }
 console.log(new A(1, 2, 3));
+
 ```
 
 # Diagnostics


### PR DESCRIPTION
## Summary

Closes https://github.com/rome/tools/issues/3183

## Test Plan

```
> cargo test -p rome_js_analyze -- no_unused
```
