### PR TITLE
feat(rome_js_formatter): trailing comma option #3305

### DIFF
--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -132,6 +132,14 @@ pub(crate) fn apply_format_settings_from_cli(
             source,
         })?;
 
+    let trailing_comma = session
+        .args
+        .opt_value_from_str("--trailing-comma")
+        .map_err(|source| Termination::ParseError {
+            argument: "--trailing-comma",
+            source,
+        })?;
+
     let javascript = configuration
         .javascript
         .get_or_insert_with(JavascriptConfiguration::default);
@@ -145,6 +153,10 @@ pub(crate) fn apply_format_settings_from_cli(
 
     if let Some(quote_style) = quote_style {
         javascript_formatter.quote_style = quote_style;
+    }
+
+    if let Some(trailing_comma) = trailing_comma {
+        javascript_formatter.trailing_comma = trailing_comma;
     }
 
     Ok(configuration)

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -46,6 +46,7 @@ const FORMAT_OPTIONS: Markup = markup! {
     "<Dim>"--line-width <number>"</Dim>"                    Change how many characters the formatter is allowed to print in a single line (default: 80)
     "<Dim>"--quote-style <single|double>"</Dim>"            Changes the quotation character for strings (default: \")
     "<Dim>"--quote-properties <as-needed|preserve>"</Dim>"  Changes when properties in object should be quoted (default: as-needed)
+    "<Dim>"--trailing-comma <all|es5>"</Dim>"               Changes trailing commas in multi-line comma-separated syntactic structures (default: all)
     "<Dim>"--stdin-file-path <string>"</Dim>"               A file name with its extension to pass when reading from standard in, e.g. echo 'let a;' | rome format --stdin-file-path file.js
     "
 };

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -1,4 +1,5 @@
 use crate::comments::{FormatJsLeadingComment, JsCommentStyle, JsComments};
+use crate::context::trailing_comma::TrailingComma;
 use rome_formatter::printer::PrinterOptions;
 use rome_formatter::{
     CstFormatContext, FormatContext, FormatElement, FormatOptions, IndentStyle, LineWidth,
@@ -9,6 +10,8 @@ use std::fmt;
 use std::fmt::Debug;
 use std::rc::Rc;
 use std::str::FromStr;
+
+pub mod trailing_comma;
 
 #[derive(Debug, Clone)]
 pub struct JsFormatContext {
@@ -139,6 +142,9 @@ pub struct JsFormatOptions {
     /// When properties in objects are quoted. Defaults to as-needed.
     quote_properties: QuoteProperties,
 
+    /// Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
+    trailing_comma: TrailingComma,
+
     /// Information related to the current file
     source_type: SourceType,
 }
@@ -151,6 +157,7 @@ impl JsFormatOptions {
             line_width: LineWidth::default(),
             quote_style: QuoteStyle::default(),
             quote_properties: QuoteProperties::default(),
+            trailing_comma: TrailingComma::default(),
         }
     }
 
@@ -174,6 +181,11 @@ impl JsFormatOptions {
         self
     }
 
+    pub fn with_trailing_comma(mut self, trailing_comma: TrailingComma) -> Self {
+        self.trailing_comma = trailing_comma;
+        self
+    }
+
     pub fn quote_style(&self) -> QuoteStyle {
         self.quote_style
     }
@@ -184,6 +196,10 @@ impl JsFormatOptions {
 
     pub fn source_type(&self) -> SourceType {
         self.source_type
+    }
+
+    pub fn trailing_comma(&self) -> TrailingComma {
+        self.trailing_comma
     }
 
     pub fn tab_width(&self) -> TabWidth {
@@ -215,7 +231,8 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Indent style: {}", self.indent_style)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
         writeln!(f, "Quote style: {}", self.quote_style)?;
-        writeln!(f, "Quote properties: {}", self.quote_properties)
+        writeln!(f, "Quote properties: {}", self.quote_properties)?;
+        writeln!(f, "Trailing comma: {}", self.trailing_comma)
     }
 }
 

--- a/crates/rome_js_formatter/src/context/trailing_comma.rs
+++ b/crates/rome_js_formatter/src/context/trailing_comma.rs
@@ -1,0 +1,88 @@
+use crate::prelude::*;
+use crate::{JsFormatContext, JsFormatOptions};
+use rome_formatter::formatter::Formatter;
+use rome_formatter::prelude::{if_group_breaks, text};
+use rome_formatter::write;
+use rome_formatter::{Format, FormatResult};
+use std::fmt;
+use std::str::FromStr;
+
+/// This enum is used within formatting functions to print or omit trailing comma.
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum FormatTrailingComma {
+    /// Print trailing comma if the option is [TrailingComma::All].
+    All,
+    /// Print trailing comma if the option is [TrailingComma::All] or [TrailingComma::ES5].
+    ES5,
+}
+
+impl FormatTrailingComma {
+    /// This function returns corresponding [TrailingSeparator] for [format_separated] function.
+    pub fn trailing_separator(&self, options: &JsFormatOptions) -> TrailingSeparator {
+        match self {
+            FormatTrailingComma::All => {
+                if options.trailing_comma.is_all() {
+                    TrailingSeparator::Allowed
+                } else {
+                    TrailingSeparator::Omit
+                }
+            }
+            FormatTrailingComma::ES5 => TrailingSeparator::Allowed,
+        }
+    }
+}
+
+impl Format<JsFormatContext> for FormatTrailingComma {
+    fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
+        if matches!(self, FormatTrailingComma::ES5) || f.options().trailing_comma().is_all() {
+            write!(f, [if_group_breaks(&text(","))])?
+        }
+
+        Ok(())
+    }
+}
+
+/// Print trailing commas wherever possible in multi-line comma-separated syntactic structures.
+#[derive(Default, Debug, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+)]
+pub enum TrailingComma {
+    /// Trailing commas wherever possible (including function parameters and calls).
+    #[default]
+    All,
+    /// Trailing commas where valid in ES5 (objects, arrays, etc.). No trailing commas in type parameters in TypeScript.
+    ES5,
+}
+
+impl TrailingComma {
+    pub const fn is_es5(&self) -> bool {
+        matches!(self, TrailingComma::ES5)
+    }
+    pub const fn is_all(&self) -> bool {
+        matches!(self, TrailingComma::All)
+    }
+}
+
+impl FromStr for TrailingComma {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "es5" | "ES5" => Ok(Self::ES5),
+            "all" | "All" => Ok(Self::All),
+            // TODO: replace this error with a diagnostic
+            _ => Err("Value not supported for TrailingComma"),
+        }
+    }
+}
+
+impl fmt::Display for TrailingComma {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TrailingComma::ES5 => std::write!(f, "ES5"),
+            TrailingComma::All => std::write!(f, "All"),
+        }
+    }
+}

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -4,6 +4,7 @@ use rome_formatter::{
 };
 use std::iter::once;
 
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::js::expressions::call_arguments::GroupedCallArgumentLayout;
 use crate::parentheses::{
     is_binary_like_left_or_right, is_callee, is_conditional_test,
@@ -179,8 +180,7 @@ impl FormatNodeRule<JsArrowFunctionExpression> for FormatJsArrowFunctionExpressi
 
                                     Ok(())
                                 })),
-                                is_last_call_arg
-                                    .then_some(format_args![if_group_breaks(&text(",")),]),
+                                is_last_call_arg.then_some(format_args![FormatTrailingComma::All,]),
                                 should_add_soft_line.then_some(format_args![soft_line_break()])
                             ])
                         ]
@@ -240,7 +240,7 @@ fn format_signature(
                             f,
                             [&soft_block_indent(&format_args![
                                 binding.format(),
-                                if_group_breaks(&text(","))
+                                FormatTrailingComma::All
                             ])]
                         )?
                     }

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::js::declarations::function_declaration::FormatFunctionOptions;
 use crate::js::expressions::arrow_function_expression::{
     is_multiline_template_starting_on_same_line, FormatJsArrowFunctionExpressionOptions,
@@ -722,7 +723,7 @@ impl<'a> Format<JsFormatContext> for FormatAllArgsBrokenOut<'a> {
                         write!(f, [entry])?;
                     }
 
-                    write!(f, [if_group_breaks(&text(","))])
+                    write!(f, [FormatTrailingComma::All])
                 })),
                 self.r_paren,
             ])

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -3,6 +3,7 @@ use rome_formatter::{write, CstFormatContext, FormatRuleWithOptions, GroupId};
 
 use crate::utils::array::write_array_node;
 
+use crate::context::trailing_comma::FormatTrailingComma;
 use rome_js_syntax::JsArrayElementList;
 use rome_rowan::{AstNode, AstSeparatedList};
 
@@ -32,13 +33,16 @@ impl FormatRule<JsArrayElementList> for FormatJsArrayElementList {
 
         match layout {
             ArrayLayout::Fill => {
+                let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
+
                 let mut filler = f.fill();
 
                 // Using format_separated is valid in this case as can_print_fill does not allow holes
-                for (element, formatted) in node
-                    .iter()
-                    .zip(node.format_separated(",").with_group_id(self.group_id))
-                {
+                for (element, formatted) in node.iter().zip(
+                    node.format_separated(",")
+                        .with_trailing_separator(trailing_separator)
+                        .with_group_id(self.group_id),
+                ) {
                     filler.entry(
                         &format_once(|f| {
                             if get_lines_before(element?.syntax()) > 1 {

--- a/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::prelude::*;
 use rome_js_syntax::JsExportNamedFromSpecifierList;
 
@@ -8,8 +9,13 @@ impl FormatRule<JsExportNamedFromSpecifierList> for FormatJsExportNamedFromSpeci
     type Context = JsFormatContext;
 
     fn fmt(&self, node: &JsExportNamedFromSpecifierList, f: &mut JsFormatter) -> FormatResult<()> {
+        let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
+
         f.join_with(&soft_line_break_or_space())
-            .entries(node.format_separated(","))
+            .entries(
+                node.format_separated(",")
+                    .with_trailing_separator(trailing_separator),
+            )
             .finish()
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::prelude::*;
 use rome_js_syntax::JsExportNamedSpecifierList;
 
@@ -8,8 +9,13 @@ impl FormatRule<JsExportNamedSpecifierList> for FormatJsExportNamedSpecifierList
     type Context = JsFormatContext;
 
     fn fmt(&self, node: &JsExportNamedSpecifierList, f: &mut JsFormatter) -> FormatResult<()> {
+        let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
+
         f.join_with(&soft_line_break_or_space())
-            .entries(node.format_separated(","))
+            .entries(
+                node.format_separated(",")
+                    .with_trailing_separator(trailing_separator),
+            )
             .finish()
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::prelude::*;
 use rome_js_syntax::JsImportAssertionEntryList;
 
@@ -8,8 +9,13 @@ impl FormatRule<JsImportAssertionEntryList> for FormatJsImportAssertionEntryList
     type Context = JsFormatContext;
 
     fn fmt(&self, node: &JsImportAssertionEntryList, f: &mut JsFormatter) -> FormatResult<()> {
+        let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
+
         f.join_with(&soft_line_break_or_space())
-            .entries(node.format_separated(","))
+            .entries(
+                node.format_separated(",")
+                    .with_trailing_separator(trailing_separator),
+            )
             .finish()
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::prelude::*;
 use rome_js_syntax::JsNamedImportSpecifierList;
 
@@ -8,8 +9,13 @@ impl FormatRule<JsNamedImportSpecifierList> for FormatJsNamedImportSpecifierList
     type Context = JsFormatContext;
 
     fn fmt(&self, node: &JsNamedImportSpecifierList, f: &mut JsFormatter) -> FormatResult<()> {
+        let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
+
         f.join_with(&soft_line_break_or_space())
-            .entries(node.format_separated(","))
+            .entries(
+                node.format_separated(",")
+                    .with_trailing_separator(trailing_separator),
+            )
             .finish()
     }
 }

--- a/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::prelude::*;
 use rome_js_syntax::{JsAnyObjectAssignmentPatternMember, JsObjectAssignmentPatternPropertyList};
 
@@ -26,7 +27,7 @@ impl FormatRule<JsObjectAssignmentPatternPropertyList>
         let trailing_separator = if has_trailing_rest {
             TrailingSeparator::Disallowed
         } else {
-            TrailingSeparator::Allowed
+            FormatTrailingComma::ES5.trailing_separator(f.options())
         };
 
         let entries = node

--- a/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::prelude::*;
 use rome_js_syntax::{JsAnyObjectBindingPatternMember, JsObjectBindingPatternPropertyList};
 
@@ -24,7 +25,7 @@ impl FormatRule<JsObjectBindingPatternPropertyList> for FormatJsObjectBindingPat
         let trailing_separator = if has_trailing_rest {
             TrailingSeparator::Disallowed
         } else {
-            TrailingSeparator::Allowed
+            FormatTrailingComma::ES5.trailing_separator(f.options())
         };
 
         let entries = node

--- a/crates/rome_js_formatter/src/js/lists/object_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_member_list.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::prelude::*;
 use rome_js_syntax::JsObjectMemberList;
 use rome_rowan::{AstNode, AstSeparatedList};
@@ -9,9 +10,14 @@ impl FormatRule<JsObjectMemberList> for FormatJsObjectMemberList {
     type Context = JsFormatContext;
 
     fn fmt(&self, node: &JsObjectMemberList, f: &mut JsFormatter) -> FormatResult<()> {
+        let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
+
         let mut join = f.join_nodes_with_soft_line();
 
-        for (element, formatted) in node.elements().zip(node.format_separated(",")) {
+        for (element, formatted) in node.elements().zip(
+            node.format_separated(",")
+                .with_trailing_separator(trailing_separator),
+        ) {
             join.entry(element.node()?.syntax(), &formatted);
         }
 

--- a/crates/rome_js_formatter/src/js/lists/parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/parameter_list.rs
@@ -1,6 +1,7 @@
 use crate::js::bindings::parameters::ParameterLayout;
 use crate::prelude::*;
 
+use crate::context::trailing_comma::FormatTrailingComma;
 use rome_js_syntax::{
     JsAnyConstructorParameter, JsAnyParameter, JsConstructorParameterList, JsLanguage,
     JsParameterList,
@@ -56,7 +57,7 @@ impl Format<JsFormatContext> for FormatJsAnyParameterList<'_> {
                 let trailing_separator = if has_trailing_rest {
                     TrailingSeparator::Disallowed
                 } else {
-                    TrailingSeparator::Allowed
+                    FormatTrailingComma::All.trailing_separator(f.options())
                 };
 
                 let mut join = f.join_nodes_with_soft_line();

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -647,6 +647,7 @@ mod tests {
     use rome_rowan::{TextRange, TextSize};
 
     use crate::check_reformat::{check_reformat, CheckReformatParams};
+    use crate::context::trailing_comma::TrailingComma;
 
     #[test]
     fn test_range_formatting() {
@@ -861,15 +862,20 @@ function() {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-const gitBaseExtension = extensions.getExtension<GitBaseExtension>(
-                               "vscode.git-base",
-                       )!.exports;
+class C {
+  one(
+    AAAAAAAAAAAAAAAAAAAAAAAAAA,
+    BBBBBBBBBBBBBBBBBBBBBBBBB,
+    BBBBBBBBBBBBBBBBBBBBBB,
+    c,
+  ) {}
+}
 
 "#;
         let syntax = SourceType::tsx();
         let tree = parse(src, FileId::zero(), syntax);
         let options = JsFormatOptions::new(syntax);
-
+        let options = options.with_trailing_comma(TrailingComma::ES5);
         let result = format_node(options.clone(), &tree.syntax())
             .unwrap()
             .print()

--- a/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/enum_member_list.rs
@@ -1,4 +1,6 @@
 use crate::prelude::*;
+
+use crate::context::trailing_comma::FormatTrailingComma;
 use rome_js_syntax::TsEnumMemberList;
 
 #[derive(Debug, Clone, Default)]
@@ -8,9 +10,14 @@ impl FormatRule<TsEnumMemberList> for FormatTsEnumMemberList {
     type Context = JsFormatContext;
 
     fn fmt(&self, node: &TsEnumMemberList, f: &mut JsFormatter) -> FormatResult<()> {
+        let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
         let mut joiner = f.join_nodes_with_soft_line();
 
-        for variant in node.format_separated(",").nodes_grouped() {
+        for variant in node
+            .format_separated(",")
+            .with_trailing_separator(trailing_separator)
+            .nodes_grouped()
+        {
             joiner.entry(variant.node()?.syntax(), &variant)
         }
 

--- a/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/tuple_type_element_list.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::prelude::*;
 use rome_js_syntax::TsTupleTypeElementList;
 
@@ -8,8 +9,14 @@ impl FormatRule<TsTupleTypeElementList> for FormatTsTupleTypeElementList {
     type Context = JsFormatContext;
 
     fn fmt(&self, node: &TsTupleTypeElementList, f: &mut JsFormatter) -> FormatResult<()> {
+        let trailing_separator = FormatTrailingComma::All.trailing_separator(f.options());
+
         f.join_with(&soft_line_break_or_space())
-            .entries(node.format_separated(",").nodes_grouped())
+            .entries(
+                node.format_separated(",")
+                    .with_trailing_separator(trailing_separator)
+                    .nodes_grouped(),
+            )
             .finish()
     }
 }

--- a/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_parameter_list.rs
@@ -1,3 +1,4 @@
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::prelude::*;
 use rome_js_syntax::TsTypeParameterList;
 use rome_rowan::AstSeparatedList;
@@ -18,7 +19,7 @@ impl FormatRule<TsTypeParameterList> for FormatTsTypeParameterList {
         let trailing_separator = if node.len() == 1 && node.trailing_separator().is_some() {
             TrailingSeparator::Mandatory
         } else {
-            TrailingSeparator::default()
+            FormatTrailingComma::All.trailing_separator(f.options())
         };
 
         f.join_with(&soft_line_break_or_space())

--- a/crates/rome_js_formatter/src/utils/array.rs
+++ b/crates/rome_js_formatter/src/utils/array.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use crate::AsFormat;
 
+use crate::context::trailing_comma::FormatTrailingComma;
 use rome_formatter::write;
 use rome_js_syntax::{
     JsAnyArrayAssignmentPatternElement, JsAnyArrayBindingPatternElement, JsAnyArrayElement,
@@ -47,7 +48,7 @@ where
                 } else if let Some(separator) = element.trailing_separator()? {
                     write!(f, [format_only_if_breaks(separator, &separator.format())])?;
                 } else {
-                    write!(f, [if_group_breaks(&text(","))])?;
+                    write!(f, [FormatTrailingComma::ES5])?;
                 };
 
                 Ok(())

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -16,6 +16,7 @@ mod quickcheck_utils;
 pub(crate) mod test_call;
 mod typescript;
 
+use crate::context::trailing_comma::FormatTrailingComma;
 use crate::parentheses::is_callee;
 pub(crate) use crate::parentheses::resolve_left_most_expression;
 use crate::prelude::*;
@@ -270,7 +271,7 @@ where
         let last = iterator.peek().is_none();
 
         if last {
-            join_with.entry(&format_args![&element, &if_group_breaks(&text(","))]);
+            join_with.entry(&format_args![&element, FormatTrailingComma::All]);
         } else {
             join_with.entry(&element);
         }

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -2,6 +2,7 @@ use rome_diagnostics::file::FileId;
 use rome_formatter::{FormatOptions, LineWidth};
 use rome_formatter::{IndentStyle, Printed};
 use rome_fs::RomePath;
+use rome_js_formatter::context::trailing_comma::TrailingComma;
 use rome_js_formatter::context::{JsFormatOptions, QuoteProperties, QuoteStyle};
 use rome_js_formatter::format_node;
 use rome_js_parser::parse;
@@ -65,6 +66,21 @@ impl From<SerializableQuoteProperties> for QuoteProperties {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
+pub enum SerializableTrailingComma {
+    All,
+    ES5,
+}
+
+impl From<SerializableTrailingComma> for TrailingComma {
+    fn from(test: SerializableTrailingComma) -> Self {
+        match test {
+            SerializableTrailingComma::All => TrailingComma::All,
+            SerializableTrailingComma::ES5 => TrailingComma::ES5,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
 pub struct SerializableFormatOptions {
     /// The indent style.
@@ -73,11 +89,14 @@ pub struct SerializableFormatOptions {
     /// What's the max width of a line. Defaults to 80.
     pub line_width: Option<u16>,
 
-    // The style for quotes. Defaults to double.
+    /// The style for quotes. Defaults to double.
     pub quote_style: Option<SerializableQuoteStyle>,
 
     /// When properties in objects are quoted. Defaults to as-needed.
     pub quote_properties: Option<SerializableQuoteProperties>,
+
+    /// Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
+    pub trailing_comma: Option<SerializableTrailingComma>,
 }
 
 impl From<SerializableFormatOptions> for JsFormatOptions {
@@ -99,6 +118,10 @@ impl From<SerializableFormatOptions> for JsFormatOptions {
             .with_quote_properties(
                 test.quote_properties
                     .map_or_else(|| QuoteProperties::AsNeeded, |value| value.into()),
+            )
+            .with_trailing_comma(
+                test.trailing_comma
+                    .map_or_else(|| TrailingComma::All, |value| value.into()),
             )
     }
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
@@ -53,6 +53,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a = [[]];
 let b = [[], []];

--- a/crates/rome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let [a, b] = c;
 let [d, ...e] = c;

--- a/crates/rome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
@@ -24,6 +24,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a = [
 	1, 2,

--- a/crates/rome_js_formatter/tests/specs/js/module/array/spaces.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/spaces.js.snap
@@ -17,6 +17,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a = [,];
 let b = [, ,];

--- a/crates/rome_js_formatter/tests/specs/js/module/array/spread.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/spread.js.snap
@@ -17,6 +17,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a = [...a, ...b];
 let b = [...a, ...b];

--- a/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js
@@ -1,0 +1,10 @@
+const a = [
+	longlonglonglongItem1longlonglonglongItem1,
+	longlonglonglongItem1longlonglonglongItem2,
+	longlonglonglongItem1longlonglonglongItem3,
+];
+
+// destructuring
+[  	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,] = [1, 2, 10];

--- a/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
@@ -1,0 +1,59 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: array_trailing_comma.js
+---
+# Input
+const a = [
+	longlonglonglongItem1longlonglonglongItem1,
+	longlonglonglongItem1longlonglonglongItem2,
+	longlonglonglongItem1longlonglonglongItem3,
+];
+
+// destructuring
+[  	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,] = [1, 2, 10];
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+const a = [
+	longlonglonglongItem1longlonglonglongItem1,
+	longlonglonglongItem1longlonglonglongItem2,
+	longlonglonglongItem1longlonglonglongItem3,
+];
+
+// destructuring
+[
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+] = [1, 2, 10];
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: ES5
+-----
+const a = [
+	longlonglonglongItem1longlonglonglongItem1,
+	longlonglonglongItem1longlonglonglongItem2,
+	longlonglonglongItem1longlonglonglongItem3,
+];
+
+// destructuring
+[
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+] = [1, 2, 10];
+

--- a/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"trailing_comma": "ES5"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -21,6 +21,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 x =
 	(bifornCringerMoshedPerplexSawder) =>

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 () => {};
 async () => {};

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -39,6 +39,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 Seq(typeDef.interface.groups).forEach((group) =>
 	Seq(group.members).forEach((member, memberName) =>

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
@@ -16,6 +16,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 it("should have the default duration when using the onClose arguments", (done) => {
 	expect(true);

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -56,6 +56,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 const testResults = results.testResults.map((testResult) =>
 	formatResult(testResult, formatter, reporter),

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
@@ -29,6 +29,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 const fn = (b) => (c) => (d) => {
 	return 3;

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -333,6 +333,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 fooooooooooooooooooooooooooooooooooooooooooooooooooo(
 	(action) => (next) => dispatch(action),

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
@@ -14,6 +14,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a, b;
 [a, /*empty*/ ,] = b;

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -166,6 +166,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 a = b;
 a += b;

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
@@ -16,6 +16,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let {
 	/* rome-ignore format: Test that the property doesn't get formatted */

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -13,6 +13,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 function foo([foo, /* not used */ /* not used */ ,]) {}
 

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 [a = "b"] = c;
 let [a = "b"] = c;

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let x = y;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -16,6 +16,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let { a } = b;
 let { d, b: c } = d;

--- a/crates/rome_js_formatter/tests/specs/js/module/call_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/call_expression.js.snap
@@ -59,6 +59,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 useEffect(() => {}, [a, b]);
 

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -82,6 +82,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class Foo extends Boar {
 	static {

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class A extends B {
 	// leading comment

--- a/crates/rome_js_formatter/tests/specs/js/module/class/private_method.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/private_method.js.snap
@@ -28,6 +28,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class Foo {
 	a = 1;

--- a/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -90,6 +90,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import {
 	func, // trailing comma removal

--- a/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
@@ -277,6 +277,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 //break left-hand side layout
 {

--- a/crates/rome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
@@ -21,6 +21,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 // another comment
 export class A {

--- a/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
@@ -12,6 +12,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 export default 1 - 43;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
@@ -16,6 +16,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 export * from "hey";
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
@@ -20,6 +20,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 export function f() {}
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 export {
 	// the boo api

--- a/crates/rome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
@@ -20,6 +20,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 export { a, b as c } from "fancy" assert { type: "json" };
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js
@@ -1,0 +1,5 @@
+export {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+};

--- a/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
@@ -1,0 +1,40 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: export_trailing_comma.js
+---
+# Input
+export {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+};
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+export {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+};
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: ES5
+-----
+export {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+};
+

--- a/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"trailing_comma": "ES5"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
@@ -14,6 +14,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 export let a, d, c;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
@@ -46,6 +46,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 a + b;
 a < b;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -12,6 +12,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 2 > (4 + ((4 * 24) % 3)) << 23 instanceof Number in data ||
 	(a in status instanceof String + 15 && foo && bar && lorem instanceof String);

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
@@ -13,6 +13,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 a["test"][5 + 5][call()];
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
@@ -21,6 +21,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 a ? b : c;
 d ? e + f : g + h;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 console.log(import.meta);
 import.meta.field =
@@ -32,6 +33,7 @@ Indent style: Spaces, size: 4
 Line width: 120
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 console.log(import.meta);
 import.meta.field =

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 "a";
 1;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -124,6 +124,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 x ?? y;
 x || y;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
@@ -17,6 +17,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 client.execute(
 	Post.selectAll().where(Post.id.eq(42)).where(Post.published.eq(true)),

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
@@ -17,6 +17,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 nock(/test/)
 	.matchHeader("Accept", "application/json")

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
@@ -24,6 +24,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 _.flatMap(this.visibilityHandlers, (fn) => fn())
 	.concat(this.record.resolved_legacy_visrules)

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 new a();
 new b(x);

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
@@ -16,6 +16,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 y++;
 y--;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
@@ -16,6 +16,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 ++y;
 --y;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
@@ -45,6 +45,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 a, b;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
@@ -32,6 +32,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 a.b;
 a?.b;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
@@ -13,6 +13,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 this;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
@@ -26,6 +26,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 delete a.a;
 void b;

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function.js.snap
@@ -44,6 +44,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 function foo() {}
 async function foo(a) {

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function_args.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function_args.js.snap
@@ -14,6 +14,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 function foo(
 	someotherlongvariableshould1,

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -28,6 +28,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 function a() {
 	// trailing comment

--- a/crates/rome_js_formatter/tests/specs/js/module/ident.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/ident.js.snap
@@ -13,6 +13,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 x;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
@@ -35,6 +35,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import "very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_";
 import "very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_very_long" assert {

--- a/crates/rome_js_formatter/tests/specs/js/module/import/default_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/default_import.js.snap
@@ -23,6 +23,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import hey from "hey";
 import hey from "hey";

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_call.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import(x);
 import("x");

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -31,6 +31,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import { hey } from "hey";
 import { hey } from "hey";

--- a/crates/rome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
@@ -12,6 +12,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import * as all from "all";
 

--- a/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js
@@ -1,0 +1,10 @@
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+} from "D";
+
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd, } from "W";

--- a/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
@@ -1,0 +1,57 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: import_trailing_comma.js
+---
+# Input
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+} from "D";
+
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd, } from "W";
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+} from "D";
+
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+} from "W";
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: ES5
+-----
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+} from "D";
+
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+} from "W";
+

--- a/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"trailing_comma": "ES5"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 #!/usr/bin/env node
 

--- a/crates/rome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
@@ -22,6 +22,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 {
 	let x = 10;

--- a/crates/rome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
@@ -28,6 +28,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 function test() {
 	let x = 10;

--- a/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
@@ -90,6 +90,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 "directive";
 // comment

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number.js.snap
@@ -14,6 +14,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 1.23e4;
 1000e3; // FIXME handle number with scientific notation #1294

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 (123).toString;
 /****/ (123).toString;

--- a/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -31,6 +31,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 const foo = {};
 

--- a/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a = {
 	get foo() {},

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
@@ -44,6 +44,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a = {
 	...spread,

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a = {
 	// leading comment

--- a/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -20,6 +20,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 const foo = {
 	"foo-bar": true,

--- a/crates/rome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
@@ -100,6 +100,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 const neverBreakAfterColonObject = {
 	"this-is-a-very-long-key-and-the-assignment-should-be-put-on-the-next-line-this-is-a-very-long-key-and-the-assignment-should-be-put-on-the-next-line-1": require(),

--- a/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js
@@ -1,0 +1,9 @@
+const b = {
+	longlonglonglongField1,
+	longlonglonglongField2,
+	longlonglonglongField3,
+};
+
+const {  	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,} = o;

--- a/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
@@ -1,0 +1,56 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: object_trailing_comma.js
+---
+# Input
+const b = {
+	longlonglonglongField1,
+	longlonglonglongField2,
+	longlonglonglongField3,
+};
+
+const {  	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,} = o;
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+const b = {
+	longlonglonglongField1,
+	longlonglonglongField2,
+	longlonglonglongField3,
+};
+
+const {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+} = o;
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: ES5
+-----
+const b = {
+	longlonglonglongField1,
+	longlonglonglongField2,
+	longlonglonglongField3,
+};
+
+const {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+} = o;
+

--- a/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"trailing_comma": "ES5"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
@@ -35,6 +35,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 (foo++)?.();
 async () => {

--- a/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
@@ -20,6 +20,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 [
 	// Prettier prints the `-2` element on the same line as the `-3`.

--- a/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
@@ -16,6 +16,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 #!/usr/bin/env node
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
@@ -21,6 +21,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 if (true) {
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -26,6 +26,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 do {
 	var foo = 4;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
@@ -41,6 +41,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 // Line break before closing `}`
 if (true) {

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 for (a in b) {
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
@@ -29,6 +29,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 for (;;) {
 	let x = 10;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
@@ -20,6 +20,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 for (a of b) {
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 if (1) 1;
 else if (2) 2;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -81,6 +81,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 if (a);
 if (a);

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 function f1() {
 	return 1;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/statement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/statement.js.snap
@@ -14,6 +14,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 debugger;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -31,6 +31,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 switch (key) {
 	case // comment

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/throw.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/throw.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 throw "Something";
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
@@ -38,6 +38,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 try {
 	var foo = 4;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
@@ -38,6 +38,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 while (true) {
 	var foo = 4;

--- a/crates/rome_js_formatter/tests/specs/js/module/string/directives.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/directives.js.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 "use preferred quote";
 "use preferred quote";
@@ -26,6 +27,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Single Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 'use preferred quote';
 'use preferred quote';
@@ -37,6 +39,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: Preserve
+Trailing comma: All
 -----
 "use preferred quote";
 "use preferred quote";

--- a/crates/rome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
@@ -50,6 +50,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class Y {
 	other = 4;
@@ -96,6 +97,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Single Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class Y {
 	other = 4;
@@ -142,6 +144,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: Preserve
+Trailing comma: All
 -----
 class Y {
 	"other" = 4;

--- a/crates/rome_js_formatter/tests/specs/js/module/string/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/string.js.snap
@@ -69,6 +69,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import hey from "hey";
 import hey from "hey";
@@ -144,6 +145,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Single Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import hey from 'hey';
 import hey from 'hey';
@@ -219,6 +221,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: Preserve
+Trailing comma: All
 -----
 import hey from "hey";
 import hey from "hey";

--- a/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -40,6 +40,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 // rome-ignore format: the following if should print inline
 if(true) statement();

--- a/crates/rome_js_formatter/tests/specs/js/module/template/template.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/template/template.js.snap
@@ -59,6 +59,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 `something`;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/with.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/with.js.snap
@@ -17,6 +17,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 with (   b)
 

--- a/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
@@ -16,6 +16,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 #!/usr/bin/env node
 

--- a/crates/rome_js_formatter/tests/specs/js/script/with.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/script/with.js.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 with (b) {
 	5;

--- a/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
@@ -33,6 +33,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 function BackTopContent(props) {
 	return (

--- a/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx.snap
@@ -82,6 +82,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 <CodeEditor
 	value={formatted_code}

--- a/crates/rome_js_formatter/tests/specs/jsx/conditional.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/conditional.jsx.snap
@@ -61,6 +61,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 (
 	bifornCringerMoshedPerplexSawder

--- a/crates/rome_js_formatter/tests/specs/jsx/element.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/element.jsx.snap
@@ -280,6 +280,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 // Single string attribute
 <div tooltip="A very long tooltip text that would otherwise make the attribute break onto the same line but it is not because of the single string layout"></div>;

--- a/crates/rome_js_formatter/tests/specs/jsx/fragment.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/fragment.jsx.snap
@@ -14,6 +14,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 <></>
 <>

--- a/crates/rome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
@@ -27,6 +27,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 <Foo />;
 

--- a/crates/rome_js_formatter/tests/specs/jsx/smoke.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/smoke.jsx.snap
@@ -12,6 +12,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 "foo";
 

--- a/crates/rome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
@@ -23,6 +23,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 // chain is-callee
 const x = (

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
@@ -17,6 +17,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let binding;
 

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
@@ -25,6 +25,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 //break after operator layout
 loooooooooooooooooooooooooong1 =

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
@@ -33,6 +33,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 const a = 1; // test
 

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
@@ -45,6 +45,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class Test {
 	prop1 = /* leading */ 1;

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
@@ -26,6 +26,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let x;
 

--- a/crates/rome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
@@ -13,6 +13,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let definiteVariable!: TypeName;
 

--- a/crates/rome_js_formatter/tests/specs/ts/call_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/call_expression.ts.snap
@@ -35,6 +35,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 app.get("/", (req, res): void => {
 	res.send("Hello World!");

--- a/crates/rome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
@@ -19,6 +19,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class SourceRemoveUnused extends SourceAction {
 	static readonly kind =

--- a/crates/rome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
@@ -47,6 +47,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class B {
 	constructor(private a: string) {}

--- a/crates/rome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
@@ -14,6 +14,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class ClassName implements Interface {}
 

--- a/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts
@@ -1,0 +1,11 @@
+// class method
+class C<    	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3,> {
+	one<    	longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3,>(adsadasdasdasdasdasdasdasdasdasdas1,dsadsadasdasdasdasdasdasdasd2, dsadsadasdasdasdasdasdasdasd) {}
+	two<    	longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3,>(adsadasdasdasdasdasdasdasdasdasdas1,dsadsadasdasdasdasdasdasdasd2, dsadsadasdasdasdasdasdasdasd) {}
+}

--- a/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
@@ -1,0 +1,86 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: class_trailing_comma.ts
+---
+# Input
+// class method
+class C<    	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3,> {
+	one<    	longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3,>(adsadasdasdasdasdasdasdasdasdasdas1,dsadsadasdasdasdasdasdasdasd2, dsadsadasdasdasdasdasdasdasd) {}
+	two<    	longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3,>(adsadasdasdasdasdasdasdasdasdasdas1,dsadsadasdasdasdasdasdasdasd2, dsadsadasdasdasdasdasdasdasd) {}
+}
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+// class method
+class C<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3,
+> {
+	one<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3,
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd,
+	) {}
+	two<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3,
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd,
+	) {}
+}
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: ES5
+-----
+// class method
+class C<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+> {
+	one<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {}
+	two<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {}
+}
+

--- a/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"trailing_comma": "ES5"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/class.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/class.ts.snap
@@ -71,6 +71,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 class Test {
 	name: string;

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 declare function test(): Promise<string>;
 

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 declare module "./test" {
 	global {

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -33,6 +33,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 interface A {}
 interface B extends A /** comment **/ {

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
@@ -99,6 +99,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 //break left-hand side layout
 const map: Map<

--- a/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
@@ -58,6 +58,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 @sealed
 class Test {

--- a/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts
@@ -1,0 +1,5 @@
+enum A {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+}

--- a/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
@@ -1,0 +1,40 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: enum_trailing_comma.ts
+---
+# Input
+enum A {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+}
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+enum A {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+}
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: ES5
+-----
+enum A {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+}
+

--- a/crates/rome_js_formatter/tests/specs/ts/enum/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/enum/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"trailing_comma": "ES5"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a: any;
 let b = a as string;

--- a/crates/rome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
@@ -13,6 +13,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let a: any;
 let b = a!;

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 let x = <const>"hello";
 let y = <string>x;

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -116,6 +116,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import * as assert from "assert";
 

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -58,6 +58,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 type A = { [a: string]: number };
 

--- a/crates/rome_js_formatter/tests/specs/ts/function/function_trailing_comma.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/function/function_trailing_comma.ts
@@ -1,0 +1,37 @@
+function test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+	>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+) {}
+const test1 = <
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+	>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+) => {};
+test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+	>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3,
+);
+
+this.test(	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3);
+
+connect(
+	mapStateToPropsmapStateToProps,
+	mapDispatchToPropsmapDispatchToProps,
+	mergePropsmergeProps,
+)(Component)

--- a/crates/rome_js_formatter/tests/specs/ts/function/function_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/function/function_trailing_comma.ts.snap
@@ -1,0 +1,140 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: function_trailing_comma.ts
+---
+# Input
+function test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+	>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+) {}
+const test1 = <
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+	>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+) => {};
+test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+	>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3,
+);
+
+this.test(	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3);
+
+connect(
+	mapStateToPropsmapStateToProps,
+	mapDispatchToPropsmapDispatchToProps,
+	mergePropsmergeProps,
+)(Component)
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+function test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3,
+>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3,
+) {}
+const test1 = <
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3,
+>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3,
+) => {};
+test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3,
+);
+
+this.test(
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3,
+);
+
+connect(
+	mapStateToPropsmapStateToProps,
+	mapDispatchToPropsmapDispatchToProps,
+	mergePropsmergeProps,
+)(Component);
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: ES5
+-----
+function test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+) {}
+const test1 = <
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+) => {};
+test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+);
+
+this.test(
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+);
+
+connect(
+	mapStateToPropsmapStateToProps,
+	mapDispatchToPropsmapDispatchToProps,
+	mergePropsmergeProps
+)(Component);
+

--- a/crates/rome_js_formatter/tests/specs/ts/function/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/function/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"trailing_comma": "ES5"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -30,6 +30,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 export type A = string;
 

--- a/crates/rome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import name = require("module_source");
 

--- a/crates/rome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
@@ -16,6 +16,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 module singleName {}
 

--- a/crates/rome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
@@ -13,6 +13,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 module a.b.c {}
 

--- a/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts
@@ -1,0 +1,22 @@
+
+// object method
+const obj = {
+	one<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+		>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {},
+	two<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+		>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {},
+};

--- a/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
@@ -1,0 +1,89 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: object_trailing_comma.ts
+---
+# Input
+
+// object method
+const obj = {
+	one<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+		>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {},
+	two<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+		>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {},
+};
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+// object method
+const obj = {
+	one<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3,
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd,
+	) {},
+	two<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3,
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd,
+	) {},
+};
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: ES5
+-----
+// object method
+const obj = {
+	one<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {},
+	two<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {},
+};
+

--- a/crates/rome_js_formatter/tests/specs/ts/object/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/object/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"trailing_comma": "ES5"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
@@ -14,6 +14,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 function a(this: string) {}
 

--- a/crates/rome_js_formatter/tests/specs/ts/parenthesis.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/parenthesis.ts.snap
@@ -14,6 +14,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 const a = (c && b) as boolean;
 const a = (<any>(c && b)) as boolean;

--- a/crates/rome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
@@ -13,6 +13,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 interface X {}
 type X = {};

--- a/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -24,6 +24,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 enum A {}
 enum B {

--- a/crates/rome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
@@ -47,6 +47,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import * as f from "f";
 
@@ -89,6 +90,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Single Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 import * as f from 'f';
 
@@ -131,6 +133,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: Preserve
+Trailing comma: All
 -----
 import * as f from "f";
 

--- a/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 interface Suppressions {
 	// rome-ignore format: test

--- a/crates/rome_js_formatter/tests/specs/ts/type/conditional.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/conditional.ts.snap
@@ -28,6 +28,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 type test = string;
 

--- a/crates/rome_js_formatter/tests/specs/ts/type/import_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/import_type.ts.snap
@@ -18,6 +18,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 type ImportType1 = typeof import("source");
 

--- a/crates/rome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
@@ -70,6 +70,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 type ShortIntersection = A & B;
 

--- a/crates/rome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
@@ -12,6 +12,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 type QualifiedType = A.B.C;
 

--- a/crates/rome_js_formatter/tests/specs/ts/type/template_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/template_type.ts.snap
@@ -15,6 +15,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 type TemplateType = `
     text

--- a/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"trailing_comma": "ES5"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts
@@ -1,0 +1,12 @@
+
+type A = [
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+];
+
+interface C<    	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,> {
+
+}

--- a/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
@@ -1,0 +1,59 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: type_trailing_comma.ts
+---
+# Input
+
+type A = [
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+];
+
+interface C<    	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,> {
+
+}
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+type A = [
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+];
+
+interface C<
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd,
+> {}
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: ES5
+-----
+type A = [
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+];
+
+interface C<
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+> {}
+

--- a/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
@@ -257,6 +257,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 type ShortUnion = A | B;
 

--- a/crates/rome_js_formatter/tests/specs/tsx/smoke.tsx.snap
+++ b/crates/rome_js_formatter/tests/specs/tsx/smoke.tsx.snap
@@ -12,6 +12,7 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
+Trailing comma: All
 -----
 "foo";
 

--- a/crates/rome_service/src/configuration/javascript.rs
+++ b/crates/rome_service/src/configuration/javascript.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use rome_js_formatter::context::{QuoteProperties, QuoteStyle};
+use rome_js_formatter::context::{trailing_comma::TrailingComma, QuoteProperties, QuoteStyle};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -39,6 +39,9 @@ pub struct JavascriptFormatter {
     /// When properties in objects are quoted. Defaults to asNeeded.
     #[serde(with = "PlainQuoteProperties")]
     pub quote_properties: QuoteProperties,
+    /// Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
+    #[serde(with = "PlainTrailingComma")]
+    pub trailing_comma: TrailingComma,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Default)]
@@ -57,4 +60,13 @@ pub enum PlainQuoteProperties {
     #[default]
     AsNeeded,
     Preserve,
+}
+
+#[derive(Deserialize, Default, Serialize, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase", remote = "TrailingComma")]
+pub enum PlainTrailingComma {
+    #[default]
+    All,
+    ES5,
 }

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -6,7 +6,7 @@ use rome_diagnostics::{Applicability, CodeSuggestion, Diagnostic};
 use rome_formatter::{FormatError, Printed};
 use rome_fs::RomePath;
 use rome_js_analyze::{analyze, analyze_with_inspect_matcher, visit_registry, RuleError};
-use rome_js_formatter::context::{QuoteProperties, QuoteStyle};
+use rome_js_formatter::context::{trailing_comma::TrailingComma, QuoteProperties, QuoteStyle};
 use rome_js_formatter::{context::JsFormatOptions, format_node};
 use rome_js_parser::Parse;
 use rome_js_semantic::{semantic_model, SemanticModelOptions};
@@ -41,6 +41,7 @@ use std::fmt::Debug;
 pub struct JsFormatSettings {
     pub quote_style: Option<QuoteStyle>,
     pub quote_properties: Option<QuoteProperties>,
+    pub trailing_comma: Option<TrailingComma>,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -68,6 +69,7 @@ impl Language for JsLanguage {
             .with_line_width(global.line_width.unwrap_or_default())
             .with_quote_style(language.quote_style.unwrap_or_default())
             .with_quote_properties(language.quote_properties.unwrap_or_default())
+            .with_trailing_comma(language.trailing_comma.unwrap_or_default())
     }
 }
 

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -45,6 +45,7 @@ impl WorkspaceSettings {
         if let Some(formatter) = formatter {
             self.languages.javascript.format.quote_style = Some(formatter.quote_style);
             self.languages.javascript.format.quote_properties = Some(formatter.quote_properties);
+            self.languages.javascript.format.trailing_comma = Some(formatter.trailing_comma);
         }
 
         // linter part

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -431,6 +431,15 @@
               "$ref": "#/definitions/QuoteStyle"
             }
           ]
+        },
+        "trailingComma": {
+          "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to \"all\".",
+          "default": "all",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TrailingComma"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -878,6 +887,13 @@
           ]
         }
       }
+    },
+    "TrailingComma": {
+      "type": "string",
+      "enum": [
+        "all",
+        "es5"
+      ]
     }
   }
 }

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -102,6 +102,10 @@ export interface JavascriptFormatter {
 	 * The style for quotes. Defaults to double.
 	 */
 	quoteStyle?: QuoteStyle;
+	/**
+	 * Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
+	 */
+	trailingComma?: TrailingComma;
 }
 export interface Rules {
 	correctness?: Correctness;
@@ -114,6 +118,7 @@ export interface Rules {
 }
 export type QuoteProperties = "asNeeded" | "preserve";
 export type QuoteStyle = "double" | "single";
+export type TrailingComma = "all" | "es5";
 /**
  * A list of rules that belong to this group
  */

--- a/website/playground/src/SettingsMenu.tsx
+++ b/website/playground/src/SettingsMenu.tsx
@@ -7,6 +7,7 @@ import { Dispatch, SetStateAction } from "react";
 import { createSetter } from "./utils";
 import QuotePropertiesSelect from "./QuotePropertiesSelect";
 import NurseryRules from "./NurseryRules";
+import TrailingCommaSelect from "./TrailingCommaSelect";
 
 interface Props {
 	settings: PlaygroundSettings;
@@ -21,6 +22,7 @@ export function SettingsMenu({
 		indentStyle,
 		quoteStyle,
 		quoteProperties,
+		trailingComma,
 		sourceType,
 		isTypeScript,
 		isJsx,
@@ -52,6 +54,10 @@ export function SettingsMenu({
 						setPlaygroundState,
 						"quoteProperties",
 					)}
+				/>
+				<TrailingCommaSelect
+					trailingComma={trailingComma}
+					setTrailingComma={createSetter(setPlaygroundState, "trailingComma")}
 				/>
 				<SourceTypeSelect
 					isTypeScript={isTypeScript}

--- a/website/playground/src/TrailingCommaSelect.tsx
+++ b/website/playground/src/TrailingCommaSelect.tsx
@@ -1,0 +1,44 @@
+import { TrailingComma } from "./types";
+
+interface Props {
+	setTrailingComma: (v: TrailingComma) => void;
+	trailingComma: TrailingComma;
+}
+
+export default function TrailingCommaSelect({
+	setTrailingComma,
+	trailingComma,
+}: Props) {
+	return (
+		<div className="pl-5 pb-5">
+			<fieldset>
+				<legend className="sr-only">Trailing Comma</legend>
+				<div className="relative flex items-start">
+					<div className="">
+						<label
+							htmlFor="trailingComma"
+							className="block text-sm font-medium text-gray-700"
+						>
+							Trailing Comma
+						</label>
+						<span id="quote-style-description" className="text-gray-500">
+							<span className="sr-only">Trailing Comma</span>
+						</span>
+						<select
+							id="trailingComma"
+							aria-describedby="quote-style-description"
+							name="quoteStyle"
+							value={trailingComma ?? "all"}
+							onChange={(e) =>
+								setTrailingComma(e.target.value as TrailingComma)}
+							className="w-[100px] mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+						>
+							<option value={TrailingComma.All}>All</option>
+							<option value={TrailingComma.ES5}>ES5</option>
+						</select>
+					</div>
+				</div>
+			</fieldset>
+		</div>
+	);
+}

--- a/website/playground/src/prettierWorker.ts
+++ b/website/playground/src/prettierWorker.ts
@@ -1,4 +1,5 @@
 import { formatWithPrettier } from "./utils";
+import { PlaygroundState } from "./types";
 
 self.addEventListener("message", (e) => {
 	switch (e.data.type) {
@@ -11,7 +12,8 @@ self.addEventListener("message", (e) => {
 				quoteStyle,
 				quoteProperties,
 				isTypeScript,
-			} = e.data.playgroundState;
+				trailingComma,
+			} = e.data.playgroundState as PlaygroundState;
 			const prettierOutput = formatWithPrettier(code, {
 				lineWidth,
 				indentStyle,
@@ -19,6 +21,7 @@ self.addEventListener("message", (e) => {
 				language: isTypeScript ? "ts" : "js",
 				quoteStyle,
 				quoteProperties,
+				trailingComma,
 			});
 
 			self.postMessage({

--- a/website/playground/src/romeWorker.ts
+++ b/website/playground/src/romeWorker.ts
@@ -1,17 +1,17 @@
 import init, {
+	Configuration,
 	DiagnosticPrinter,
 	RomePath,
 	Workspace,
-	Configuration,
 } from "@rometools/wasm-web";
 import {
-	SourceType,
+	IndentStyle,
 	LoadingState,
 	PlaygroundState,
-	IndentStyle,
-	RomeOutput,
-	QuoteStyle,
 	QuoteProperties,
+	QuoteStyle,
+	RomeOutput,
+	SourceType,
 } from "./types";
 
 let workspace: Workspace | null = null;
@@ -83,6 +83,7 @@ self.addEventListener("message", async (e) => {
 				sourceType,
 				cursorPosition,
 				enabledNurseryRules,
+				trailingComma,
 			} = playgroundState;
 
 			const configuration: Configuration = {
@@ -103,6 +104,7 @@ self.addEventListener("message", async (e) => {
 							quoteProperties === QuoteProperties.Preserve
 								? "preserve"
 								: "asNeeded",
+						trailingComma,
 					},
 				},
 			};

--- a/website/playground/src/types.ts
+++ b/website/playground/src/types.ts
@@ -17,6 +17,10 @@ export enum QuoteProperties {
 	AsNeeded = "as-needed",
 	Preserve = "preserve",
 }
+export enum TrailingComma {
+	All = "all",
+	ES5 = "es5",
+}
 export enum LoadingState {
 	Loading,
 	Success,
@@ -40,6 +44,7 @@ export interface PlaygroundState {
 	quoteStyle: QuoteStyle;
 	quoteProperties: QuoteProperties;
 	sourceType: SourceType;
+	trailingComma: TrailingComma;
 	isTypeScript: boolean;
 	isJsx: boolean;
 	cursorPosition: number;
@@ -59,6 +64,7 @@ export const defaultRomeConfig: RomeConfiguration = {
 	quoteStyle: QuoteStyle.Double,
 	quoteProperties: QuoteProperties.AsNeeded,
 	sourceType: SourceType.Module,
+	trailingComma: TrailingComma.All,
 	isTypeScript: false,
 	isJsx: false,
 	cursorPosition: 0,
@@ -80,6 +86,7 @@ export type PlaygroundSettings = Pick<
 	| "quoteStyle"
 	| "quoteProperties"
 	| "sourceType"
+	| "trailingComma"
 	| "isTypeScript"
 	| "isJsx"
 	| "enabledNurseryRules"

--- a/website/playground/src/utils.ts
+++ b/website/playground/src/utils.ts
@@ -9,6 +9,7 @@ import {
 	QuoteProperties,
 	RomeConfiguration,
 	SourceType,
+	TrailingComma,
 } from "./types";
 
 export function classNames(
@@ -67,6 +68,9 @@ export function usePlaygroundState(
 		quoteProperties:
 			(searchParams.get("quoteProperties") as QuoteProperties) ??
 			defaultRomeConfig.quoteProperties,
+		trailingComma:
+			(searchParams.get("trailingComma") as TrailingComma) ??
+			defaultRomeConfig.trailingComma,
 		indentWidth: parseInt(
 			searchParams.get("indentWidth") ?? defaultRomeConfig.indentWidth,
 		),
@@ -130,6 +134,7 @@ export function formatWithPrettier(
 		language: "js" | "ts";
 		quoteStyle: QuoteStyle;
 		quoteProperties: QuoteProperties;
+		trailingComma: TrailingComma;
 	},
 ): { code: string; ir: string } {
 	try {
@@ -141,6 +146,7 @@ export function formatWithPrettier(
 			plugins: [parserBabel],
 			singleQuote: options.quoteStyle === QuoteStyle.Single,
 			quoteProps: options.quoteProperties,
+			trailingComma: options.trailingComma,
 		};
 
 		// @ts-ignore

--- a/website/src/_includes/docs/project-config.md
+++ b/website/src/_includes/docs/project-config.md
@@ -8,8 +8,8 @@ The configuration file must be placed at the root of your project, usually at th
 
 All properties are **optional**, you can even have an empty config!
 
-We are deliberately lean with the supported configuration.
-We do not include options just for the sake of personalization.
+We are deliberately lean with the supported configuration. 
+We do not include options just for the sake of personalization. 
 We aim to offer everything out of the box and only introduce configuration if [absolutely necessary](https://rome.tools/#philosophy).
 
 ```json
@@ -47,16 +47,16 @@ An array of Unix shell style patterns.
 
 #### `linter.rules.recommended`
 
-Enables the [recommended rules](/docs/lint/rules) for all the groups.
+Enables the [recommended rules](/docs/lint/rules) for all the groups. 
 
 > Default: `true`
 
 
-#### `linter.rules.correctness`
+#### `linter.rules.correctness` 
 
-A list of rules for `Correctness` category.
+A list of rules for `Correctness` category.  
 
-#### `linter.rules.correctness.recommended`
+#### `linter.rules.correctness.recommended` 
 
 Enables the [recommended rules](/docs/lint/rules) for the category `Correctness`.
 
@@ -132,7 +132,7 @@ Example:
 Enables Rome's formatter
 
 > Default: `true`
-
+ 
 
 #### `formatter.ignore`
 
@@ -247,7 +247,7 @@ Just add `"warn"` as value of the rule. Example:
 }
 ```
 
-This is useful in cases there's being a refactor going on and there's need to make the
+This is useful in cases there's being a refactor going on and there's need to make the 
 CI passing.
 
 #### Pass options to a rule

--- a/website/src/_includes/docs/project-config.md
+++ b/website/src/_includes/docs/project-config.md
@@ -8,8 +8,8 @@ The configuration file must be placed at the root of your project, usually at th
 
 All properties are **optional**, you can even have an empty config!
 
-We are deliberately lean with the supported configuration. 
-We do not include options just for the sake of personalization. 
+We are deliberately lean with the supported configuration.
+We do not include options just for the sake of personalization.
 We aim to offer everything out of the box and only introduce configuration if [absolutely necessary](https://rome.tools/#philosophy).
 
 ```json
@@ -47,16 +47,16 @@ An array of Unix shell style patterns.
 
 #### `linter.rules.recommended`
 
-Enables the [recommended rules](/docs/lint/rules) for all the groups. 
+Enables the [recommended rules](/docs/lint/rules) for all the groups.
 
 > Default: `true`
 
 
-#### `linter.rules.correctness` 
+#### `linter.rules.correctness`
 
-A list of rules for `Correctness` category.  
+A list of rules for `Correctness` category.
 
-#### `linter.rules.correctness.recommended` 
+#### `linter.rules.correctness.recommended`
 
 Enables the [recommended rules](/docs/lint/rules) for the category `Correctness`.
 
@@ -132,7 +132,7 @@ Example:
 Enables Rome's formatter
 
 > Default: `true`
- 
+
 
 #### `formatter.ignore`
 
@@ -247,7 +247,7 @@ Just add `"warn"` as value of the rule. Example:
 }
 ```
 
-This is useful in cases there's being a refactor going on and there's need to make the 
+This is useful in cases there's being a refactor going on and there's need to make the
 CI passing.
 
 #### Pass options to a rule


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Add support for a [trailing_comma](https://prettier.io/docs/en/options.html#trailing-commas) option that can either be `es5` or` all` (default)

Close https://github.com/rome/tools/issues/3305

## Test Plan

Add new snapshots

`cargo test -p rome_js_formatter`
