### PR TITLE
fix(rome_diagnostics): force the diagnostics separator line to be at least 10 characters wide

### DIFF
--- a/crates/rome_diagnostics/src/v2/display.rs
+++ b/crates/rome_diagnostics/src/v2/display.rs
@@ -125,10 +125,12 @@ impl<'fmt, D: Diagnostic + ?Sized> fmt::Display for PrintHeader<'fmt, D> {
         }
 
         // Load the printed width for the header, and fill the rest of the line
-        // with the '━' line character up to 100 characters
+        // with the '━' line character up to 100 columns with at least 10 characters
         const HEADER_WIDTH: usize = 100;
+        const MIN_WIDTH: usize = 10;
+
         let text_width = slot.map_or(0, |writer| writer.width);
-        let line_width = HEADER_WIDTH.saturating_sub(text_width);
+        let line_width = HEADER_WIDTH.saturating_sub(text_width).max(MIN_WIDTH);
         f.write_str(&"\u{2501}".repeat(line_width))
     }
 }

--- a/crates/rome_js_analyze/tests/specs/correctness/noMultipleSpacesInRegularExpressionLiterals.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noMultipleSpacesInRegularExpressionLiterals.js.snap
@@ -21,7 +21,7 @@ expression: noMultipleSpacesInRegularExpressionLiterals.js
 
 # Diagnostics
 ```
-noMultipleSpacesInRegularExpressionLiterals.js:7:2 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  
+noMultipleSpacesInRegularExpressionLiterals.js:7:2 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━
 
   ! This regular expression contains unclear uses of multiple spaces.
   
@@ -45,7 +45,7 @@ noMultipleSpacesInRegularExpressionLiterals.js:7:2 lint/correctness/noMultipleSp
 ```
 
 ```
-noMultipleSpacesInRegularExpressionLiterals.js:8:2 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  
+noMultipleSpacesInRegularExpressionLiterals.js:8:2 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━
 
   ! This regular expression contains unclear uses of multiple spaces.
   
@@ -69,7 +69,7 @@ noMultipleSpacesInRegularExpressionLiterals.js:8:2 lint/correctness/noMultipleSp
 ```
 
 ```
-noMultipleSpacesInRegularExpressionLiterals.js:9:5 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  
+noMultipleSpacesInRegularExpressionLiterals.js:9:5 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━
 
   ! This regular expression contains unclear uses of multiple spaces.
   
@@ -93,7 +93,7 @@ noMultipleSpacesInRegularExpressionLiterals.js:9:5 lint/correctness/noMultipleSp
 ```
 
 ```
-noMultipleSpacesInRegularExpressionLiterals.js:10:5 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  
+noMultipleSpacesInRegularExpressionLiterals.js:10:5 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━
 
   ! This regular expression contains unclear uses of multiple spaces.
   
@@ -117,7 +117,7 @@ noMultipleSpacesInRegularExpressionLiterals.js:10:5 lint/correctness/noMultipleS
 ```
 
 ```
-noMultipleSpacesInRegularExpressionLiterals.js:11:5 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  
+noMultipleSpacesInRegularExpressionLiterals.js:11:5 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━
 
   ! This regular expression contains unclear uses of multiple spaces.
   
@@ -141,7 +141,7 @@ noMultipleSpacesInRegularExpressionLiterals.js:11:5 lint/correctness/noMultipleS
 ```
 
 ```
-noMultipleSpacesInRegularExpressionLiterals.js:12:11 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  
+noMultipleSpacesInRegularExpressionLiterals.js:12:11 lint/correctness/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━
 
   ! This regular expression contains unclear uses of multiple spaces.
   

--- a/crates/rome_js_analyze/tests/specs/correctness/useSimplifiedLogicExpression.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/useSimplifiedLogicExpression.js.snap
@@ -27,7 +27,7 @@ const r4 = !boolExpr1 || !boolExpr2;
 
 # Diagnostics
 ```
-useSimplifiedLogicExpression.js:7:12 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━
+useSimplifiedLogicExpression.js:7:12 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━
 
   ! Logical expression contains unnecessary complexity.
   
@@ -46,7 +46,7 @@ useSimplifiedLogicExpression.js:7:12 lint/correctness/useSimplifiedLogicExpressi
 ```
 
 ```
-useSimplifiedLogicExpression.js:7:27 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━
+useSimplifiedLogicExpression.js:7:27 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━
 
   ! Logical expression contains unnecessary complexity.
   
@@ -65,7 +65,7 @@ useSimplifiedLogicExpression.js:7:27 lint/correctness/useSimplifiedLogicExpressi
 ```
 
 ```
-useSimplifiedLogicExpression.js:10:11 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━
+useSimplifiedLogicExpression.js:10:11 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━
 
   ! Logical expression contains unnecessary complexity.
   
@@ -84,7 +84,7 @@ useSimplifiedLogicExpression.js:10:11 lint/correctness/useSimplifiedLogicExpress
 ```
 
 ```
-useSimplifiedLogicExpression.js:12:12 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━
+useSimplifiedLogicExpression.js:12:12 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━
 
   ! Logical expression contains unnecessary complexity.
   
@@ -103,7 +103,7 @@ useSimplifiedLogicExpression.js:12:12 lint/correctness/useSimplifiedLogicExpress
 ```
 
 ```
-useSimplifiedLogicExpression.js:14:12 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━
+useSimplifiedLogicExpression.js:14:12 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━
 
   ! Logical expression contains unnecessary complexity.
   
@@ -122,7 +122,7 @@ useSimplifiedLogicExpression.js:14:12 lint/correctness/useSimplifiedLogicExpress
 ```
 
 ```
-useSimplifiedLogicExpression.js:17:12 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━
+useSimplifiedLogicExpression.js:17:12 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━
 
   ! Logical expression contains unnecessary complexity.
   
@@ -146,7 +146,7 @@ useSimplifiedLogicExpression.js:17:12 lint/correctness/useSimplifiedLogicExpress
 ```
 
 ```
-useSimplifiedLogicExpression.js:18:1 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━
+useSimplifiedLogicExpression.js:18:1 lint/correctness/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━
 
   ! Logical expression contains unnecessary complexity.
   

--- a/website/src/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren.md
+++ b/website/src/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren.md
@@ -18,7 +18,7 @@ function createMarkup() {
 <Component dangerouslySetInnerHTML={createMarkup()}>"child1"</Component>
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">nursery/noDangerouslySetInnerHtmlWithChildren.js:4:12 <a href="https://rome.tools/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren">lint/nursery/noDangerouslySetInnerHtmlWithChildren</a> 
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noDangerouslySetInnerHtmlWithChildren.js:4:12 <a href="https://rome.tools/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren">lint/nursery/noDangerouslySetInnerHtmlWithChildren</a> ━━━━━━━━━━
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid passing both </span><span style="color: Orange;"><strong>children</strong></span><span style="color: Orange;"> and the </span><span style="color: Orange;"><strong>dangerouslySetInnerHTML</strong></span><span style="color: Orange;"> prop.</span>
   
@@ -47,7 +47,7 @@ function createMarkup() {
 <Component dangerouslySetInnerHTML={createMarkup()} children="child1" />
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">nursery/noDangerouslySetInnerHtmlWithChildren.js:4:12 <a href="https://rome.tools/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren">lint/nursery/noDangerouslySetInnerHtmlWithChildren</a> 
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noDangerouslySetInnerHtmlWithChildren.js:4:12 <a href="https://rome.tools/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren">lint/nursery/noDangerouslySetInnerHtmlWithChildren</a> ━━━━━━━━━━
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid passing both </span><span style="color: Orange;"><strong>children</strong></span><span style="color: Orange;"> and the </span><span style="color: Orange;"><strong>dangerouslySetInnerHTML</strong></span><span style="color: Orange;"> prop.</span>
   
@@ -73,7 +73,7 @@ function createMarkup() {
 React.createElement('div', { dangerouslySetInnerHTML: { __html: 'HTML' } }, 'children')
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">nursery/noDangerouslySetInnerHtmlWithChildren.js:1:30 <a href="https://rome.tools/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren">lint/nursery/noDangerouslySetInnerHtmlWithChildren</a> 
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noDangerouslySetInnerHtmlWithChildren.js:1:30 <a href="https://rome.tools/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren">lint/nursery/noDangerouslySetInnerHtmlWithChildren</a> ━━━━━━━━━━
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">Avoid passing both </span><span style="color: Orange;"><strong>children</strong></span><span style="color: Orange;"> and the </span><span style="color: Orange;"><strong>dangerouslySetInnerHTML</strong></span><span style="color: Orange;"> prop.</span>
   

--- a/website/src/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals.md
+++ b/website/src/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals.md
@@ -17,7 +17,7 @@ Disallow unclear usage of multiple space characters in regular expression litera
 /   /
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:2 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:2 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
   
@@ -37,7 +37,7 @@ Disallow unclear usage of multiple space characters in regular expression litera
 /  foo/
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:2 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:2 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
   
@@ -57,7 +57,7 @@ Disallow unclear usage of multiple space characters in regular expression litera
 /foo   /
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:5 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:5 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
   
@@ -77,7 +77,7 @@ Disallow unclear usage of multiple space characters in regular expression litera
 /foo  bar/
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:5 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:5 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
   
@@ -97,7 +97,7 @@ Disallow unclear usage of multiple space characters in regular expression litera
 /foo   bar    baz/
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:5 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:5 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
   
@@ -117,7 +117,7 @@ Disallow unclear usage of multiple space characters in regular expression litera
 /foo [ba]r  b(a|z)/
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:11 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/noMultipleSpacesInRegularExpressionLiterals.js:1:11 <a href="https://rome.tools/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">lint/correctness/noMultipleSpacesInRegularExpressionLiterals</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This regular expression contains unclear uses of multiple spaces.</span>
   

--- a/website/src/docs/lint/rules/noUnusedTemplateLiteral.md
+++ b/website/src/docs/lint/rules/noUnusedTemplateLiteral.md
@@ -17,7 +17,7 @@ Disallow template literals if interpolation and special-character handling are n
 const foo = `bar`
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/noUnusedTemplateLiteral.js:1:13 <a href="https://rome.tools/docs/lint/rules/noUnusedTemplateLiteral">lint/correctness/noUnusedTemplateLiteral</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━
+{% raw %}<pre class="language-text"><code class="language-text">correctness/noUnusedTemplateLiteral.js:1:13 <a href="https://rome.tools/docs/lint/rules/noUnusedTemplateLiteral">lint/correctness/noUnusedTemplateLiteral</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Do not use template literals if interpolation and special-character handling are not needed.</span>
   
@@ -37,7 +37,7 @@ const foo = `bar`
 const foo = `bar `
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/noUnusedTemplateLiteral.js:1:13 <a href="https://rome.tools/docs/lint/rules/noUnusedTemplateLiteral">lint/correctness/noUnusedTemplateLiteral</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━
+{% raw %}<pre class="language-text"><code class="language-text">correctness/noUnusedTemplateLiteral.js:1:13 <a href="https://rome.tools/docs/lint/rules/noUnusedTemplateLiteral">lint/correctness/noUnusedTemplateLiteral</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Do not use template literals if interpolation and special-character handling are not needed.</span>
   

--- a/website/src/docs/lint/rules/noVoidElementsWithChildren.md
+++ b/website/src/docs/lint/rules/noVoidElementsWithChildren.md
@@ -15,7 +15,7 @@ This rules prevents void elements (AKA self-closing elements) from having childr
 <br>invalid child</br>
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">nursery/noVoidElementsWithChildren.js:1:1 <a href="https://rome.tools/docs/lint/rules/noVoidElementsWithChildren">lint/nursery/noVoidElementsWithChildren</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noVoidElementsWithChildren.js:1:1 <a href="https://rome.tools/docs/lint/rules/noVoidElementsWithChildren">lint/nursery/noVoidElementsWithChildren</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;"><strong>br</strong></span><span style="color: Orange;"> is a void element tag and must not have </span><span style="color: Orange;"><strong>children</strong></span><span style="color: Orange;">.</span>
   
@@ -33,7 +33,7 @@ This rules prevents void elements (AKA self-closing elements) from having childr
 <img alt="some text" children={"some child"} />
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">nursery/noVoidElementsWithChildren.js:1:1 <a href="https://rome.tools/docs/lint/rules/noVoidElementsWithChildren">lint/nursery/noVoidElementsWithChildren</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noVoidElementsWithChildren.js:1:1 <a href="https://rome.tools/docs/lint/rules/noVoidElementsWithChildren">lint/nursery/noVoidElementsWithChildren</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;"><strong>img</strong></span><span style="color: Orange;"> is a void element tag and must not have </span><span style="color: Orange;"><strong>children</strong></span><span style="color: Orange;">.</span>
   
@@ -51,7 +51,7 @@ This rules prevents void elements (AKA self-closing elements) from having childr
 React.createElement('img', {}, 'child')
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">nursery/noVoidElementsWithChildren.js:1:1 <a href="https://rome.tools/docs/lint/rules/noVoidElementsWithChildren">lint/nursery/noVoidElementsWithChildren</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━
+{% raw %}<pre class="language-text"><code class="language-text">nursery/noVoidElementsWithChildren.js:1:1 <a href="https://rome.tools/docs/lint/rules/noVoidElementsWithChildren">lint/nursery/noVoidElementsWithChildren</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;"><strong>img</strong></span><span style="color: Orange;"> is a void element tag and must not have </span><span style="color: Orange;"><strong>children</strong></span><span style="color: Orange;">.</span>
   

--- a/website/src/docs/lint/rules/useSimplifiedLogicExpression.md
+++ b/website/src/docs/lint/rules/useSimplifiedLogicExpression.md
@@ -18,7 +18,7 @@ const boolExp = true;
 const r = true && boolExp;
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:2:11 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:2:11 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Logical expression contains unnecessary complexity.</span>
   
@@ -38,7 +38,7 @@ const boolExp2 = true;
 const r2 = boolExp || true;
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:2:12 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:2:12 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Logical expression contains unnecessary complexity.</span>
   
@@ -58,7 +58,7 @@ const nonNullExp = 123;
 const r3 = null ?? nonNullExp;
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:2:12 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:2:12 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Logical expression contains unnecessary complexity.</span>
   
@@ -79,7 +79,7 @@ const boolExpr2 = false;
 const r4 = !boolExpr1 || !boolExpr2;
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:3:12 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:3:12 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Logical expression contains unnecessary complexity.</span>
   
@@ -104,7 +104,7 @@ const boolExp2 = true;
 const r2 = !!boolExp2;
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:2:12 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> 
+{% raw %}<pre class="language-text"><code class="language-text">correctness/useSimplifiedLogicExpression.js:2:12 <a href="https://rome.tools/docs/lint/rules/useSimplifiedLogicExpression">lint/correctness/useSimplifiedLogicExpression</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Logical expression contains unnecessary complexity.</span>
   

--- a/website/src/docs/lint/rules/useSingleCaseStatement.md
+++ b/website/src/docs/lint/rules/useSingleCaseStatement.md
@@ -23,7 +23,7 @@ switch (foo) {
 }
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/useSingleCaseStatement.js:4:9 <a href="https://rome.tools/docs/lint/rules/useSingleCaseStatement">lint/correctness/useSingleCaseStatement</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━
+{% raw %}<pre class="language-text"><code class="language-text">correctness/useSingleCaseStatement.js:4:9 <a href="https://rome.tools/docs/lint/rules/useSingleCaseStatement">lint/correctness/useSingleCaseStatement</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">A switch case should only have a single statement. If you want more, then wrap it in a block.</span>
   

--- a/website/src/docs/lint/rules/useSingleVarDeclarator.md
+++ b/website/src/docs/lint/rules/useSingleVarDeclarator.md
@@ -17,7 +17,7 @@ Disallow multiple variable declarations in the same variable statement
 let foo, bar;
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">correctness/useSingleVarDeclarator.js:1:1 <a href="https://rome.tools/docs/lint/rules/useSingleVarDeclarator">lint/correctness/useSingleVarDeclarator</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━
+{% raw %}<pre class="language-text"><code class="language-text">correctness/useSingleVarDeclarator.js:1:1 <a href="https://rome.tools/docs/lint/rules/useSingleVarDeclarator">lint/correctness/useSingleVarDeclarator</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Declare variables separately</span>
   


### PR DESCRIPTION
## Summary

Fixes #3391

The new diagnostics print a line of `━` characters at the end of the header line to fill the width up to 100 columns, but when the header line is long (for instance if the file path is very long or if the diagnostic has additional tags) this means the separators isn't displayed. This PR adds a minimal width, to force the line to be at least 10 characters wide.

## Test Plan

I've updated a few snapshot files that were impacted by this change
