### PR TITLE
feat(rome_analyze): use serde to deserialize rule settings

### DIFF
--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -15,7 +15,7 @@ rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 bitflags = "1.3.2"
 rustc-hash = { workspace = true }
-serde = { version = "1.0.136", features = ["derive"], optional = true }
+serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["raw_value"]}
 schemars = { version = "0.8.10", optional = true }
 
@@ -24,4 +24,4 @@ rome_js_syntax = { path = "../rome_js_syntax" }
 rome_js_factory = { path = "../rome_js_factory" }
 
 [features]
-serde = ["dep:serde", "schemars"]
+serde = ["schemars"]

--- a/crates/rome_analyze/src/context.rs
+++ b/crates/rome_analyze/src/context.rs
@@ -1,7 +1,8 @@
 use crate::{
     registry::RuleRoot, AnalyzerOptions, CannotCreateServicesError, FromServices, Queryable, Rule,
-    ServiceBag,
+    RuleKey, ServiceBag,
 };
+use serde::Deserialize;
 use std::ops::Deref;
 
 type RuleQueryResult<R> = <<R as Rule>::Query as Queryable>::Output;
@@ -11,6 +12,7 @@ pub struct RuleContext<'a, R>
 where
     R: ?Sized + Rule,
 {
+    rule_key: RuleKey,
     query_result: &'a RuleQueryResult<R>,
     root: &'a RuleRoot<R>,
     services: RuleServiceBag<R>,
@@ -22,12 +24,14 @@ where
     R: ?Sized + Rule,
 {
     pub fn new(
+        rule_key: RuleKey,
         query_result: &'a RuleQueryResult<R>,
         root: &'a RuleRoot<R>,
         services: &ServiceBag,
         options: &'a AnalyzerOptions,
     ) -> Result<Self, CannotCreateServicesError> {
         Ok(Self {
+            rule_key,
             query_result,
             root,
             services: FromServices::from_services(services)?,
@@ -47,6 +51,52 @@ where
     /// Returns the analyzer options
     pub fn options(&self) -> &AnalyzerOptions {
         self.options
+    }
+
+    /// It retrieves the options that belong to a rule, if they exist.
+    ///
+    /// In order to retrieve a typed data structure, the function has to accept a `FromType`, a
+    /// `ToType` (this one, inferrable by the compiler) and a closure that does the mapping.
+    ///
+    /// Usually, options are a `serde::RawValue` and need to be mapped to a sized type.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,ignore
+    /// use rome_analyze::{declare_rule, Rule, RuleCategory, RuleMeta, RuleMetadata};
+    /// use rome_analyze::context::RuleContext;
+    /// use serde::Deserialize;
+    /// declare_rule! {    
+    ///     /// Some doc
+    ///     pub(crate) Name {
+    ///         version: "0.0.0",
+    ///         name: "name",
+    ///         recommended: true,
+    ///     }
+    /// }
+    ///
+    /// #[derive(Deserialize)]
+    /// struct RuleSettings {}
+    ///
+    /// impl Rule for Name {
+    ///     const CATEGORY: RuleCategory = RuleCategory::Lint;
+    ///     type Query = ();
+    ///     type State = ();
+    ///     type Signals = ();
+    ///
+    ///     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+    ///         let options = ctx.rule_settings::<RuleSettings>();
+    ///     }
+    /// }
+    /// ```
+    pub fn rule_settings<'de, ToType: Deserialize<'de>>(&'de self) -> Option<ToType> {
+        self.options
+            .configuration
+            .rules
+            .get_rule(&self.rule_key)
+            .map(|options| serde_json::from_str::<ToType>(options.value()))
+            // TODO: ignore the error for now, it should be handled differently https://github.com/rome/tools/issues/3346
+            .and_then(|result| result.ok())
     }
 }
 

--- a/crates/rome_analyze/src/context.rs
+++ b/crates/rome_analyze/src/context.rs
@@ -12,7 +12,6 @@ pub struct RuleContext<'a, R>
 where
     R: ?Sized + Rule,
 {
-    rule_key: RuleKey,
     query_result: &'a RuleQueryResult<R>,
     root: &'a RuleRoot<R>,
     services: RuleServiceBag<R>,
@@ -21,17 +20,15 @@ where
 
 impl<'a, R> RuleContext<'a, R>
 where
-    R: ?Sized + Rule,
+    R: Rule + Sized,
 {
     pub fn new(
-        rule_key: RuleKey,
         query_result: &'a RuleQueryResult<R>,
         root: &'a RuleRoot<R>,
         services: &ServiceBag,
         options: &'a AnalyzerOptions,
     ) -> Result<Self, CannotCreateServicesError> {
         Ok(Self {
-            rule_key,
             query_result,
             root,
             services: FromServices::from_services(services)?,
@@ -93,7 +90,7 @@ where
         self.options
             .configuration
             .rules
-            .get_rule(&self.rule_key)
+            .get_rule(&RuleKey::rule::<R>())
             .map(|options| serde_json::from_str::<ToType>(options.value()))
             // TODO: ignore the error for now, it should be handled differently https://github.com/rome/tools/issues/3346
             .and_then(|result| result.ok())

--- a/crates/rome_analyze/src/options.rs
+++ b/crates/rome_analyze/src/options.rs
@@ -1,15 +1,16 @@
 use crate::RuleKey;
+use serde::Deserialize;
 use serde_json::value::RawValue;
 use std::collections::HashMap;
 
 /// A convenient new type data structure to store the options that belong to a rule
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct RuleOptions(Box<RawValue>);
 
 impl RuleOptions {
-    /// It returns the [RawValue] for the relative rule
-    pub fn value(&self) -> &RawValue {
-        &self.0
+    /// It returns the string contained in [RawValue], for the relative rule
+    pub fn value(&self) -> &str {
+        self.0.get()
     }
 
     /// Creates a new [RuleOptions]
@@ -50,47 +51,5 @@ pub struct AnalyzerConfiguration {
 #[derive(Debug, Clone, Default)]
 pub struct AnalyzerOptions {
     /// A data structured derived from the [`rome.json`] file
-    configuration: AnalyzerConfiguration,
-}
-
-impl AnalyzerOptions {
-    /// It retrieves the options that belong to a rule, if they exist.
-    ///
-    /// In order to retrieve a typed data structure, the function has to accept a `FromType`, a
-    /// `ToType` (this one, inferrable by the compiler) and a closure that does the mapping.
-    ///
-    /// Usually, options are a `serde::RawValue` and need to be mapped to a sized type.
-    ///
-    /// ## Examples
-    ///
-    /// ```rust,ignore
-    /// use rome_analyze::{declare_rule, Rule, RuleCategory, RuleMeta, RuleMetadata};
-    /// use rome_analyze::context::RuleContext;
-    /// declare_rule! {    
-    ///     /// Some doc
-    ///     pub(crate) Name {
-    ///         version: "0.0.0",
-    ///         name: "name",
-    ///         recommended: true,
-    ///     }
-    /// }
-    ///
-    /// impl Rule for Name {
-    ///     const CATEGORY: RuleCategory = RuleCategory::Lint;
-    ///     type Query = ();
-    ///     type State = ();
-    ///     type Signals = ();
-    ///
-    ///     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-    ///         let options = ctx.options();
-    ///     }
-    /// }
-    /// ```
-    pub fn rule_options<F: FnOnce(&RuleOptions) -> ToType, ToType>(
-        &self,
-        rule_key: &RuleKey,
-        mapper: F,
-    ) -> Option<ToType> {
-        self.configuration.rules.get_rule(rule_key).map(mapper)
-    }
+    pub configuration: AnalyzerConfiguration,
 }

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -288,13 +288,16 @@ impl<L: Language + Default> RegistryRule<L> {
             // if the query doesn't match
             let query_result =
                 <R::Query as Queryable>::unwrap_match(params.services, &params.query);
-
-            let ctx =
-                match RuleContext::new(&query_result, params.root, params.services, params.options)
-                {
-                    Ok(ctx) => ctx,
-                    Err(_) => return,
-                };
+            let ctx = match RuleContext::new(
+                RuleKey::rule::<R>(),
+                &query_result,
+                params.root,
+                params.services,
+                params.options,
+            ) {
+                Ok(ctx) => ctx,
+                Err(_) => return,
+            };
 
             for result in R::run(&ctx) {
                 let text_range =

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -288,16 +288,12 @@ impl<L: Language + Default> RegistryRule<L> {
             // if the query doesn't match
             let query_result =
                 <R::Query as Queryable>::unwrap_match(params.services, &params.query);
-            let ctx = match RuleContext::new(
-                RuleKey::rule::<R>(),
-                &query_result,
-                params.root,
-                params.services,
-                params.options,
-            ) {
-                Ok(ctx) => ctx,
-                Err(_) => return,
-            };
+            let ctx =
+                match RuleContext::new(&query_result, params.root, params.services, params.options)
+                {
+                    Ok(ctx) => ctx,
+                    Err(_) => return,
+                };
 
             for result in R::run(&ctx) {
                 let text_range =

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -3,7 +3,7 @@ use crate::{
     context::RuleContext,
     registry::{RuleLanguage, RuleRoot},
     rule::Rule,
-    AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, ServiceBag,
+    AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, RuleKey, ServiceBag,
 };
 use rome_console::MarkupBuf;
 use rome_diagnostics::{
@@ -121,14 +121,27 @@ where
     R: Rule,
 {
     fn diagnostic(&self) -> Option<AnalyzerDiagnostic> {
-        let ctx =
-            RuleContext::new(&self.query_result, self.root, self.services, &self.options).ok()?;
+        let ctx = RuleContext::new(
+            RuleKey::rule::<R>(),
+            &self.query_result,
+            self.root,
+            self.services,
+            &self.options,
+        )
+        .ok()?;
+
         R::diagnostic(&ctx, &self.state).map(|diag| diag.into_analyzer_diagnostic(self.file_id))
     }
 
     fn action(&self) -> Option<AnalyzerAction<RuleLanguage<R>>> {
-        let ctx =
-            RuleContext::new(&self.query_result, self.root, self.services, &self.options).ok()?;
+        let ctx = RuleContext::new(
+            RuleKey::rule::<R>(),
+            &self.query_result,
+            self.root,
+            self.services,
+            &self.options,
+        )
+        .ok()?;
 
         R::action(&ctx, &self.state).map(|action| AnalyzerAction {
             group_name: <R::Group as RuleGroup>::NAME,

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -3,7 +3,7 @@ use crate::{
     context::RuleContext,
     registry::{RuleLanguage, RuleRoot},
     rule::Rule,
-    AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, RuleKey, ServiceBag,
+    AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, ServiceBag,
 };
 use rome_console::MarkupBuf;
 use rome_diagnostics::{
@@ -121,27 +121,15 @@ where
     R: Rule,
 {
     fn diagnostic(&self) -> Option<AnalyzerDiagnostic> {
-        let ctx = RuleContext::new(
-            RuleKey::rule::<R>(),
-            &self.query_result,
-            self.root,
-            self.services,
-            &self.options,
-        )
-        .ok()?;
+        let ctx =
+            RuleContext::new(&self.query_result, self.root, self.services, &self.options).ok()?;
 
         R::diagnostic(&ctx, &self.state).map(|diag| diag.into_analyzer_diagnostic(self.file_id))
     }
 
     fn action(&self) -> Option<AnalyzerAction<RuleLanguage<R>>> {
-        let ctx = RuleContext::new(
-            RuleKey::rule::<R>(),
-            &self.query_result,
-            self.root,
-            self.services,
-            &self.options,
-        )
-        .ok()?;
+        let ctx =
+            RuleContext::new(&self.query_result, self.root, self.services, &self.options).ok()?;
 
         R::action(&ctx, &self.state).map(|action| AnalyzerAction {
             group_name: <R::Group as RuleGroup>::NAME,

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -17,7 +17,7 @@ rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 roaring = "0.9.0"
 rustc-hash = { workspace = true }
-serde = { version = "1.0.136", features = ["derive"], optional = true }
+serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["raw_value"] }
 
 [dev-dependencies]

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -9,6 +9,7 @@ use rome_js_syntax::{
     suppression::{parse_suppression_comment, SuppressionCategory},
     JsLanguage,
 };
+use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, error::Error};
 
 mod analyzers;
@@ -210,8 +211,7 @@ mod tests {
 }
 
 /// Series of errors encountered when running rules on a file
-#[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum RuleError {
     /// The rule with the specified name replaced the root of the file with a node that is not a valid root for that language.
     ReplacedRootWithNonRootError { rule_name: Cow<'static, str> },

--- a/crates/rome_js_analyze/src/utils/rename.rs
+++ b/crates/rome_js_analyze/src/utils/rename.rs
@@ -4,6 +4,7 @@ use rome_js_syntax::{
     JsSyntaxNode, JsSyntaxToken,
 };
 use rome_rowan::{AstNode, BatchMutation, SyntaxNodeCast, TriviaPiece};
+use serde::{Deserialize, Serialize};
 
 pub trait RenamableNode {
     fn declaration(&self, model: &SemanticModel) -> Option<JsSyntaxNode>;
@@ -49,7 +50,7 @@ impl RenamableNode for JsAnyRenamableDeclaration {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Deserialize, Serialize)]
 pub enum RenameError {
     CannotFindDeclaration,
     CannotBeRenamed {

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -17,7 +17,7 @@ rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 rome_formatter = { path = "../rome_formatter", features = ["serde"] }
 rome_fs = { path = "../rome_fs", features = ["serde"] }
-rome_js_analyze = { path = "../rome_js_analyze", features = ["serde"] }
+rome_js_analyze = { path = "../rome_js_analyze" }
 rome_js_syntax = { path = "../rome_js_syntax", features = ["serde"] }
 rome_js_parser = { path = "../rome_js_parser" }
 rome_js_factory = { path = "../rome_js_factory", optional = true }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/3343 
Closes https://github.com/rome/tools/issues/3344 
Closes https://github.com/rome/tools/issues/3345

The function `rule_options` has been renamed `rule_settings` and it's been lifted inside the `AnalyzerContext`. The `AnalyzerContext` now accepts a `RuleKey`, which is needed to retrieve and deserialize the JSON string coming from the configuration.

`serde` is not optional anymore (I thought the entity of the change was bigger).

The handling of the error has been left out on purpose for the time being, and it will be handled in a different PR

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The current CI should work

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
