### PR TITLE
fix(rome_js_analyze): fix the debug bound checks of the CFG visitor

### DIFF
--- a/crates/rome_js_analyze/tests/specs/nursery/noUnreachable/NestedBlocks.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnreachable/NestedBlocks.js
@@ -1,0 +1,9 @@
+function Outer() {
+    label: {
+        function Inner() {
+            label2: {
+                break label2;
+            };
+        }
+    };
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnreachable/NestedBlocks.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnreachable/NestedBlocks.js.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: NestedBlocks.js
+---
+# Input
+```js
+function Outer() {
+    label: {
+        function Inner() {
+            label2: {
+                break label2;
+            };
+        }
+    };
+}
+
+```
+
+


### PR DESCRIPTION
## Summary

Fixes #3390

The `NodeVisitor` implementation used to build the Control Flow Graph has some additional checks in debug mode to ensure the CFG builder for a given function does not access any state belonging to another function, but offsets in the visitor state stack were not properly calculated to account for this leading to panics when break or continue statements needed to access said stack.

## Test Plan

I added an additional test case that could reliably reproduce the panic before the fix, and no longer does with the changes applied.
