### PR TITLE
fix(rome_fs): improve the messaging of the "unhandled file type" diagnostic

### DIFF
--- a/crates/rome_cli/tests/snapshots/main_check/fs_error_symlink.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/fs_error_symlink.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Emitted Messages
+
+```block
+prefix/ci.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Symbolic links are not supported
+  
+  i Rome does not currently support visiting the content of symbolic links since it could lead to an infinite traversal loop
+  
+
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_check/fs_error_unknown.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/fs_error_unknown.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Emitted Messages
+
+```block
+prefix/ci.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Encountered an unknown file type
+  
+  i Rome encountered a file system entry that's neither a file, directory or symbolic link
+  
+
+```
+
+

--- a/crates/rome_fs/src/fs/os.rs
+++ b/crates/rome_fs/src/fs/os.rs
@@ -1,13 +1,12 @@
 //! Implementation of the [FileSystem] and related traits for the underlying OS filesystem
-use super::{BoxedTraversal, File};
+use super::{BoxedTraversal, File, UnhandledDiagnostic, UnhandledKind};
 use crate::fs::{FileSystemExt, OpenOptions};
 use crate::{
     fs::{TraversalContext, TraversalScope},
     FileSystem, RomePath,
 };
 use rayon::{scope, Scope};
-use rome_diagnostics::v2::{adapters::IoError, console, Diagnostic, DiagnosticExt, Error, FileId};
-use rome_diagnostics::v2::{Advices, LogCategory, Visit};
+use rome_diagnostics::v2::{adapters::IoError, DiagnosticExt, Error, FileId};
 use std::{
     ffi::OsStr,
     fs,
@@ -208,56 +207,6 @@ fn handle_dir<'scope>(
             file_id,
             file_kind: UnhandledKind::from(file_type),
         }));
-    }
-}
-
-#[derive(Debug, Diagnostic)]
-#[diagnostic(severity = Warning, category = "internalError/fs")]
-struct UnhandledDiagnostic {
-    #[location(resource)]
-    file_id: FileId,
-    #[message]
-    #[description]
-    #[advice]
-    file_kind: UnhandledKind,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum UnhandledKind {
-    Symlink,
-    Other,
-}
-
-impl console::fmt::Display for UnhandledKind {
-    fn fmt(&self, fmt: &mut console::fmt::Formatter) -> io::Result<()> {
-        match self {
-            UnhandledKind::Symlink => fmt.write_str("Symbolic links are not supported"),
-            UnhandledKind::Other => fmt.write_str("Encountered an unknown file type"),
-        }
-    }
-}
-
-impl std::fmt::Display for UnhandledKind {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            UnhandledKind::Symlink => write!(fmt, "Symbolic links are not supported"),
-            UnhandledKind::Other => write!(fmt, "Encountered an unknown file type"),
-        }
-    }
-}
-
-impl Advices for UnhandledKind {
-    fn record(&self, visitor: &mut dyn Visit) -> io::Result<()> {
-        match self {
-            UnhandledKind::Symlink => visitor.record_log(
-                LogCategory::Info,
-                &"Rome does not currently support visiting the content of symbolic links since it could lead to an infinite traversal loop",
-            ),
-            UnhandledKind::Other => visitor.record_log(
-                LogCategory::Info,
-                &"Rome encountered a file system entry that's neither a file, directory or symbolic link",
-            ),
-        }
     }
 }
 

--- a/crates/rome_fs/src/lib.rs
+++ b/crates/rome_fs/src/lib.rs
@@ -3,8 +3,8 @@ mod interner;
 mod path;
 
 pub use fs::{
-    FileSystem, FileSystemExt, MemoryFileSystem, OpenOptions, OsFileSystem, TraversalContext,
-    TraversalScope,
+    ErrorEntry, FileSystem, FileSystemExt, MemoryFileSystem, OpenOptions, OsFileSystem,
+    TraversalContext, TraversalScope,
 };
 pub use interner::{AtomicInterner, IndexSetInterner, PathInterner};
 pub use path::RomePath;


### PR DESCRIPTION
## Summary

Fixes #3329

This PR changes the rendering of the `UnhandledDiagnostic` diagnostic type, emitted by the `OsFileSystem` when an unknown file type is encountered. It adds an explicit error message and description, along with an information advices providing additional details. It also adds a specialized version of the error message when the unhandled file is a symbolic link, as that's the most common case for this error to be raised. Finally, it downgrades the severity of the diagnostic from error to warning, since this is not a "fatal" error that should cause the traversal to abort.

The diagnostic should now be printed as follow when encountering a symbolic link:
```text
..\test-link\link internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ! Symbolic links are not supported

  i Rome does not currently support visiting the content of symbolic links since it could lead to an infinite traversal loop
```

In the less likely case that the CLI encounters a completely unknown file type, the following message is displayed instead:
```text
..\test-link\unknown internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ! Encountered an unknown file type

  i Rome encountered a file system entry that's neither a file, directory or symbolic link
```

## Test Plan

This diagnostic is emitted by low-level code in response to an event from the underlying file system, so it's unfortunately hard to reliably test and reproduce across platforms.
