### PR TITLE
fix(rome_js_formatter): Arrow chain trailing comments

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -458,10 +458,18 @@ impl Format<JsFormatContext> for ArrowChain {
                         soft_block_indent(&format_tail_body),
                         text(")")
                     ])]
-                )
+                )?;
             } else {
-                write!(f, [format_tail_body])
+                write!(f, [format_tail_body])?;
             }
+
+            // Format the trailing comments of all arrow function EXCEPT the first one because
+            // the comments of the head get formatted as part of the `FormatJsArrowFunctionExpression` call.
+            for arrow in self.arrows().skip(1) {
+                write!(f, [format_trailing_comments(arrow.syntax())])?;
+            }
+
+            Ok(())
         });
 
         let format_tail_body = format_with(|f| {
@@ -489,7 +497,7 @@ impl Format<JsFormatContext> for ArrowChain {
                         .should_expand(break_before_chain),
                     space(),
                     tail.fat_arrow_token().format(),
-                    indent_if_group_breaks(&format_tail_body, group_id)
+                    indent_if_group_breaks(&format_tail_body, group_id),
                 ]
             )?;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js
@@ -1,0 +1,9 @@
+x = (bifornCringerMoshedPerplexSawder) => ((askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) => (f00) => {
+		averredBathersBoxroomBuggyNurl();
+	} // BOOM
+)
+
+x2 = (a) => ((askTrovenaBeenaDependsRowans1, askTrovenaBeenaDependsRowans2, askTrovenaBeenaDependsRowans3) => {
+		c();
+	} /* ! */ // KABOOM
+)

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: arrow_chain_comments.js
+---
+# Input
+x = (bifornCringerMoshedPerplexSawder) => ((askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) => (f00) => {
+		averredBathersBoxroomBuggyNurl();
+	} // BOOM
+)
+
+x2 = (a) => ((askTrovenaBeenaDependsRowans1, askTrovenaBeenaDependsRowans2, askTrovenaBeenaDependsRowans3) => {
+		c();
+	} /* ! */ // KABOOM
+)
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+-----
+x =
+	(bifornCringerMoshedPerplexSawder) =>
+	(askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) =>
+	(f00) => {
+		averredBathersBoxroomBuggyNurl();
+	}; // BOOM
+
+x2 =
+	(a) =>
+	(
+		askTrovenaBeenaDependsRowans1,
+		askTrovenaBeenaDependsRowans2,
+		askTrovenaBeenaDependsRowans3,
+	) => {
+		c();
+	} /* ! */; // KABOOM
+


### PR DESCRIPTION
This PR fixes an issue where trailing comments of arrow expressions that are part of an arrow chain (arrow expressions that are the body of another arrow) were dropped.

The manual handling of comments is necessary because the arrow chain formatting doesn't call into the `FormatJsArrowFunctionExpression` of nested arrow functions.

The implementation already handles the formatting of leading comments correctly.

## Tests

I added a new snapshot test and verified that running rome format on prettier yields no more "dropped comments" errors.
