### PR TITLE
feat(rome_js_formatter): new print fill entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,7 @@ version = "0.0.0"
 dependencies = [
  "cfg-if",
  "countme",
+ "drop_bomb",
  "indexmap",
  "rome_diagnostics",
  "rome_js_parser",

--- a/crates/rome_formatter/Cargo.toml
+++ b/crates/rome_formatter/Cargo.toml
@@ -17,6 +17,7 @@ schemars = { version = "0.8.10", optional = true }
 rustc-hash = "1.1.0"
 countme = "3.0.1"
 indexmap = "1.9.1"
+drop_bomb = "0.1.5"
 
 [dev-dependencies]
 rome_js_parser = { path = "../rome_js_parser"}

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -785,9 +785,10 @@ impl<'a, 'print> FitsOnLine<'a, 'print> {
             &self.printer.options,
         );
 
-        if !matches!(self.queue.top(), Some(FormatElement::Tag(Tag::StartEntry)))
-            && !matches!(self.queue.top(), Some(FormatElement::Tag(Tag::EndFill)))
-        {
+        if !matches!(
+            self.queue.top(),
+            Some(FormatElement::Tag(Tag::StartEntry | Tag::EndFill))
+        ) {
             self.queue.skip_content(TagKind::Entry);
         }
 

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -833,14 +833,6 @@ impl<'a, 'print> FitsOnLine<'a, 'print> {
 
         let fits = all_fit.fits();
 
-        // Advance the queue to the next entry
-        if !matches!(
-            self.queue.top(),
-            Some(FormatElement::Tag(Tag::StartEntry | Tag::EndFill))
-        ) {
-            self.queue.skip_content(TagKind::Entry);
-        }
-
         self.printer.state.fits_stack = fits_stack.finish();
         self.printer.state.fits_stack.clear();
 

--- a/crates/rome_formatter/src/printer/queue.rs
+++ b/crates/rome_formatter/src/printer/queue.rs
@@ -335,6 +335,7 @@ impl FitsPredicate for SingleEntryPredicate {
 
                     if *depth == 0 {
                         *self = SingleEntryPredicate::Done;
+                        return Ok(false);
                     }
 
                     true

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -861,9 +861,13 @@ function() {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-function test() {
-return srcPipe.pipe(generator.stream).pipe(compile()).pipe(gulp.dest(out));
-}"#;
+ (
+  <div>
+    <br />
+    texttexttexttexttexttexttexttexttexxxxxxxxxxttextxxxtexttext{typeeeggggee}{" "}
+  </div>
+);
+"#;
         let syntax = SourceType::jsx();
         let tree = parse(src, FileId::zero(), syntax);
         let options = JsFormatOptions::new(syntax);


### PR DESCRIPTION
## Summary

We have a jsx formatting problem with the current `print_fill_entries`.  
The problem is well described in https://github.com/rome/tools/pull/3251#issuecomment-1264447408
This PR tries to implement @MichaReiser [proposal](https://github.com/rome/tools/pull/3251#issuecomment-1264460093)

## Test Plan

Tested that https://github.com/rome/tools/pull/3251 now formats correctly
![Screenshot 2022-10-10 at 7 48 19 AM](https://user-images.githubusercontent.com/6227442/194800709-35996d55-1220-490d-b177-cdc88312d88f.png)
