### PR TITLE
perf(rome_formater): Inline `FormatElement::Text`

### DIFF
--- a/crates/rome_formatter/src/arguments.rs
+++ b/crates/rome_formatter/src/arguments.rs
@@ -145,14 +145,14 @@ mod tests {
         assert_eq!(
             buffer.into_vec(),
             vec![
-                FormatElement::Text(Text::Static { text: "function" }),
+                FormatElement::StaticText { text: "function" },
                 FormatElement::Space,
-                FormatElement::Text(Text::Static { text: "a" }),
+                FormatElement::StaticText { text: "a" },
                 FormatElement::Space,
                 // Group
                 FormatElement::Tag(Tag::StartGroup(tag::Group::new())),
-                FormatElement::Text(Text::Static { text: "(" }),
-                FormatElement::Text(Text::Static { text: ")" }),
+                FormatElement::StaticText { text: "(" },
+                FormatElement::StaticText { text: ")" },
                 FormatElement::Tag(Tag::EndGroup)
             ]
         );

--- a/crates/rome_formatter/src/buffer.rs
+++ b/crates/rome_formatter/src/buffer.rs
@@ -20,14 +20,14 @@ pub trait Buffer {
     /// # Examples
     ///
     /// ```
-    /// use rome_formatter::{Buffer, FormatElement, FormatState, SimpleFormatContext, Text, VecBuffer};
+    /// use rome_formatter::{Buffer, FormatElement, FormatState, SimpleFormatContext, VecBuffer};
     ///
     /// let mut state = FormatState::new(SimpleFormatContext::default());
     /// let mut buffer = VecBuffer::new(&mut state);
     ///
-    /// buffer.write_element(FormatElement::Text(Text::Static { text: "test"})).unwrap();
+    /// buffer.write_element(FormatElement::StaticText { text: "test"}).unwrap();
     ///
-    /// assert_eq!(buffer.into_vec(), vec![FormatElement::Text(Text::Static { text: "test" })]);
+    /// assert_eq!(buffer.into_vec(), vec![FormatElement::StaticText { text: "test" }]);
     /// ```
     ///
     fn write_element(&mut self, element: FormatElement) -> FormatResult<()>;
@@ -46,14 +46,14 @@ pub trait Buffer {
     ///
     /// ```
     /// use rome_formatter::prelude::*;
-    /// use rome_formatter::{Buffer, FormatState, SimpleFormatContext, Text, VecBuffer, format_args};
+    /// use rome_formatter::{Buffer, FormatState, SimpleFormatContext, VecBuffer, format_args};
     ///
     /// let mut state = FormatState::new(SimpleFormatContext::default());
     /// let mut buffer = VecBuffer::new(&mut state);
     ///
     /// buffer.write_fmt(format_args!(text("Hello World"))).unwrap();
     ///
-    /// assert_eq!(buffer.into_vec(), vec![FormatElement::Text(Text::Static { text: "Hello World" })]);
+    /// assert_eq!(buffer.into_vec(), vec![FormatElement::StaticText{ text: "Hello World" }]);
     /// ```
     fn write_fmt(mut self: &mut Self, arguments: Arguments<Self::Context>) -> FormatResult<()> {
         write(&mut self, arguments)
@@ -466,10 +466,10 @@ where
 /// assert_eq!(
 ///     formatted.document().as_ref(),
 ///     &[
-///         FormatElement::Text(Text::Static { text: "The next soft line or space gets replaced by a space" }),
+///         FormatElement::StaticText { text: "The next soft line or space gets replaced by a space" },
 ///         FormatElement::Space,
-///         FormatElement::Text(Text::Static { text: "and the line here" }),
-///         FormatElement::Text(Text::Static { text: "is removed entirely." })
+///         FormatElement::StaticText { text: "and the line here" },
+///         FormatElement::StaticText { text: "is removed entirely." }
 ///     ]
 /// );
 ///
@@ -635,10 +635,10 @@ pub trait BufferExtensions: Buffer + Sized {
     ///     assert_eq!(
     ///         recorded.deref(),
     ///         &[
-    ///             FormatElement::Text(Text::Static{ text: "A" }),
-    ///             FormatElement::Text(Text::Static{ text: "B" }),
-    ///             FormatElement::Text(Text::Static{ text: "C" }),
-    ///             FormatElement::Text(Text::Static{ text: "D" })
+    ///             FormatElement::StaticText{ text: "A" },
+    ///             FormatElement::StaticText{ text: "B" },
+    ///             FormatElement::StaticText{ text: "C" },
+    ///             FormatElement::StaticText{ text: "D" }
     ///         ]
     ///     );
     ///

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -265,7 +265,7 @@ pub struct StaticText {
 
 impl<Context> Format<Context> for StaticText {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Text(Text::Static { text: self.text }))
+        f.write_element(FormatElement::StaticText { text: self.text })
     }
 }
 
@@ -290,10 +290,10 @@ pub struct DynamicText<'a> {
 
 impl<Context> Format<Context> for DynamicText<'_> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Text(Text::Dynamic {
+        f.write_element(FormatElement::DynamicText {
             text: self.text.to_string().into_boxed_str(),
             source_position: self.position,
-        }))
+        })
     }
 }
 
@@ -335,15 +335,15 @@ impl<L: Language, Context> Format<Context> for SyntaxTokenCowSlice<'_, L> {
                 let relative_range = range - self.token.text_range().start();
                 let slice = self.token.token_text().slice(relative_range);
 
-                f.write_element(FormatElement::Text(Text::SyntaxTokenTextSlice {
+                f.write_element(FormatElement::SyntaxTokenTextSlice {
                     slice,
                     source_position: self.start,
-                }))
+                })
             }
-            Cow::Owned(text) => f.write_element(FormatElement::Text(Text::Dynamic {
+            Cow::Owned(text) => f.write_element(FormatElement::DynamicText {
                 text: text.to_string().into_boxed_str(),
                 source_position: self.start,
-            })),
+            }),
         }
     }
 }
@@ -377,10 +377,10 @@ pub struct SyntaxTokenTextSlice {
 
 impl<Context> Format<Context> for SyntaxTokenTextSlice {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Text(Text::SyntaxTokenTextSlice {
+        f.write_element(FormatElement::SyntaxTokenTextSlice {
             slice: self.text.clone(),
             source_position: self.source_position,
-        }))
+        })
     }
 }
 

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -30,11 +30,11 @@ pub enum FormatElement {
     StaticText { text: &'static str },
 
     /// Token constructed from the input source as a dynamic
-    /// string and a range in the input source
+    /// string with its start position in the input document.
     DynamicText {
-        // There's no need for the text to be mutable, using `Box<str>` safes 8 bytes over `String`.
+        /// There's no need for the text to be mutable, using `Box<str>` safes 8 bytes over `String`.
         text: Box<str>,
-        // The position of the dynamic token in the unformatted source code
+        /// The start position of the dynamic token in the unformatted source code
         source_position: TextSize,
     },
 

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -229,6 +229,10 @@ impl FormatElement {
                 | FormatElement::StaticText { .. }
         )
     }
+
+    pub const fn is_space(&self) -> bool {
+        matches!(self, FormatElement::Space)
+    }
 }
 
 impl FormatElements for FormatElement {

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -29,8 +29,8 @@ pub enum FormatElement {
     /// Token constructed by the formatter from a static string
     StaticText { text: &'static str },
 
-    /// Token constructed from the input source as a dynamics
-    /// string and a range of the input source
+    /// Token constructed from the input source as a dynamic
+    /// string and a range in the input source
     DynamicText {
         // There's no need for the text to be mutable, using `Box<str>` safes 8 bytes over `String`.
         text: Box<str>,

--- a/crates/rome_formatter/src/format_element/document.rs
+++ b/crates/rome_formatter/src/format_element/document.rs
@@ -209,7 +209,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                         _ => unreachable!(),
                     }
 
-                    let is_next_text = iter.peek().map_or(false, |e| e.is_text());
+                    let is_next_text = iter.peek().map_or(false, |e| e.is_text() || e.is_space());
 
                     if !is_next_text {
                         write!(f, [text("\"")])?;
@@ -679,16 +679,16 @@ mod tests {
         use Tag::*;
 
         let document = Document::from(vec![
-            FormatElement::Text(Text::Static { text: "[" }),
+            FormatElement::StaticText { text: "[" },
             FormatElement::Tag(StartGroup(tag::Group::new())),
             FormatElement::Tag(StartIndent),
             FormatElement::Line(LineMode::Soft),
-            FormatElement::Text(Text::Static { text: "a" }),
+            FormatElement::StaticText { text: "a" },
             // Close group instead of indent
             FormatElement::Tag(EndGroup),
             FormatElement::Line(LineMode::Soft),
             FormatElement::Tag(EndIndent),
-            FormatElement::Text(Text::Static { text: "]" }),
+            FormatElement::StaticText { text: "]" },
             // End tag without start
             FormatElement::Tag(EndIndent),
             // Start tag without an end

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -55,7 +55,7 @@ pub use builders::BestFitting;
 
 use crate::builders::syntax_token_cow_slice;
 use crate::comments::{CommentStyle, Comments, SourceComment};
-pub use format_element::{normalize_newlines, FormatElement, Text, LINE_TERMINATORS};
+pub use format_element::{normalize_newlines, FormatElement, LINE_TERMINATORS};
 pub use group_id::GroupId;
 use rome_rowan::{
     Language, SyntaxElement, SyntaxError, SyntaxNode, SyntaxResult, SyntaxToken, SyntaxTriviaPiece,

--- a/crates/rome_formatter/src/macros.rs
+++ b/crates/rome_formatter/src/macros.rs
@@ -58,9 +58,9 @@ macro_rules! format_args {
 /// assert_eq!(
 ///     buffer.into_vec(),
 ///     vec![
-///         FormatElement::Text(Text::Static { text: "Hello" }),
+///         FormatElement::StaticText { text: "Hello" },
 ///         FormatElement::Space,
-///         FormatElement::Text(Text::Static { text: "World" }),
+///         FormatElement::StaticText { text: "World" },
 ///     ]
 ///  );
 /// #  Ok(())
@@ -89,7 +89,7 @@ macro_rules! write {
 /// dbg_write!(buffer, [text("Hello")])?;
 /// // ^-- prints: [src/main.rs:7][0] = StaticToken("Hello")
 ///
-/// assert_eq!(buffer.into_vec(), vec![FormatElement::Text(Text::Static { text: "Hello" })]);
+/// assert_eq!(buffer.into_vec(), vec![FormatElement::StaticText { text: "Hello" }]);
 /// # Ok(())
 /// # }
 /// ```
@@ -131,9 +131,9 @@ macro_rules! dbg_write {
 /// assert_eq!(
 ///     formatted.into_document(),
 ///     Document::from(vec![
-///         FormatElement::Text(Text::Static { text: "(" }),
-///         FormatElement::Text(Text::Static { text: "a" }),
-///         FormatElement::Text(Text::Static { text: ")" }),
+///         FormatElement::StaticText { text: "(" },
+///         FormatElement::StaticText { text: "a" },
+///         FormatElement::StaticText { text: ")" },
 ///     ])
 /// );
 /// ```
@@ -357,7 +357,7 @@ mod tests {
 
         assert_eq!(
             buffer.into_vec(),
-            vec![FormatElement::Text(Text::Static { text: "test" })]
+            vec![FormatElement::StaticText { text: "test" }]
         );
     }
 
@@ -375,11 +375,11 @@ mod tests {
         assert_eq!(
             buffer.into_vec(),
             vec![
-                FormatElement::Text(Text::Static { text: "a" }),
+                FormatElement::StaticText { text: "a" },
                 FormatElement::Space,
-                FormatElement::Text(Text::Static { text: "simple" }),
+                FormatElement::StaticText { text: "simple" },
                 FormatElement::Space,
-                FormatElement::Text(Text::Static { text: "test" })
+                FormatElement::StaticText { text: "test" }
             ]
         );
     }

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -102,7 +102,7 @@ impl<'a> Printer<'a> {
             FormatElement::SyntaxTokenTextSlice {
                 slice,
                 source_position,
-            } => self.print_text(&slice, Some(*source_position)),
+            } => self.print_text(slice, Some(*source_position)),
 
             FormatElement::Line(line_mode) => {
                 if args.mode().is_flat()

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -94,64 +94,15 @@ impl<'a> Printer<'a> {
                 }
             }
 
-            FormatElement::Text(token) => {
-                if !self.state.pending_indent.is_empty() {
-                    let (indent_char, repeat_count) = match self.options.indent_style() {
-                        IndentStyle::Tab => ('\t', 1),
-                        IndentStyle::Space(count) => (' ', count),
-                    };
-
-                    let indent = std::mem::take(&mut self.state.pending_indent);
-                    let total_indent_char_count = indent.level() as usize * repeat_count as usize;
-
-                    self.state
-                        .buffer
-                        .reserve(total_indent_char_count + indent.align() as usize);
-
-                    for _ in 0..total_indent_char_count {
-                        self.print_char(indent_char);
-                    }
-
-                    for _ in 0..indent.align() {
-                        self.print_char(' ');
-                    }
-                }
-
-                // Print pending spaces
-                if self.state.pending_space {
-                    self.print_str(" ");
-                    self.state.pending_space = false;
-                }
-
-                // Insert source map markers before and after the token
-                //
-                // If the token has source position information the start marker
-                // will use the start position of the original token, and the end
-                // marker will use that position + the text length of the token
-                //
-                // If the token has no source position (was created by the formatter)
-                // both the start and end marker will use the last known position
-                // in the input source (from state.source_position)
-                if let Some(source) = token.source_position() {
-                    self.state.source_position = *source;
-                }
-
-                self.push_marker(SourceMarker {
-                    source: self.state.source_position,
-                    dest: self.state.buffer.text_len(),
-                });
-
-                self.print_str(token);
-
-                if token.source_position().is_some() {
-                    self.state.source_position += TextSize::of(&**token);
-                }
-
-                self.push_marker(SourceMarker {
-                    source: self.state.source_position,
-                    dest: self.state.buffer.text_len(),
-                });
-            }
+            FormatElement::StaticText { text } => self.print_text(text, None),
+            FormatElement::DynamicText {
+                text,
+                source_position,
+            } => self.print_text(text, Some(*source_position)),
+            FormatElement::SyntaxTokenTextSlice {
+                slice,
+                source_position,
+            } => self.print_text(&slice, Some(*source_position)),
 
             FormatElement::Line(line_mode) => {
                 if args.mode().is_flat()
@@ -325,6 +276,65 @@ impl<'a> Printer<'a> {
         let result = measure.fits(&mut AllPredicate);
         measure.finish();
         result
+    }
+
+    fn print_text(&mut self, text: &str, source_position: Option<TextSize>) {
+        if !self.state.pending_indent.is_empty() {
+            let (indent_char, repeat_count) = match self.options.indent_style() {
+                IndentStyle::Tab => ('\t', 1),
+                IndentStyle::Space(count) => (' ', count),
+            };
+
+            let indent = std::mem::take(&mut self.state.pending_indent);
+            let total_indent_char_count = indent.level() as usize * repeat_count as usize;
+
+            self.state
+                .buffer
+                .reserve(total_indent_char_count + indent.align() as usize);
+
+            for _ in 0..total_indent_char_count {
+                self.print_char(indent_char);
+            }
+
+            for _ in 0..indent.align() {
+                self.print_char(' ');
+            }
+        }
+
+        // Print pending spaces
+        if self.state.pending_space {
+            self.print_str(" ");
+            self.state.pending_space = false;
+        }
+
+        // Insert source map markers before and after the token
+        //
+        // If the token has source position information the start marker
+        // will use the start position of the original token, and the end
+        // marker will use that position + the text length of the token
+        //
+        // If the token has no source position (was created by the formatter)
+        // both the start and end marker will use the last known position
+        // in the input source (from state.source_position)
+        if let Some(source) = source_position {
+            self.state.source_position = source;
+        }
+
+        self.push_marker(SourceMarker {
+            source: self.state.source_position,
+            dest: self.state.buffer.text_len(),
+        });
+
+        self.print_str(text);
+
+        if source_position.is_some() {
+            self.state.source_position += text.text_len();
+        }
+
+        self.push_marker(SourceMarker {
+            source: self.state.source_position,
+            dest: self.state.buffer.text_len(),
+        });
     }
 
     fn push_marker(&mut self, marker: SourceMarker) {
@@ -989,37 +999,9 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 }
             }
 
-            FormatElement::Text(token) => {
-                let indent = std::mem::take(&mut self.state.pending_indent);
-                self.state.line_width += indent.level() as usize
-                    * self.options().indent_width() as usize
-                    + indent.align() as usize;
-
-                if self.state.pending_space {
-                    self.state.line_width += 1;
-                }
-
-                for c in token.chars() {
-                    let char_width = match c {
-                        '\t' => self.options().tab_width as usize,
-                        '\n' => {
-                            return Ok(if self.must_be_flat {
-                                Fits::No
-                            } else {
-                                Fits::Yes
-                            });
-                        }
-                        c => c.width().unwrap_or(0),
-                    };
-                    self.state.line_width += char_width;
-                }
-
-                if self.state.line_width > self.options().print_width.into() {
-                    return Ok(Fits::No);
-                }
-
-                self.state.pending_space = false;
-            }
+            FormatElement::StaticText { text } => return Ok(self.fits_text(text)),
+            FormatElement::DynamicText { text, .. } => return Ok(self.fits_text(text)),
+            FormatElement::SyntaxTokenTextSlice { slice, .. } => return Ok(self.fits_text(slice)),
 
             FormatElement::LineSuffixBoundary => {
                 if self.state.has_line_suffix {
@@ -1153,6 +1135,39 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
         }
 
         Ok(Fits::Maybe)
+    }
+
+    fn fits_text(&mut self, text: &str) -> Fits {
+        let indent = std::mem::take(&mut self.state.pending_indent);
+        self.state.line_width += indent.level() as usize * self.options().indent_width() as usize
+            + indent.align() as usize;
+
+        if self.state.pending_space {
+            self.state.line_width += 1;
+        }
+
+        for c in text.chars() {
+            let char_width = match c {
+                '\t' => self.options().tab_width as usize,
+                '\n' => {
+                    return if self.must_be_flat {
+                        Fits::No
+                    } else {
+                        Fits::Yes
+                    };
+                }
+                c => c.width().unwrap_or(0),
+            };
+            self.state.line_width += char_width;
+        }
+
+        if self.state.line_width > self.options().print_width.into() {
+            return Fits::No;
+        }
+
+        self.state.pending_space = false;
+
+        Fits::Maybe
     }
 
     fn finish(mut self) {

--- a/crates/rome_formatter/src/source_map.rs
+++ b/crates/rome_formatter/src/source_map.rs
@@ -206,8 +206,9 @@ impl TransformSourceMap {
     /// in the original, untransformed source code.
     ///
     /// The printer creates a source map that allows mapping positions from the newly formatted document
-    /// back to the locations of the tree. However, the source positions stored in [crate::FormatElement::Text]
-    /// are relative to the transformed tree and not the original tree passed to [crate::format_node].
+    /// back to the locations of the tree. However, the source positions stored in [crate::FormatElement::DynamicText]
+    /// and [crate::FormatElement::SyntaxTokenText] are relative to the transformed tree
+    /// and not the original tree passed to [crate::format_node].
     ///
     /// This function re-maps the positions from the positions in the transformed tree back to the positions
     /// in the original, untransformed tree.

--- a/crates/rome_formatter/src/source_map.rs
+++ b/crates/rome_formatter/src/source_map.rs
@@ -207,7 +207,7 @@ impl TransformSourceMap {
     ///
     /// The printer creates a source map that allows mapping positions from the newly formatted document
     /// back to the locations of the tree. However, the source positions stored in [crate::FormatElement::DynamicText]
-    /// and [crate::FormatElement::SyntaxTokenText] are relative to the transformed tree
+    /// and [crate::FormatElement::SyntaxTokenTextSlice] are relative to the transformed tree
     /// and not the original tree passed to [crate::format_node].
     ///
     /// This function re-maps the positions from the positions in the transformed tree back to the positions

--- a/crates/rome_js_formatter/src/utils/jsx.rs
+++ b/crates/rome_js_formatter/src/utils/jsx.rs
@@ -418,10 +418,10 @@ impl JsxWord {
 
 impl Format<JsFormatContext> for JsxWord {
     fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
-        f.write_element(FormatElement::Text(Text::SyntaxTokenTextSlice {
+        f.write_element(FormatElement::SyntaxTokenTextSlice {
             source_position: self.source_position,
             slice: self.text.clone(),
-        }))
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

This PR inlines the `Text` enum into the `FormatElement` enum to reduce the size of `FormatElement` from 32 to 24 bytes.

The largest variant of `FormatElement` is `FormatElement::Text` with a size of 24 bytes, which makes `FormatElement` 32 bytes wide because it adds one byte for the variant tag + 7 bytes of padding. 

The size of `Text` is 24 bytes:
* 1 byte for the union tag.
* 20 bytes for the largest variant `SyntaxTokenText`: 
  * 16 bytes for the slice  (8 bytes for `GreenToken` + 8 bytes for the text range)
  * 4 bytes for the source position
* 3 bytes of padding

This means, that we reserve 10 bytes of padding even for the largest enum variant (even worse for e.g. `LineSuffixBoundary` that has 31 bytes of padding). 

This PR inlines `Text` to avoid having to pad twice, once for `Text` and once on `FormatElement` which results in a size reduction of `FormatElement` to 24 bytes (3 bytes of padding for `SyntaxTokenText`). 

The downside of this change is that matching on text becomes more complicated and it removes the `Eq` implementation that compared `Text` by the string content. 

## Test Plan

<details>
<summary>This change results in a 20% peak memory consumption reduction: Max Bytes: 87.29 MB down to 69.48 MB</summary>


```bash
cargo run -p xtask_bench --release --features=dhat-heap -- --feature=formatter  --criterion=false --filter tex
```

### Main

```
[tex-chtml-full.js] - using [/home/micha/git/rome/target/tex-chtml-full.js]
Start
Formatted
        Memory
                Current Blocks: 208143
                Current Bytes: 87.09 MB
                Max Blocks: 208146
                Max Bytes: 87.29 MB
                Total Blocks: 3689951
                Total Bytes: 370.88 MB
Printed
        Memory
                Current Blocks: 148775
                Current Bytes: 21.44 MB
                Max Blocks: 208150
                Max Bytes: 97.12 MB
                Total Blocks: 71
                Total Bytes: 20.06 MB
Benchmark: https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-chtml-full.js
        Formatting: 8.768215985s
                      ----------
        Total:        8.768215985s

Summary
-------
tex-chtml-full.js, Formatting: 8.768215985s
dhat: Total:     463,866,958 bytes in 3,870,874 blocks
dhat: At t-gmax: 101,839,473 bytes in 208,150 blocks
dhat: At t-end:  1,152 bytes in 3 blocks
dhat: The data has been saved to dhat-heap.json, and is viewable with dhat/dh_view.html
```

### This Branch

```
[tex-chtml-full.js] - using [/home/micha/git/rome/target/tex-chtml-full.js]
Start
Formatted
        Memory
                Current Blocks: 208143
                Current Bytes: 69.28 MB
                Max Blocks: 208146
                Max Bytes: 69.48 MB
                Total Blocks: 3689951
                Total Bytes: 329.41 MB
Printed
        Memory
                Current Blocks: 148775
                Current Bytes: 21.44 MB
                Max Blocks: 208150
                Max Bytes: 79.32 MB
                Total Blocks: 71
                Total Bytes: 20.06 MB
Benchmark: https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-chtml-full.js
        Formatting: 8.808443181s
                      ----------
        Total:        8.808443181s

Summary
-------
tex-chtml-full.js, Formatting: 8.808443181s
dhat: Total:     420,388,694 bytes in 3,870,874 blocks
dhat: At t-gmax: 83,169,561 bytes in 208,150 blocks
dhat: At t-end:  1,152 bytes in 3 blocks
dhat: The data has been saved to dhat-heap.json, and is viewable with dhat/dh_view.html
``` 

</details>

I expect performance to improve a bit because it reduces the amount of data written during formatting. However, I don't expect too big of an improvement because the size reduction isn't big enough to make 4 format elements fit into a single cache line of 64 bytes (it's now 2 2/3 which probably is of very little use)

Local perf results:

```
group                                    main                                    text
-----                                    ----                                    ----
formatter/checker.ts                     1.00    216.2±1.31ms    12.0 MB/sec     1.02   221.4±18.09ms    11.7 MB/sec
formatter/compiler.js                    1.10   133.0±12.24ms     7.9 MB/sec     1.00    120.6±8.90ms     8.7 MB/sec
formatter/d3.min.js                      1.00     92.1±1.55ms     2.8 MB/sec     1.05    96.5±10.32ms     2.7 MB/sec
formatter/dojo.js                        1.00      6.5±0.02ms    10.6 MB/sec     1.06      6.8±0.63ms    10.0 MB/sec
formatter/ios.d.ts                       1.08   145.6±19.56ms    12.8 MB/sec     1.00   134.9±14.83ms    13.8 MB/sec
formatter/jquery.min.js                  1.00     26.7±0.11ms     3.1 MB/sec     1.04     27.9±2.55ms     3.0 MB/sec
formatter/math.js                        1.04    196.6±9.30ms     3.3 MB/sec     1.00   189.0±15.78ms     3.4 MB/sec
formatter/parser.ts                      1.04      4.6±0.01ms    10.7 MB/sec     1.00      4.4±0.07ms    11.0 MB/sec
formatter/pixi.min.js                    1.09   112.7±11.09ms     3.9 MB/sec     1.00    103.6±8.16ms     4.2 MB/sec
formatter/react-dom.production.min.js    1.07     33.6±3.26ms     3.4 MB/sec     1.00     31.5±3.08ms     3.7 MB/sec
formatter/react.production.min.js        1.02  1533.8±24.99µs     4.0 MB/sec     1.00  1498.6±12.46µs     4.1 MB/sec
formatter/router.ts                      1.07      4.1±0.38ms    15.0 MB/sec     1.00      3.8±0.21ms    16.1 MB/sec
formatter/tex-chtml-full.js              1.10   265.7±23.36ms     3.4 MB/sec     1.00   240.8±20.58ms     3.8 MB/sec
formatter/three.min.js                   1.00    126.8±9.68ms     4.6 MB/sec     1.00   127.0±13.34ms     4.6 MB/sec
formatter/typescript.js                  1.01   873.1±69.30ms    10.9 MB/sec     1.00   866.7±77.22ms    11.0 MB/sec
formatter/vue.global.prod.js             1.05     45.6±4.58ms     2.6 MB/sec     1.00     43.4±4.41ms     2.8 MB/sec
```