### PR TITLE
refactor(rome_analyze): automatically derive the rule category in `declare_rule!`

### DIFF
--- a/crates/rome_analyze/CONTRIBUTING.md
+++ b/crates/rome_analyze/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Let's say we want to create a new rule called `useAwesomeTricks`, which uses the
 2. run the cargo alias `cargo codegen analyzer`, this command will update the file called `nursery.rs`
 inside the `semantic_analyzers` folder
 3. from there, use the [`declare_rule`](#declare_rule) macro to create a new type
-   ```rust
+   ```rust,ignore
    use rome_analyze::declare_rule;
     
    declare_rule! {
@@ -160,7 +160,7 @@ for more information about it;
  # Example
 
  The macro itself expect the following syntax:
- ```rust
+ ```rust,ignore
 use rome_analyze::declare_rule;
 
  declare_rule! {
@@ -185,7 +185,7 @@ use rome_analyze::declare_rule;
  blocks in Rust doc-comments are assumed to be written in Rust by default
  the language of the test must be explicitly specified, for instance:
 
- ```rust
+ ```rust,ignore
 use rome_analyze::declare_rule;
 declare_rule! {
      /// Disallow the use of `var`
@@ -206,7 +206,7 @@ declare_rule! {
  Additionally, it's possible to declare that a test should emit a diagnostic
  by adding `expect_diagnostic` to the language metadata:
 
- ```rust
+ ```rust,ignore
 use rome_analyze::declare_rule;
  declare_rule! {
      ///  Disallow the use of `var`
@@ -235,7 +235,7 @@ use rome_analyze::declare_rule;
 
  In order to do, the macro allows to add additional field to add the reason for deprecation
 
- ```rust
+ ```rust,ignore
 use rome_analyze::declare_rule;
 
  declare_rule! {

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -558,7 +558,7 @@ impl<'analysis> AnalysisFilter<'analysis> {
         G: RuleGroup,
         R: Rule,
     {
-        self.categories.contains(R::CATEGORY.into())
+        self.categories.contains(R::METADATA.category.into())
             && self.enabled_rules.map_or(true, |enabled_rules| {
                 enabled_rules
                     .iter()

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -62,8 +62,8 @@ impl RuleKey {
         Self { group, rule }
     }
 
-    pub fn rule<G: RuleGroup, R: Rule>() -> Self {
-        Self::new(G::NAME, R::METADATA.name)
+    pub fn rule<R: Rule>() -> Self {
+        Self::new(<R::Group as RuleGroup>::NAME, R::METADATA.name)
     }
 }
 

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -189,7 +189,7 @@ pub trait GroupLanguage {
 }
 
 /// This trait is implemented for tuples of [Rule] types of size 1 to 29 if the
-/// languageof all the groups in the tuple share the same associated
+/// language of all the groups in the tuple share the same associated
 /// [Language] (which is then aliased as the `Language` associated type on
 /// [CategoryLanguage] itself). It is used to ensure all the groups in a given
 /// category are all querying the same underlying language

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -56,7 +56,7 @@ pub trait RuleMeta {
 ///
 /// The macro itself expect the following syntax:
 ///
-/// ```rust
+/// ```rust,ignore
 ///use rome_analyze::declare_rule;
 ///
 /// declare_rule! {

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -21,25 +21,16 @@ pub struct RuleMetadata {
     pub docs: &'static str,
     /// Whether a rule is recommended or not
     pub recommended: bool,
-    /// The category this rule belong to, this is used for broadly filtering
-    /// rules when running the analyzer
-    pub category: RuleCategory,
 }
 
 impl RuleMetadata {
-    pub const fn new(
-        version: &'static str,
-        name: &'static str,
-        docs: &'static str,
-        category: RuleCategory,
-    ) -> Self {
+    pub const fn new(version: &'static str, name: &'static str, docs: &'static str) -> Self {
         Self {
             deprecated: None,
             version,
             name,
             docs,
             recommended: false,
-            category,
         }
     }
 
@@ -55,6 +46,7 @@ impl RuleMetadata {
 }
 
 pub trait RuleMeta {
+    type Group: RuleGroup;
     const METADATA: RuleMetadata;
 }
 
@@ -90,8 +82,9 @@ macro_rules! declare_rule {
         $vis enum $id {}
 
         impl $crate::RuleMeta for $id {
+            type Group = super::Group;
             const METADATA: $crate::RuleMetadata =
-                $crate::RuleMetadata::new($version, $name, concat!( $( $doc, "\n", )* ), super::CATEGORY) $( .$key($value) )*;
+                $crate::RuleMetadata::new($version, $name, concat!( $( $doc, "\n", )* )) $( .$key($value) )*;
         }
 
         // Declare a new `rule_category!` macro in the module context that
@@ -111,9 +104,10 @@ macro_rules! declare_rule {
 /// disabled at once
 pub trait RuleGroup {
     type Language: Language;
+    type Category: GroupCategory;
     /// The name of this group, displayed in the diagnostics emitted by its rules
     const NAME: &'static str;
-    /// Register all the rules belonging to this group into `registry` if they match `filter`
+    /// Register all the rules belonging to this group into `registry`
     fn push_rules(registry: &mut RuleRegistry<Self::Language>, filter: &AnalysisFilter);
 }
 
@@ -126,15 +120,16 @@ macro_rules! declare_group {
 
         impl $crate::RuleGroup for $id {
             type Language = <( $( $( $rule )::* , )* ) as $crate::GroupLanguage>::Language;
+            type Category = super::Category;
 
             const NAME: &'static str = $name;
 
             fn push_rules(registry: &mut $crate::RuleRegistry<Self::Language>, filter: &$crate::AnalysisFilter) {
-                $( if filter.match_rule::<Self, $( $rule )::*>() { registry.push::<Self, $( $rule )::*>(); } )*
+                $( registry.push_rule::<$( $rule )::*>(filter); )*
             }
         }
 
-        pub(self) use super::CATEGORY;
+        pub(self) use $id as Group;
 
         // Declare a `group_category!` macro in the context of this module (and
         // all its children). This macro takes the name of a rule as a string
@@ -153,12 +148,52 @@ macro_rules! declare_group {
     };
 }
 
-/// This trait is implemented for tuples of [Rule] types of size 1 to 20 if the
+/// A group category is a collection of rule groups under a given category ID,
+/// serving as a broad classification on the kind of diagnostic or code action
+/// these rule emit, and allowing whole categories of rules to be disabled at
+/// once depending on the kind of analysis being performed
+pub trait GroupCategory {
+    type Language: Language;
+    /// The category ID used for all groups and rule belonging to this category
+    const CATEGORY: RuleCategory;
+    /// Register all the groups belonging to this category into `registry`
+    fn push_groups(registry: &mut RuleRegistry<Self::Language>, filter: &AnalysisFilter);
+}
+
+#[macro_export]
+macro_rules! declare_category {
+    ( $vis:vis $id:ident { kind: $kind:ident, groups: [ $( $( $group:ident )::* , )* ] } ) => {
+        $vis enum $id {}
+
+        impl $crate::GroupCategory for $id {
+            type Language = <( $( $( $group )::* , )* ) as $crate::CategoryLanguage>::Language;
+
+            const CATEGORY: $crate::RuleCategory = $crate::RuleCategory::$kind;
+
+            fn push_groups(registry: &mut $crate::RuleRegistry<Self::Language>, filter: &$crate::AnalysisFilter) {
+                $( registry.push_group::<$( $group )::*>(filter); )*
+            }
+        }
+
+        pub(self) use $id as Category;
+    };
+}
+
+/// This trait is implemented for tuples of [Rule] types of size 1 to 29 if the
 /// query type of all the rules in the tuple share the same associated
 /// [Language] (which is then aliased as the `Language` associated type on
 /// [GroupLanguage] itself). It is used to ensure all the rules in a given
 /// group are all querying the same underlying language
 pub trait GroupLanguage {
+    type Language: Language;
+}
+
+/// This trait is implemented for tuples of [Rule] types of size 1 to 29 if the
+/// languageof all the groups in the tuple share the same associated
+/// [Language] (which is then aliased as the `Language` associated type on
+/// [CategoryLanguage] itself). It is used to ensure all the groups in a given
+/// category are all querying the same underlying language
+pub trait CategoryLanguage {
     type Language: Language;
 }
 
@@ -170,6 +205,13 @@ macro_rules! impl_group_language {
             $head: Rule $( , $rest: Rule, <$rest as Rule>::Query: Queryable<Language = RuleLanguage<$head>> )*
         {
             type Language = RuleLanguage<$head>;
+        }
+
+        impl<$head $( , $rest )*> CategoryLanguage for ($head, $( $rest ),*)
+        where
+            $head: RuleGroup $( , $rest: RuleGroup<Language = <$head as RuleGroup>::Language> )*
+        {
+            type Language = <$head as RuleGroup>::Language;
         }
 
         impl_group_language!( $( $rest ),* );

--- a/crates/rome_js_analyze/src/analyzers.rs
+++ b/crates/rome_js_analyze/src/analyzers.rs
@@ -1,10 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 mod correctness;
-pub(super) use self::correctness::Correctness;
 mod nursery;
-pub(super) use self::nursery::Nursery;
 mod style;
-pub(super) use self::style::Style;
-#[doc = r" The ID of this rule category, used in child modules as `super::CATEGORY`"]
-pub(self) const CATEGORY: rome_analyze::RuleCategory = rome_analyze::RuleCategory::Lint;
+::rome_analyze::declare_category! { pub (crate) Analyzers { kind : Lint , groups : [self :: correctness :: Correctness , self :: nursery :: Nursery , self :: style :: Style ,] } }

--- a/crates/rome_js_analyze/src/analyzers.rs
+++ b/crates/rome_js_analyze/src/analyzers.rs
@@ -6,3 +6,5 @@ mod nursery;
 pub(super) use self::nursery::Nursery;
 mod style;
 pub(super) use self::style::Style;
+#[doc = r" The ID of this rule category, used in child modules as `super::CATEGORY`"]
+pub(self) const CATEGORY: rome_analyze::RuleCategory = rome_analyze::RuleCategory::Lint;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_async_promise_executor.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_async_promise_executor.rs
@@ -1,4 +1,4 @@
-use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{JsAnyExpression, JsAnyFunction, JsNewExpression, JsNewExpressionFields};
 use rome_rowan::{AstNode, AstSeparatedList};
@@ -42,8 +42,6 @@ declare_rule! {
 }
 
 impl Rule for NoAsyncPromiseExecutor {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsNewExpression>;
     type State = JsAnyFunction;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_comment_text.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_comment_text.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -42,8 +40,6 @@ declare_rule! {
 }
 
 impl Rule for NoCommentText {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsxText>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_compare_neg_zero.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_compare_neg_zero.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -41,8 +39,6 @@ declare_rule! {
 }
 
 impl Rule for NoCompareNegZero {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsBinaryExpression>;
     type State = NoCompareNegZeroState;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_debugger.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_debugger.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_syntax::JsDebuggerStatement;
@@ -33,8 +31,6 @@ declare_rule! {
 }
 
 impl Rule for NoDebugger {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsDebuggerStatement>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_delete.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_delete.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -44,8 +42,6 @@ declare_rule! {
 }
 
 impl Rule for NoDelete {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsUnaryExpression>;
     type State = MemberExpression;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -54,8 +52,6 @@ declare_rule! {
 }
 
 impl Rule for NoDoubleEquals {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsBinaryExpression>;
     type State = JsSyntaxToken;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_empty_pattern.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_empty_pattern.rs
@@ -1,4 +1,4 @@
-use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{JsArrayBindingPattern, JsObjectBindingPattern};
 use rome_rowan::{declare_node_union, AstNode, AstSeparatedList};
@@ -40,8 +40,6 @@ declare_rule! {
 }
 
 impl Rule for NoEmptyPattern {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsAnyBindPatternLike>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_extra_boolean_cast.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_extra_boolean_cast.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_syntax::{
@@ -146,8 +144,6 @@ fn is_negation(node: &JsSyntaxNode) -> Option<JsUnaryExpression> {
 }
 
 impl Rule for NoExtraBooleanCast {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsAnyExpression>;
     type State = (JsAnyExpression, ExtraBooleanCastType);
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_implicit_boolean.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_implicit_boolean.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -51,8 +49,6 @@ declare_rule! {
 }
 
 impl Rule for NoImplicitBoolean {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsxAttribute>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_multiple_spaces_in_regular_expression_literals.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_multiple_spaces_in_regular_expression_literals.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_syntax::{JsRegexLiteralExpression, JsSyntaxKind, JsSyntaxToken, TextRange, TextSize};
@@ -65,8 +63,6 @@ declare_rule! {
 }
 
 impl Rule for NoMultipleSpacesInRegularExpressionLiterals {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsRegexLiteralExpression>;
     type State = Vec<(usize, usize)>;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_shadow_restricted_names.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_shadow_restricted_names.rs
@@ -1,5 +1,5 @@
 use crate::globals::runtime::BUILTIN;
-use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::JsIdentifierBinding;
 use rome_rowan::AstNode;
@@ -42,8 +42,6 @@ pub struct State {
 }
 
 impl Rule for NoShadowRestrictedNames {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsIdentifierBinding>;
     type State = State;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_sparse_array.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_sparse_array.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -27,8 +25,6 @@ declare_rule! {
 }
 
 impl Rule for NoSparseArray {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsArrayExpression>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_unnecessary_continue.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_unnecessary_continue.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_syntax::{JsContinueStatement, JsLabeledStatement, JsSyntaxKind, JsSyntaxNode};
@@ -80,8 +78,6 @@ declare_rule! {
 }
 
 impl Rule for NoUnnecessaryContinue {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsContinueStatement>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_unsafe_negation.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_unsafe_negation.rs
@@ -1,7 +1,5 @@
 use crate::JsRuleAction;
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -40,8 +38,6 @@ declare_rule! {
 }
 
 impl Rule for NoUnsafeNegation {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsInOrInstanceOfExpression>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_unused_template_literal.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_unused_template_literal.rs
@@ -1,6 +1,6 @@
 use crate::JsRuleAction;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -44,8 +44,6 @@ declare_rule! {
 }
 
 impl Rule for NoUnusedTemplateLiteral {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsTemplate>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/use_block_statements.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_block_statements.rs
@@ -1,9 +1,7 @@
 use std::iter;
 
 use rome_analyze::context::RuleContext;
-use rome_analyze::{
-    declare_rule, ActionCategory, Ast, Rule, RuleAction, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{declare_rule, ActionCategory, Ast, Rule, RuleAction, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -78,8 +76,6 @@ declare_node_union! {
 }
 
 impl Rule for UseBlockStatements {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsAnyBlockStatement>;
     type State = UseBlockStatementsOperationType;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/use_simplified_logic_expression.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_simplified_logic_expression.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -57,8 +55,6 @@ declare_rule! {
 }
 
 impl Rule for UseSimplifiedLogicExpression {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsLogicalExpression>;
     /// First element of tuple is if the expression is simplified by [De Morgan's Law](https://en.wikipedia.org/wiki/De_Morgan%27s_laws) rule, the second element is the expression to replace.
     type State = (bool, JsAnyExpression);

--- a/crates/rome_js_analyze/src/analyzers/correctness/use_single_case_statement.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_single_case_statement.rs
@@ -1,8 +1,6 @@
 use std::iter;
 
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -49,8 +47,6 @@ declare_rule! {
 }
 
 impl Rule for UseSingleCaseStatement {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsCaseClause>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/use_single_var_declarator.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_single_var_declarator.rs
@@ -1,8 +1,6 @@
 use std::iter;
 
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -39,8 +37,6 @@ declare_rule! {
 }
 
 impl Rule for UseSingleVarDeclarator {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsVariableStatement>;
     type State = (
         JsSyntaxToken,

--- a/crates/rome_js_analyze/src/analyzers/correctness/use_template.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_template.rs
@@ -1,7 +1,5 @@
 use rome_analyze::RuleSuppressions;
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -55,8 +53,6 @@ declare_rule! {
 }
 
 impl Rule for UseTemplate {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsBinaryExpression>;
     type State = Vec<JsAnyExpression>;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/use_valid_typeof.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_valid_typeof.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -78,8 +76,6 @@ declare_rule! {
 }
 
 impl Rule for UseValidTypeof {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsBinaryExpression>;
     type State = (TypeofError, Option<(JsAnyExpression, JsTypeName)>);
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/correctness/use_while.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_while.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -30,8 +28,6 @@ declare_rule! {
 }
 
 impl Rule for UseWhile {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsForStatement>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_new_symbol.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_new_symbol.rs
@@ -1,7 +1,5 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -36,8 +34,6 @@ declare_rule! {
 }
 
 impl Rule for NoNewSymbol {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsNewExpression>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_unreachable.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_unreachable.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, collections::VecDeque, num::NonZeroU32, vec::IntoIter};
 
 use roaring::bitmap::RoaringBitmap;
-use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_control_flow::{builder::BlockId, ExceptionHandler, Instruction, InstructionKind};
 use rome_js_syntax::{JsLanguage, JsReturnStatement, JsSyntaxElement, JsSyntaxKind, TextRange};
@@ -48,8 +48,6 @@ declare_rule! {
 }
 
 impl Rule for NoUnreachable {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = ControlFlowGraph;
     type State = UnreachableRange;
     type Signals = UnreachableRanges;

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_optional_chain.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_optional_chain.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -85,8 +83,6 @@ pub(crate) enum UseOptionalChainState {
 }
 
 impl Rule for UseOptionalChain {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsLogicalExpression>;
     type State = UseOptionalChainState;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/style/no_negation_else.rs
+++ b/crates/rome_js_analyze/src/analyzers/style/no_negation_else.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -44,8 +42,6 @@ declare_rule! {
 }
 
 impl Rule for NoNegationElse {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsAnyCondition>;
     type State = JsUnaryExpression;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/style/use_self_closing_elements.rs
+++ b/crates/rome_js_analyze/src/analyzers/style/use_self_closing_elements.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -61,8 +59,6 @@ declare_rule! {
 }
 
 impl Rule for UseSelfClosingElements {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsxElement>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
+++ b/crates/rome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
@@ -1,6 +1,4 @@
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -50,8 +48,6 @@ declare_rule! {
 }
 
 impl Rule for UseShorthandArrayType {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<TsReferenceType>;
     type State = TsType;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/assists.rs
+++ b/crates/rome_js_analyze/src/assists.rs
@@ -1,6 +1,4 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 mod correctness;
-pub(super) use self::correctness::Correctness;
-#[doc = r" The ID of this rule category, used in child modules as `super::CATEGORY`"]
-pub(self) const CATEGORY: rome_analyze::RuleCategory = rome_analyze::RuleCategory::Action;
+::rome_analyze::declare_category! { pub (crate) Assists { kind : Action , groups : [self :: correctness :: Correctness ,] } }

--- a/crates/rome_js_analyze/src/assists.rs
+++ b/crates/rome_js_analyze/src/assists.rs
@@ -2,3 +2,5 @@
 
 mod correctness;
 pub(super) use self::correctness::Correctness;
+#[doc = r" The ID of this rule category, used in child modules as `super::CATEGORY`"]
+pub(self) const CATEGORY: rome_analyze::RuleCategory = rome_analyze::RuleCategory::Action;

--- a/crates/rome_js_analyze/src/assists/correctness/flip_bin_exp.rs
+++ b/crates/rome_js_analyze/src/assists/correctness/flip_bin_exp.rs
@@ -1,4 +1,4 @@
-use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleCategory};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
@@ -25,8 +25,6 @@ declare_rule! {
 }
 
 impl Rule for FlipBinExp {
-    const CATEGORY: RuleCategory = RuleCategory::Action;
-
     type Query = Ast<JsBinaryExpression>;
     type State = JsSyntaxKind;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/assists/correctness/inline_variable.rs
+++ b/crates/rome_js_analyze/src/assists/correctness/inline_variable.rs
@@ -1,4 +1,4 @@
-use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_semantic::{AllReferencesExtensions, Reference};
@@ -35,8 +35,6 @@ pub(crate) struct State {
 }
 
 impl Rule for InlineVariable {
-    const CATEGORY: RuleCategory = RuleCategory::Action;
-
     type Query = Semantic<JsVariableDeclarator>;
     type State = State;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/registry.rs
+++ b/crates/rome_js_analyze/src/registry.rs
@@ -4,12 +4,8 @@ use rome_analyze::{AnalysisFilter, RuleRegistry};
 use rome_js_syntax::JsLanguage;
 pub(crate) fn build_registry(filter: &AnalysisFilter) -> RuleRegistry<JsLanguage> {
     let mut registry = RuleRegistry::default();
-    registry.push_group::<crate::analyzers::Correctness>(filter);
-    registry.push_group::<crate::analyzers::Nursery>(filter);
-    registry.push_group::<crate::analyzers::Style>(filter);
-    registry.push_group::<crate::semantic_analyzers::Correctness>(filter);
-    registry.push_group::<crate::semantic_analyzers::Nursery>(filter);
-    registry.push_group::<crate::semantic_analyzers::Style>(filter);
-    registry.push_group::<crate::assists::Correctness>(filter);
+    registry.push_category::<crate::analyzers::Analyzers>(filter);
+    registry.push_category::<crate::semantic_analyzers::SemanticAnalyzers>(filter);
+    registry.push_category::<crate::assists::Assists>(filter);
     registry
 }

--- a/crates/rome_js_analyze/src/semantic_analyzers.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers.rs
@@ -1,10 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 mod correctness;
-pub(super) use self::correctness::Correctness;
 mod nursery;
-pub(super) use self::nursery::Nursery;
 mod style;
-pub(super) use self::style::Style;
-#[doc = r" The ID of this rule category, used in child modules as `super::CATEGORY`"]
-pub(self) const CATEGORY: rome_analyze::RuleCategory = rome_analyze::RuleCategory::Lint;
+::rome_analyze::declare_category! { pub (crate) SemanticAnalyzers { kind : Lint , groups : [self :: correctness :: Correctness , self :: nursery :: Nursery , self :: style :: Style ,] } }

--- a/crates/rome_js_analyze/src/semantic_analyzers.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers.rs
@@ -6,3 +6,5 @@ mod nursery;
 pub(super) use self::nursery::Nursery;
 mod style;
 pub(super) use self::style::Style;
+#[doc = r" The ID of this rule category, used in child modules as `super::CATEGORY`"]
+pub(self) const CATEGORY: rome_analyze::RuleCategory = rome_analyze::RuleCategory::Lint;

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_arguments.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_arguments.rs
@@ -1,5 +1,5 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
-use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::JsReferenceIdentifier;
 use rome_rowan::AstNode;
@@ -33,8 +33,6 @@ declare_rule! {
 }
 
 impl Rule for NoArguments {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsReferenceIdentifier>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_catch_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_catch_assign.rs
@@ -1,5 +1,5 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
-use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{JsCatchClause, JsSyntaxNode};
 use rome_rowan::AstNode;
@@ -38,8 +38,6 @@ declare_rule! {
 }
 
 impl Rule for NoCatchAssign {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     /// Why use [JsCatchClause] instead of [JsIdentifierAssignment] ? Because this could reduce search range.
     /// We only compare the declaration of [JsCatchClause] with all descent [JsIdentifierAssignment] of its body.
     type Query = Semantic<JsCatchClause>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_dupe_args.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_dupe_args.rs
@@ -1,4 +1,4 @@
-use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{
     JsAnyArrayBindingPatternElement, JsAnyBinding, JsAnyBindingPattern, JsAnyFormalParameter,
@@ -41,8 +41,6 @@ declare_rule! {
 }
 
 impl Rule for NoDupeArgs {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Ast<JsAnyFunctionAndMethod>;
     type State = JsIdentifierBinding;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_function_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_function_assign.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_semantic::{AllReferencesExtensions, Reference};
 use rome_js_syntax::{JsFunctionDeclaration, JsIdentifierBinding};
@@ -106,8 +106,6 @@ pub struct State {
 }
 
 impl Rule for NoFunctionAssign {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsFunctionDeclaration>;
     type State = State;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_import_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_import_assign.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{
     JsDefaultImportSpecifier, JsIdentifierAssignment, JsIdentifierBinding, JsImportDefaultClause,
@@ -56,8 +56,6 @@ declare_rule! {
 }
 
 impl Rule for NoImportAssign {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsAnyImportLike>;
     /// The first element of the tuple is the invalid `JsIdentifierAssignment`, the second element of the tuple is the imported `JsIdentifierBinding`.
     type State = (JsIdentifierAssignment, JsIdentifierBinding);

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_label_var.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_label_var.rs
@@ -1,5 +1,5 @@
 use crate::{semantic_services::Semantic, JsRuleAction};
-use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{JsLabeledStatement, JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::AstNode;
@@ -30,8 +30,6 @@ declare_rule! {
 }
 
 impl Rule for NoLabelVar {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsLabeledStatement>;
     /// The first element of the tuple is the name of the binding, the second element of the tuple is the label name
     type State = (JsSyntaxNode, JsSyntaxToken);

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_array_index_key.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_array_index_key.rs
@@ -1,7 +1,7 @@
 use crate::react::{is_react_call_api, ReactApiCall, ReactCloneElementCall};
 use crate::semantic_services::Semantic;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_semantic::SemanticModel;
 use rome_js_syntax::{
@@ -120,7 +120,6 @@ pub(crate) struct NoArrayIndexKeyState {
 }
 
 impl Rule for NoArrayIndexKey {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
     type Query = Semantic<NoArrayIndexKeyQuery>;
     type State = NoArrayIndexKeyState;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_children_prop.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_children_prop.rs
@@ -1,7 +1,7 @@
 use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{JsCallExpression, JsPropertyObjectMember, JsxAttribute, JsxName};
 use rome_rowan::{declare_node_union, AstNode};
@@ -39,7 +39,6 @@ pub(crate) enum NoChildrenPropState {
 }
 
 impl Rule for NoChildrenProp {
-    const CATEGORY: RuleCategory = RuleCategory::Syntax;
     type Query = Semantic<NoChildrenPropQuery>;
     type State = NoChildrenPropState;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_dangerously_set_inner_html.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_dangerously_set_inner_html.rs
@@ -1,7 +1,7 @@
 use crate::react::ReactCreateElementCall;
 use crate::semantic_services::Semantic;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Severity;
 use rome_js_syntax::{JsCallExpression, JsLiteralMemberName, JsxAnyAttributeName, JsxAttribute};
@@ -43,8 +43,6 @@ pub(crate) enum NoDangerState {
 }
 
 impl Rule for NoDangerouslySetInnerHtml {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsAnyCreateElement>;
     type State = NoDangerState;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_dangerously_set_inner_html_with_children.rs
@@ -1,7 +1,7 @@
 use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_semantic::SemanticModel;
 use rome_js_syntax::{
@@ -153,7 +153,6 @@ impl JsAnyCreateElement {
 }
 
 impl Rule for NoDangerouslySetInnerHtmlWithChildren {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
     type Query = Semantic<JsAnyCreateElement>;
     type State = RuleState;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_render_return_value.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_render_return_value.rs
@@ -1,6 +1,6 @@
 use crate::semantic_services::Semantic;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_semantic::SemanticModel;
 use rome_js_syntax::JsSyntaxKind::JS_IMPORT;
@@ -41,8 +41,6 @@ declare_rule! {
 }
 
 impl Rule for NoRenderReturnValue {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsCallExpression>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_undeclared_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_undeclared_variables.rs
@@ -4,7 +4,7 @@ use crate::globals::runtime::ES_2021;
 use crate::globals::typescript::TYPESCRIPT_BUILTIN;
 use crate::semantic_services::Semantic;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_semantic::Scope;
 use rome_js_syntax::{JsReferenceIdentifier, JsxReferenceIdentifier};
@@ -32,7 +32,6 @@ declare_node_union! {
 }
 
 impl Rule for NoUndeclaredVariables {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
     type Query = Semantic<NoUndeclaredVariablesQuery>;
     type State = String;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_unused_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_unused_variables.rs
@@ -1,5 +1,5 @@
 use crate::semantic_services::Semantic;
-use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_semantic::{AllReferencesExtensions, SemanticScopeExtensions};
 use rome_js_syntax::{
@@ -165,8 +165,6 @@ fn is_typescript_unused_ok(binding: &JsIdentifierBinding) -> Option<()> {
 }
 
 impl Rule for NoUnusedVariables {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsIdentifierBinding>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_useless_fragments.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_useless_fragments.rs
@@ -2,7 +2,7 @@ use crate::react::{jsx_member_name_is_react_fragment, jsx_reference_identifier_i
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, ActionCategory, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make::{
@@ -96,8 +96,6 @@ impl NoUselessFragmentsQuery {
 }
 
 impl Rule for NoUselessFragments {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<NoUselessFragmentsQuery>;
     type State = NoUselessFragmentsState;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_void_elements_with_children.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_void_elements_with_children.rs
@@ -2,7 +2,7 @@ use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, ActionCategory, Rule, RuleDiagnostic};
 use rome_console::{markup, MarkupBuf};
 use rome_diagnostics::Applicability;
 use rome_js_factory::make::{jsx_attribute_list, jsx_self_closing_element};
@@ -191,7 +191,6 @@ impl NoVoidElementsWithChildrenState {
 }
 
 impl Rule for NoVoidElementsWithChildren {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
     type Query = Semantic<NoVoidElementsWithChildrenQuery>;
     type State = NoVoidElementsWithChildrenState;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_button_type.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_button_type.rs
@@ -1,6 +1,6 @@
 use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
-use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Severity;
 use rome_js_syntax::{
@@ -59,8 +59,6 @@ pub(crate) struct UseButtonTypeState {
 }
 
 impl Rule for UseButtonType {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<UseButtonTypeQuery>;
     type State = UseButtonTypeState;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_camel_case.rs
@@ -3,9 +3,7 @@ use crate::{
     utils::{rename::RenameSymbolExtensions, ToCamelCase},
     JsRuleAction,
 };
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_semantic::{AllReferencesExtensions, IsExportedCanBeQueried, SemanticModel};
@@ -97,8 +95,6 @@ fn is_non_camel_ok(binding: &JsIdentifierBinding, model: &SemanticModel) -> Opti
 }
 
 impl Rule for UseCamelCase {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsAnyCamelCaseName>;
     type State = State;
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_fragment_syntax.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_fragment_syntax.rs
@@ -2,7 +2,7 @@ use crate::react::{jsx_member_name_is_react_fragment, jsx_reference_identifier_i
 use crate::semantic_services::Semantic;
 use crate::JsRuleAction;
 use rome_analyze::context::RuleContext;
-use rome_analyze::{declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic};
+use rome_analyze::{declare_rule, ActionCategory, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make::{
@@ -35,7 +35,6 @@ declare_rule! {
 }
 
 impl Rule for UseFragmentSyntax {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
     type Query = Semantic<JsxElement>;
     type State = ();
     type Signals = Option<Self::State>;

--- a/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
@@ -1,7 +1,5 @@
 use crate::{semantic_services::Semantic, utils::batch::JsBatchMutation, JsRuleAction};
-use rome_analyze::{
-    context::RuleContext, declare_rule, ActionCategory, Rule, RuleCategory, RuleDiagnostic,
-};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_semantic::{AllReferencesExtensions, Reference};
@@ -84,8 +82,6 @@ pub struct State {
 }
 
 impl Rule for NoShoutyConstants {
-    const CATEGORY: RuleCategory = RuleCategory::Lint;
-
     type Query = Semantic<JsVariableDeclarator>;
     type State = State;
     type Signals = Option<Self::State>;

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -387,6 +387,7 @@ pub struct Nursery {
 #[doc = r" A list of rules that belong to this group"]
 struct NurserySchema {
     no_array_index_key: Option<RuleConfiguration>,
+    no_children_prop: Option<RuleConfiguration>,
     no_dangerously_set_inner_html: Option<RuleConfiguration>,
     no_dangerously_set_inner_html_with_children: Option<RuleConfiguration>,
     no_new_symbol: Option<RuleConfiguration>,
@@ -403,8 +404,9 @@ struct NurserySchema {
 }
 impl Nursery {
     const CATEGORY_NAME: &'static str = "nursery";
-    pub(crate) const CATEGORY_RULES: [&'static str; 14] = [
+    pub(crate) const CATEGORY_RULES: [&'static str; 15] = [
         "noArrayIndexKey",
+        "noChildrenProp",
         "noDangerouslySetInnerHtml",
         "noDangerouslySetInnerHtmlWithChildren",
         "noNewSymbol",

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -491,6 +491,16 @@
             }
           ]
         },
+        "noChildrenProp": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "noDangerouslySetInnerHtml": {
           "anyOf": [
             {

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -156,6 +156,7 @@ export interface Correctness {
  */
 export interface Nursery {
 	noArrayIndexKey?: RuleConfiguration;
+	noChildrenProp?: RuleConfiguration;
 	noDangerouslySetInnerHtml?: RuleConfiguration;
 	noDangerouslySetInnerHtmlWithChildren?: RuleConfiguration;
 	noNewSymbol?: RuleConfiguration;

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -260,6 +260,13 @@ to promote these rules into a more appropriate category.
 Discourage the usage of Array index in keys.
 </div>
 <div class="rule">
+<h3 data-toc-exclude id="noChildrenProp">
+	<a href="/docs/lint/rules/noChildrenProp">noChildrenProp (since v0.10.0)</a>
+	<a class="header-anchor" href="#noChildrenProp"></a>
+</h3>
+Prevent passing of <strong>children</strong> as props.
+</div>
+<div class="rule">
 <h3 data-toc-exclude id="noDangerouslySetInnerHtml">
 	<a href="/docs/lint/rules/noDangerouslySetInnerHtml">noDangerouslySetInnerHtml (since v0.10.0)</a>
 	<a class="header-anchor" href="#noDangerouslySetInnerHtml"></a>

--- a/website/src/docs/lint/rules/noChildrenProp.md
+++ b/website/src/docs/lint/rules/noChildrenProp.md
@@ -1,0 +1,48 @@
+---
+title: Lint Rule noChildrenProp
+layout: layouts/rule.liquid
+---
+
+# noChildrenProp (since v0.10.0)
+
+Prevent passing of **children** as props.
+
+When using JSX, the children should be nested between the opening and closing tags.
+When not using JSX, the children should be passed as additional arguments to `React.createElement`.
+
+## Examples
+
+### Invalid
+
+```jsx
+<FirstComponent children={'foo'} />
+```
+
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noChildrenProp.js:1:17 <a href="https://rome.tools/docs/lint/rules/noChildrenProp">lint/nursery/noChildrenProp</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid passing </span><span style="color: Orange;"><strong>children</strong></span><span style="color: Orange;"> using a prop</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;FirstComponent children={'foo'} /&gt;
+   <strong>   │ </strong>                <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The canonical way to pass children in React is to use JSX elements</span>
+  
+</code></pre>{% endraw %}
+
+```jsx
+React.createElement('div', { children: 'foo' });
+```
+
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noChildrenProp.js:1:30 <a href="https://rome.tools/docs/lint/rules/noChildrenProp">lint/nursery/noChildrenProp</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid passing </span><span style="color: Orange;"><strong>children</strong></span><span style="color: Orange;"> using a prop</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>React.createElement('div', { children: 'foo' });
+   <strong>   │ </strong>                             <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The canonical way to pass children in React is to use additional arguments to React.createElement</span>
+  
+</code></pre>{% endraw %}
+

--- a/xtask/codegen/src/generate_analyzer.rs
+++ b/xtask/codegen/src/generate_analyzer.rs
@@ -61,9 +61,19 @@ fn generate_category(
         );
     }
 
+    let category_id = match name {
+        "syntax" => format_ident!("Syntax"),
+        "analyzers" | "semantic_analyzers" => format_ident!("Lint"),
+        "assists" => format_ident!("Action"),
+        _ => panic!("unimplemented analyzer category {name:?}"),
+    };
+
     let groups = groups.into_iter().map(|(_, tokens)| tokens);
     let tokens = xtask::reformat(quote! {
         #( #groups )*
+
+        /// The ID of this rule category, used in child modules as `super::CATEGORY`
+        pub(self) const CATEGORY: rome_analyze::RuleCategory = rome_analyze::RuleCategory::#category_id;
     })?;
 
     fs2::write(


### PR DESCRIPTION
## Summary

This PR modifies the `declare_rule!` macro to automatically assign the correct `RuleCategory` to the metadata of a rule, instead of having to explicitly specify it as an associated constant on the `Rule` trait. This change relies on the specific module structure of the language analyzer implementations, specifically that rules are implemented in nested modules following the `<category>::<group>::<rule>` pattern in order to access information about the group of the rule using `super`, and information about the category using `super::super`.

I also decided to try and go one step further with this change by actually tying the rule to their group, and the groups to their category at the type system level (using an associated type on a trait). This means the category / group / rule hierarchy is now cyclic as each of these item knows both about it's parent and / or children, but that doesn't pose any problem in practice since this is only type-level metadata that gets resolved lazily by the Rust compiler as the generic code gets monomorphized. It does allow making a number of generic functions simple however, since they now only need to be generic on the type of a lint rule and can access the type of the group using the `Group` associated type, instead of being provided with the group as a second generic type.

## Test Plan

This is mostly type-level only change, it should only have minimal impact on the how the code works. One notable exception is a change to the filtering code (filtering of categories and groups now happens earlier in the registry building code), but this behavior is largely covered by the existing analyzer tests.
