### PR TITLE
fix(rome_service): disallow large files from being parsed and analyzed

### DIFF
--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -9,8 +9,8 @@ use rome_diagnostics::{
     v2::{
         self,
         adapters::{IoError, StdError},
-        category, Advices, Category, Diagnostic, DiagnosticExt, Error, FilePath, LogCategory,
-        PrintDescription, PrintDiagnostic, Severity, Visit,
+        category, Advices, Category, Diagnostic, DiagnosticExt, Error, FilePath, PrintDescription,
+        PrintDiagnostic, Severity, Visit,
     },
     MAXIMUM_DISPLAYABLE_DIAGNOSTICS,
 };
@@ -238,14 +238,8 @@ struct FormatDiffAdvice<'a> {
 
 impl Advices for FormatDiffAdvice<'_> {
     fn record(&self, visitor: &mut dyn Visit) -> io::Result<()> {
-        // Skip printing the diff for files over 1Mb (probably a minified file)
-        let max_len = self.old.len().max(self.new.len());
-        if max_len >= 1_000_000 {
-            visitor.record_log(LogCategory::Info, &"[Diff not printed for file over 1Mb]")
-        } else {
-            let diff = TextEdit::from_unicode_words(self.old, self.new);
-            visitor.record_diff(&diff)
-        }
+        let diff = TextEdit::from_unicode_words(self.old, self.new);
+        visitor.record_diff(&diff)
     }
 }
 

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -724,6 +724,34 @@ mod check {
             result,
         ));
     }
+
+    #[test]
+    fn file_too_large() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("check.js");
+        fs.insert(file_path.into(), "statement();\n".repeat(80660).as_bytes());
+
+        let result = run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![OsString::from("check"), file_path.as_os_str().into()]),
+        );
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        // Do not store the content of the file in the snapshot
+        fs.remove(file_path);
+
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "file_too_large",
+            fs,
+            console,
+            result,
+        ));
+    }
 }
 
 mod ci {
@@ -929,6 +957,34 @@ mod ci {
         assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "ci_does_not_run_linter",
+            fs,
+            console,
+            result,
+        ));
+    }
+
+    #[test]
+    fn file_too_large() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("ci.js");
+        fs.insert(file_path.into(), "statement();\n".repeat(80660).as_bytes());
+
+        let result = run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![OsString::from("ci"), file_path.as_os_str().into()]),
+        );
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        // Do not store the content of the file in the snapshot
+        fs.remove(file_path);
+
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "file_too_large",
             fs,
             console,
             result,
@@ -1735,6 +1791,38 @@ mod format {
         assert_cli_snapshot(SnapshotPayload::new(
             module_path!(),
             "does_not_format_ignored_files",
+            fs,
+            console,
+            result,
+        ));
+    }
+
+    #[test]
+    fn file_too_large() {
+        let mut fs = MemoryFileSystem::default();
+        let mut console = BufferConsole::default();
+
+        let file_path = Path::new("format.js");
+        fs.insert(file_path.into(), "statement();\n".repeat(80660).as_bytes());
+
+        let result = run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![
+                OsString::from("format"),
+                file_path.as_os_str().into(),
+                OsString::from("--write"),
+            ]),
+        );
+
+        assert!(result.is_ok(), "run_cli returned {result:?}");
+
+        // Do not store the content of the file in the snapshot
+        fs.remove(file_path);
+
+        assert_cli_snapshot(SnapshotPayload::new(
+            module_path!(),
+            "file_too_large",
             fs,
             console,
             result,

--- a/crates/rome_cli/tests/snapshots/main_check/file_too_large.snap
+++ b/crates/rome_cli/tests/snapshots/main_check/file_too_large.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Emitted Messages
+
+```block
+check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file check.js could not be parsed because it's too large (the file is 1.0 MiB long, but the size limit is 1.0 MiB)
+  
+
+```
+
+```block
+Skipped 1 files
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_ci/file_too_large.snap
+++ b/crates/rome_cli/tests/snapshots/main_ci/file_too_large.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Emitted Messages
+
+```block
+ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file ci.js could not be parsed because it's too large (the file is 1.0 MiB long, but the size limit is 1.0 MiB)
+  
+
+```
+
+```block
+Skipped 1 files
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_format/file_too_large.snap
+++ b/crates/rome_cli/tests/snapshots/main_format/file_too_large.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Emitted Messages
+
+```block
+format.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file format.js could not be parsed because it's too large (the file is 1.0 MiB long, but the size limit is 1.0 MiB)
+  
+
+```
+
+```block
+Skipped 1 files
+```
+
+

--- a/crates/rome_fs/src/fs/memory.rs
+++ b/crates/rome_fs/src/fs/memory.rs
@@ -60,6 +60,11 @@ impl MemoryFileSystem {
         self.errors.insert(path, kind);
     }
 
+    /// Remove a file from the filesystem
+    pub fn remove(&mut self, path: &Path) {
+        self.files.0.write().remove(path);
+    }
+
     pub fn files(self) -> IntoIter<PathBuf, FileEntry> {
         let files = self.files.0.into_inner();
         files.into_iter()

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -1,3 +1,4 @@
+use rome_console::fmt::Bytes;
 use rome_console::{Console, EnvConsole};
 use rome_formatter::FormatError;
 use rome_fs::{FileSystem, OsFileSystem, RomePath};
@@ -71,6 +72,12 @@ pub enum RomeError {
     TransportError(TransportError),
     /// Emitted when the file is ignored and should not be processed
     FileIgnored(PathBuf),
+    /// Emitted when a file could not be parsed because it's larger than the size limite
+    FileTooLarge {
+        path: PathBuf,
+        size: usize,
+        limit: usize,
+    },
 }
 
 impl Debug for RomeError {
@@ -162,6 +169,9 @@ impl Display for RomeError {
             }
             RomeError::FileIgnored(path) => {
                 write!(f, "The file {} was ignored", path.display())
+            }
+            RomeError::FileTooLarge { path, size, limit } => {
+                write!(f, "The file {} could not be parsed because it's too large (the file is {} long, but the size limit is {})", path.display(), Bytes(*size), Bytes(*limit))
             }
         }
     }

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -169,6 +169,18 @@ impl WorkspaceServer {
                     .parse
                     .ok_or_else(self.build_capability_error(rome_path))?;
 
+                /// Limit the size of files to 1.0 MiB
+                const SIZE_LIMIT: usize = 1024 * 1024;
+
+                let size = document.content.as_bytes().len();
+                if size >= SIZE_LIMIT {
+                    return Err(RomeError::FileTooLarge {
+                        path: rome_path.to_path_buf(),
+                        size,
+                        limit: SIZE_LIMIT,
+                    });
+                }
+
                 let parsed = parse(rome_path, document.language_hint, &document.content);
 
                 Ok(entry.insert(parsed).clone())

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -170,14 +170,14 @@ impl WorkspaceServer {
                     .ok_or_else(self.build_capability_error(rome_path))?;
 
                 /// Limit the size of files to 1.0 MiB
-                const SIZE_LIMIT: usize = 1024 * 1024;
+                const SIZE_LIMIT_IN_BYTES: usize = 1024 * 1024;
 
                 let size = document.content.as_bytes().len();
-                if size >= SIZE_LIMIT {
+                if size >= SIZE_LIMIT_IN_BYTES {
                     return Err(RomeError::FileTooLarge {
                         path: rome_path.to_path_buf(),
                         size,
-                        limit: SIZE_LIMIT,
+                        limit: SIZE_LIMIT_IN_BYTES,
                     });
                 }
 


### PR DESCRIPTION
## Summary

Fixes #3330

This PR adds a maximum size threshold to the Workspace after which files are no longer parsed, analyzed or formatted. At the moment I've hard-coded this limit to 1 MiB, but it should be trivial to expose this limit in the configuration file or the CLI if users really want to process very large files.

As part of the new message for this new error, I've added a new `Bytes` utility to `rome_console` that prints a quantity in bytes using the correct binary unit (B, KiB, MiB, GiB or TiB)

## Test Plan

I've added new test cases for the CLI that ensures files larger than the size threshold are not checked or formatted, and the correct diagnostic is emitted.
