### PR TITLE
feat(rome_js_semantic): simple globals resolution

### DIFF
--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -1,7 +1,7 @@
 use super::rename::*;
 use crate::utils::batch::JsBatchMutation;
 use rome_diagnostics::file::FileId;
-use rome_js_semantic::semantic_model;
+use rome_js_semantic::{semantic_model, SemanticModelOptions};
 use rome_js_syntax::{JsFormalParameter, JsIdentifierBinding, JsVariableDeclarator, SourceType};
 use rome_rowan::{AstNode, BatchMutationExt, SyntaxNodeCast};
 
@@ -9,7 +9,7 @@ use rome_rowan::{AstNode, BatchMutationExt, SyntaxNodeCast};
 /// Asserts the renaming worked.
 pub fn assert_rename_ok(before: &str, expected: &str) {
     let r = rome_js_parser::parse(before, FileId::zero(), SourceType::js_module());
-    let model = semantic_model(&r.tree());
+    let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
     let binding_a = r
         .syntax()
@@ -30,7 +30,7 @@ pub fn assert_rename_ok(before: &str, expected: &str) {
 /// Asserts the renaming to fail.
 pub fn assert_rename_nok(before: &str) {
     let r = rome_js_parser::parse(before, FileId::zero(), SourceType::js_module());
-    let model = semantic_model(&r.tree());
+    let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
     let binding_a = r
         .syntax()

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -285,7 +285,7 @@ mod test {
 
     fn assert_closure(code: &str, name: &str, captures: &[&str]) {
         let r = rome_js_parser::parse(code, FileId::zero(), SourceType::tsx());
-        let model = semantic_model(&r.tree());
+        let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
         let closure = if name != "ARROWFUNCTION" {
             let node = r
@@ -327,7 +327,7 @@ mod test {
 
     fn get_closure_children(code: &str, name: &str) -> Vec<Closure> {
         let r = rome_js_parser::parse(code, FileId::zero(), SourceType::tsx());
-        let model = semantic_model(&r.tree());
+        let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
         let closure = if name != "ARROWFUNCTION" {
             let node = r

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -8,7 +8,7 @@ use rome_js_analyze::{analyze, analyze_with_inspect_matcher, metadata, RuleError
 use rome_js_formatter::context::{QuoteProperties, QuoteStyle};
 use rome_js_formatter::{context::JsFormatOptions, format_node};
 use rome_js_parser::Parse;
-use rome_js_semantic::semantic_model;
+use rome_js_semantic::{semantic_model, SemanticModelOptions};
 use rome_js_syntax::{
     JsAnyRoot, JsLanguage, JsSyntaxNode, SourceType, TextRange, TextSize, TokenAtOffset,
 };
@@ -456,7 +456,7 @@ fn rename(
     new_name: String,
 ) -> Result<RenameResult, RomeError> {
     let root = parse.tree();
-    let model = semantic_model(&root);
+    let model = semantic_model(&root, SemanticModelOptions::default());
 
     if let Some(node) = parse
         .syntax()


### PR DESCRIPTION
## Summary

This PR implements a simple global resolution for the semantic model.

## Test Plan

```
> cargo test -p rome_js_semantic -- ok_semantic_model_globals
```
