### PR TITLE
fix(rome_js_syntax): pick trimmed text instead the raw text

### DIFF
--- a/crates/rome_js_syntax/src/expr_ext.rs
+++ b/crates/rome_js_syntax/src/expr_ext.rs
@@ -469,13 +469,15 @@ impl JsStringLiteralExpression {
     ///
     /// ```
     /// use rome_js_factory::make::{js_string_literal_expression, ident};
+    /// use rome_rowan::TriviaPieceKind;
     ///
-    ///let string = js_string_literal_expression(ident("foo"));
+    ///let string = js_string_literal_expression(ident("foo")
+    ///     .with_leading_trivia(vec![(TriviaPieceKind::Whitespace, " ")]));
     /// assert_eq!(string.inner_string_text().unwrap().text(), "foo");
     /// ```
     pub fn inner_string_text(&self) -> SyntaxResult<SyntaxTokenText> {
         let value = self.value_token()?;
-        let mut text = value.token_text();
+        let mut text = value.token_text_trimmed();
 
         static QUOTES: [char; 2] = ['"', '\''];
 

--- a/crates/rome_js_syntax/src/import_ext.rs
+++ b/crates/rome_js_syntax/src/import_ext.rs
@@ -36,13 +36,14 @@ impl JsModuleSource {
     /// ```
     /// use rome_js_factory::make::{ident, js_module_source};
     /// use rome_js_syntax::{JsAnyBinding, JsAnyImportClause, T};
-    /// let source = js_module_source(ident("react"));
+    /// use rome_rowan::TriviaPieceKind;
+    /// let source = js_module_source(ident("react").with_leading_trivia(vec![(TriviaPieceKind::Whitespace, " ")]));
     /// let text = source.inner_string_text().unwrap();
     /// assert_eq!(text.text(), "react");
     /// ```
     pub fn inner_string_text(&self) -> SyntaxResult<SyntaxTokenText> {
         let value = self.value_token()?;
-        let mut text = value.token_text();
+        let mut text = value.token_text_trimmed();
 
         static QUOTES: [char; 2] = ['"', '\''];
 

--- a/crates/rome_js_syntax/src/jsx_ext.rs
+++ b/crates/rome_js_syntax/src/jsx_ext.rs
@@ -11,13 +11,14 @@ impl JsxString {
     ///
     /// ```
     /// use rome_js_factory::make::{jsx_ident, jsx_string};
+    /// use rome_rowan::TriviaPieceKind;
     ///
-    ///let string = jsx_string(jsx_ident("button"));
+    ///let string = jsx_string(jsx_ident("button").with_leading_trivia(vec![(TriviaPieceKind::Whitespace, " ")]));
     /// assert_eq!(string.inner_string_text().unwrap().text(), "button");
     /// ```
     pub fn inner_string_text(&self) -> SyntaxResult<SyntaxTokenText> {
         let value = self.value_token()?;
-        let mut text = value.token_text();
+        let mut text = value.token_text_trimmed();
 
         static QUOTES: [char; 2] = ['"', '\''];
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes a small bug found in https://github.com/rome/tools/pull/3336#discussion_r987789842

The `inner_string_text` functions were using the whole text, while they should use the trimmed text.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I updated the doc tests by adding some trivia, to demonstrate that the issue is fixed.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
