### PR TITLE
fix(rome_js_formatter): Fix dropped initializer comments

### DIFF
--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -861,13 +861,17 @@ function() {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-let obj2 // Comment
-= {
-  key: 'val'
-}
+const b4 = (
+	<div>
+		Text <a data-very-long-prop-breakline-rome-playground data-other>
+			some link
+		</a>{" "}
+		| some other text,{" "}
+	</div>
+);
 
 "#;
-        let syntax = SourceType::ts();
+        let syntax = SourceType::jsx();
         let tree = parse(src, FileId::zero(), syntax);
         let options = JsFormatOptions::new(syntax);
 

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -861,17 +861,13 @@ function() {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-const b4 = (
-	<div>
-		Text <a data-very-long-prop-breakline-rome-playground data-other>
-			some link
-		</a>{" "}
-		| some other text,{" "}
-	</div>
-);
+let obj2 // Comment
+= {
+  key: 'val'
+}
 
 "#;
-        let syntax = SourceType::jsx();
+        let syntax = SourceType::ts();
         let tree = parse(src, FileId::zero(), syntax);
         let options = JsFormatOptions::new(syntax);
 

--- a/crates/rome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/rome_js_formatter/src/utils/assignment_like.rs
@@ -538,7 +538,12 @@ impl JsAnyAssignmentLike {
                     let expression = initializer.expression()?;
                     write!(
                         f,
-                        [space(), with_assignment_layout(&expression, Some(layout))]
+                        [
+                            space(),
+                            format_leading_comments(initializer.syntax()),
+                            with_assignment_layout(&expression, Some(layout)),
+                            format_trailing_comments(initializer.syntax())
+                        ]
                     )?;
                 }
                 Ok(())
@@ -552,7 +557,12 @@ impl JsAnyAssignmentLike {
                     let expression = initializer.expression()?;
                     write!(
                         f,
-                        [space(), with_assignment_layout(&expression, Some(layout))]
+                        [
+                            space(),
+                            format_leading_comments(initializer.syntax()),
+                            with_assignment_layout(&expression, Some(layout)),
+                            format_trailing_comments(initializer.syntax())
+                        ]
                     )?;
                 }
                 Ok(())
@@ -826,7 +836,8 @@ impl JsAnyAssignmentLike {
                 should_break_after_operator(expression, comments)?
             }
             RightAssignmentLike::JsInitializerClause(initializer) => {
-                should_break_after_operator(&initializer.expression()?, comments)?
+                comments.has_leading_own_line_comment(initializer.syntax())
+                    || should_break_after_operator(&initializer.expression()?, comments)?
             }
             RightAssignmentLike::TsType(TsType::TsUnionType(ty)) => {
                 comments.has_leading_comments(ty.syntax())

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts
@@ -1,0 +1,21 @@
+const a = // test
+	1;
+
+const b =
+	/* leading */
+	2;
+
+const c
+	/* leading */
+	= 3;
+
+
+const d: string // 1
+	= // 2
+	4;
+
+
+const e: string // 1
+	= // 2
+	{ object: 5 };
+

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
@@ -1,0 +1,53 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: assignment_comments.ts
+---
+# Input
+const a = // test
+	1;
+
+const b =
+	/* leading */
+	2;
+
+const c
+	/* leading */
+	= 3;
+
+
+const d: string // 1
+	= // 2
+	4;
+
+
+const e: string // 1
+	= // 2
+	{ object: 5 };
+
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+-----
+const a = 1; // test
+
+const b =
+	/* leading */
+	2;
+
+const c =
+	/* leading */
+	3;
+
+const d: string = 4; // 1 // 2
+
+const e: string =
+	// 1
+	// 2
+	{ object: 5 };
+

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts
@@ -1,0 +1,33 @@
+class Test {
+	prop1 = /* leading */ 1;
+
+	prop2 = // test
+		2;
+
+	prop3 // test
+		= 3;
+
+	prop4 // test
+		= 4;
+
+	prop5 // test
+		= 5 // a
+
+	prop6
+		/* leading */
+		= 6 // c
+
+	prop7 =
+		/* leading */
+		7 // c
+
+	prop8 /* comment */ = 8;
+
+	prop9: string // 1
+		= // 2
+	3;
+
+	prop10: any // 1
+	= // 2
+		{ object: 3}
+}

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
@@ -1,0 +1,75 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: property_assignment_comments.ts
+---
+# Input
+class Test {
+	prop1 = /* leading */ 1;
+
+	prop2 = // test
+		2;
+
+	prop3 // test
+		= 3;
+
+	prop4 // test
+		= 4;
+
+	prop5 // test
+		= 5 // a
+
+	prop6
+		/* leading */
+		= 6 // c
+
+	prop7 =
+		/* leading */
+		7 // c
+
+	prop8 /* comment */ = 8;
+
+	prop9: string // 1
+		= // 2
+	3;
+
+	prop10: any // 1
+	= // 2
+		{ object: 3}
+}
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+-----
+class Test {
+	prop1 = /* leading */ 1;
+
+	prop2 = 2; // test
+
+	prop3 = 3; // test
+
+	prop4 = 4; // test
+
+	prop5 = 5; // test // a
+
+	prop6 =
+		/* leading */
+		6; // c
+
+	prop7 =
+		/* leading */
+		7; // c
+
+	prop8 /* comment */ = 8;
+
+	prop9: string = 3; // 1 // 2
+
+	prop10: any = // 1 // 2
+		{ object: 3 };
+}
+


### PR DESCRIPTION
This PR fixes an issue where comments associated with initializers in variable declarators or class properties were dropped. I noticed this when formatting the `vscode` repo.

## Tests

I added a bunch of new snapshot tests to verify the placement of comments for properties and variable declarators (fewer for variable declarators, because there are already many in Prettier's test suite).

I also run Rome format on the vscode repo to verify that there are no more diagnostics about dropped comments
