### PR TITLE
fix(rome_diagnostics): fix unknown rule warning false positive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ version = "0.0.0"
 dependencies = [
  "countme",
  "insta",
+ "lazy_static",
  "roaring",
  "rome_analyze",
  "rome_console",

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -64,8 +64,7 @@ impl MetadataRegistry {
     /// Return a unique identifier for a rule group if it's known by this registry
     pub fn find_group(&self, group: &str) -> Option<GroupKey> {
         let key = self.inner.get(group)?;
-        let (key, _) = key.inner;
-        Some(GroupKey::new(key))
+        Some(key.into_group_key())
     }
 
     /// Return a unique identifier for a rule if it's known by this registry
@@ -128,8 +127,8 @@ struct PhaseRules<L: Language> {
 }
 
 pub struct RuleRegistryBuilder<'a, L: Language> {
-    pub registry: RuleRegistry<L>,
-    pub filter: &'a AnalysisFilter<'a>,
+    registry: RuleRegistry<L>,
+    filter: &'a AnalysisFilter<'a>,
 }
 
 impl<L: Language + Default> RegistryVisitor<L> for RuleRegistryBuilder<'_, L> {
@@ -255,6 +254,11 @@ pub struct MetadataKey {
 }
 
 impl MetadataKey {
+    fn into_group_key(self) -> GroupKey {
+        let (group, _) = self.inner;
+        GroupKey::new(group)
+    }
+
     fn into_rule_key(self) -> RuleKey {
         let (group, rule) = self.inner;
         RuleKey::new(group, rule)

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -1,4 +1,4 @@
-use std::{borrow, collections::BTreeMap};
+use std::{borrow, collections::BTreeSet};
 
 use rome_diagnostics::v2::Error;
 use rome_rowan::{AstNode, Language, RawSyntaxKind, SyntaxKind, SyntaxNode};
@@ -34,6 +34,64 @@ impl Phase for () {
     }
 }
 
+pub trait RegistryVisitor<L: Language> {
+    /// Record the category `C` to this visitor
+    fn record_category<C: GroupCategory<Language = L>>(&mut self) {
+        C::record_groups(self);
+    }
+
+    /// Record the group `G` to this visitor
+    fn record_group<G: RuleGroup<Language = L>>(&mut self) {
+        G::record_rules(self);
+    }
+
+    /// Record the rule `R` to this visitor
+    fn record_rule<R>(&mut self)
+    where
+        R: Rule + 'static,
+        R::Query: Queryable<Language = L>,
+        <R::Query as Queryable>::Output: Clone;
+}
+
+/// Stores metadata information for all the rules in the registry, sorted
+/// alphabetically
+#[derive(Default)]
+pub struct MetadataRegistry {
+    inner: BTreeSet<MetadataKey>,
+}
+
+impl MetadataRegistry {
+    /// Return a unique identifier for a rule group if it's known by this registry
+    pub fn find_group(&self, group: &str) -> Option<GroupKey> {
+        let key = self.inner.get(group)?;
+        let (key, _) = key.inner;
+        Some(GroupKey::new(key))
+    }
+
+    /// Return a unique identifier for a rule if it's known by this registry
+    pub fn find_rule(&self, group: &str, rule: &str) -> Option<RuleKey> {
+        let key = self.inner.get(&(group, rule))?;
+        Some(key.into_rule_key())
+    }
+
+    pub(crate) fn insert_rule(&mut self, group: &'static str, rule: &'static str) {
+        self.inner.insert(MetadataKey {
+            inner: (group, rule),
+        });
+    }
+}
+
+impl<L: Language> RegistryVisitor<L> for MetadataRegistry {
+    fn record_rule<R>(&mut self)
+    where
+        R: Rule + 'static,
+        R::Query: Queryable<Language = L>,
+        <R::Query as Queryable>::Output: Clone,
+    {
+        self.insert_rule(<R::Group as RuleGroup>::NAME, R::METADATA.name);
+    }
+}
+
 /// The rule registry holds type-erased instances of all active analysis rules
 /// for each phase.
 /// What defines a phase is the set of services that a phase offers. Currently
@@ -41,13 +99,20 @@ impl Phase for () {
 /// - Syntax Phase: No services are offered, thus its rules can be run immediately;
 /// - Semantic Phase: Offers the semantic model, thus these rules can only run
 /// after the "SemanticModel" is ready, which demands a whole transverse of the parsed tree.
-#[derive(Default)]
 pub struct RuleRegistry<L: Language> {
-    /// Stores metadata information for all the rules in the registry, sorted
-    /// alphabetically
-    metadata: BTreeMap<MetadataKey, RuleMetadata>,
     /// Holds a collection of rules for each phase.
     phase_rules: [PhaseRules<L>; 2],
+}
+
+impl<L: Language + Default> RuleRegistry<L> {
+    pub fn builder<'a>(filter: &'a AnalysisFilter<'a>) -> RuleRegistryBuilder<'a, L> {
+        RuleRegistryBuilder {
+            registry: RuleRegistry {
+                phase_rules: Default::default(),
+            },
+            filter,
+        }
+    }
 }
 
 /// Holds a collection of rules for each phase.
@@ -62,32 +127,37 @@ struct PhaseRules<L: Language> {
     rule_states: Vec<RuleState<L>>,
 }
 
-impl<L: Language + Default> RuleRegistry<L> {
-    pub fn push_category<C: GroupCategory<Language = L>>(&mut self, filter: &AnalysisFilter) {
-        if filter.match_category::<C>() {
-            C::push_groups(self, filter);
+pub struct RuleRegistryBuilder<'a, L: Language> {
+    pub registry: RuleRegistry<L>,
+    pub filter: &'a AnalysisFilter<'a>,
+}
+
+impl<L: Language + Default> RegistryVisitor<L> for RuleRegistryBuilder<'_, L> {
+    fn record_category<C: GroupCategory<Language = L>>(&mut self) {
+        if self.filter.match_category::<C>() {
+            C::record_groups(self);
         }
     }
 
-    pub fn push_group<G: RuleGroup<Language = L>>(&mut self, filter: &AnalysisFilter) {
-        if filter.match_group::<G>() {
-            G::push_rules(self, filter);
+    fn record_group<G: RuleGroup<Language = L>>(&mut self) {
+        if self.filter.match_group::<G>() {
+            G::record_rules(self);
         }
     }
 
     /// Add the rule `R` to the list of rules stores in this registry instance
-    pub fn push_rule<R>(&mut self, filter: &AnalysisFilter)
+    fn record_rule<R>(&mut self)
     where
         R: Rule + 'static,
         R::Query: Queryable<Language = L>,
         <R::Query as Queryable>::Output: Clone,
     {
-        if !filter.match_rule::<R>() {
+        if !self.filter.match_rule::<R>() {
             return;
         }
 
         let phase = R::phase() as usize;
-        let phase = &mut self.phase_rules[phase];
+        let phase = &mut self.registry.phase_rules[phase];
 
         let rule = RegistryRule::new::<R>(phase.rule_states.len());
 
@@ -121,42 +191,16 @@ impl<L: Language + Default> RuleRegistry<L> {
         }
 
         phase.rule_states.push(RuleState::default());
-
-        self.metadata.insert(
-            MetadataKey {
-                inner: (<R::Group as RuleGroup>::NAME, R::METADATA.name),
-            },
-            R::METADATA,
-        );
     }
+}
 
-    /// Returns an iterator over the name and documentation of all active rules
-    /// in this instance of the registry
-    pub fn metadata(self) -> impl Iterator<Item = RegistryRuleMetadata> {
-        self.metadata.into_iter().map(|(key, value)| {
-            let (group, _) = key.inner;
-            RegistryRuleMetadata { group, rule: value }
-        })
+impl<L: Language> RuleRegistryBuilder<'_, L> {
+    pub fn build(self) -> RuleRegistry<L> {
+        self.registry
     }
 }
 
 impl<L: Language> QueryMatcher<L> for RuleRegistry<L> {
-    fn find_group(&self, group: &str) -> Option<GroupKey> {
-        self.metadata.keys().find_map(|key| {
-            let (key, _) = key.inner;
-            if key == group {
-                Some(GroupKey::new(key))
-            } else {
-                None
-            }
-        })
-    }
-
-    fn find_rule(&self, group: &str, rule: &str) -> Option<RuleKey> {
-        let (key, _) = self.metadata.get_key_value(&(group, rule))?;
-        Some(key.into_rule_key())
-    }
-
     fn match_query(&mut self, mut params: MatchQueryParams<L>) {
         let phase = &mut self.phase_rules[params.phase as usize];
 
@@ -206,7 +250,7 @@ pub type LanguageRoot<L> = <L as Language>::Root;
 
 /// Key struct for a rule in the metadata map, sorted alphabetically
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct MetadataKey {
+pub struct MetadataKey {
     inner: (&'static str, &'static str),
 }
 
@@ -220,6 +264,12 @@ impl MetadataKey {
 impl<'a> borrow::Borrow<(&'a str, &'a str)> for MetadataKey {
     fn borrow(&self) -> &(&'a str, &'a str) {
         &self.inner
+    }
+}
+
+impl borrow::Borrow<str> for MetadataKey {
+    fn borrow(&self) -> &str {
+        self.inner.0
     }
 }
 

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -1,7 +1,7 @@
 use crate::categories::{ActionCategory, RuleCategory};
 use crate::context::RuleContext;
-use crate::registry::{RuleLanguage, RuleSuppressions};
-use crate::{AnalysisFilter, AnalyzerDiagnostic, Phase, Phases, Queryable, RuleRegistry};
+use crate::registry::{RegistryVisitor, RuleLanguage, RuleSuppressions};
+use crate::{AnalyzerDiagnostic, Phase, Phases, Queryable};
 use rome_console::fmt::Display;
 use rome_console::{markup, MarkupBuf};
 use rome_diagnostics::v2::Category;
@@ -109,7 +109,7 @@ pub trait RuleGroup {
     /// The name of this group, displayed in the diagnostics emitted by its rules
     const NAME: &'static str;
     /// Register all the rules belonging to this group into `registry`
-    fn push_rules(registry: &mut RuleRegistry<Self::Language>, filter: &AnalysisFilter);
+    fn record_rules<V: RegistryVisitor<Self::Language> + ?Sized>(registry: &mut V);
 }
 
 /// This macro is used by the codegen script to declare an analyzer rule group,
@@ -125,8 +125,8 @@ macro_rules! declare_group {
 
             const NAME: &'static str = $name;
 
-            fn push_rules(registry: &mut $crate::RuleRegistry<Self::Language>, filter: &$crate::AnalysisFilter) {
-                $( registry.push_rule::<$( $rule )::*>(filter); )*
+            fn record_rules<V: $crate::RegistryVisitor<Self::Language> + ?Sized>(registry: &mut V) {
+                $( registry.record_rule::<$( $rule )::*>(); )*
             }
         }
 
@@ -158,7 +158,7 @@ pub trait GroupCategory {
     /// The category ID used for all groups and rule belonging to this category
     const CATEGORY: RuleCategory;
     /// Register all the groups belonging to this category into `registry`
-    fn push_groups(registry: &mut RuleRegistry<Self::Language>, filter: &AnalysisFilter);
+    fn record_groups<V: RegistryVisitor<Self::Language> + ?Sized>(registry: &mut V);
 }
 
 #[macro_export]
@@ -171,8 +171,8 @@ macro_rules! declare_category {
 
             const CATEGORY: $crate::RuleCategory = $crate::RuleCategory::$kind;
 
-            fn push_groups(registry: &mut $crate::RuleRegistry<Self::Language>, filter: &$crate::AnalysisFilter) {
-                $( registry.push_group::<$( $group )::*>(filter); )*
+            fn record_groups<V: $crate::RegistryVisitor<Self::Language> + ?Sized>(registry: &mut V) {
+                $( registry.record_group::<$( $group )::*>(); )*
             }
         }
 

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -56,10 +56,9 @@ mod tests {
     };
 
     use crate::{
-        matcher::{GroupKey, MatchQueryParams},
-        registry::Phases,
-        Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, ControlFlow, Never, QueryMatch,
-        QueryMatcher, RuleKey, ServiceBag, SyntaxVisitor,
+        matcher::MatchQueryParams, registry::Phases, Analyzer, AnalyzerContext, AnalyzerOptions,
+        AnalyzerSignal, ControlFlow, MetadataRegistry, Never, QueryMatch, QueryMatcher, ServiceBag,
+        SyntaxVisitor,
     };
 
     #[derive(Default)]
@@ -68,14 +67,6 @@ mod tests {
     }
 
     impl<'a> QueryMatcher<RawLanguage> for &'a mut BufferMatcher {
-        fn find_group(&self, _group: &str) -> Option<GroupKey> {
-            None
-        }
-
-        fn find_rule(&self, _group: &str, _rule: &str) -> Option<RuleKey> {
-            None
-        }
-
         fn match_query(&mut self, params: MatchQueryParams<RawLanguage>) {
             match params.query {
                 QueryMatch::Syntax(node) => {
@@ -113,7 +104,14 @@ mod tests {
         let mut emit_signal =
             |_: &dyn AnalyzerSignal<RawLanguage>| -> ControlFlow<Never> { unreachable!() };
 
-        let mut analyzer = Analyzer::new(&mut matcher, |_| unreachable!(), &mut emit_signal);
+        let metadata = MetadataRegistry::default();
+
+        let mut analyzer = Analyzer::new(
+            &metadata,
+            &mut matcher,
+            |_| unreachable!(),
+            &mut emit_signal,
+        );
 
         analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
 

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -19,6 +19,7 @@ roaring = "0.9.0"
 rustc-hash = { workspace = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["raw_value"] }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -28,7 +28,7 @@ use crate::semantic_services::{SemanticModelBuilderVisitor, SemanticModelVisitor
 pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
 
 /// Return the static [MetadataRegistry] for the JS analyzer rules
-fn metadata() -> &'static MetadataRegistry {
+pub fn metadata() -> &'static MetadataRegistry {
     lazy_static::lazy_static! {
         static ref METADATA: MetadataRegistry = {
             let mut metadata = MetadataRegistry::default();

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -1,8 +1,8 @@
 use control_flow::make_visitor;
 use rome_analyze::{
     AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, ControlFlow,
-    InspectMatcher, LanguageRoot, MatchQueryParams, Phases, RegistryRuleMetadata, RuleAction,
-    ServiceBag, SyntaxVisitor,
+    InspectMatcher, LanguageRoot, MatchQueryParams, MetadataRegistry, Phases, RuleAction,
+    RuleRegistry, ServiceBag, SyntaxVisitor,
 };
 use rome_diagnostics::file::FileId;
 use rome_js_syntax::{
@@ -22,17 +22,22 @@ mod semantic_analyzers;
 mod semantic_services;
 pub mod utils;
 
-use crate::{
-    registry::build_registry,
-    semantic_services::{SemanticModelBuilderVisitor, SemanticModelVisitor},
-};
+pub use crate::registry::visit_registry;
+use crate::semantic_services::{SemanticModelBuilderVisitor, SemanticModelVisitor};
 
 pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
 
-/// Return an iterator over the name and documentation of all the rules
-/// implemented by the JS analyzer
-pub fn metadata(filter: &AnalysisFilter) -> impl Iterator<Item = RegistryRuleMetadata> {
-    build_registry(filter).metadata()
+/// Return the static [MetadataRegistry] for the JS analyzer rules
+fn metadata() -> &'static MetadataRegistry {
+    lazy_static::lazy_static! {
+        static ref METADATA: MetadataRegistry = {
+            let mut metadata = MetadataRegistry::default();
+            visit_registry(&mut metadata);
+            metadata
+        };
+    }
+
+    &*METADATA
 }
 
 /// Run the analyzer on the provided `root`: this process will use the given `filter`
@@ -67,8 +72,12 @@ where
             .collect()
     }
 
+    let mut registry = RuleRegistry::builder(&filter);
+    visit_registry(&mut registry);
+
     let mut analyzer = Analyzer::new(
-        InspectMatcher::new(build_registry(&filter), inspect_matcher),
+        metadata(),
+        InspectMatcher::new(registry.build(), inspect_matcher),
         parse_linter_suppression_comment,
         &mut emit_signal,
     );
@@ -108,7 +117,7 @@ where
 #[cfg(test)]
 mod tests {
 
-    use rome_analyze::{AnalyzerOptions, Never};
+    use rome_analyze::{AnalyzerOptions, Never, RuleCategories};
     use rome_diagnostics::Severity;
     use rome_diagnostics::{file::FileId, v2::category};
     use rome_js_parser::parse;
@@ -210,6 +219,33 @@ mod tests {
                 TextRange::new(TextSize::from(853), TextSize::from(855)),
             ]
         );
+    }
+
+    #[test]
+    fn suppression_syntax() {
+        const SOURCE: &str = "
+            // rome-ignore lint(correctness/noDoubleEquals): single rule
+            a == b;
+        ";
+
+        let parsed = parse(SOURCE, FileId::zero(), SourceType::js_module());
+
+        let filter = AnalysisFilter {
+            categories: RuleCategories::SYNTAX,
+            ..AnalysisFilter::default()
+        };
+
+        let options = AnalyzerOptions::default();
+        analyze(FileId::zero(), &parsed.tree(), filter, &options, |signal| {
+            if let Some(diag) = signal.diagnostic() {
+                let diag = diag.into_diagnostic(Severity::Warning);
+                let code = diag.code.unwrap();
+                let primary = diag.primary.as_ref().unwrap();
+                panic!("unexpected diagnostic {code:?} at {primary:?}");
+            }
+
+            ControlFlow::<Never>::Continue(())
+        });
     }
 }
 

--- a/crates/rome_js_analyze/src/registry.rs
+++ b/crates/rome_js_analyze/src/registry.rs
@@ -1,11 +1,9 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use rome_analyze::{AnalysisFilter, RuleRegistry};
+use rome_analyze::RegistryVisitor;
 use rome_js_syntax::JsLanguage;
-pub(crate) fn build_registry(filter: &AnalysisFilter) -> RuleRegistry<JsLanguage> {
-    let mut registry = RuleRegistry::default();
-    registry.push_category::<crate::analyzers::Analyzers>(filter);
-    registry.push_category::<crate::semantic_analyzers::SemanticAnalyzers>(filter);
-    registry.push_category::<crate::assists::Assists>(filter);
-    registry
+pub fn visit_registry<V: RegistryVisitor<JsLanguage>>(registry: &mut V) {
+    registry.record_category::<crate::analyzers::Analyzers>();
+    registry.record_category::<crate::semantic_analyzers::SemanticAnalyzers>();
+    registry.record_category::<crate::assists::Assists>();
 }

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -29,5 +29,5 @@ serde_json = { version = "1.0.74", optional = true }
 rome_service = { path = "../../crates/rome_service", features = ["schemars"], optional = true }
 
 [features]
-configuration = ["rome_analyze", "rome_js_analyze"]
+configuration = ["rome_analyze", "rome_js_analyze", "rome_js_syntax"]
 schema = ["schemars", "serde_json", "rome_rowan", "rome_service", "rome_js_syntax", "rome_js_factory", "rome_js_formatter"]

--- a/xtask/codegen/src/generate_analyzer.rs
+++ b/xtask/codegen/src/generate_analyzer.rs
@@ -73,7 +73,7 @@ fn generate_category(
     entries.insert(
         key,
         quote! {
-            registry.push_category::<crate::#module_name::#category_name>(filter);
+            registry.record_category::<crate::#module_name::#category_name>();
         },
     );
 
@@ -199,13 +199,11 @@ fn update_registry_builder(
         .map(|(_, tokens)| tokens);
 
     let tokens = xtask::reformat(quote! {
-        use rome_analyze::{AnalysisFilter, RuleRegistry};
+        use rome_analyze::RegistryVisitor;
         use rome_js_syntax::JsLanguage;
 
-        pub(crate) fn build_registry(filter: &AnalysisFilter) -> RuleRegistry<JsLanguage> {
-            let mut registry = RuleRegistry::default();
+        pub fn visit_registry<V: RegistryVisitor<JsLanguage>>(registry: &mut V) {
             #( #categories )*
-            registry
         }
     })?;
 

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -60,11 +60,11 @@ fn main() -> Result<()> {
     let mut errors = Vec::new();
 
     #[derive(Default)]
-    struct RulesVisitor {
+    struct LintRulesVisitor {
         groups: BTreeMap<&'static str, BTreeMap<&'static str, RuleMetadata>>,
     }
 
-    impl RegistryVisitor<JsLanguage> for RulesVisitor {
+    impl RegistryVisitor<JsLanguage> for LintRulesVisitor {
         fn record_category<C: GroupCategory<Language = JsLanguage>>(&mut self) {
             if matches!(C::CATEGORY, RuleCategory::Lint) {
                 C::record_groups(self);
@@ -84,10 +84,10 @@ fn main() -> Result<()> {
         }
     }
 
-    let mut visitor = RulesVisitor::default();
+    let mut visitor = LintRulesVisitor::default();
     visit_registry(&mut visitor);
 
-    let RulesVisitor { groups } = visitor;
+    let LintRulesVisitor { groups } = visitor;
 
     for (group, rules) in groups {
         let (group_name, description) = match group {

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -1,12 +1,15 @@
 use pulldown_cmark::{html::write_html, CodeBlockKind, Event, LinkType, Parser, Tag};
-use rome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, RuleCategories, RuleFilter};
+use rome_analyze::{
+    AnalysisFilter, AnalyzerOptions, ControlFlow, GroupCategory, Queryable, RegistryVisitor, Rule,
+    RuleCategory, RuleFilter, RuleGroup, RuleMetadata,
+};
 use rome_console::{
     fmt::{Formatter, HTML},
     markup, Markup,
 };
 use rome_diagnostics::{file::FileId, file::SimpleFile, Diagnostic};
-use rome_js_analyze::{analyze, metadata};
-use rome_js_syntax::{Language, LanguageVariant, ModuleKind, SourceType};
+use rome_js_analyze::{analyze, visit_registry};
+use rome_js_syntax::{JsLanguage, Language, LanguageVariant, ModuleKind, SourceType};
 use rome_service::settings::WorkspaceSettings;
 use std::{
     collections::BTreeMap,
@@ -56,19 +59,35 @@ fn main() -> Result<()> {
     // failure instead of just the first one
     let mut errors = Vec::new();
 
-    let filter = AnalysisFilter {
-        categories: RuleCategories::LINT,
-        ..AnalysisFilter::default()
-    };
-
-    // Ensure the list of rules is stored alphabetically
-    let mut groups = BTreeMap::new();
-    for meta in metadata(&filter) {
-        groups
-            .entry(meta.group)
-            .or_insert_with(BTreeMap::new)
-            .insert(meta.rule.name, meta.rule);
+    #[derive(Default)]
+    struct RulesVisitor {
+        groups: BTreeMap<&'static str, BTreeMap<&'static str, RuleMetadata>>,
     }
+
+    impl RegistryVisitor<JsLanguage> for RulesVisitor {
+        fn record_category<C: GroupCategory<Language = JsLanguage>>(&mut self) {
+            if matches!(C::CATEGORY, RuleCategory::Lint) {
+                C::record_groups(self);
+            }
+        }
+
+        fn record_rule<R>(&mut self)
+        where
+            R: Rule + 'static,
+            R::Query: Queryable<Language = JsLanguage>,
+            <R::Query as Queryable>::Output: Clone,
+        {
+            self.groups
+                .entry(<R::Group as RuleGroup>::NAME)
+                .or_insert_with(BTreeMap::new)
+                .insert(R::METADATA.name, R::METADATA);
+        }
+    }
+
+    let mut visitor = RulesVisitor::default();
+    visit_registry(&mut visitor);
+
+    let RulesVisitor { groups } = visitor;
 
     for (group, rules) in groups {
         let (group_name, description) = match group {


### PR DESCRIPTION
## Summary

Fixes #3406

This PR changes how the "rule registry" concept of the analyzer works by splitting its various use-case into separate types implemented at different location in the codebase through a common `RegistryVisitor` trait. This trait makes it possible to differentiate between the "static registry" containing all the rules for a given language (implemented through the new `visit_registry` function replacing `build_registry`), and various "dynamic registries" that get built on demand throughout the codebase: the analyzer holds both a fast set of all the known rules and a `RuleRegistry` containing only the active rules, the `lintdoc` tools builds a list of the lint rules only, the LSP also needs to build a list of the code action rules, ...

## Test Plan

I've added an additional test for suppression comments to ensure the analyzer does not emit an "unknown rule" diagnostic on a suppression comment for a rule whose category is disabled. The rest of the change should be covered by the existing tests for the corresponding area of the codebase.
