### PR TITLE
fix(rome_cli): improve the main help text

### DIFF
--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -12,7 +12,7 @@ const MAIN: Markup = markup! {
 
 "<Emphasis>"COMMANDS:"</Emphasis>"
     - "<Emphasis>"check"</Emphasis>"        Run the linter on a set of files
-    - "<Emphasis>"ci"</Emphasis>"           Run the linter and formatter check on a set of files
+    - "<Emphasis>"ci"</Emphasis>"           Run the linter and check the formatting of a set of files
     - "<Emphasis>"format"</Emphasis>"       Run the formatter on a set of files
     - "<Emphasis>"help"</Emphasis>"         Prints this help message
     - "<Emphasis>"init"</Emphasis>"         Bootstraps a new rome project

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -11,11 +11,13 @@ const MAIN: Markup = markup! {
 "Rome CLI v"{VERSION}"
 
 "<Emphasis>"COMMANDS:"</Emphasis>"
-    - "<Emphasis>"check"</Emphasis>"
-    - "<Emphasis>"ci"</Emphasis>"
-    - "<Emphasis>"format"</Emphasis>"
-    - "<Emphasis>"init"</Emphasis>"
-    - "<Emphasis>"help"</Emphasis>"
+    - "<Emphasis>"check"</Emphasis>"        Run the linter on a set of files
+    - "<Emphasis>"ci"</Emphasis>"           Run the linter and formatter check on a set of files
+    - "<Emphasis>"format"</Emphasis>"       Run the formatter on a set of files
+    - "<Emphasis>"help"</Emphasis>"         Prints this help message
+    - "<Emphasis>"init"</Emphasis>"         Bootstraps a new rome project
+    - "<Emphasis>"start"</Emphasis>"        Start the Rome daemon server process
+    - "<Emphasis>"stop"</Emphasis>"         Stop the Rome daemon server process
 
 "<Emphasis>"OPTIONS:"</Emphasis>"
     "<Dim>"--no-colors"</Dim>"      Disable the formatting of markup (print everything as plain text)


### PR DESCRIPTION
## Summary

Fixes #3415

This adds the `start` and `stop` commands to the list of commands documented in the "main" help text printed by `rome --help`. I also took the opportunity to add a short summary for the commands in the list to make it easier to see what each command is doing at a glance without having to print the full help text for each command.

## Test Plan

N/A
