### PR TITLE
fix(rome_js_semantic): correctly push/pop scopes for ts function types

### DIFF
--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -270,7 +270,7 @@ impl SemanticEventExtractor {
             | JS_FUNCTION_BODY
             | TS_INTERFACE_DECLARATION
             | TS_ENUM_DECLARATION
-            | TS_TYPE_ALIAS_DECLARATION 
+            | TS_TYPE_ALIAS_DECLARATION
             | TS_FUNCTION_TYPE => {
                 self.push_scope(
                     node.text_range(),

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -270,7 +270,8 @@ impl SemanticEventExtractor {
             | JS_FUNCTION_BODY
             | TS_INTERFACE_DECLARATION
             | TS_ENUM_DECLARATION
-            | TS_TYPE_ALIAS_DECLARATION => {
+            | TS_TYPE_ALIAS_DECLARATION 
+            | TS_FUNCTION_TYPE => {
                 self.push_scope(
                     node.text_range(),
                     ScopeHoisting::DontHoistDeclarationsToParent,
@@ -486,6 +487,7 @@ impl SemanticEventExtractor {
             | TS_INTERFACE_DECLARATION
             | TS_ENUM_DECLARATION
             | TS_TYPE_ALIAS_DECLARATION
+            | TS_FUNCTION_TYPE
             | JS_BLOCK_STATEMENT
             | JS_FOR_STATEMENT
             | JS_FOR_OF_STATEMENT

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -202,3 +202,10 @@ assert_semantics! {
     ok_class_reference,
         "class A/*#A*/ {} new A/*READ A*/();",
 }
+
+// Typescript types
+
+assert_semantics! {
+    ok_typescript_function_type,
+        "function f (a/*#A1*/, b: (a/*#A2*/) => any) { return b(a/*READ A1*/); };",
+}


### PR DESCRIPTION
## Summary

Closes https://github.com/rome/tools/issues/3170

## Test Plan

```
> cargo test -p rome_js_semantic -- ok_typescript_function_type  
```
