### PR TITLE
perf(rome_js_analyze): improve the performance of noUndeclaredVariables

### DIFF
--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -195,7 +195,7 @@ mod tests {
         fn match_query(&mut self, params: MatchQueryParams<RawLanguage>) {
             let node = match params.query {
                 QueryMatch::Syntax(node) => node,
-                QueryMatch::ControlFlowGraph(..) => unreachable!(),
+                _ => unreachable!(),
             };
 
             if node.kind() != RawLanguageKind::LITERAL_EXPRESSION {

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -81,7 +81,7 @@ mod tests {
                 QueryMatch::Syntax(node) => {
                     self.nodes.push(node.kind());
                 }
-                QueryMatch::ControlFlowGraph(..) => unreachable!(),
+                _ => unreachable!(),
             }
         }
     }

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -21,7 +21,10 @@ mod semantic_analyzers;
 mod semantic_services;
 pub mod utils;
 
-use crate::{registry::build_registry, semantic_services::SemanticModelBuilderVisitor};
+use crate::{
+    registry::build_registry,
+    semantic_services::{SemanticModelBuilderVisitor, SemanticModelVisitor},
+};
 
 pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
 
@@ -72,6 +75,7 @@ where
     analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
     analyzer.add_visitor(Phases::Syntax, SemanticModelBuilderVisitor::new(root));
 
+    analyzer.add_visitor(Phases::Semantic, SemanticModelVisitor);
     analyzer.add_visitor(Phases::Semantic, SyntaxVisitor::default());
 
     analyzer.run(AnalyzerContext {

--- a/crates/rome_js_analyze/tests/specs/nursery/noUndeclaredVariables.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUndeclaredVariables.js
@@ -3,6 +3,9 @@ foobar;
 function f() {
     lorem;
 }
+assignment = "value";
+<Missing />;
+
 // valid
 document;
 navigator;

--- a/crates/rome_js_analyze/tests/specs/nursery/noUndeclaredVariables.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUndeclaredVariables.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 98
 expression: noUndeclaredVariables.js
 ---
 # Input
@@ -9,6 +10,9 @@ foobar;
 function f() {
     lorem;
 }
+assignment = "value";
+<Missing />;
+
 // valid
 document;
 navigator;
@@ -40,7 +44,37 @@ noUndeclaredVariables.js:4:5 lint/nursery/noUndeclaredVariables ━━━━━�
   > 4 │     lorem;
       │     ^^^^^
     5 │ }
-    6 │ // valid
+    6 │ assignment = "value";
+  
+
+```
+
+```
+noUndeclaredVariables.js:6:1 lint/nursery/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The assignment variable is undeclared
+  
+    4 │     lorem;
+    5 │ }
+  > 6 │ assignment = "value";
+      │ ^^^^^^^^^^
+    7 │ <Missing />;
+    8 │ 
+  
+
+```
+
+```
+noUndeclaredVariables.js:7:2 lint/nursery/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The Missing variable is undeclared
+  
+    5 │ }
+    6 │ assignment = "value";
+  > 7 │ <Missing />;
+      │  ^^^^^^^
+    8 │ 
+    9 │ // valid
   
 
 ```

--- a/crates/rome_js_semantic/src/tests/assertions.rs
+++ b/crates/rome_js_semantic/src/tests/assertions.rs
@@ -126,7 +126,7 @@ pub fn assert(code: &str, test_name: &str) {
             SemanticEvent::HoistedRead { range, .. } => range.start(),
             SemanticEvent::Write { range, .. } => range.start(),
             SemanticEvent::HoistedWrite { range, .. } => range.start(),
-            SemanticEvent::UnresolvedReference { range } => range.start(),
+            SemanticEvent::UnresolvedReference { range, .. } => range.start(),
             SemanticEvent::Exported { range } => range.start(),
         };
 


### PR DESCRIPTION
## Summary

This PR improves the performance of the `noUndeclaredVariables` rule by deriving the `Queryable` trait on the `SemanticServices` type. This allows individual rules to query the `SemanticModel` as a whole and "manually" traverse it to emit a sequence of signals, instead of having to match on individual AST nodes. This is particularly useful for `noUndeclaredVariables`, since it's a lot cheaper to iterate on the list of all the unresolved references in the semantic model than to match on all the identifier nodes in the syntax tree.

Side note: while it may seem useful to use this new capability to query the semantic model for other lint rules, it is primarily intended as an advanced feature for optimizations and as such should only be used if you know what you're doing. I'm currently considering a way to implement `Queryable` on `rome_js_semantic` types such as `Reference`, `Scope` or `Binding`, and this would allow rules to directly express queries on semantic model concepts without have to implement the traversal and search logic themselves.

## Test Plan

This is an infrastructure only change, it should not impact the results of the `noUndeclaredVariables` rule (or any other rules)
