### PR TITLE
feat(rome_js_analyze): consider unary expressions in `useSimplifiedLogicExpression`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/correctness/use_simplified_logic_expression.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_simplified_logic_expression.rs
@@ -2,11 +2,12 @@ use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
+use rome_js_syntax::JsUnaryOperator::LogicalNot;
 use rome_js_syntax::{
     JsAnyExpression, JsAnyLiteralExpression, JsBooleanLiteralExpression, JsLogicalExpression,
     JsUnaryExpression, JsUnaryOperator, T,
 };
-use rome_rowan::{AstNode, AstNodeExt, BatchMutationExt};
+use rome_rowan::{declare_node_union, AstNode, AstNodeExt, BatchMutationExt};
 
 use crate::JsRuleAction;
 
@@ -37,6 +38,11 @@ declare_rule! {
     /// const boolExpr2 = false;
     /// const r4 = !boolExpr1 || !boolExpr2;
     /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// const boolExp2 = true;
+    /// const r2 = !!boolExp2;
+    /// ```
     /// ### Valid
     /// ```js
     /// const boolExpr3 = true;
@@ -44,7 +50,6 @@ declare_rule! {
     /// const r5 = !(boolExpr1 && boolExpr2);
     /// const boolExpr5 = true;
     /// const boolExpr6 = false;
-    /// const r6 = !!boolExpr1 || !!boolExpr2;
     /// ```
     ///
     pub(crate) UseSimplifiedLogicExpression {
@@ -54,69 +59,91 @@ declare_rule! {
     }
 }
 
+declare_node_union! {
+    pub(crate) AnyLogicalLikeExpression = JsLogicalExpression | JsUnaryExpression
+}
+
 impl Rule for UseSimplifiedLogicExpression {
-    type Query = Ast<JsLogicalExpression>;
+    type Query = Ast<AnyLogicalLikeExpression>;
     /// First element of tuple is if the expression is simplified by [De Morgan's Law](https://en.wikipedia.org/wiki/De_Morgan%27s_laws) rule, the second element is the expression to replace.
     type State = (bool, JsAnyExpression);
     type Signals = Option<Self::State>;
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
-        let left = node.left().ok()?;
-        let right = node.right().ok()?;
-        match node.operator().ok()? {
-            rome_js_syntax::JsLogicalOperator::NullishCoalescing
-                if matches!(
-                    left,
-                    JsAnyExpression::JsAnyLiteralExpression(
-                        JsAnyLiteralExpression::JsNullLiteralExpression(_)
-                    )
-                ) =>
-            {
-                return Some((false, right));
+        match node {
+            AnyLogicalLikeExpression::JsLogicalExpression(node) => {
+                let left = node.left().ok()?;
+                let right = node.right().ok()?;
+                match node.operator().ok()? {
+                    rome_js_syntax::JsLogicalOperator::NullishCoalescing
+                        if matches!(
+                            left,
+                            JsAnyExpression::JsAnyLiteralExpression(
+                                JsAnyLiteralExpression::JsNullLiteralExpression(_)
+                            )
+                        ) =>
+                    {
+                        return Some((false, right));
+                    }
+                    rome_js_syntax::JsLogicalOperator::LogicalOr => {
+                        if let JsAnyExpression::JsAnyLiteralExpression(
+                            JsAnyLiteralExpression::JsBooleanLiteralExpression(literal),
+                        ) = left
+                        {
+                            return simplify_or_expression(literal, right)
+                                .map(|expr| (false, expr));
+                        }
+
+                        if let JsAnyExpression::JsAnyLiteralExpression(
+                            JsAnyLiteralExpression::JsBooleanLiteralExpression(literal),
+                        ) = right
+                        {
+                            return simplify_or_expression(literal, left).map(|expr| (false, expr));
+                        }
+
+                        if could_apply_de_morgan(node).unwrap_or(false) {
+                            return simplify_de_morgan(node)
+                                .map(|expr| (true, JsAnyExpression::JsUnaryExpression(expr)));
+                        }
+                    }
+                    rome_js_syntax::JsLogicalOperator::LogicalAnd => {
+                        if let JsAnyExpression::JsAnyLiteralExpression(
+                            JsAnyLiteralExpression::JsBooleanLiteralExpression(literal),
+                        ) = left
+                        {
+                            return simplify_and_expression(literal, right)
+                                .map(|expr| (false, expr));
+                        }
+
+                        if let JsAnyExpression::JsAnyLiteralExpression(
+                            JsAnyLiteralExpression::JsBooleanLiteralExpression(literal),
+                        ) = right
+                        {
+                            return simplify_and_expression(literal, left)
+                                .map(|expr| (false, expr));
+                        }
+
+                        if could_apply_de_morgan(node).unwrap_or(false) {
+                            return simplify_de_morgan(node)
+                                .map(|expr| (true, JsAnyExpression::JsUnaryExpression(expr)));
+                        }
+                    }
+                    _ => return None,
+                }
             }
-            rome_js_syntax::JsLogicalOperator::LogicalOr => {
-                if let JsAnyExpression::JsAnyLiteralExpression(
-                    JsAnyLiteralExpression::JsBooleanLiteralExpression(literal),
-                ) = left
-                {
-                    return simplify_or_expression(literal, right).map(|expr| (false, expr));
-                }
-
-                if let JsAnyExpression::JsAnyLiteralExpression(
-                    JsAnyLiteralExpression::JsBooleanLiteralExpression(literal),
-                ) = right
-                {
-                    return simplify_or_expression(literal, left).map(|expr| (false, expr));
-                }
-
-                if could_apply_de_morgan(node).unwrap_or(false) {
-                    return simplify_de_morgan(node)
-                        .map(|expr| (true, JsAnyExpression::JsUnaryExpression(expr)));
+            AnyLogicalLikeExpression::JsUnaryExpression(unary_expression) => {
+                if unary_expression.operator().ok()? == LogicalNot {
+                    let nested_unary = unary_expression.argument().ok()?;
+                    let nested_unary = nested_unary.as_js_unary_expression()?;
+                    if nested_unary.operator().ok()? == LogicalNot {
+                        let expression = nested_unary.argument().ok()?;
+                        return Some((false, expression));
+                    }
                 }
             }
-            rome_js_syntax::JsLogicalOperator::LogicalAnd => {
-                if let JsAnyExpression::JsAnyLiteralExpression(
-                    JsAnyLiteralExpression::JsBooleanLiteralExpression(literal),
-                ) = left
-                {
-                    return simplify_and_expression(literal, right).map(|expr| (false, expr));
-                }
-
-                if let JsAnyExpression::JsAnyLiteralExpression(
-                    JsAnyLiteralExpression::JsBooleanLiteralExpression(literal),
-                ) = right
-                {
-                    return simplify_and_expression(literal, left).map(|expr| (false, expr));
-                }
-
-                if could_apply_de_morgan(node).unwrap_or(false) {
-                    return simplify_de_morgan(node)
-                        .map(|expr| (true, JsAnyExpression::JsUnaryExpression(expr)));
-                }
-            }
-            _ => return None,
         }
+
         None
     }
 
@@ -137,10 +164,19 @@ impl Rule for UseSimplifiedLogicExpression {
         let mut mutation = ctx.root().begin();
 
         let (is_simplified_by_de_morgan, expr) = state;
-        mutation.replace_node(
-            JsAnyExpression::JsLogicalExpression(node.clone()),
-            expr.clone(),
-        );
+        match node {
+            AnyLogicalLikeExpression::JsLogicalExpression(node) => {
+                mutation.replace_node(
+                    JsAnyExpression::JsLogicalExpression(node.clone()),
+                    expr.clone(),
+                );
+            }
+            AnyLogicalLikeExpression::JsUnaryExpression(unary) => mutation.replace_element(
+                unary.clone().into_syntax().into(),
+                expr.clone().into_syntax().into(),
+            ),
+        }
+
         let message = if *is_simplified_by_de_morgan {
             "Reduce the complexity of the logical expression."
         } else {

--- a/crates/rome_js_analyze/tests/specs/correctness/useSimplifiedLogicExpression.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/useSimplifiedLogicExpression.js
@@ -15,3 +15,4 @@ const r3 = null ?? nonNullExp;
 const boolExpr1 = true;
 const boolExpr2 = false;
 const r4 = !boolExpr1 || !boolExpr2;
+!!x

--- a/crates/rome_js_analyze/tests/specs/correctness/useSimplifiedLogicExpression.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/useSimplifiedLogicExpression.js.snap
@@ -21,10 +21,49 @@ const r3 = null ?? nonNullExp;
 const boolExpr1 = true;
 const boolExpr2 = false;
 const r4 = !boolExpr1 || !boolExpr2;
+!!x
 
 ```
 
 # Diagnostics
+```
+useSimplifiedLogicExpression.js:7:12 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━
+
+  ! Logical expression contains unnecessary complexity.
+  
+    5 │ const boolExpr5 = true;
+    6 │ const boolExpr6 = false;
+  > 7 │ const r6 = !!boolExpr1 || !!boolExpr2;
+      │            ^^^^^^^^^^^
+    8 │ // invalid
+    9 │ const boolExp = true;
+  
+  i Suggested fix: Discard redundant terms from the logical expression.
+  
+    7 │ const·r6·=·!!boolExpr1·||·!!boolExpr2;
+      │            --                         
+
+```
+
+```
+useSimplifiedLogicExpression.js:7:27 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━
+
+  ! Logical expression contains unnecessary complexity.
+  
+    5 │ const boolExpr5 = true;
+    6 │ const boolExpr6 = false;
+  > 7 │ const r6 = !!boolExpr1 || !!boolExpr2;
+      │                           ^^^^^^^^^^^
+    8 │ // invalid
+    9 │ const boolExp = true;
+  
+  i Suggested fix: Discard redundant terms from the logical expression.
+  
+    7 │ const·r6·=·!!boolExpr1·||·!!boolExpr2;
+      │                           --          
+
+```
+
 ```
 useSimplifiedLogicExpression.js:10:11 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━
 
@@ -91,7 +130,8 @@ useSimplifiedLogicExpression.js:17:12 lint/correctness/useSimplifiedLogicExpress
     16 │ const boolExpr2 = false;
   > 17 │ const r4 = !boolExpr1 || !boolExpr2;
        │            ^^^^^^^^^^^^^^^^^^^^^^^^
-    18 │ 
+    18 │ !!x
+    19 │ 
   
   i Suggested fix: Reduce the complexity of the logical expression.
   
@@ -99,8 +139,27 @@ useSimplifiedLogicExpression.js:17:12 lint/correctness/useSimplifiedLogicExpress
     16 16 │   const·boolExpr2·=·false;
     17    │ - const·r4·=·!boolExpr1·||·!boolExpr2;
        17 │ + const·r4·=·!(boolExpr1·&&·boolExpr2);
-    18 18 │   
+    18 18 │   !!x
+    19 19 │   
   
+
+```
+
+```
+useSimplifiedLogicExpression.js:18:1 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━
+
+  ! Logical expression contains unnecessary complexity.
+  
+    16 │ const boolExpr2 = false;
+    17 │ const r4 = !boolExpr1 || !boolExpr2;
+  > 18 │ !!x
+       │ ^^^
+    19 │ 
+  
+  i Suggested fix: Discard redundant terms from the logical expression.
+  
+    18 │ !!x
+       │ -- 
 
 ```
 

--- a/website/src/docs/lint/rules/useSimplifiedLogicExpression.md
+++ b/website/src/docs/lint/rules/useSimplifiedLogicExpression.md
@@ -99,6 +99,26 @@ const r4 = !boolExpr1 || !boolExpr2;
   
 </code></pre>{% endraw %}
 
+```jsx
+const boolExp2 = true;
+const r2 = !!boolExp2;
+```
+
+{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:2:12 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Logical expression contains unnecessary complexity.</span>
+  
+    <strong>1 │ </strong>const boolExp2 = true;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>const r2 = !!boolExp2;
+   <strong>   │ </strong>           <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Discard redundant terms from the logical expression.</span>
+  
+<strong>  </strong><strong>  2 │ </strong>const<span style="opacity: 0.8;">·</span>r2<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span><span style="color: Tomato;">!</span><span style="color: Tomato;">!</span>boolExp2;
+<strong>  </strong><strong>    │ </strong>           <span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>         
+</code></pre>{% endraw %}
+
 ### Valid
 
 ```jsx
@@ -107,6 +127,5 @@ const boolExpr4 = false;
 const r5 = !(boolExpr1 && boolExpr2);
 const boolExpr5 = true;
 const boolExpr6 = false;
-const r6 = !!boolExpr1 || !!boolExpr2;
 ```
 


### PR DESCRIPTION

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Adds handling of double negations for `useSimplifiedLogicExpression`. This some missing logic present in the old Rome classic.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new test cases

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
