### PR TITLE
refactor(rome_analyzer): use new diagnostics for `AnalyzerDiagnostic`

### DIFF
--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -1,10 +1,9 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../CONTRIBUTING.md")]
 
-use rome_console::fmt::Display;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BinaryHeap};
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 use std::ops;
 
 mod categories;
@@ -421,19 +420,19 @@ where
                     let signal = DiagnosticSignal::new(move || {
                         let diag = match group_rule {
                             Some((group, rule)) => SuppressionDiagnostic::new(
+                                file_id,
                                 range,
                                 markup! {
                                     "Unknown lint rule "{group}"/"{rule}" in suppression comment"
                                 },
-                                file_id,
                             ),
 
                             None => SuppressionDiagnostic::new(
+                                file_id,
                                 range,
                                 markup! {
                                     "Unknown lint rule group "{rule}" in suppression comment"
                                 },
-                                file_id,
                             ),
                         };
 
@@ -631,10 +630,10 @@ impl<'analysis> AnalysisFilter<'analysis> {
 pub enum AnalyzerDiagnostic {
     /// It holds various info related to diagnostics emitted by the rules
     Rule {
-        /// The severity of the rule
-        severity: Option<Severity>,
         /// Reference to the file
         file_id: FileId,
+        /// The severity of the rule
+        severity: Option<Severity>,
         /// The diagnostic emitted by a rule
         rule_diagnostic: RuleDiagnostic,
         /// Series of code suggestions offered by rule code actions
@@ -657,13 +656,7 @@ impl Diagnostic for AnalyzerDiagnostic {
         match self {
             AnalyzerDiagnostic::Rule {
                 rule_diagnostic, ..
-            } => {
-                if let Some(description) = &rule_diagnostic.description {
-                    write!(fmt, "{}", description)
-                } else {
-                    Ok(())
-                }
-            }
+            } => Debug::fmt(&rule_diagnostic.message, fmt),
             AnalyzerDiagnostic::Raw(error) => error.description(fmt),
         }
     }
@@ -672,7 +665,7 @@ impl Diagnostic for AnalyzerDiagnostic {
         match self {
             AnalyzerDiagnostic::Rule {
                 rule_diagnostic, ..
-            } => fmt.write_markup(markup!({ rule_diagnostic.message })),
+            } => rome_console::fmt::Display::fmt(&rule_diagnostic.message, fmt),
             AnalyzerDiagnostic::Raw(error) => error.message(fmt),
         }
     }
@@ -688,13 +681,7 @@ impl Diagnostic for AnalyzerDiagnostic {
         match self {
             AnalyzerDiagnostic::Rule {
                 rule_diagnostic, ..
-            } => {
-                if let Some(tags) = rule_diagnostic.tag {
-                    tags
-                } else {
-                    DiagnosticTags::empty()
-                }
-            }
+            } => rule_diagnostic.tags,
             AnalyzerDiagnostic::Raw(error) => error.tags(),
         }
     }
@@ -731,8 +718,8 @@ impl Diagnostic for AnalyzerDiagnostic {
                         &markup! { {detail.message} }.to_owned(),
                     )?;
                     if let Some(location) = Location::builder()
-                        .resource(file_id)
                         .span(&detail.range)
+                        .resource(file_id)
                         .build()
                     {
                         visitor.record_frame(location)?;
@@ -795,7 +782,7 @@ impl AnalyzerDiagnostic {
             ..
         } = self
         {
-            rule_diagnostic.tag = Some(DiagnosticTags::FIXABLE);
+            rule_diagnostic.tags = DiagnosticTags::FIXABLE;
             suggestions.push(suggestion)
         }
     }
@@ -806,21 +793,25 @@ impl AnalyzerDiagnostic {
 pub(crate) struct SuppressionDiagnostic {
     #[severity]
     severity: Severity,
-    #[location(resource)]
-    file_id: FileId,
     #[location(span)]
     range: TextRange,
+    #[location(resource)]
+    file_id: FileId,
     #[message]
     message: MarkupBuf,
 }
 
 impl SuppressionDiagnostic {
-    pub(crate) fn new(range: TextRange, message: impl Display, file_id: FileId) -> Self {
+    pub(crate) fn new(
+        file_id: FileId,
+        range: TextRange,
+        message: impl rome_console::fmt::Display,
+    ) -> Self {
         Self {
+            file_id,
             severity: Severity::Warning,
             range,
             message: markup!({ message }).to_owned(),
-            file_id,
         }
     }
 }

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -153,7 +153,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use rome_diagnostics::{file::FileId, v2::category, Diagnostic, Severity};
+    use rome_diagnostics::v2::{Diagnostic, Error, Severity};
+    use rome_diagnostics::{file::FileId, v2::category};
     use rome_rowan::{
         raw_language::{RawLanguage, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
         AstNode, TextRange, TextSize, TriviaPiece, TriviaPieceKind,
@@ -168,6 +169,15 @@ mod tests {
     use super::MatchQueryParams;
 
     struct SuppressionMatcher;
+
+    #[derive(Debug, Diagnostic)]
+    #[diagnostic(category = "args/fileNotFound", message = "test_suppression")]
+    struct TestDiagnostic {
+        #[location(resource)]
+        location: FileId,
+        #[location(span)]
+        span: TextRange,
+    }
 
     impl QueryMatcher<RawLanguage> for SuppressionMatcher {
         /// Emits a warning diagnostic for all literal expressions
@@ -184,17 +194,10 @@ mod tests {
             let span = node.text_trimmed_range();
             params.signal_queue.push(SignalEntry {
                 signal: Box::new(DiagnosticSignal::new(move || {
-                    AnalyzerDiagnostic::from_diagnostic(
-                        Diagnostic::warning(
-                            FileId::zero(),
-                            // This is a random category for testing that's
-                            // pretty much guaranteed to never be emitted by
-                            // the analyzer
-                            category!("args/fileNotFound"),
-                            "test_suppression",
-                        )
-                        .primary(span, ""),
-                    )
+                    AnalyzerDiagnostic::from_error(Error::from(TestDiagnostic {
+                        span,
+                        location: FileId::zero(),
+                    }))
                 })),
                 rule: RuleKey::new("group", "rule"),
                 text_range: span,
@@ -294,15 +297,13 @@ mod tests {
 
         let mut diagnostics = Vec::new();
         let mut emit_signal = |signal: &dyn AnalyzerSignal<RawLanguage>| -> ControlFlow<Never> {
-            let diag = signal
-                .diagnostic()
-                .expect("diagnostic")
-                .into_diagnostic(Severity::Warning);
+            let mut diag = signal.diagnostic().expect("diagnostic");
+            diag.set_severity(Severity::Warning);
 
-            let code = diag.code.expect("code");
-            let label = diag.primary.expect("primary label");
+            let code = diag.category().expect("code");
+            let range = diag.get_span().expect("range");
 
-            diagnostics.push((code, label.span.range));
+            diagnostics.push((code, range));
             ControlFlow::Continue(())
         };
 

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -6,9 +6,10 @@ use crate::{
     AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, ServiceBag,
 };
 use rome_console::MarkupBuf;
+use rome_diagnostics::v2::advice::CodeSuggestionAdvice;
 use rome_diagnostics::{
     file::{FileId, FileSpan},
-    Applicability, CodeSuggestion,
+    Applicability,
 };
 use rome_rowan::{BatchMutation, Language};
 
@@ -63,14 +64,15 @@ pub struct AnalyzerAction<L: Language> {
     pub mutation: BatchMutation<L>,
 }
 
-impl<L> From<AnalyzerAction<L>> for CodeSuggestion
+impl<L> From<AnalyzerAction<L>> for CodeSuggestionAdvice<MarkupBuf>
 where
     L: Language,
 {
     fn from(action: AnalyzerAction<L>) -> Self {
         let (range, suggestion) = action.mutation.as_text_edits().unwrap_or_default();
 
-        CodeSuggestion {
+        dbg!(&range);
+        CodeSuggestionAdvice {
             span: FileSpan {
                 file: action.file_id,
                 range,
@@ -78,7 +80,6 @@ where
             applicability: action.applicability,
             msg: action.message,
             suggestion,
-            labels: Vec::new(),
         }
     }
 }

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -7,10 +7,7 @@ use crate::{
 };
 use rome_console::MarkupBuf;
 use rome_diagnostics::v2::advice::CodeSuggestionAdvice;
-use rome_diagnostics::{
-    file::{FileId, FileSpan},
-    Applicability,
-};
+use rome_diagnostics::{file::FileId, Applicability};
 use rome_rowan::{BatchMutation, Language};
 
 /// Event raised by the analyzer when a [Rule](crate::Rule)
@@ -69,14 +66,9 @@ where
     L: Language,
 {
     fn from(action: AnalyzerAction<L>) -> Self {
-        let (range, suggestion) = action.mutation.as_text_edits().unwrap_or_default();
+        let (_, suggestion) = action.mutation.as_text_edits().unwrap_or_default();
 
-        dbg!(&range);
         CodeSuggestionAdvice {
-            span: FileSpan {
-                file: action.file_id,
-                range,
-            },
             applicability: action.applicability,
             msg: action.message,
             suggestion,

--- a/crates/rome_console/src/lib.rs
+++ b/crates/rome_console/src/lib.rs
@@ -12,7 +12,7 @@ mod write;
 pub use self::markup::{Markup, MarkupBuf, MarkupElement, MarkupNode};
 pub use rome_markup::markup;
 
-/// Determines the "ouput stream" a message should get printed to
+/// Determines the "output stream" a message should get printed to
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LogLevel {
     /// Print the message to the `Error` stream of the console, for instance

--- a/crates/rome_diagnostics/src/v2/advice.rs
+++ b/crates/rome_diagnostics/src/v2/advice.rs
@@ -3,7 +3,6 @@ use super::{
     location::{AsResource, AsSourceCode, AsSpan},
     Location,
 };
-use crate::file::FileSpan;
 use crate::Applicability;
 use rome_console::fmt::{self, Display};
 use rome_console::markup;
@@ -165,7 +164,6 @@ where
 /// Utility type implementing [Advices] that emits a
 /// code suggestion with the provided text
 pub struct CodeSuggestionAdvice<M> {
-    pub span: FileSpan,
     pub applicability: Applicability,
     pub msg: M,
     pub suggestion: TextEdit,

--- a/crates/rome_diagnostics/src/v2/advice.rs
+++ b/crates/rome_diagnostics/src/v2/advice.rs
@@ -1,14 +1,15 @@
-use std::io;
-
-use rome_console::fmt::{self, Display};
-use rome_text_edit::TextEdit;
-use serde::{Deserialize, Serialize};
-
 use super::{
     display::Backtrace,
     location::{AsResource, AsSourceCode, AsSpan},
     Location,
 };
+use crate::file::FileSpan;
+use crate::Applicability;
+use rome_console::fmt::{self, Display};
+use rome_console::markup;
+use rome_text_edit::TextEdit;
+use serde::{Deserialize, Serialize};
+use std::io;
 
 /// Trait implemented by types that support emitting advices into a diagnostic
 pub trait Advices {
@@ -157,5 +158,36 @@ where
 {
     fn record(&self, visitor: &mut dyn Visit) -> io::Result<()> {
         visitor.record_command(self.command.as_ref())
+    }
+}
+
+#[derive(Debug)]
+/// Utility type implementing [Advices] that emits a
+/// code suggestion with the provided text
+pub struct CodeSuggestionAdvice<M> {
+    pub span: FileSpan,
+    pub applicability: Applicability,
+    pub msg: M,
+    pub suggestion: TextEdit,
+}
+
+impl<M> Advices for CodeSuggestionAdvice<M>
+where
+    M: Display,
+{
+    fn record(&self, visitor: &mut dyn Visit) -> io::Result<()> {
+        let applicability = match self.applicability {
+            Applicability::Always => "Safe fix",
+            Applicability::MaybeIncorrect => "Suggested fix",
+        };
+
+        visitor.record_log(
+            LogCategory::Info,
+            &markup! {
+                {applicability}": "{self.msg}
+            },
+        )?;
+
+        visitor.record_diff(&self.suggestion)
     }
 }

--- a/crates/rome_diagnostics/src/v2/display.rs
+++ b/crates/rome_diagnostics/src/v2/display.rs
@@ -7,6 +7,7 @@ use unicode_width::UnicodeWidthStr;
 mod backtrace;
 mod diff;
 mod frame;
+mod message;
 
 use crate::v2::display::frame::SourceFile;
 
@@ -16,6 +17,7 @@ use super::{
 };
 
 pub use self::backtrace::{set_bottom_frame, Backtrace};
+pub use self::message::MessageAndDescription;
 
 /// Helper struct from printing the description of a diagnostic into any
 /// formatter implementing [std::fmt::Write].

--- a/crates/rome_diagnostics/src/v2/display/message.rs
+++ b/crates/rome_diagnostics/src/v2/display/message.rs
@@ -1,0 +1,80 @@
+use rome_console::fmt::{Formatter, Termcolor};
+use rome_console::{markup, MarkupBuf};
+use termcolor::NoColor;
+
+/// Convenient type that can be used when message and descriptions match, and they need to be
+/// displayed using different formatters
+///
+/// ## Examples
+///
+/// ```
+/// use rome_diagnostics::v2::{Diagnostic, MessageAndDescription};
+///
+/// #[derive(Debug, Diagnostic)]
+/// struct TestDiagnostic {
+///     #[message]
+///     #[description]
+///     message: MessageAndDescription
+/// }
+/// ```
+#[derive(Debug)]
+pub struct MessageAndDescription {
+    /// Shown when medium supports custom markup
+    message: MarkupBuf,
+    /// Shown when the medium doesn't support markup
+    description: String,
+}
+
+impl MessageAndDescription {
+    /// It sets a custom message. It updates only the message.
+    pub fn set_message(&mut self, new_message: MarkupBuf) {
+        self.message = new_message;
+    }
+
+    /// It sets a custom description. It updates only the description
+    pub fn set_description(&mut self, new_description: String) {
+        self.description = new_description;
+    }
+}
+
+impl From<String> for MessageAndDescription {
+    fn from(description: String) -> Self {
+        Self {
+            message: markup! { {description} }.to_owned(),
+            description,
+        }
+    }
+}
+
+impl From<MarkupBuf> for MessageAndDescription {
+    fn from(message: MarkupBuf) -> Self {
+        let description = markup_to_string(&message);
+        Self {
+            message,
+            description,
+        }
+    }
+}
+
+impl std::fmt::Display for MessageAndDescription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.description)
+    }
+}
+
+impl rome_console::fmt::Display for MessageAndDescription {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::io::Result<()> {
+        fmt.write_markup(markup! {{self.message}})
+    }
+}
+
+/// Utility function to transform a [MarkupBuf] into a [String]
+fn markup_to_string(markup: &MarkupBuf) -> String {
+    let mut buffer = Vec::new();
+    let mut write = Termcolor(NoColor::new(&mut buffer));
+    let mut fmt = Formatter::new(&mut write);
+    fmt.write_markup(markup! { {markup} })
+        .expect("to have written in the buffer");
+
+    String::from_utf8(buffer).expect("to have convert a buffer into a String")
+}

--- a/crates/rome_diagnostics/src/v2/error.rs
+++ b/crates/rome_diagnostics/src/v2/error.rs
@@ -39,7 +39,7 @@ pub struct Error {
 /// Implement the [Diagnostic] trait as inherent methods on the [Error] type.
 impl Error {
     /// Calls [Diagnostic::category] on the [Diagnostic] wrapped by this [Error].
-    pub fn category(&self) -> Option<&Category> {
+    pub fn category(&self) -> Option<&'static Category> {
         self.as_diagnostic().category()
     }
 

--- a/crates/rome_diagnostics/src/v2/mod.rs
+++ b/crates/rome_diagnostics/src/v2/mod.rs
@@ -20,7 +20,9 @@ pub use advice::{
 };
 pub use context::{Context, DiagnosticExt};
 pub use diagnostic::{Diagnostic, DiagnosticTags, Severity};
-pub use display::{set_bottom_frame, Backtrace, PrintDescription, PrintDiagnostic};
+pub use display::{
+    set_bottom_frame, Backtrace, MessageAndDescription, PrintDescription, PrintDiagnostic,
+};
 pub use error::{Error, Result};
 pub use location::{FileId, FilePath, LineIndex, LineIndexBuf, Location, Resource, SourceCode};
 

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_delete.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_delete.rs
@@ -66,7 +66,7 @@ impl Rule for NoDelete {
             RuleDiagnostic::new(rule_category!(),node.range(), markup! {
                 "This is an unexpected use of the "<Emphasis>"delete"</Emphasis>" operator."
             })
-            .summary("This is an unexpected use of the `delete` operator.\nReplace this expression with an `undefined` assignment")
+            .description("This is an unexpected use of the `delete` operator.\nReplace this expression with an `undefined` assignment")
         )
     }
 

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
@@ -82,13 +82,13 @@ impl Rule for NoDoubleEquals {
             RuleDiagnostic::new(rule_category!(),op.text_trimmed_range(), markup! {
                 "Use "<Emphasis>{suggestion}</Emphasis>" instead of "<Emphasis>{text_trimmed}</Emphasis>
             })
-            .primary( markup! {
+            .note( markup! {
                 <Emphasis>{text_trimmed}</Emphasis>" is only allowed when comparing against "<Emphasis>"null"</Emphasis>
             })
-            .footer_note(markup! {
+            .note(markup! {
                 "Using "<Emphasis>{suggestion}</Emphasis>" may be unsafe if you are relying on type coercion"
             })
-            .summary(format!("Use {suggestion} instead of {text_trimmed}.\n{text_trimmed} is only allowed when comparing against `null`"))
+            .description(format!("Use {suggestion} instead of {text_trimmed}.\n{text_trimmed} is only allowed when comparing against `null`"))
         )
     }
 

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_extra_boolean_cast.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_extra_boolean_cast.rs
@@ -230,7 +230,7 @@ impl Rule for NoExtraBooleanCast {
                     {title}
                 },
             )
-            .footer_note(note),
+            .note(note),
         )
     }
 

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_shadow_restricted_names.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_shadow_restricted_names.rs
@@ -70,7 +70,7 @@ impl Rule for NoShadowRestrictedNames {
                 "Do not shadow the global \"" {state.shadowed_name} "\" property."
             },
         )
-        .footer_note(
+        .note(
             markup! {"Consider renaming this variable. It's easy to confuse the origin of variables when they're named after a known global."},
         );
 

--- a/crates/rome_js_analyze/src/analyzers/correctness/use_valid_typeof.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/use_valid_typeof.rs
@@ -207,13 +207,13 @@ impl Rule for UseValidTypeof {
         Some(match err {
             TypeofError::InvalidLiteral(range, literal) => {
                 RuleDiagnostic::new(rule_category!(), range, TITLE)
-                    .primary("not a valid type name")
-                    .summary(format!("{TITLE}: \"{literal}\" is not a valid type name"))
+                    .note("not a valid type name")
+                    .description(format!("{TITLE}: \"{literal}\" is not a valid type name"))
             }
             TypeofError::InvalidExpression(range) => {
                 RuleDiagnostic::new(rule_category!(), range, TITLE)
-                    .primary("not a string literal")
-                    .summary(format!("{TITLE}: this expression is not a string literal",))
+                    .note("not a string literal")
+                    .description(format!("{TITLE}: this expression is not a string literal",))
             }
         })
     }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_unreachable.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_unreachable.rs
@@ -81,7 +81,7 @@ impl Rule for NoUnreachable {
                 "This code will never be reached ..."
             },
         )
-        .summary("This code is unreachable")
+        .description("This code is unreachable")
         .unnecessary();
 
         // Pluralize and adapt the error message accordingly based on the
@@ -92,7 +92,7 @@ impl Rule for NoUnreachable {
             [] => {}
             // A single node is responsible for this range being unreachable
             [node] => {
-                diagnostic = diagnostic.secondary(
+                diagnostic = diagnostic.detail(
                     node.range,
                     format_args!(
                         "... because this statement will {} beforehand",
@@ -104,8 +104,8 @@ impl Rule for NoUnreachable {
             [node_a, node_b] => {
                 if node_a.kind == node_b.kind {
                     diagnostic = diagnostic
-                        .secondary(node_a.range, "... because either this statement ...")
-                        .secondary(
+                        .detail(node_a.range, "... because either this statement ...")
+                        .detail(
                             node_b.range,
                             format_args!(
                                 "... or this statement will {} beforehand",
@@ -114,14 +114,14 @@ impl Rule for NoUnreachable {
                         );
                 } else {
                     diagnostic = diagnostic
-                        .secondary(
+                        .detail(
                             node_a.range,
                             format_args!(
                                 "... because either this statement will {} ...",
                                 node_a.reason()
                             ),
                         )
-                        .secondary(
+                        .detail(
                             node_b.range,
                             format_args!(
                                 "... or this statement will {} beforehand",
@@ -150,12 +150,11 @@ impl Rule for NoUnreachable {
                     for (index, node) in terminators.iter().enumerate() {
                         if index == 0 {
                             diagnostic = diagnostic
-                                .secondary(node.range, "... because either this statement, ...");
+                                .detail(node.range, "... because either this statement, ...");
                         } else if index < last {
-                            diagnostic =
-                                diagnostic.secondary(node.range, "... this statement, ...");
+                            diagnostic = diagnostic.detail(node.range, "... this statement, ...");
                         } else {
-                            diagnostic = diagnostic.secondary(
+                            diagnostic = diagnostic.detail(
                                 node.range,
                                 format_args!(
                                     "... or this statement will {} beforehand",
@@ -167,7 +166,7 @@ impl Rule for NoUnreachable {
                 } else {
                     for (index, node) in terminators.iter().enumerate() {
                         if index == 0 {
-                            diagnostic = diagnostic.secondary(
+                            diagnostic = diagnostic.detail(
                                 node.range,
                                 format_args!(
                                     "... because either this statement will {}, ...",
@@ -175,12 +174,12 @@ impl Rule for NoUnreachable {
                                 ),
                             );
                         } else if index < last {
-                            diagnostic = diagnostic.secondary(
+                            diagnostic = diagnostic.detail(
                                 node.range,
                                 format_args!("... this statement will {}, ...", node.reason()),
                             );
                         } else {
-                            diagnostic = diagnostic.secondary(
+                            diagnostic = diagnostic.detail(
                                 node.range,
                                 format_args!(
                                     "... or this statement will {} beforehand",

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_anchor_content.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_anchor_content.rs
@@ -151,7 +151,7 @@ impl Rule for UseAnchorContent {
             markup! {
 				"Provide screen reader accessible content when using "<Emphasis>"`a`"</Emphasis>" elements."
 			}
-        ).footer_note(
+        ).note(
 			markup! {
 				"All links on a page should have content that is accessible to screen readers."
 			}

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_blank_target.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_blank_target.rs
@@ -186,7 +186,7 @@ impl Rule for UseBlankTarget {
             markup! {
                 "Avoid using "<Emphasis>"target=\"_blank\""</Emphasis>" without "<Emphasis>"rel=\"noreferrer\""</Emphasis>"."
             },
-        ).footer_note(
+        ).note(
             markup!{
                 "Opening external links in new tabs without rel=\"noreferrer\" is a security risk. See \
                 "<Hyperlink href="https://html.spec.whatwg.org/multipage/links.html#link-type-noopener">"the explanation"</Hyperlink>" for more details."

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_key_with_click_events.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_key_with_click_events.rs
@@ -115,7 +115,7 @@ impl Rule for UseKeyWithClickEvents {
             markup! {
                 "Enforce to have the "<Emphasis>"onClick"</Emphasis>" mouse event with the "<Emphasis>"onKeyUp"</Emphasis>", the "<Emphasis>"onKeyDown"</Emphasis>", or the "<Emphasis>"onKeyPress"</Emphasis>" keyboard event."
             },
-        ).footer_note(markup! {
+        ).note(markup! {
             "Actions triggered using mouse events should have corresponding keyboard events to account for keyboard-only navigation."
         }))
     }

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_valid_anchor.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_valid_anchor.rs
@@ -227,8 +227,8 @@ impl Rule for UseValidAnchor {
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
         let diagnostic = RuleDiagnostic::new(rule_category!(), state.range(), state.message())
-            .footer_note(state.note())
-            .footer_note(
+            .note(state.note())
+            .note(
             markup! {
                 "Check "<Hyperlink href="https://marcysutton.com/links-vs-buttons-in-modern-web-applications">"this thorough explanation"</Hyperlink>" to better understand the context."
             }

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -118,7 +118,10 @@ where
 mod tests {
 
     use rome_analyze::{AnalyzerOptions, Never, RuleCategories};
-    use rome_diagnostics::Severity;
+    use rome_console::fmt::{Formatter, Termcolor};
+    use rome_console::{markup, Markup};
+    use rome_diagnostics::termcolor::NoColor;
+    use rome_diagnostics::v2::{Diagnostic, DiagnosticExt, PrintDiagnostic, Severity};
     use rome_diagnostics::{file::FileId, v2::category};
     use rome_js_parser::parse;
     use rome_js_syntax::{SourceType, TextRange, TextSize};
@@ -128,12 +131,21 @@ mod tests {
     #[ignore]
     #[test]
     fn quick_test() {
-        const SOURCE: &str = r#"[0, [12]].map(Number).flat()
+        fn markup_to_string(markup: Markup) -> String {
+            let mut buffer = Vec::new();
+            let mut write = Termcolor(NoColor::new(&mut buffer));
+            let mut fmt = Formatter::new(&mut write);
+            fmt.write_markup(markup).unwrap();
+
+            String::from_utf8(buffer).unwrap()
+        }
+
+        const SOURCE: &str = r#"<input disabled />
         "#;
 
         let parsed = parse(SOURCE, FileId::zero(), SourceType::jsx());
 
-        let mut error_ranges = Vec::new();
+        let mut error_ranges: Vec<TextRange> = Vec::new();
         let options = AnalyzerOptions::default();
         analyze(
             FileId::zero(),
@@ -141,17 +153,20 @@ mod tests {
             AnalysisFilter::default(),
             &options,
             |signal| {
-                if let Some(diag) = signal.diagnostic() {
-                    let diag = diag.into_diagnostic(Severity::Warning);
-                    let primary = diag.primary.as_ref().unwrap();
-
-                    error_ranges.push(primary.span.range);
-                }
-
-                if let Some(action) = signal.action() {
-                    let new_code = action.mutation.commit();
-
-                    eprintln!("{new_code}");
+                if let Some(mut diag) = signal.diagnostic() {
+                    diag.set_severity(Severity::Warning);
+                    error_ranges.push(diag.location().unwrap().span.unwrap());
+                    if let Some(action) = signal.action() {
+                        let new_code = action.mutation.commit();
+                        eprintln!("{new_code}");
+                    }
+                    let error = diag
+                        .with_file_path("example.js")
+                        .with_file_source_code(SOURCE);
+                    let text = markup_to_string(markup! {
+                        {PrintDiagnostic(&error)}
+                    });
+                    eprintln!("{text}");
                 }
 
                 ControlFlow::<Never>::Continue(())
@@ -186,7 +201,7 @@ mod tests {
 
         let parsed = parse(SOURCE, FileId::zero(), SourceType::js_module());
 
-        let mut error_ranges = Vec::new();
+        let mut error_ranges: Vec<TextRange> = Vec::new();
         let options = AnalyzerOptions::default();
         analyze(
             FileId::zero(),
@@ -194,13 +209,13 @@ mod tests {
             AnalysisFilter::default(),
             &options,
             |signal| {
-                if let Some(diag) = signal.diagnostic() {
-                    let diag = diag.into_diagnostic(Severity::Warning);
-                    let code = diag.code.unwrap();
-                    let primary = diag.primary.as_ref().unwrap();
+                if let Some(mut diag) = signal.diagnostic() {
+                    diag.set_severity(Severity::Warning);
+                    let code = diag.category().unwrap();
+                    let location = diag.location().unwrap();
 
                     if code == category!("lint/correctness/noDoubleEquals") {
-                        error_ranges.push(primary.span.range);
+                        error_ranges.push(location.span.unwrap());
                     }
                 }
 
@@ -234,11 +249,10 @@ mod tests {
 
         let options = AnalyzerOptions::default();
         analyze(FileId::zero(), &parsed.tree(), filter, &options, |signal| {
-            if let Some(diag) = signal.diagnostic() {
-                let diag = diag.into_diagnostic(Severity::Warning);
-                let code = diag.code.unwrap();
-                let primary = diag.primary.as_ref().unwrap();
-                panic!("unexpected diagnostic {code:?} at {primary:?}");
+            if let Some(mut diag) = signal.diagnostic() {
+                diag.set_severity(Severity::Warning);
+                let code = diag.category().unwrap();
+                panic!("unexpected diagnostic {code:?}");
             }
 
             ControlFlow::<Never>::Continue(())

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -160,9 +160,7 @@ mod tests {
                         let new_code = action.mutation.commit();
                         eprintln!("{new_code}");
                     }
-                    let error = diag
-                        .with_file_path("example.js")
-                        .with_file_source_code(SOURCE);
+                    let error = diag.with_file_path("ahahah").with_file_source_code(SOURCE);
                     let text = markup_to_string(markup! {
                         {PrintDiagnostic(&error)}
                     });
@@ -211,11 +209,14 @@ mod tests {
             |signal| {
                 if let Some(mut diag) = signal.diagnostic() {
                     diag.set_severity(Severity::Warning);
-                    let code = diag.category().unwrap();
-                    let location = diag.location().unwrap();
+                    let span = diag.get_span();
+                    let error = diag
+                        .with_file_path(FileId::zero())
+                        .with_file_source_code(SOURCE);
+                    let code = error.category().unwrap();
 
                     if code == category!("lint/correctness/noDoubleEquals") {
-                        error_ranges.push(location.span.unwrap());
+                        error_ranges.push(span.unwrap());
                     }
                 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_arguments.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_arguments.rs
@@ -63,7 +63,7 @@ impl Rule for NoArguments {
             markup! {
                 "Use the "<Emphasis>"rest parameters"</Emphasis>" instead of "<Emphasis>"arguments"</Emphasis>"."
             },
-        ).footer_note(markup! {<Emphasis>"arguments"</Emphasis>" does not have "<Emphasis>"Array.prototype"</Emphasis>" methods and can be inconvenient to use."}))
+        ).note(markup! {<Emphasis>"arguments"</Emphasis>" does not have "<Emphasis>"Array.prototype"</Emphasis>" methods and can be inconvenient to use."}))
     }
 
     fn action(_: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_catch_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_catch_assign.rs
@@ -87,14 +87,14 @@ impl Rule for NoCatchAssign {
                 " Do not "<Emphasis>"reassign catch parameters."</Emphasis>""
             },
         )
-        .secondary(
+        .detail(
             catch_binding_syntax.text_trimmed_range(),
             markup! {
                 "The catch parameter is declared here"
             },
         );
 
-        Some(diagnostic.footer_note("Use a local variable instead."))
+        Some(diagnostic.note("Use a local variable instead."))
     }
 
     fn action(_: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_function_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_function_assign.rs
@@ -141,7 +141,7 @@ impl Rule for NoFunctionAssign {
         let mut hoisted_quantity = 0;
         for reference in state.all_writes.iter() {
             let node = reference.node();
-            diag = diag.secondary(node.text_trimmed_range(), "Reassigned here.");
+            diag = diag.detail(node.text_trimmed_range(), "Reassigned here.");
 
             hoisted_quantity += if reference.is_using_hoisted_declaration() {
                 1
@@ -151,14 +151,14 @@ impl Rule for NoFunctionAssign {
         }
 
         let diag = if hoisted_quantity > 0 {
-            diag.footer_note(
+            diag.note(
                 markup! {"Reassignment happens here because the function declaration is hoisted."},
             )
         } else {
             diag
         };
 
-        let diag = diag.footer_note(markup! {"Use a local variable instead."});
+        let diag = diag.note(markup! {"Use a local variable instead."});
 
         Some(diag)
     }

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_import_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_import_assign.rs
@@ -112,8 +112,8 @@ impl Rule for NoImportAssign {
                     "The imported variable "<Emphasis>{name.to_string()}</Emphasis>" is read-only"
                 },
             )
-            .footer_note(markup! {"Use a local variable instead of reassigning an import."})
-            .secondary(
+            .note(markup! {"Use a local variable instead of reassigning an import."})
+            .detail(
                 import_binding.syntax().text_trimmed_range(),
                 markup! {
                     "The variable is imported here"

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_label_var.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_label_var.rs
@@ -62,10 +62,10 @@ impl Rule for NoLabelVar {
                 "Do not use the "<Emphasis>{name}</Emphasis>" variable name as a label"
             },
         )
-        .secondary(binding_syntax_node.text_trimmed_range(), markup! {
+        .detail(binding_syntax_node.text_trimmed_range(), markup! {
             "The variable is declared here"
         },)
-        .footer_note(markup! {"Creating a label with the same name as an in-scope variable leads to confusion."}))
+        .note(markup! {"Creating a label with the same name as an in-scope variable leads to confusion."}))
     }
 
     fn action(_: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_array_index_key.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_array_index_key.rs
@@ -174,12 +174,12 @@ impl Rule for NoArrayIndexKey {
             incorrect_prop.syntax().text_trimmed_range(),
             markup! {"Avoid using the index of an array as key property in an element."},
         )
-        .secondary(
+        .detail(
             incorrect_key.syntax().text_trimmed_range(),
             markup! {"This is the source of the key value."},
-        ).footer_note(
+        ).note(
             markup! {"The order of the items may change, and this also affects performances and component state."}
-        ).footer_note(
+        ).note(
             markup! {
                 "Check the "<Hyperlink href="https://reactjs.org/docs/lists-and-keys.html#keys">"React documentation"</Hyperlink>". "
             }

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_children_prop.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_children_prop.rs
@@ -99,7 +99,7 @@ impl Rule for NoChildrenProp {
                     "Avoid passing "<Emphasis>"children"</Emphasis>" using a prop"
                 },
             )
-            .footer_note(footer_help),
+            .note(footer_help),
         )
     }
 }

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_const_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_const_assign.rs
@@ -84,7 +84,7 @@ impl Rule for NoConstAssign {
                 node.syntax().text_trimmed_range(),
                 markup! {"Can't assign "<Emphasis>{name}</Emphasis>" because it's a constant"},
             )
-            .secondary(
+            .detail(
                 state,
                 markup! {"This is where the variable is defined as constant"},
             ),

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_dangerously_set_inner_html.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_dangerously_set_inner_html.rs
@@ -3,7 +3,6 @@ use crate::semantic_services::Semantic;
 use rome_analyze::context::RuleContext;
 use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
-use rome_diagnostics::Severity;
 use rome_js_syntax::{JsCallExpression, JsLiteralMemberName, JsxAnyAttributeName, JsxAttribute};
 use rome_rowan::{declare_node_union, AstNode};
 
@@ -106,8 +105,8 @@ impl Rule for NoDangerouslySetInnerHtml {
                 "Avoid passing content using the "<Emphasis>"dangerouslySetInnerHTML"</Emphasis>" prop."
             }
                 .to_owned(),
-        ).footer(
-            Severity::Warning,
+        ).warning(
+
             "Setting content using code can expose users to cross-site scripting (XSS) attacks",
         );
         Some(diagnostic)

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_dangerously_set_inner_html_with_children.rs
@@ -186,9 +186,9 @@ impl Rule for NoDangerouslySetInnerHtmlWithChildren {
             markup! {
                 "Avoid passing both "<Emphasis>"children"</Emphasis>" and the "<Emphasis>"dangerouslySetInnerHTML"</Emphasis>" prop."
             },
-        ).secondary(state.children_kind.text_trimmed_range(), markup! {
+        ).detail(state.children_kind.text_trimmed_range(), markup! {
             "This is the source of the children prop"
-        }).footer_note(
+        }).note(
             markup! {
                 "Setting HTML content will inadvertently override any passed children in React"
             }

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_positive_tabindex.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_positive_tabindex.rs
@@ -3,7 +3,6 @@ use crate::semantic_services::Semantic;
 use rome_analyze::context::RuleContext;
 use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
-use rome_diagnostics::Severity;
 use rome_js_semantic::SemanticModel;
 use rome_js_syntax::{
     JsCallExpression, JsNumberLiteralExpression, JsPropertyObjectMember, JsStringLiteralExpression,
@@ -157,8 +156,7 @@ impl Rule for NoPositiveTabindex {
             state,
             markup!{"Avoid positive values for the "<Emphasis>"tabIndex"</Emphasis>" prop."}.to_owned(),
         )
-        .footer(
-            Severity::Note,
+        .note(
             markup!{
 				"Elements with a positive "<Emphasis>"tabIndex"</Emphasis>" override natural page content order. This causes elements without a positive tab index to come last when navigating using a keyboard."
 			}.to_owned(),

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_render_return_value.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_render_return_value.rs
@@ -76,7 +76,7 @@ impl Rule for NoRenderReturnValue {
             markup! {
                 "Do not depend on the value returned by the function "<Emphasis>"ReactDOM.render()"</Emphasis>"."
             },
-        ).footer_note(markup! {
+        ).note(markup! {
 "The returned value is legacy and future versions of react might return that value asynchronously."
 "
 Check the "<Hyperlink href="https://facebook.github.io/react/docs/react-dom.html#render">"React documentation"</Hyperlink>" for more information."

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_restricted_globals.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_restricted_globals.rs
@@ -81,7 +81,7 @@ impl Rule for NoRestrictedGlobals {
                     "Do not use the global variable "<Emphasis>{text}</Emphasis>"."
                 },
             )
-            .footer_note(markup! {
+            .note(markup! {
                 "Use a local variable instead."
             }),
         )

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_unused_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_unused_variables.rs
@@ -271,7 +271,7 @@ impl Rule for NoUnusedVariables {
             },
         );
 
-        let diag = diag.footer_note(
+        let diag = diag.note(
             markup! {"Unused variables usually are result of incomplete refactoring, typos and other source of bugs."},
         );
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_button_type.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_button_type.rs
@@ -2,7 +2,6 @@ use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::semantic_services::Semantic;
 use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
-use rome_diagnostics::Severity;
 use rome_js_syntax::{
     JsCallExpression, JsObjectExpression, JsStringLiteralExpression, JsxAnyElementName,
     JsxOpeningElement, JsxString,
@@ -160,11 +159,11 @@ impl Rule for UseButtonType {
             state.node.syntax().text_trimmed_range(),
             message
         )
-            .footer(Severity::Note, markup! {
+            .note(markup! {
                 "The default  "<Emphasis>"type"</Emphasis>" of a button is "<Emphasis>"submit"</Emphasis>", which causes the submission of a form when placed inside a `form` element. "
                 "This is likely not the behaviour that you want inside a React application."
             })
-            .footer_help(
+            .note(
             markup! {
 
                 "Allowed button types are: "<Emphasis>"submit"</Emphasis>", "<Emphasis>"button"</Emphasis>" or "<Emphasis>"reset"</Emphasis>""

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_fragment_syntax.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_fragment_syntax.rs
@@ -108,7 +108,7 @@ impl Rule for UseFragmentSyntax {
                     "Use shorthand syntax for Fragment elements instead of standard syntax."
                 },
             )
-            .footer_note(markup! {
+            .note(markup! {
                 "Shorthand fragment syntax saves keystrokes and is only inapplicable when keys are required."
             }),
         )

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_key_with_mouse_events.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_key_with_mouse_events.rs
@@ -201,7 +201,7 @@ impl Rule for UseKeyWithMouseEvents {
                 node.syntax().text_trimmed_range(),
                 state.message(),
             )
-            .footer_note(footer_note_text),
+            .note(footer_note_text),
         )
     }
 }

--- a/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
@@ -124,10 +124,10 @@ impl Rule for NoShoutyConstants {
 
         for reference in state.references.iter() {
             let node = reference.node();
-            diag = diag.secondary(node.text_trimmed_range(), "Used here.")
+            diag = diag.detail(node.text_trimmed_range(), "Used here.")
         }
 
-        let diag = diag.footer_note(
+        let diag = diag.note(
             markup! {"You should avoid declaring constants with a string that's the same
     value as the variable name. It introduces a level of unnecessary
     indirection when it's only two additional characters to inline."},

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -1,24 +1,23 @@
-use std::{
-    ffi::OsStr, fmt::Write, fs::read_to_string, os::raw::c_int, path::Path, slice, sync::Once,
-};
-
-use similar::TextDiff;
-
 use rome_analyze::{
-    AnalysisFilter, AnalyzerAction, AnalyzerOptions, ControlFlow, Never, RuleFilter,
+    AnalysisFilter, AnalyzerAction, AnalyzerDiagnostic, AnalyzerOptions, ControlFlow, Never,
+    RuleFilter,
 };
 use rome_console::{
     fmt::{Formatter, Termcolor},
     markup, Markup,
 };
 use rome_diagnostics::file::FileId;
-use rome_diagnostics::Severity;
-use rome_diagnostics::{file::SimpleFile, termcolor::NoColor, Diagnostic};
+use rome_diagnostics::termcolor::NoColor;
+use rome_diagnostics::v2::{DiagnosticExt, PrintDiagnostic, Severity};
 use rome_js_parser::{
     parse,
     test_utils::{assert_errors_are_absent, has_unknown_nodes_or_empty_slots},
 };
 use rome_js_syntax::{JsLanguage, SourceType};
+use similar::TextDiff;
+use std::{
+    ffi::OsStr, fmt::Write, fs::read_to_string, os::raw::c_int, path::Path, slice, sync::Once,
+};
 
 tests_macros::gen_tests! {"tests/specs/**/*.{cjs,js,jsx,tsx,ts}", crate::run_test, "module"}
 
@@ -46,11 +45,11 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     let mut code_fixes = Vec::new();
     let options = AnalyzerOptions::default();
     rome_js_analyze::analyze(FileId::zero(), &root, filter, &options, |event| {
-        if let Some(diag) = event.diagnostic() {
-            let mut diag = diag.into_diagnostic(Severity::Warning);
+        if let Some(mut diag) = event.diagnostic() {
+            diag.set_severity(Severity::Warning);
             if let Some(action) = event.action() {
                 check_code_action(input_file, &input_code, source_type, &action);
-                diag.suggestions.push(action.into());
+                diag.add_code_suggestion(action.into());
             }
 
             diagnostics.push(diagnostic_to_string(file_name, &input_code, diag));
@@ -132,10 +131,10 @@ fn markup_to_string(markup: Markup) -> String {
     String::from_utf8(buffer).unwrap()
 }
 #[allow(clippy::let_and_return)]
-fn diagnostic_to_string(name: &str, source: &str, diag: Diagnostic) -> String {
-    let file = SimpleFile::new(name.into(), source.into());
+fn diagnostic_to_string(name: &str, source: &str, diag: AnalyzerDiagnostic) -> String {
+    let error = diag.with_file_path(name).with_file_source_code(source);
     let text = markup_to_string(markup! {
-        {diag.display(&file)}
+        {PrintDiagnostic(&error)}
     });
 
     text

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -132,7 +132,9 @@ fn markup_to_string(markup: Markup) -> String {
 }
 #[allow(clippy::let_and_return)]
 fn diagnostic_to_string(name: &str, source: &str, diag: AnalyzerDiagnostic) -> String {
-    let error = diag.with_file_path(name).with_file_source_code(source);
+    let error = diag
+        .with_file_path((name, FileId::zero()))
+        .with_file_source_code(source);
     let text = markup_to_string(markup! {
         {PrintDiagnostic(&error)}
     });

--- a/crates/rome_js_analyze/tests/specs/correctness/noDoubleEquals.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noDoubleEquals.js.snap
@@ -18,12 +18,12 @@ noDoubleEquals.js:1:18 lint/correctness/noDoubleEquals  FIXABLE  ━━━━━
 
   ! Use === instead of ==
   
-  ! == is only allowed when comparing against null
-  
   > 1 │ const isZero = a == 0;
       │                  ^^
     2 │ const isNonZero = a != 0;
     3 │ 
+  
+  i == is only allowed when comparing against null
   
   i Using === may be unsafe if you are relying on type coercion
   
@@ -39,13 +39,13 @@ noDoubleEquals.js:2:21 lint/correctness/noDoubleEquals  FIXABLE  ━━━━━
 
   ! Use !== instead of !=
   
-  ! != is only allowed when comparing against null
-  
     1 │ const isZero = a == 0;
   > 2 │ const isNonZero = a != 0;
       │                     ^^
     3 │ 
     4 │ const isNull = a == null;
+  
+  i != is only allowed when comparing against null
   
   i Using !== may be unsafe if you are relying on type coercion
   

--- a/crates/rome_js_analyze/tests/specs/correctness/useValidTypeof.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/useValidTypeof.js.snap
@@ -30,13 +30,13 @@ useValidTypeof.js:7:16 lint/correctness/useValidTypeof ━━━━━━━━�
 
   ! Invalid `typeof` comparison value
   
-  ! not a valid type name
-  
     6 │ // Invalid literals
   > 7 │ typeof foo === "strnig"
       │                ^^^^^^^^
     8 │ typeof foo == "undefimed"
     9 │ typeof bar != "nunber"
+  
+  i not a valid type name
   
 
 ```
@@ -46,14 +46,14 @@ useValidTypeof.js:8:15 lint/correctness/useValidTypeof ━━━━━━━━�
 
   ! Invalid `typeof` comparison value
   
-  ! not a valid type name
-  
      6 │ // Invalid literals
      7 │ typeof foo === "strnig"
    > 8 │ typeof foo == "undefimed"
        │               ^^^^^^^^^^^
      9 │ typeof bar != "nunber"
     10 │ typeof bar !== "fucntion"
+  
+  i not a valid type name
   
 
 ```
@@ -63,14 +63,14 @@ useValidTypeof.js:9:15 lint/correctness/useValidTypeof ━━━━━━━━�
 
   ! Invalid `typeof` comparison value
   
-  ! not a valid type name
-  
      7 │ typeof foo === "strnig"
      8 │ typeof foo == "undefimed"
    > 9 │ typeof bar != "nunber"
        │               ^^^^^^^^
     10 │ typeof bar !== "fucntion"
     11 │ 
+  
+  i not a valid type name
   
 
 ```
@@ -80,14 +80,14 @@ useValidTypeof.js:10:16 lint/correctness/useValidTypeof ━━━━━━━━
 
   ! Invalid `typeof` comparison value
   
-  ! not a valid type name
-  
      8 │ typeof foo == "undefimed"
      9 │ typeof bar != "nunber"
   > 10 │ typeof bar !== "fucntion"
        │                ^^^^^^^^^^
     11 │ 
     12 │ // Invalid expressions
+  
+  i not a valid type name
   
 
 ```
@@ -97,13 +97,13 @@ useValidTypeof.js:13:16 lint/correctness/useValidTypeof  FIXABLE  ━━━━�
 
   ! Invalid `typeof` comparison value
   
-  ! not a string literal
-  
     12 │ // Invalid expressions
   > 13 │ typeof foo === undefined
        │                ^^^^^^^^^
     14 │ typeof bar == Object
     15 │ typeof foo === baz
+  
+  i not a string literal
   
   i Suggested fix: Compare the result of `typeof` with a valid type name
   
@@ -117,14 +117,14 @@ useValidTypeof.js:14:15 lint/correctness/useValidTypeof  FIXABLE  ━━━━�
 
   ! Invalid `typeof` comparison value
   
-  ! not a string literal
-  
     12 │ // Invalid expressions
     13 │ typeof foo === undefined
   > 14 │ typeof bar == Object
        │               ^^^^^^
     15 │ typeof foo === baz
     16 │ typeof foo == 5
+  
+  i not a string literal
   
   i Suggested fix: Compare the result of `typeof` with a valid type name
   
@@ -143,14 +143,14 @@ useValidTypeof.js:15:16 lint/correctness/useValidTypeof ━━━━━━━━
 
   ! Invalid `typeof` comparison value
   
-  ! not a string literal
-  
     13 │ typeof foo === undefined
     14 │ typeof bar == Object
   > 15 │ typeof foo === baz
        │                ^^^
     16 │ typeof foo == 5
     17 │ typeof foo == -5
+  
+  i not a string literal
   
 
 ```
@@ -160,14 +160,14 @@ useValidTypeof.js:16:15 lint/correctness/useValidTypeof ━━━━━━━━
 
   ! Invalid `typeof` comparison value
   
-  ! not a string literal
-  
     14 │ typeof bar == Object
     15 │ typeof foo === baz
   > 16 │ typeof foo == 5
        │               ^
     17 │ typeof foo == -5
     18 │ 
+  
+  i not a string literal
   
 
 ```
@@ -177,13 +177,13 @@ useValidTypeof.js:17:15 lint/correctness/useValidTypeof ━━━━━━━━
 
   ! Invalid `typeof` comparison value
   
-  ! not a string literal
-  
     15 │ typeof foo === baz
     16 │ typeof foo == 5
   > 17 │ typeof foo == -5
        │               ^^
     18 │ 
+  
+  i not a string literal
   
 
 ```

--- a/crates/rome_service/src/configuration/linter/mod.rs
+++ b/crates/rome_service/src/configuration/linter/mod.rs
@@ -5,7 +5,7 @@ pub use crate::configuration::linter::rules::Rules;
 use crate::settings::LinterSettings;
 use crate::{ConfigurationError, MatchOptions, Matcher, RomeError};
 use indexmap::IndexSet;
-use rome_diagnostics::Severity;
+use rome_diagnostics::v2::Severity;
 pub use rules::*;
 #[cfg(feature = "schemars")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -3,8 +3,7 @@
 use crate::{ConfigurationError, RomeError, RuleConfiguration};
 use indexmap::{IndexMap, IndexSet};
 use rome_analyze::RuleFilter;
-use rome_diagnostics::v2::Category;
-use rome_diagnostics::Severity;
+use rome_diagnostics::v2::{Category, Severity};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -105,7 +104,9 @@ impl Rules {
             None
         }
     }
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     #[doc = r" It returns a tuple of filters. The first element of the tuple are the enabled rules,"]
     #[doc = r" while the second element are the disabled rules."]
     #[doc = r""]
@@ -317,7 +318,9 @@ impl Correctness {
         RuleFilter::Rule("correctness", Self::CATEGORY_RULES[26]),
         RuleFilter::Rule("correctness", Self::CATEGORY_RULES[27]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -337,7 +340,9 @@ impl Correctness {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -445,7 +450,9 @@ impl Nursery {
     ];
     const RECOMMENDED_RULES: [&'static str; 0] = [];
     const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 0] = [];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -465,7 +472,9 @@ impl Nursery {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -539,7 +548,9 @@ impl Style {
         RuleFilter::Rule("style", Self::CATEGORY_RULES[2]),
         RuleFilter::Rule("style", Self::CATEGORY_RULES[3]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -559,7 +570,9 @@ impl Style {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -30,6 +30,7 @@ use super::{
 use crate::configuration::to_analyzer_configuration;
 use crate::file_handlers::{FixAllParams, Language as LanguageId};
 use indexmap::IndexSet;
+use rome_diagnostics::v2::Error;
 use rome_diagnostics::{v2, v2::Diagnostic};
 use rome_js_analyze::utils::rename::{RenameError, RenameSymbolExtensions};
 use std::borrow::Cow;
@@ -233,7 +234,7 @@ fn lint(
             if let Some(action) = signal.action() {
                 diagnostic.add_code_suggestion(action.into());
             }
-            diagnostics.push(v2::serde::Diagnostic::new(diagnostic));
+            diagnostics.push(v2::serde::Diagnostic::new(Error::from(diagnostic)));
         }
 
         ControlFlow::<Never>::Continue(())

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -1,8 +1,16 @@
+use crate::{
+    settings::{FormatSettings, Language, LanguageSettings, LanguagesSettings, SettingsHandle},
+    workspace::{
+        server::AnyParse, CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult,
+        PullActionsResult, RenameResult,
+    },
+    RomeError, Rules,
+};
 use rome_analyze::{
     AnalysisFilter, AnalyzerOptions, ControlFlow, GroupCategory, Never, QueryMatch,
     RegistryVisitor, RuleCategories, RuleCategory, RuleFilter, RuleGroup,
 };
-use rome_diagnostics::{Applicability, CodeSuggestion, Diagnostic};
+use rome_diagnostics::{Applicability, CodeSuggestion};
 use rome_formatter::{FormatError, Printed};
 use rome_fs::RomePath;
 use rome_js_analyze::{analyze, analyze_with_inspect_matcher, visit_registry, RuleError};
@@ -15,15 +23,6 @@ use rome_js_syntax::{
 };
 use rome_rowan::{AstNode, BatchMutationExt, Direction};
 
-use crate::{
-    settings::{FormatSettings, Language, LanguageSettings, LanguagesSettings, SettingsHandle},
-    workspace::{
-        server::AnyParse, CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult,
-        PullActionsResult, RenameResult,
-    },
-    RomeError, Rules,
-};
-
 use super::{
     AnalyzerCapabilities, DebugCapabilities, ExtensionHandler, FormatterCapabilities, Mime,
     ParserCapabilities,
@@ -31,7 +30,7 @@ use super::{
 use crate::configuration::to_analyzer_configuration;
 use crate::file_handlers::{FixAllParams, Language as LanguageId};
 use indexmap::IndexSet;
-use rome_diagnostics::Severity;
+use rome_diagnostics::{v2, v2::Diagnostic};
 use rome_js_analyze::utils::rename::{RenameError, RenameSymbolExtensions};
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -213,29 +212,28 @@ fn lint(
     filter: AnalysisFilter,
     rules: Option<&Rules>,
     settings: SettingsHandle,
-) -> Vec<Diagnostic> {
+) -> Vec<v2::serde::Diagnostic> {
     let tree = parse.tree();
     let mut diagnostics = parse.into_diagnostics();
 
     let file_id = rome_path.file_id();
     let analyzer_options = compute_analyzer_options(&settings);
     analyze(file_id, &tree, filter, &analyzer_options, |signal| {
-        if let Some(diagnostic) = signal.diagnostic() {
+        if let Some(mut diagnostic) = signal.diagnostic() {
             // We do now check if the severity of the diagnostics should be changed.
             // The configuration allows to change the severity of the diagnostics emitted by rules.
             let severity = diagnostic
-                .code()
+                .category()
                 .filter(|category| category.name().starts_with("lint/"))
                 .and_then(|category| rules.as_ref()?.get_severity_from_code(category))
-                .unwrap_or(Severity::Error);
+                .unwrap_or(v2::Severity::Error);
 
-            let mut diagnostic = diagnostic.into_diagnostic(severity);
+            diagnostic.set_severity(severity);
 
             if let Some(action) = signal.action() {
-                diagnostic.suggestions.push(action.into());
+                diagnostic.add_code_suggestion(action.into());
             }
-
-            diagnostics.push(diagnostic);
+            diagnostics.push(v2::serde::Diagnostic::new(diagnostic));
         }
 
         ControlFlow::<Never>::Continue(())

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -63,7 +63,10 @@ impl WorkspaceSettings {
     /// The code of the has the following pattern: `{group}/{rule_name}`.
     ///
     /// It returns [None] if the `code` doesn't match any rule.
-    pub fn get_severity_from_rule_code(&self, code: &Category) -> Option<Severity> {
+    pub fn get_severity_from_rule_code(
+        &self,
+        code: &Category,
+    ) -> Option<rome_diagnostics::v2::Severity> {
         let rules = self.linter.rules.as_ref();
         if let Some(rules) = rules {
             rules.get_severity_from_code(code)

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -242,8 +242,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
         use crate::{ConfigurationError, RomeError, RuleConfiguration};
         use rome_analyze::RuleFilter;
         use indexmap::{IndexMap, IndexSet};
-        use rome_diagnostics::Severity;
-        use rome_diagnostics::v2::Category;
+        use rome_diagnostics::v2::{Category, Severity};
 
         #[derive(Deserialize, Serialize, Debug, Clone)]
         #[cfg_attr(feature = "schemars", derive(JsonSchema))]


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/3393

This PR refactors `AnalyzerDiagnostic` and partially `RuleDiagnostic` to use the new diagnostics. It also introduces a new `SuppressionDiagnostic`, to allow emit diagnostics that don't belong to rules but belong to the analyzer.

- refactored a bit the APIs of the `RuleDiagnostic`. I removed `primary`, `footer` and `secondary`. We do now have `.detail()` for `.secondary()`, `.note()`/`.warning()` to replace `.footer()` APIs. `footer()` is now private and only accessible via `note`/`warning`. The sparse usage of `primary()` has been migrated to use `.note()`
- `AnalyzerDiagnostic` now implements the trait `Diagnostic` and implement all its functions
- `RuleDiagnostic` now exposes a method called `detail` instead of `secondary`



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

There are tiny changes on the existing diagnostics, but the majority of them should not change. I run locally `cargo t` in the analyzer

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
