### PR TITLE
chore: use workspace metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ members = [
 	"xtask/libs_bench",
 	"xtask/contributors",
 ]
+[workspace.package]
+edition = "2021"
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
+license = "MIT"
 
 [profile.release-with-debug]
 inherits = "release"

--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_analyze"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_cli"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/rome_console/Cargo.toml
+++ b/crates/rome_console/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_console"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_control_flow/Cargo.toml
+++ b/crates/rome_control_flow/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_control_flow"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_css_factory/Cargo.toml
+++ b/crates/rome_css_factory/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_css_factory"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_css_syntax/Cargo.toml
+++ b/crates/rome_css_syntax/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_css_syntax"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rome_diagnostics/Cargo.toml
+++ b/crates/rome_diagnostics/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rome_diagnostics"
 version = "0.0.0"
 authors = ["RSLint developers"]
-edition = "2021"
+edition .workspace= true
 license = "MIT"
 description = "Pretty error reporting library based on codespan-reporting built for the RSLint project"
 

--- a/crates/rome_diagnostics_categories/Cargo.toml
+++ b/crates/rome_diagnostics_categories/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_diagnostics_categories"
 version = "0.0.0"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 serde = { version = "1.0.136", optional = true }

--- a/crates/rome_diagnostics_macros/Cargo.toml
+++ b/crates/rome_diagnostics_macros/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_diagnostics_macros"
 version = "0.0.0"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/rome_flags/Cargo.toml
+++ b/crates/rome_flags/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_flags"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_formatter/Cargo.toml
+++ b/crates/rome_formatter/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_formatter"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_fs/Cargo.toml
+++ b/crates/rome_fs/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_fs"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_js_analyze"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 rome_analyze = { path = "../rome_analyze" }

--- a/crates/rome_js_factory/Cargo.toml
+++ b/crates/rome_js_factory/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_js_factory"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_js_formatter/Cargo.toml
+++ b/crates/rome_js_formatter/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_js_formatter"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_js_parser/Cargo.toml
+++ b/crates/rome_js_parser/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2021"
 name = "rome_js_parser"
 version = "0.0.0"
-authors = ["Rome Tools Developers and Contributors"]
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "An extremely fast ECMAScript parser made for the rslint project"
-repository = "https://github.com/rome/tools"
 
 [dependencies]
 rome_diagnostics = { path = "../rome_diagnostics" }

--- a/crates/rome_js_semantic/Cargo.toml
+++ b/crates/rome_js_semantic/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2021"
 name = "rome_js_semantic"
 version = "0.0.0"
-authors = ["Rome Tools Developers and Contributors"]
-license = "MIT"
 description = "Semantic model for the JavaScript language"
-repository = "https://github.com/rome/tools"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 rome_rowan = { path = "../rome_rowan" }

--- a/crates/rome_js_syntax/Cargo.toml
+++ b/crates/rome_js_syntax/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2021"
 name = "rome_js_syntax"
 version = "0.0.0"
-authors = ["Rome Tools"]
 description = "SyntaxKind and common rowan definitions for rome_js_parser"
-license = "MIT"
-repository = "https://github.com/rome/tools"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 rome_rowan = { path = "../rome_rowan" }

--- a/crates/rome_json_factory/Cargo.toml
+++ b/crates/rome_json_factory/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_json_factory"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_json_syntax/Cargo.toml
+++ b/crates/rome_json_syntax/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rome_json_syntax"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools"]
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "SyntaxKind and common rowan definitions for rome_json_parser"
-license = "MIT"
-repository = "https://github.com/rome/tools"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_lsp"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_markup/Cargo.toml
+++ b/crates/rome_markup/Cargo.toml
@@ -2,10 +2,10 @@
 name = "rome_markup"
 version = "0.0.0"
 description = ""
-license = "MIT"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/rome_rowan/Cargo.toml
+++ b/crates/rome_rowan/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"
 description = "Library for generic lossless syntax trees"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 rustc-hash = { workspace = true }

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rome_service"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
-license = "MIT"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rome_text_edit/Cargo.toml
+++ b/crates/rome_text_edit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rome_text_edit"
 version = "0.0.0"
 authors = ["RSLint developers"]
-edition = "2021"
+edition.workspace = true
 license = "MIT"
 description = "Simple text editing crate ported from rust-analyzer for the RSLint project"
 

--- a/crates/rome_text_size/Cargo.toml
+++ b/crates/rome_text_size/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rome_text_size"
 version = "0.0.0"
-edition = "2018"
+edition.workspace = true
 
 authors = [
     "Aleksey Kladov <aleksey.kladov@gmail.com>",

--- a/crates/rome_wasm/Cargo.toml
+++ b/crates/rome_wasm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rome_wasm"
 version = "0.0.0"
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-repository = "https://github.com/rome/tools"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "WebAssembly bindings to the Rome Workspace API"
-license = "MIT"
 
 
 [lib]

--- a/crates/rome_wasm/Cargo.toml
+++ b/crates/rome_wasm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rome_wasm"
 version = "0.0.0"
-edition.workspace = true
-authors.workspace = true
-repository.workspace = true
-license.workspace = true
+edition = "2021"
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
 description = "WebAssembly bindings to the Rome Workspace API"
+license = "MIT"
 
 
 [lib]

--- a/crates/tests_macros/Cargo.toml
+++ b/crates/tests_macros/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "tests_macros"
 version = "0.0.0"
-description = ""
-license = "MIT"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "xtask"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "xtask_bench"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "xtask_codegen"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/xtask/contributors/Cargo.toml
+++ b/xtask/contributors/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "xtask_contributors"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/xtask/coverage/Cargo.toml
+++ b/xtask/coverage/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "xtask_coverage"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/xtask/libs_bench/Cargo.toml
+++ b/xtask/libs_bench/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "xtask_libs_bench"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/xtask/lintdoc/Cargo.toml
+++ b/xtask/lintdoc/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "xtask_lintdoc"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This is a chore PR, it uses the new [workspace feature](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table) to move all the repeated info inside the main `Cargo.toml`. Info that have been moved:
- `authors`
- `edition`
- `license`
- `repository`

I didn't change those crates that were a fork of another project. In those crates, I just changed edition.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current CI should pass

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
