### PR TITLE
feat(rome_js_analyzer): rule `noAutofocus`

### DIFF
--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -52,6 +52,7 @@ define_dategories! {
     "lint/nursery/useFragmentSyntax": "https://rome.tools/docs/lint/rules/useFragmentSyntax",
     "lint/nursery/noArrayIndexKey": "https://rome.tools/docs/lint/rules/noArrayIndexKey",
     "lint/nursery/noDangerouslySetInnerHtmlWithChildren": "https://rome.tools/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren",
+    "lint/nursery/noAutofocus": "https://rome.tools/docs/lint/rules/noAutofocus",
     "lint/style/noNegationElse": "https://rome.tools/docs/lint/rules/noNegationElse",
     "lint/style/noShoutyConstants": "https://rome.tools/docs/lint/rules/noShoutyConstants",
     "lint/style/useSelfClosingElements": "https://rome.tools/docs/lint/rules/useSelfClosingElements",

--- a/crates/rome_js_analyze/src/analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery.rs
@@ -1,7 +1,8 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 use rome_analyze::declare_group;
+mod no_auto_focus;
 mod no_new_symbol;
 mod no_unreachable;
 mod use_optional_chain;
-declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_new_symbol :: NoNewSymbol , self :: no_unreachable :: NoUnreachable , self :: use_optional_chain :: UseOptionalChain ,] } }
+declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_auto_focus :: NoAutoFocus , self :: no_new_symbol :: NoNewSymbol , self :: no_unreachable :: NoUnreachable , self :: use_optional_chain :: UseOptionalChain ,] } }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_auto_focus.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_auto_focus.rs
@@ -1,0 +1,119 @@
+use crate::JsRuleAction;
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
+use rome_console::markup;
+use rome_diagnostics::Applicability;
+use rome_js_syntax::{JsxAttribute, JsxSelfClosingElement, JsxSelfClosingElementFields};
+use rome_rowan::{AstNode, BatchMutationExt};
+
+declare_rule! {
+    /// Avoid the `autoFocus` attribute
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <input autoFocus />
+    /// ```
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <input autoFocus="true" />
+    /// ```
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <input autoFocus={"false"} />
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```jsx
+    /// <input />
+    ///```
+    ///
+    /// ```jsx
+    /// <input autoFocus={undefined} />
+    ///```
+    ///
+    /// ```jsx
+    /// <Input autoFocus={"false"} />
+    ///```
+    pub(crate) NoAutoFocus {
+        version: "10.0.0",
+        name: "noAutofocus",
+        recommended: false,
+    }
+}
+
+impl Rule for NoAutoFocus {
+    type Query = Ast<JsxSelfClosingElement>;
+    type State = JsxAttribute;
+    type Signals = Option<Self::State>;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        let JsxSelfClosingElementFields {
+            l_angle_token: _,
+            name,
+            type_arguments: _,
+            attributes: _,
+            slash_token: _,
+            r_angle_token: _,
+        } = node.as_fields();
+
+        if name.ok()?.text().trim() == "input" {
+            let attribute = node.find_attribute_by_name("autoFocus").ok()??;
+            match attribute.initializer() {
+                Some(initializer) => match initializer.value().ok() {
+                    Some(value) => {
+                        let value = match value.as_jsx_expression_attribute_value() {
+                            Some(value) => value,
+                            None => return Some(attribute),
+                        };
+                        let value = match value.expression().ok() {
+                            Some(value) => value.text(),
+                            None => return Some(attribute),
+                        };
+                        if value.trim() == "undefined" {
+                            return None;
+                        } else {
+                            return Some(attribute);
+                        }
+                    }
+                    None => {
+                        return Some(attribute);
+                    }
+                },
+                None => {
+                    return Some(attribute);
+                }
+            }
+        }
+
+        None
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, attr: &Self::State) -> Option<RuleDiagnostic> {
+        Some(RuleDiagnostic::new(
+            rule_category!(),
+            attr.range(),
+            markup! {
+                "Avoid the "<Emphasis>"autoFocus"</Emphasis>" attribute."
+            }
+            .to_owned(),
+        ))
+    }
+
+    fn action(ctx: &RuleContext<Self>, attr: &Self::State) -> Option<JsRuleAction> {
+        let mut mutation = ctx.root().begin();
+
+        mutation.remove_node(attr.to_owned());
+
+        Some(JsRuleAction {
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::MaybeIncorrect,
+            message: markup! { "Remove the "<Emphasis>"autoFocus"</Emphasis>" attribute." }
+                .to_owned(),
+            mutation,
+        })
+    }
+}

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_auto_focus.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_auto_focus.rs
@@ -71,7 +71,7 @@ impl Rule for NoAutoFocus {
     fn diagnostic(_ctx: &RuleContext<Self>, attr: &Self::State) -> Option<RuleDiagnostic> {
         Some(RuleDiagnostic::new(
             rule_category!(),
-            attr.range(),
+            attr.syntax().text_trimmed_range(),
             markup! {
                 "Avoid the "<Emphasis>"autoFocus"</Emphasis>" attribute."
             },

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_auto_focus.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_auto_focus.rs
@@ -51,9 +51,9 @@ impl Rule for NoAutoFocus {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let name = node.name().ok()?;
+        let name = node.name().ok()?.syntax().text_trimmed();
 
-        if name.syntax().text_trimmed() == "input" {
+        if name == "input" {
             let attribute = node.find_attribute_by_name("autoFocus").ok()??;
 
             if let Some(value) = get_attribute_value(&attribute) {

--- a/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusInvalid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusInvalid.jsx
@@ -1,0 +1,5 @@
+<>
+    <input autoFocus />
+    <input autoFocus="true" />
+    <input autoFocus={"false"} />
+</>

--- a/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusInvalid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusInvalid.jsx
@@ -1,5 +1,7 @@
 <>
+    <button autoFocus />
     <input autoFocus />
     <input autoFocus="true" />
+    <input autoFocus={undefined} />
     <input autoFocus={"false"} />
 </>

--- a/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusInvalid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusInvalid.jsx.snap
@@ -5,28 +5,30 @@ expression: noAutoFocusInvalid.jsx
 # Input
 ```js
 <>
+    <button autoFocus />
     <input autoFocus />
     <input autoFocus="true" />
+    <input autoFocus={undefined} />
     <input autoFocus={"false"} />
 </>
 ```
 
 # Diagnostics
 ```
-noAutoFocusInvalid.jsx:2:12 lint/nursery/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+noAutoFocusInvalid.jsx:2:13 lint/nursery/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Avoid the autoFocus attribute.
   
     1 │ <>
-  > 2 │     <input autoFocus />
-      │            ^^^^^^^^^
-    3 │     <input autoFocus="true" />
-    4 │     <input autoFocus={"false"} />
+  > 2 │     <button autoFocus />
+      │             ^^^^^^^^^
+    3 │     <input autoFocus />
+    4 │     <input autoFocus="true" />
   
   i Suggested fix: Remove the autoFocus attribute.
   
-    2 │ ····<input·autoFocus·/>
-      │            ----------  
+    2 │ ····<button·autoFocus·/>
+      │             ----------  
 
 ```
 
@@ -36,16 +38,16 @@ noAutoFocusInvalid.jsx:3:12 lint/nursery/noAutofocus  FIXABLE  ━━━━━�
   ! Avoid the autoFocus attribute.
   
     1 │ <>
-    2 │     <input autoFocus />
-  > 3 │     <input autoFocus="true" />
-      │            ^^^^^^^^^^^^^^^^
-    4 │     <input autoFocus={"false"} />
-    5 │ </>
+    2 │     <button autoFocus />
+  > 3 │     <input autoFocus />
+      │            ^^^^^^^^^
+    4 │     <input autoFocus="true" />
+    5 │     <input autoFocus={undefined} />
   
   i Suggested fix: Remove the autoFocus attribute.
   
-    3 │ ····<input·autoFocus="true"·/>
-      │            -----------------  
+    3 │ ····<input·autoFocus·/>
+      │            ----------  
 
 ```
 
@@ -54,15 +56,53 @@ noAutoFocusInvalid.jsx:4:12 lint/nursery/noAutofocus  FIXABLE  ━━━━━�
 
   ! Avoid the autoFocus attribute.
   
-    2 │     <input autoFocus />
-    3 │     <input autoFocus="true" />
-  > 4 │     <input autoFocus={"false"} />
-      │            ^^^^^^^^^^^^^^^^^^^
-    5 │ </>
+    2 │     <button autoFocus />
+    3 │     <input autoFocus />
+  > 4 │     <input autoFocus="true" />
+      │            ^^^^^^^^^^^^^^^^
+    5 │     <input autoFocus={undefined} />
+    6 │     <input autoFocus={"false"} />
   
   i Suggested fix: Remove the autoFocus attribute.
   
-    4 │ ····<input·autoFocus={"false"}·/>
+    4 │ ····<input·autoFocus="true"·/>
+      │            -----------------  
+
+```
+
+```
+noAutoFocusInvalid.jsx:5:12 lint/nursery/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid the autoFocus attribute.
+  
+    3 │     <input autoFocus />
+    4 │     <input autoFocus="true" />
+  > 5 │     <input autoFocus={undefined} />
+      │            ^^^^^^^^^^^^^^^^^^^^^
+    6 │     <input autoFocus={"false"} />
+    7 │ </>
+  
+  i Suggested fix: Remove the autoFocus attribute.
+  
+    5 │ ····<input·autoFocus={undefined}·/>
+      │            ----------------------  
+
+```
+
+```
+noAutoFocusInvalid.jsx:6:12 lint/nursery/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid the autoFocus attribute.
+  
+    4 │     <input autoFocus="true" />
+    5 │     <input autoFocus={undefined} />
+  > 6 │     <input autoFocus={"false"} />
+      │            ^^^^^^^^^^^^^^^^^^^
+    7 │ </>
+  
+  i Suggested fix: Remove the autoFocus attribute.
+  
+    6 │ ····<input·autoFocus={"false"}·/>
       │            --------------------  
 
 ```

--- a/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusInvalid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusInvalid.jsx.snap
@@ -1,0 +1,70 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: noAutoFocusInvalid.jsx
+---
+# Input
+```js
+<>
+    <input autoFocus />
+    <input autoFocus="true" />
+    <input autoFocus={"false"} />
+</>
+```
+
+# Diagnostics
+```
+noAutoFocusInvalid.jsx:2:12 lint/nursery/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid the autoFocus attribute.
+  
+    1 │ <>
+  > 2 │     <input autoFocus />
+      │            ^^^^^^^^^
+    3 │     <input autoFocus="true" />
+    4 │     <input autoFocus={"false"} />
+  
+  i Suggested fix: Remove the autoFocus attribute.
+  
+    2 │ ····<input·autoFocus·/>
+      │            ----------  
+
+```
+
+```
+noAutoFocusInvalid.jsx:3:12 lint/nursery/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid the autoFocus attribute.
+  
+    1 │ <>
+    2 │     <input autoFocus />
+  > 3 │     <input autoFocus="true" />
+      │            ^^^^^^^^^^^^^^^^
+    4 │     <input autoFocus={"false"} />
+    5 │ </>
+  
+  i Suggested fix: Remove the autoFocus attribute.
+  
+    3 │ ····<input·autoFocus="true"·/>
+      │            -----------------  
+
+```
+
+```
+noAutoFocusInvalid.jsx:4:12 lint/nursery/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid the autoFocus attribute.
+  
+    2 │     <input autoFocus />
+    3 │     <input autoFocus="true" />
+  > 4 │     <input autoFocus={"false"} />
+      │            ^^^^^^^^^^^^^^^^^^^
+    5 │ </>
+  
+  i Suggested fix: Remove the autoFocus attribute.
+  
+    4 │ ····<input·autoFocus={"false"}·/>
+      │            --------------------  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusValid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusValid.jsx
@@ -1,0 +1,5 @@
+<>
+	<input />
+    <input autoFocus={undefined} />
+    <Input autoFocus={"false"} />
+</>

--- a/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusValid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusValid.jsx
@@ -1,5 +1,6 @@
 <>
-	<input />
-    <input autoFocus={undefined} />
-    <Input autoFocus={"false"} />
+	<div />
+	<button />
+    <input />
+    <MyComponent autoFocus={true} />
 </>

--- a/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusValid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusValid.jsx.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: noAutoFocusValid.jsx
+---
+# Input
+```js
+<>
+	<input />
+    <input autoFocus={undefined} />
+    <Input autoFocus={"false"} />
+</>
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusValid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noAutofocus/noAutoFocusValid.jsx.snap
@@ -5,9 +5,10 @@ expression: noAutoFocusValid.jsx
 # Input
 ```js
 <>
-	<input />
-    <input autoFocus={undefined} />
-    <Input autoFocus={"false"} />
+	<div />
+	<button />
+    <input />
+    <MyComponent autoFocus={true} />
 </>
 ```
 

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -387,6 +387,7 @@ pub struct Nursery {
 #[doc = r" A list of rules that belong to this group"]
 struct NurserySchema {
     no_array_index_key: Option<RuleConfiguration>,
+    no_autofocus: Option<RuleConfiguration>,
     no_children_prop: Option<RuleConfiguration>,
     no_dangerously_set_inner_html: Option<RuleConfiguration>,
     no_dangerously_set_inner_html_with_children: Option<RuleConfiguration>,
@@ -404,8 +405,9 @@ struct NurserySchema {
 }
 impl Nursery {
     const CATEGORY_NAME: &'static str = "nursery";
-    pub(crate) const CATEGORY_RULES: [&'static str; 15] = [
+    pub(crate) const CATEGORY_RULES: [&'static str; 16] = [
         "noArrayIndexKey",
+        "noAutofocus",
         "noChildrenProp",
         "noDangerouslySetInnerHtml",
         "noDangerouslySetInnerHtmlWithChildren",

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -491,6 +491,16 @@
             }
           ]
         },
+        "noAutofocus": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "noChildrenProp": {
           "anyOf": [
             {

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -156,6 +156,7 @@ export interface Correctness {
  */
 export interface Nursery {
 	noArrayIndexKey?: RuleConfiguration;
+	noAutofocus?: RuleConfiguration;
 	noChildrenProp?: RuleConfiguration;
 	noDangerouslySetInnerHtml?: RuleConfiguration;
 	noDangerouslySetInnerHtmlWithChildren?: RuleConfiguration;
@@ -306,6 +307,7 @@ export type Category =
 	| "lint/nursery/useFragmentSyntax"
 	| "lint/nursery/noArrayIndexKey"
 	| "lint/nursery/noDangerouslySetInnerHtmlWithChildren"
+	| "lint/nursery/noAutofocus"
 	| "lint/style/noNegationElse"
 	| "lint/style/noShoutyConstants"
 	| "lint/style/useSelfClosingElements"

--- a/rome.json
+++ b/rome.json
@@ -13,7 +13,8 @@
 				"noUselessFragments": "error",
 				"noNewSymbol": "error",
 				"noVoidElementsWithChildren": "error",
-				"noDangerouslySetInnerHtmlWithChildren": "error"
+				"noDangerouslySetInnerHtmlWithChildren": "error",
+				"noAutofocus": "error"
 			}
 		}
 	}

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -260,6 +260,13 @@ to promote these rules into a more appropriate category.
 Discourage the usage of Array index in keys.
 </div>
 <div class="rule">
+<h3 data-toc-exclude id="noAutofocus">
+	<a href="/docs/lint/rules/noAutofocus">noAutofocus (since v10.0.0)</a>
+	<a class="header-anchor" href="#noAutofocus"></a>
+</h3>
+Avoid the <code>autoFocus</code> attribute
+</div>
+<div class="rule">
 <h3 data-toc-exclude id="noChildrenProp">
 	<a href="/docs/lint/rules/noChildrenProp">noChildrenProp (since v0.10.0)</a>
 	<a class="header-anchor" href="#noChildrenProp"></a>

--- a/website/src/docs/lint/rules/noAutofocus.md
+++ b/website/src/docs/lint/rules/noAutofocus.md
@@ -65,6 +65,24 @@ Avoid the `autoFocus` attribute
 <strong>  </strong><strong>    │ </strong>       <span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>  
 </code></pre>{% endraw %}
 
+```jsx
+<input autoFocus={undefined} />
+```
+
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noAutofocus.js:1:8 <a href="https://rome.tools/docs/lint/rules/noAutofocus">lint/nursery/noAutofocus</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid the </span><span style="color: Orange;"><strong>autoFocus</strong></span><span style="color: Orange;"> attribute.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;input autoFocus={undefined} /&gt;
+   <strong>   │ </strong>       <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove the </span><span style="color: rgb(38, 148, 255);"><strong>autoFocus</strong></span><span style="color: rgb(38, 148, 255);"> attribute.</span>
+  
+<strong>  </strong><strong>  1 │ </strong>&lt;input<span style="opacity: 0.8;">·</span><span style="color: Tomato;">a</span><span style="color: Tomato;">u</span><span style="color: Tomato;">t</span><span style="color: Tomato;">o</span><span style="color: Tomato;">F</span><span style="color: Tomato;">o</span><span style="color: Tomato;">c</span><span style="color: Tomato;">u</span><span style="color: Tomato;">s</span><span style="color: Tomato;">=</span><span style="color: Tomato;">{</span><span style="color: Tomato;">u</span><span style="color: Tomato;">n</span><span style="color: Tomato;">d</span><span style="color: Tomato;">e</span><span style="color: Tomato;">f</span><span style="color: Tomato;">i</span><span style="color: Tomato;">n</span><span style="color: Tomato;">e</span><span style="color: Tomato;">d</span><span style="color: Tomato;">}</span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span>/&gt;
+<strong>  </strong><strong>    │ </strong>       <span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>  
+</code></pre>{% endraw %}
+
 ### Valid
 
 ```jsx
@@ -72,10 +90,15 @@ Avoid the `autoFocus` attribute
 ```
 
 ```jsx
-<input autoFocus={undefined} />
+<div />
 ```
 
 ```jsx
-<Input autoFocus={"false"} />
+<button />
+```
+
+```jsx
+// `autoFocus` prop in user created component is valid
+<MyComponent autoFocus={true} />
 ```
 

--- a/website/src/docs/lint/rules/noAutofocus.md
+++ b/website/src/docs/lint/rules/noAutofocus.md
@@ -1,0 +1,81 @@
+---
+title: Lint Rule noAutofocus
+layout: layouts/rule.liquid
+---
+
+# noAutofocus (since v10.0.0)
+
+Avoid the `autoFocus` attribute
+
+## Examples
+
+### Invalid
+
+```jsx
+<input autoFocus />
+```
+
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noAutofocus.js:1:8 <a href="https://rome.tools/docs/lint/rules/noAutofocus">lint/nursery/noAutofocus</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid the </span><span style="color: Orange;"><strong>autoFocus</strong></span><span style="color: Orange;"> attribute.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;input autoFocus /&gt;
+   <strong>   │ </strong>       <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove the </span><span style="color: rgb(38, 148, 255);"><strong>autoFocus</strong></span><span style="color: rgb(38, 148, 255);"> attribute.</span>
+  
+<strong>  </strong><strong>  1 │ </strong>&lt;input<span style="opacity: 0.8;">·</span><span style="color: Tomato;">a</span><span style="color: Tomato;">u</span><span style="color: Tomato;">t</span><span style="color: Tomato;">o</span><span style="color: Tomato;">F</span><span style="color: Tomato;">o</span><span style="color: Tomato;">c</span><span style="color: Tomato;">u</span><span style="color: Tomato;">s</span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span>/&gt;
+<strong>  </strong><strong>    │ </strong>       <span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>  
+</code></pre>{% endraw %}
+
+```jsx
+<input autoFocus="true" />
+```
+
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noAutofocus.js:1:8 <a href="https://rome.tools/docs/lint/rules/noAutofocus">lint/nursery/noAutofocus</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid the </span><span style="color: Orange;"><strong>autoFocus</strong></span><span style="color: Orange;"> attribute.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;input autoFocus=&quot;true&quot; /&gt;
+   <strong>   │ </strong>       <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove the </span><span style="color: rgb(38, 148, 255);"><strong>autoFocus</strong></span><span style="color: rgb(38, 148, 255);"> attribute.</span>
+  
+<strong>  </strong><strong>  1 │ </strong>&lt;input<span style="opacity: 0.8;">·</span><span style="color: Tomato;">a</span><span style="color: Tomato;">u</span><span style="color: Tomato;">t</span><span style="color: Tomato;">o</span><span style="color: Tomato;">F</span><span style="color: Tomato;">o</span><span style="color: Tomato;">c</span><span style="color: Tomato;">u</span><span style="color: Tomato;">s</span><span style="color: Tomato;">=</span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">t</span><span style="color: Tomato;">r</span><span style="color: Tomato;">u</span><span style="color: Tomato;">e</span><span style="color: Tomato;">&quot;</span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span>/&gt;
+<strong>  </strong><strong>    │ </strong>       <span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>  
+</code></pre>{% endraw %}
+
+```jsx
+<input autoFocus={"false"} />
+```
+
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noAutofocus.js:1:8 <a href="https://rome.tools/docs/lint/rules/noAutofocus">lint/nursery/noAutofocus</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid the </span><span style="color: Orange;"><strong>autoFocus</strong></span><span style="color: Orange;"> attribute.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;input autoFocus={&quot;false&quot;} /&gt;
+   <strong>   │ </strong>       <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove the </span><span style="color: rgb(38, 148, 255);"><strong>autoFocus</strong></span><span style="color: rgb(38, 148, 255);"> attribute.</span>
+  
+<strong>  </strong><strong>  1 │ </strong>&lt;input<span style="opacity: 0.8;">·</span><span style="color: Tomato;">a</span><span style="color: Tomato;">u</span><span style="color: Tomato;">t</span><span style="color: Tomato;">o</span><span style="color: Tomato;">F</span><span style="color: Tomato;">o</span><span style="color: Tomato;">c</span><span style="color: Tomato;">u</span><span style="color: Tomato;">s</span><span style="color: Tomato;">=</span><span style="color: Tomato;">{</span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">f</span><span style="color: Tomato;">a</span><span style="color: Tomato;">l</span><span style="color: Tomato;">s</span><span style="color: Tomato;">e</span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">}</span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span>/&gt;
+<strong>  </strong><strong>    │ </strong>       <span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>  
+</code></pre>{% endraw %}
+
+### Valid
+
+```jsx
+<input />
+```
+
+```jsx
+<input autoFocus={undefined} />
+```
+
+```jsx
+<Input autoFocus={"false"} />
+```
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Closes #3297 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
Added test cases to test the situations according to [this docs](https://github.com/rome/tools/blob/archived-js/website/src/docs/lint/rules/a11y/noAutofocus.md).

<img width="1475" alt="Screenshot 2022-10-06 at 10 05 50 PM" src="https://user-images.githubusercontent.com/7545747/194334538-d22d4fa9-655b-4d73-b365-75d73b04f7ec.png">
<img width="1475" alt="Screenshot 2022-10-06 at 10 05 56 PM" src="https://user-images.githubusercontent.com/7545747/194334551-d4c99b19-8a88-4289-a1d1-97082fa2a81f.png">
<img width="1475" alt="Screenshot 2022-10-06 at 10 06 02 PM" src="https://user-images.githubusercontent.com/7545747/194334595-c5431eb3-d6ba-4eda-881c-fde5039de40e.png">

