### PR TITLE
chore(rome_js_analyze): better use of `Option`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/nursery/use_key_with_click_events.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_key_with_click_events.rs
@@ -62,8 +62,11 @@ impl Rule for UseKeyWithClickEvents {
 
         match node {
             JsxAnyElement::JsxOpeningElement(element) => {
-                element.name().ok()?.as_jsx_name()?;
-                element.find_attribute_by_name("onClick").ok()??;
+                if element.name().ok()?.as_jsx_name().is_none()
+                    || element.find_attribute_by_name("onClick").ok()?.is_none()
+                {
+                    return None;
+                }
 
                 for attr in element.attributes().into_iter() {
                     let name = attr
@@ -83,8 +86,11 @@ impl Rule for UseKeyWithClickEvents {
                 Some(())
             }
             JsxAnyElement::JsxSelfClosingElement(element) => {
-                element.name().ok()?.as_jsx_name()?;
-                element.find_attribute_by_name("onClick").ok()??;
+                if element.name().ok()?.as_jsx_name().is_none()
+                    || element.find_attribute_by_name("onClick").ok()?.is_none()
+                {
+                    return None;
+                }
 
                 for attr in element.attributes().into_iter() {
                     let name = attr

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_key_with_mouse_events.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_key_with_mouse_events.rs
@@ -174,9 +174,7 @@ impl Rule for UseKeyWithMouseEvents {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
-        node.is_custom_component()?;
-
-        if node.has_spread_attribute() {
+        if node.is_custom_component().is_none() || node.has_spread_attribute() {
             return None;
         }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

In the recent PRs there were few places where we did use the try operator, but in these places it wasn't explicit enough **why** we were using it. 

I changed the code to use `is_none` and early return.  

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The CI should work

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
