### PR TITLE
feat(rome_cli): Add server logs to `rage` command

### DIFF
--- a/crates/rome_cli/src/commands/daemon.rs
+++ b/crates/rome_cli/src/commands/daemon.rs
@@ -1,9 +1,11 @@
-use std::env;
-
 use rome_console::{markup, ConsoleExt};
 use rome_lsp::ServerFactory;
 use rome_service::{workspace::WorkspaceClient, RomeError, TransportError};
+use std::env;
+use std::path::PathBuf;
+use std::{fs, io};
 use tokio::runtime::Runtime;
+use tracing::subscriber::Interest;
 use tracing::{debug_span, metadata::LevelFilter, Instrument, Metadata};
 use tracing_subscriber::{
     layer::{Context, Filter},
@@ -89,6 +91,35 @@ pub(crate) fn print_socket() -> Result<(), Termination> {
     Ok(())
 }
 
+const fn log_file_name_prefix() -> &'static str {
+    "server.log"
+}
+
+pub(crate) fn read_most_recent_log_file() -> io::Result<Option<String>> {
+    let logs_dir = rome_log_dir();
+
+    let most_recent = fs::read_dir(logs_dir)?
+        .into_iter()
+        .flatten()
+        .filter(|file| file.file_type().map_or(false, |ty| ty.is_file()))
+        .filter_map(|file| {
+            match file
+                .file_name()
+                .to_str()?
+                .split_once(log_file_name_prefix())
+            {
+                Some((_, date_part)) if date_part.split('-').count() == 4 => Some(file.path()),
+                _ => None,
+            }
+        })
+        .max();
+
+    match most_recent {
+        Some(file) => Ok(Some(fs::read_to_string(file)?)),
+        None => Ok(None),
+    }
+}
+
 /// Setup the [tracing]-based logging system for the server
 /// The events received by the subscriber are filtered at the `info` level,
 /// then printed using the [HierarchicalLayer] layer, and the resulting text
@@ -96,8 +127,7 @@ pub(crate) fn print_socket() -> Result<(), Termination> {
 /// `rome-logs/server.log.yyyy-MM-dd-HH` files inside the system temporary
 /// directory)
 fn setup_tracing_subscriber() {
-    let logs_dir = env::temp_dir().join("rome-logs");
-    let file_appender = tracing_appender::rolling::hourly(logs_dir, "server.log");
+    let file_appender = tracing_appender::rolling::hourly(rome_log_dir(), log_file_name_prefix());
 
     registry()
         .with(
@@ -113,13 +143,20 @@ fn setup_tracing_subscriber() {
         .init();
 }
 
+pub(super) fn rome_log_dir() -> PathBuf {
+    match env::var_os("ROME_LOG_DIR") {
+        Some(directory) => PathBuf::from(directory),
+        None => env::temp_dir().join("rome-logs"),
+    }
+}
+
 /// Tracing filter enabling:
 /// - All spans and events at level info or higher
 /// - All spans and events at level debug in crates whose name starts with `rome`
 struct LoggingFilter;
 
-impl<S> Filter<S> for LoggingFilter {
-    fn enabled(&self, meta: &Metadata<'_>, _cx: &Context<'_, S>) -> bool {
+impl LoggingFilter {
+    fn is_enabled(&self, meta: &Metadata<'_>) -> bool {
         let filter = if meta.target().starts_with("rome") {
             LevelFilter::DEBUG
         } else {
@@ -127,6 +164,20 @@ impl<S> Filter<S> for LoggingFilter {
         };
 
         meta.level() <= &filter
+    }
+}
+
+impl<S> Filter<S> for LoggingFilter {
+    fn enabled(&self, meta: &Metadata<'_>, _cx: &Context<'_, S>) -> bool {
+        self.is_enabled(meta)
+    }
+
+    fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> Interest {
+        if self.is_enabled(meta) {
+            Interest::always()
+        } else {
+            Interest::never()
+        }
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {

--- a/crates/rome_cli/src/commands/rage.rs
+++ b/crates/rome_cli/src/commands/rage.rs
@@ -8,6 +8,7 @@ use rome_service::{load_config, DynRef, Workspace};
 use std::{env, io, ops::Deref};
 use tokio::runtime::Runtime;
 
+use crate::commands::daemon::read_most_recent_log_file;
 use crate::{service, CliSession, Termination, VERSION};
 
 /// Handler for the `rage` command
@@ -25,11 +26,13 @@ pub(crate) fn rage(mut session: CliSession) -> Result<(), Termination> {
     {KeyValuePair("OS", markup!({std::env::consts::OS}))}
 
     {Section("Environment")}
+    {EnvVarOs("ROME_LOG_DIR")}
     {EnvVarOs("NO_COLOR")}
     {EnvVarOs("TERM")}
 
     {RageConfiguration(&session.app.fs)}
     {WorkspaceRage(session.app.workspace.deref())}
+    {ConnectedClientServerLog(session.app.workspace.deref())}
     ));
 
     if session.app.workspace.server_info().is_none() {
@@ -86,11 +89,11 @@ impl Display for RunningRomeServer {
 
         match service::open_transport(runtime) {
             Ok(None) => {
-                markup!(
+                return markup!(
                     {Section("Server")}
                     {KeyValuePair("Status", markup!(<Dim>"stopped"</Dim>))}
                 )
-                .fmt(f)?;
+                .fmt(f);
             }
             Ok(Some(transport)) => {
                 markup!("\n"<Emphasis>"Running Rome Server:"</Emphasis>" "{HorizontalLine::new(78)}"
@@ -113,7 +116,7 @@ impl Display for RunningRomeServer {
             }
         };
 
-        Ok(())
+        RomeServerLog.fmt(f)
     }
 }
 
@@ -191,5 +194,38 @@ impl Display for KeyValuePair<'_> {
         value.fmt(fmt)?;
 
         fmt.write_str("\n")
+    }
+}
+
+struct RomeServerLog;
+
+impl Display for RomeServerLog {
+    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
+        if let Ok(Some(log)) = read_most_recent_log_file() {
+            markup!("\n"<Emphasis><Underline>"Rome Server Log:"</Underline></Emphasis>"
+
+"<Warn>"\u{26a0} Please check the log file before sharing it publicly as it may contain sensitive information. For example:
+    * Path names that may reveal your name, a project name, or the name of your employer.
+    * The content of source files and configurations that are copyright protected.
+"</Warn>)
+            .fmt(fmt)?;
+
+            write!(fmt, "\n{log}")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Prints the server logs but only if the client is connected to a rome server.
+struct ConnectedClientServerLog<'a>(&'a dyn Workspace);
+
+impl Display for ConnectedClientServerLog<'_> {
+    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
+        if self.0.server_info().is_some() {
+            RomeServerLog.fmt(fmt)
+        } else {
+            Ok(())
+        }
     }
 }

--- a/crates/rome_cli/src/commands/rage.rs
+++ b/crates/rome_cli/src/commands/rage.rs
@@ -204,9 +204,9 @@ impl Display for RomeServerLog {
         if let Ok(Some(log)) = read_most_recent_log_file() {
             markup!("\n"<Emphasis><Underline>"Rome Server Log:"</Underline></Emphasis>"
 
-"<Warn>"\u{26a0} Please check the log file before sharing it publicly as it may contain sensitive information. For example:
-    * Path names that may reveal your name, a project name, or the name of your employer.
-    * The content of source files and configurations that are copyright protected.
+"<Warn>"\u{26a0} Please review the content of the log file before sharing it publicly as it may contain sensitive information:
+  * Path names that may reveal your name, a project name, or the name of your employer.
+  * Source code
 "</Warn>)
             .fmt(fmt)?;
 

--- a/crates/rome_cli/tests/commands/rage.rs
+++ b/crates/rome_cli/tests/commands/rage.rs
@@ -1,18 +1,21 @@
 use crate::run_cli;
 use crate::snap_test::{CliSnapshot, SnapshotPayload};
 use pico_args::Arguments;
-use rome_console::BufferConsole;
-use rome_fs::MemoryFileSystem;
+use rome_cli::Termination;
+use rome_console::{BufferConsole, Console};
+use rome_fs::{FileSystem, MemoryFileSystem};
 use rome_service::DynRef;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+use std::{env, fs};
 
 #[test]
 fn ok() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
+    let result = run_rage(
         DynRef::Borrowed(&mut fs),
         DynRef::Borrowed(&mut console),
         Arguments::from_vec(vec![OsString::from("rage")]),
@@ -42,7 +45,7 @@ fn with_configuration() {
 }"#,
     );
 
-    let result = run_cli(
+    let result = run_rage(
         DynRef::Borrowed(&mut fs),
         DynRef::Borrowed(&mut console),
         Arguments::from_vec(vec![OsString::from("rage")]),
@@ -72,7 +75,7 @@ fn with_malformed_configuration() {
 }"#,
     );
 
-    let result = run_cli(
+    let result = run_rage(
         DynRef::Borrowed(&mut fs),
         DynRef::Borrowed(&mut console),
         Arguments::from_vec(vec![OsString::from("rage")]),
@@ -87,6 +90,84 @@ fn with_malformed_configuration() {
         console,
         result,
     ));
+}
+
+#[test]
+fn with_server_logs() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let result = {
+        let log_dir = TestLogDir::new("rome-test-logs");
+        fs::create_dir_all(&log_dir.path).expect("Failed to create test log directory");
+
+        fs::write(&log_dir.path.join("server.log.2022-10-14-16"), r#"
+┐rome_cli::commands::daemon::Running Server{pid=195434}
+├─2547ms INFO rome_lsp::server Starting Rome Language Server...
+├─15333ms INFO rome_lsp::server Starting Rome Language Server...
+├─15347ms INFO rome_lsp::server Attempting to load the configuration from 'rome.json' file
+├─15347ms INFO rome_service::configuration Attempting to load the configuration file at path "/home/micha/git/ant-design/rome.json"
+├─15347ms ERROR rome_service::configuration Could not find the file configuration at "/home/micha/git/ant-design/rome.json"
+├─15347ms ERROR rome_service::configuration Reason: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+├─┐rome_js_parser::parse::parse{file_id=FileId(0)}
+├─┘
+├─┐rome_js_parser::parse::parse{file_id=FileId(1)}
+├─┘
+├─16108ms INFO rome_lsp::server Starting Rome Language Server...
+├─41801ms INFO rome_lsp::server Starting Rome Language Server...
+├─41802ms INFO rome_lsp::server Sending shutdown signal
+INFO rome_cli::commands::daemon Received shutdown signal
+├─41802ms ERROR tower_lsp::transport failed to encode message: failed to encode response: Broken pipe (os error 32)
+┘
+┐rome_cli::commands::daemon::Running Server{pid=197796}
+├─2822ms INFO rome_lsp::server Starting Rome Language Server...
+├─7550ms INFO rome_lsp::server Starting Rome Language Server...
+├─7551ms INFO rome_lsp::server Attempting to load the configuration from 'rome.json' file
+├─7551ms INFO rome_service::configuration Attempting to load the configuration file at path "/home/micha/git/ant-design/rome.json"
+├─7551ms ERROR rome_service::configuration Could not find the file configuration at "/home/micha/git/ant-design/rome.json"
+├─7551ms ERROR rome_service::configuration Reason: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+├─┐rome_js_parser::parse::parse{file_id=FileId(0)}
+├─┘
+├─┐rome_js_parser::parse::parse{file_id=FileId(1)}
+├─┘
+├─7897ms INFO rome_lsp::server Starting Rome Language Server...
+"#,
+        ).expect("Failed to write log file");
+
+        fs::write(
+            &log_dir.path.join("server.log.2022-10-14-15").to_path_buf(),
+            r#"
+Not most recent log file
+"#,
+        )
+        .expect("Failed to write configuration file");
+
+        run_cli(
+            DynRef::Borrowed(&mut fs),
+            DynRef::Borrowed(&mut console),
+            Arguments::from_vec(vec![OsString::from("rage")]),
+        )
+    };
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_rage_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "with_server_logs",
+        fs,
+        console,
+        result,
+    ));
+}
+
+/// Runs the `rage` command mocking out the log directory.
+fn run_rage<'app>(
+    fs: DynRef<'app, dyn FileSystem>,
+    console: DynRef<'app, dyn Console>,
+    args: Arguments,
+) -> Result<(), Termination> {
+    let _test_dir = TestLogDir::new("rome-rage-test");
+    run_cli(fs, console, args)
 }
 
 fn assert_rage_snapshot(payload: SnapshotPayload<'_>) {
@@ -122,4 +203,36 @@ fn assert_rage_snapshot(payload: SnapshotPayload<'_>) {
         insta::assert_snapshot!(test_name, content);
 
     });
+}
+
+/// Mutex to guarantee that the `rage` tests run sequentially. Necessary to avoid race conditions
+/// when reading the server logs.
+static RAGE_GUARD: Mutex<()> = Mutex::new(());
+
+/// Mocks out the directory from which `rage` reads the server logs. Ensures that the test directory
+/// gets removed at the end of the test.
+struct TestLogDir {
+    path: PathBuf,
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl TestLogDir {
+    fn new(name: &str) -> Self {
+        let guard = RAGE_GUARD.lock().unwrap();
+        let path = env::temp_dir().join(name);
+
+        env::set_var("ROME_LOG_DIR", &path);
+
+        Self {
+            path,
+            _guard: guard,
+        }
+    }
+}
+
+impl Drop for TestLogDir {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.path).ok();
+        env::remove_var("ROME_LOG_DIR");
+    }
 }

--- a/crates/rome_cli/tests/commands/rage.rs
+++ b/crates/rome_cli/tests/commands/rage.rs
@@ -135,7 +135,7 @@ INFO rome_cli::commands::daemon Received shutdown signal
         ).expect("Failed to write log file");
 
         fs::write(
-            &log_dir.path.join("server.log.2022-10-14-15").to_path_buf(),
+            &log_dir.path.join("server.log.2022-10-14-15"),
             r#"
 Not most recent log file
 "#,

--- a/crates/rome_cli/tests/commands/rage.rs
+++ b/crates/rome_cli/tests/commands/rage.rs
@@ -182,7 +182,8 @@ fn assert_rage_snapshot(payload: SnapshotPayload<'_>) {
             .lines()
             .map(|line| match line.trim_start().split_once(':') {
                 Some((
-                    "CPU Architecture" | "OS" | "NO_COLOR" | "TERM" | "Color support",
+                    "CPU Architecture" | "OS" | "NO_COLOR" | "TERM" | "ROME_LOG_DIR"
+                    | "Color support",
                     value,
                 )) => line.replace(value.trim_start(), "**PLACEHOLDER**"),
                 _ => line.to_string(),

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
@@ -14,7 +14,7 @@ Platform:
   OS:                   **PLACEHOLDER**
 
 Environment:
-  ROME_LOG_DIR:         "/tmp/rome-rage-test"
+  ROME_LOG_DIR:         **PLACEHOLDER**
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
 

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
@@ -14,6 +14,7 @@ Platform:
   OS:                   **PLACEHOLDER**
 
 Environment:
+  ROME_LOG_DIR:         "/tmp/rome-rage-test"
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
 

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
@@ -24,7 +24,7 @@ Platform:
   OS:                   **PLACEHOLDER**
 
 Environment:
-  ROME_LOG_DIR:         "/tmp/rome-rage-test"
+  ROME_LOG_DIR:         **PLACEHOLDER**
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
 

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
@@ -24,6 +24,7 @@ Platform:
   OS:                   **PLACEHOLDER**
 
 Environment:
+  ROME_LOG_DIR:         "/tmp/rome-rage-test"
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
 

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
@@ -24,7 +24,7 @@ Platform:
   OS:                   **PLACEHOLDER**
 
 Environment:
-  ROME_LOG_DIR:         "/tmp/rome-rage-test"
+  ROME_LOG_DIR:         **PLACEHOLDER**
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
 

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
@@ -24,6 +24,7 @@ Platform:
   OS:                   **PLACEHOLDER**
 
 Environment:
+  ROME_LOG_DIR:         "/tmp/rome-rage-test"
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
 

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
@@ -1,0 +1,71 @@
+---
+source: crates/rome_cli/tests/commands/rage.rs
+expression: content
+---
+# Emitted Messages
+
+```block
+CLI:
+  Version:              0.0.0
+  Color support:        **PLACEHOLDER**
+
+Platform:
+  CPU Architecture:     **PLACEHOLDER**
+  OS:                   **PLACEHOLDER**
+
+Environment:
+  ROME_LOG_DIR:         "/tmp/rome-test-logs"
+  NO_COLOR:             **PLACEHOLDER**
+  TERM:                 **PLACEHOLDER**
+
+Rome Configuration:
+  Status:               unset
+
+Server:
+  Version:              0.0.0
+  Name:                 rome_lsp
+  CPU Architecture:     **PLACEHOLDER**
+  OS:                   **PLACEHOLDER**
+
+Workspace:
+  Open Documents:       0
+
+Rome Server Log:
+
+! Please check the log file before sharing it publicly as it may contain sensitive information. For example:
+    * Path names that may reveal your name, a project name, or the name of your employer.
+    * The content of source files and configurations that are copyright protected.
+
+
+┐rome_cli::commands::daemon::Running Server{pid=195434}
+├─2547ms INFO rome_lsp::server Starting Rome Language Server...
+├─15333ms INFO rome_lsp::server Starting Rome Language Server...
+├─15347ms INFO rome_lsp::server Attempting to load the configuration from 'rome.json' file
+├─15347ms INFO rome_service::configuration Attempting to load the configuration file at path "/home/micha/git/ant-design/rome.json"
+├─15347ms ERROR rome_service::configuration Could not find the file configuration at "/home/micha/git/ant-design/rome.json"
+├─15347ms ERROR rome_service::configuration Reason: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+├─┐rome_js_parser::parse::parse{file_id=FileId(0)}
+├─┘
+├─┐rome_js_parser::parse::parse{file_id=FileId(1)}
+├─┘
+├─16108ms INFO rome_lsp::server Starting Rome Language Server...
+├─41801ms INFO rome_lsp::server Starting Rome Language Server...
+├─41802ms INFO rome_lsp::server Sending shutdown signal
+INFO rome_cli::commands::daemon Received shutdown signal
+├─41802ms ERROR tower_lsp::transport failed to encode message: failed to encode response: Broken pipe (os error 32)
+┘
+┐rome_cli::commands::daemon::Running Server{pid=197796}
+├─2822ms INFO rome_lsp::server Starting Rome Language Server...
+├─7550ms INFO rome_lsp::server Starting Rome Language Server...
+├─7551ms INFO rome_lsp::server Attempting to load the configuration from 'rome.json' file
+├─7551ms INFO rome_service::configuration Attempting to load the configuration file at path "/home/micha/git/ant-design/rome.json"
+├─7551ms ERROR rome_service::configuration Could not find the file configuration at "/home/micha/git/ant-design/rome.json"
+├─7551ms ERROR rome_service::configuration Reason: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+├─┐rome_js_parser::parse::parse{file_id=FileId(0)}
+├─┘
+├─┐rome_js_parser::parse::parse{file_id=FileId(1)}
+├─┘
+├─7897ms INFO rome_lsp::server Starting Rome Language Server...
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
@@ -32,9 +32,9 @@ Workspace:
 
 Rome Server Log:
 
-! Please check the log file before sharing it publicly as it may contain sensitive information. For example:
-    * Path names that may reveal your name, a project name, or the name of your employer.
-    * The content of source files and configurations that are copyright protected.
+! Please review the content of the log file before sharing it publicly as it may contain sensitive information:
+  * Path names that may reveal your name, a project name, or the name of your employer.
+  * Source code
 
 
 ┐rome_cli::commands::daemon::Running Server{pid=195434}

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
@@ -14,7 +14,7 @@ Platform:
   OS:                   **PLACEHOLDER**
 
 Environment:
-  ROME_LOG_DIR:         "/tmp/rome-test-logs"
+  ROME_LOG_DIR:         **PLACEHOLDER**
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
 


### PR DESCRIPTION
## Summary

This PR adds the server log to the output of the `rage` command. 

I initially considered implementing the LSP `trace` notification but preferred to not go with it in the end because:

* Reading the server log from the disk has the advantage that we can extract log messages that have been written **before** rage was called compared to only the log messages written when rage `rage` was run
* The other approach would probably not have worked because the notifications sent by the LSP server would be send AFTER the `rome/rage` command has completed. It would be necessary to implement some wait mechanism on the client to give the server time to send the notifications and then consume every one of them. 

I still plan to spend some time today to explore if it is possible to implement the trace notification because that can be useful when debugging the VS Code plugin but I no longer plan to use it for the `rage` command.

## Test Plan

I added a new test (that was painful because of race conditions)

![image](https://user-images.githubusercontent.com/1203881/196412548-09e9ed0a-4553-4a9d-bb85-b939bd4b8f82.png)

## Open Question

- [ ] Should we include the logs by default or only if a `--include-logs` argument is present?

