### PR TITLE
fix(rome_diagnostics_macros): correctly ignore unknown attributes

### DIFF
--- a/crates/rome_diagnostics/tests/macros/unknown_field_attr.stderr
+++ b/crates/rome_diagnostics/tests/macros/unknown_field_attr.stderr
@@ -1,9 +1,3 @@
-error: unknown attribute
- --> tests/macros/unknown_field_attr.rs:5:7
-  |
-5 |     #[unknown_attr]
-  |       ^^^^^^^^^^^^
-
 error: cannot find attribute `unknown_attr` in this scope
  --> tests/macros/unknown_field_attr.rs:5:7
   |

--- a/crates/rome_diagnostics_macros/src/parse.rs
+++ b/crates/rome_diagnostics_macros/src/parse.rs
@@ -168,8 +168,6 @@ impl DeriveInput {
                     result.source = Some(ident.clone());
                     continue;
                 }
-
-                abort!(attr.path.span(), "unknown attribute");
             }
         }
 


### PR DESCRIPTION
## Summary

The Rust Compiler already has a mechanism in place to emit an error when an unknown attribute is used in the code, so the procedural macro should simply ignore attributes it doesn't known about. Not only does this prevent a duplicate diagnostic from being emitted, but it's also important to allow attributes from the language (such as the `#[doc = ""]` attribute that doc-comments desugar to) or other proc-macros on types that derive `Diagnostic`

## Test Plan

The "unknown attribute" case is already covered but the test suite of the macro, the snapshot has been updated to ensure that only one diagnostic is emitted by the compiler.
