### PR TITLE
fix(rome_js_formatter): JSX Expression child closing parentheses #3376

### DIFF
--- a/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx
+++ b/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx
@@ -1,0 +1,21 @@
+function BackTopContent(props){
+	return (
+		<CSSMotion>
+			{({ className: motionClassName }) =>
+				cloneElement(className => ({
+					className
+				}))}
+		</CSSMotion>
+	);
+}
+
+function BackTopContent(props){
+	return (
+		<CSSMotion>
+			{({ className: motionClassName }) =>
+				cloneElement(className => ({
+					className
+				}))/*with comment*/}
+		</CSSMotion>
+	);
+}

--- a/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
@@ -1,0 +1,61 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: arrow_function.jsx
+---
+# Input
+function BackTopContent(props){
+	return (
+		<CSSMotion>
+			{({ className: motionClassName }) =>
+				cloneElement(className => ({
+					className
+				}))}
+		</CSSMotion>
+	);
+}
+
+function BackTopContent(props){
+	return (
+		<CSSMotion>
+			{({ className: motionClassName }) =>
+				cloneElement(className => ({
+					className
+				}))/*with comment*/}
+		</CSSMotion>
+	);
+}
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+-----
+function BackTopContent(props) {
+	return (
+		<CSSMotion>
+			{({ className: motionClassName }) =>
+				cloneElement((className) => ({
+					className,
+				}))
+			}
+		</CSSMotion>
+	);
+}
+
+function BackTopContent(props) {
+	return (
+		<CSSMotion>
+			{
+				({ className: motionClassName }) =>
+					cloneElement((className) => ({
+						className,
+					})) /*with comment*/
+			}
+		</CSSMotion>
+	);
+}
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix https://github.com/rome/tools/issues/3376

## Test Plan

`cargo test -p rome_js_formatter`
