### PR TITLE
 refactor(rome_service): use `serde::Diagnostic` in the workspace

### DIFF
--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -6,8 +6,9 @@ use crate::{
     AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, ServiceBag,
 };
 use rome_console::MarkupBuf;
+use rome_diagnostics::file::FileSpan;
 use rome_diagnostics::v2::advice::CodeSuggestionAdvice;
-use rome_diagnostics::{file::FileId, Applicability};
+use rome_diagnostics::{file::FileId, Applicability, CodeSuggestion};
 use rome_rowan::{BatchMutation, Language};
 
 /// Event raised by the analyzer when a [Rule](crate::Rule)
@@ -72,6 +73,26 @@ where
             applicability: action.applicability,
             msg: action.message,
             suggestion,
+        }
+    }
+}
+
+impl<L> From<AnalyzerAction<L>> for CodeSuggestion
+where
+    L: Language,
+{
+    fn from(action: AnalyzerAction<L>) -> Self {
+        let (range, suggestion) = action.mutation.as_text_edits().unwrap_or_default();
+
+        CodeSuggestion {
+            span: FileSpan {
+                file: action.file_id,
+                range,
+            },
+            applicability: action.applicability,
+            msg: action.message,
+            suggestion,
+            labels: vec![],
         }
     }
 }

--- a/crates/rome_cli/tests/snapshots/main_commands_check/parse_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/parse_error.snap
@@ -22,7 +22,11 @@ check.js:2:1 parse ━━━━━━━━━━━━━━━━━━━━�
 
   × expected `(` but instead the file ends
   
-  × the file ends here
+    1 │ if
+  > 2 │ 
+      │ 
+  
+  i the file ends here
   
     1 │ if
   > 2 │ 

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/ci_parse_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/ci_parse_error.snap
@@ -22,7 +22,11 @@ ci.js:2:1 parse ━━━━━━━━━━━━━━━━━━━━━�
 
   × expected `(` but instead the file ends
   
-  × the file ends here
+    1 │ if
+  > 2 │ 
+      │ 
+  
+  i the file ends here
   
     1 │ if
   > 2 │ 

--- a/crates/rome_diagnostics/src/v2/display/message.rs
+++ b/crates/rome_diagnostics/src/v2/display/message.rs
@@ -17,7 +17,7 @@ use termcolor::NoColor;
 ///     message: MessageAndDescription
 /// }
 /// ```
-#[derive(Debug)]
+// #[derive(Debug)]
 pub struct MessageAndDescription {
     /// Shown when medium supports custom markup
     message: MarkupBuf,
@@ -59,6 +59,12 @@ impl From<MarkupBuf> for MessageAndDescription {
 impl std::fmt::Display for MessageAndDescription {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.description)
+    }
+}
+
+impl std::fmt::Debug for MessageAndDescription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
     }
 }
 

--- a/crates/rome_diagnostics/src/v2/display/message.rs
+++ b/crates/rome_diagnostics/src/v2/display/message.rs
@@ -17,7 +17,6 @@ use termcolor::NoColor;
 ///     message: MessageAndDescription
 /// }
 /// ```
-// #[derive(Debug)]
 pub struct MessageAndDescription {
     /// Shown when medium supports custom markup
     message: MarkupBuf,

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
@@ -82,7 +82,7 @@ impl Rule for NoDoubleEquals {
             RuleDiagnostic::new(rule_category!(),op.text_trimmed_range(), markup! {
                 "Use "<Emphasis>{suggestion}</Emphasis>" instead of "<Emphasis>{text_trimmed}</Emphasis>
             })
-            .note( markup! {
+            .detail( op.text_trimmed_range(),markup! {
                 <Emphasis>{text_trimmed}</Emphasis>" is only allowed when comparing against "<Emphasis>"null"</Emphasis>
             })
             .note(markup! {

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
@@ -88,7 +88,7 @@ impl Rule for NoDoubleEquals {
                 "Use "<Emphasis>{suggestion}</Emphasis>" instead of "<Emphasis>{text_trimmed}</Emphasis>
             },
         )
-        .detail(op.text_trimmed_range(),markup! {
+        .detail(op.text_trimmed_range(), markup! {
             <Emphasis>{text_trimmed}</Emphasis>" is only allowed when comparing against "<Emphasis>"null"</Emphasis>
         }).note(markup! {
             "Using "<Emphasis>{suggestion}</Emphasis>" may be unsafe if you are relying on type coercion"

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_double_equals.rs
@@ -74,22 +74,26 @@ impl Rule for NoDoubleEquals {
         Some(op)
     }
 
-    fn diagnostic(_: &RuleContext<Self>, op: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(_ctx: &RuleContext<Self>, op: &Self::State) -> Option<RuleDiagnostic> {
         let text_trimmed = op.text_trimmed();
         let suggestion = if op.kind() == EQ2 { "===" } else { "!==" };
-
-        Some(
-            RuleDiagnostic::new(rule_category!(),op.text_trimmed_range(), markup! {
+        let description = format!(
+            "Use {} instead of {}.\n{} is only allowed when comparing against `null`",
+            suggestion, text_trimmed, text_trimmed
+        );
+        Some(RuleDiagnostic::new(
+            rule_category!(),
+            op.text_trimmed_range(),
+            markup! {
                 "Use "<Emphasis>{suggestion}</Emphasis>" instead of "<Emphasis>{text_trimmed}</Emphasis>
-            })
-            .detail( op.text_trimmed_range(),markup! {
-                <Emphasis>{text_trimmed}</Emphasis>" is only allowed when comparing against "<Emphasis>"null"</Emphasis>
-            })
-            .note(markup! {
-                "Using "<Emphasis>{suggestion}</Emphasis>" may be unsafe if you are relying on type coercion"
-            })
-            .description(format!("Use {suggestion} instead of {text_trimmed}.\n{text_trimmed} is only allowed when comparing against `null`"))
+            },
         )
+        .detail(op.text_trimmed_range(),markup! {
+            <Emphasis>{text_trimmed}</Emphasis>" is only allowed when comparing against "<Emphasis>"null"</Emphasis>
+        }).note(markup! {
+            "Using "<Emphasis>{suggestion}</Emphasis>" may be unsafe if you are relying on type coercion"
+        })
+        .description(description))
     }
 
     fn action(ctx: &RuleContext<Self>, op: &Self::State) -> Option<JsRuleAction> {

--- a/crates/rome_js_analyze/tests/specs/correctness/noDoubleEquals.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noDoubleEquals.js.snap
@@ -25,6 +25,11 @@ noDoubleEquals.js:1:18 lint/correctness/noDoubleEquals  FIXABLE  ━━━━━
   
   i == is only allowed when comparing against null
   
+  > 1 │ const isZero = a == 0;
+      │                  ^^
+    2 │ const isNonZero = a != 0;
+    3 │ 
+  
   i Using === may be unsafe if you are relying on type coercion
   
   i Suggested fix: Use ===
@@ -46,6 +51,12 @@ noDoubleEquals.js:2:21 lint/correctness/noDoubleEquals  FIXABLE  ━━━━━
     4 │ const isNull = a == null;
   
   i != is only allowed when comparing against null
+  
+    1 │ const isZero = a == 0;
+  > 2 │ const isNonZero = a != 0;
+      │                     ^^
+    3 │ 
+    4 │ const isNull = a == null;
   
   i Using !== may be unsafe if you are relying on type coercion
   

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -30,7 +30,6 @@ use super::{
 use crate::configuration::to_analyzer_configuration;
 use crate::file_handlers::{FixAllParams, Language as LanguageId};
 use indexmap::IndexSet;
-use rome_diagnostics::v2::Error;
 use rome_diagnostics::{v2, v2::Diagnostic};
 use rome_js_analyze::utils::rename::{RenameError, RenameSymbolExtensions};
 use std::borrow::Cow;
@@ -234,7 +233,7 @@ fn lint(
             if let Some(action) = signal.action() {
                 diagnostic.add_code_suggestion(action.into());
             }
-            diagnostics.push(v2::serde::Diagnostic::new(Error::from(diagnostic)));
+            diagnostics.push(v2::serde::Diagnostic::new(diagnostic));
         }
 
         ControlFlow::<Never>::Continue(())

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 pub use javascript::JsFormatSettings;
 use rome_analyze::AnalysisFilter;
-use rome_diagnostics::Diagnostic;
 use rome_formatter::Printed;
 use rome_fs::RomePath;
 use rome_js_syntax::{TextRange, TextSize};
@@ -158,8 +157,13 @@ pub(crate) struct DebugCapabilities {
     pub(crate) debug_formatter_ir: Option<DebugFormatterIR>,
 }
 
-type Lint =
-    fn(&RomePath, AnyParse, AnalysisFilter, Option<&Rules>, SettingsHandle) -> Vec<Diagnostic>;
+type Lint = fn(
+    &RomePath,
+    AnyParse,
+    AnalysisFilter,
+    Option<&Rules>,
+    SettingsHandle,
+) -> Vec<rome_diagnostics::v2::serde::Diagnostic>;
 type CodeActions =
     fn(&RomePath, AnyParse, TextRange, Option<&Rules>, SettingsHandle) -> PullActionsResult;
 type FixAll = fn(FixAllParams) -> Result<FixFileResult, RomeError>;

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -1,7 +1,6 @@
 use crate::{Configuration, MatchOptions, Matcher, RomeError, Rules};
 use indexmap::IndexSet;
 use rome_diagnostics::v2::Category;
-use rome_diagnostics::Severity;
 use rome_formatter::{IndentStyle, LineWidth};
 use rome_fs::RomePath;
 use rome_js_syntax::JsLanguage;

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -15,10 +15,11 @@ use crate::{
 use dashmap::{mapref::entry::Entry, DashMap};
 use indexmap::IndexSet;
 use rome_analyze::{AnalysisFilter, RuleFilter};
-use rome_diagnostics::file::SimpleFile;
-use rome_diagnostics::{v2, Diagnostic, Severity};
+use rome_diagnostics::v2;
+use rome_diagnostics::v2::{serde::Diagnostic, DiagnosticExt};
 use rome_formatter::Printed;
 use rome_fs::RomePath;
+use rome_js_parser::ParseDiagnostic;
 use rome_rowan::{AstNode, Language as RowanLanguage, SendNode, SyntaxNode};
 use std::{any::type_name, panic::RefUnwindSafe, sync::RwLock};
 
@@ -59,7 +60,7 @@ pub(crate) struct Document {
 #[derive(Clone)]
 pub(crate) struct AnyParse {
     pub(crate) root: SendNode,
-    pub(crate) diagnostics: Vec<Diagnostic>,
+    pub(crate) diagnostics: Vec<ParseDiagnostic>,
 }
 
 impl AnyParse {
@@ -83,14 +84,13 @@ impl AnyParse {
         N::unwrap_cast(self.syntax::<N::Language>())
     }
 
+    /// This function transforms diagnostics coming from the parser into serializable diagnostics
     pub(crate) fn into_diagnostics(self) -> Vec<Diagnostic> {
-        self.diagnostics
+        self.diagnostics.into_iter().map(Diagnostic::new).collect()
     }
 
     fn has_errors(&self) -> bool {
-        self.diagnostics
-            .iter()
-            .any(|diag| diag.severity >= Severity::Error)
+        self.diagnostics.iter().any(|diag| diag.is_error())
     }
 }
 
@@ -387,14 +387,14 @@ impl Workspace for WorkspaceServer {
             .documents
             .get(&params.path)
             .ok_or(RomeError::NotFound)?;
-
-        let files = SimpleFile::new(params.path.display().to_string(), document.content.clone());
-
+        let source_code = document.content.as_str();
         Ok(PullDiagnosticsResult {
             diagnostics: diagnostics
                 .into_iter()
                 .map(|diag| {
-                    let diag = diag.as_diagnostic(&files);
+                    let diag = diag
+                        .with_file_path(params.path.as_path().display().to_string())
+                        .with_file_source_code(source_code);
                     v2::serde::Diagnostic::new(diag)
                 })
                 .collect(),

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -383,19 +383,12 @@ impl Workspace for WorkspaceServer {
             });
         }
 
-        let document = self
-            .documents
-            .get(&params.path)
-            .ok_or(RomeError::NotFound)?;
-        let source_code = document.content.as_str();
         Ok(PullDiagnosticsResult {
             diagnostics: diagnostics
                 .into_iter()
                 .map(|diag| {
-                    let diag = diag
-                        .with_file_path(params.path.as_path().display().to_string())
-                        .with_file_source_code(source_code);
-                    v2::serde::Diagnostic::new(diag)
+                    let diag = diag.with_file_path(params.path.as_path().display().to_string());
+                    Diagnostic::new(diag)
                 })
                 .collect(),
         })

--- a/website/src/docs/lint/rules/noDoubleEquals.md
+++ b/website/src/docs/lint/rules/noDoubleEquals.md
@@ -29,7 +29,11 @@ foo == bar
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Use </span><span style="color: Tomato;"><strong>===</strong></span><span style="color: Tomato;"> instead of </span><span style="color: Tomato;"><strong>==</strong></span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;"><strong>==</strong></span><span style="color: Tomato;"> is only allowed when comparing against </span><span style="color: Tomato;"><strong>null</strong></span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>foo == bar
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);"><strong>==</strong></span><span style="color: rgb(38, 148, 255);"> is only allowed when comparing against </span><span style="color: rgb(38, 148, 255);"><strong>null</strong></span>
   
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>foo == bar
    <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>

--- a/website/src/docs/lint/rules/useAnchorContent.md
+++ b/website/src/docs/lint/rules/useAnchorContent.md
@@ -85,7 +85,11 @@ Accessible means that the content is not hidden using the `aria-hidden` attribut
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">expected `&gt;` but instead the file ends</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">the file ends here</span>
+    <strong>1 │ </strong>&lt;a&gt;&lt;span aria-hidden=&quot;true&quot;&gt;content&lt;/span&gt;&lt;/a
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>
+   <strong>   │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">the file ends here</span>
   
     <strong>1 │ </strong>&lt;a&gt;&lt;span aria-hidden=&quot;true&quot;&gt;content&lt;/span&gt;&lt;/a
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>

--- a/website/src/docs/lint/rules/useValidTypeof.md
+++ b/website/src/docs/lint/rules/useValidTypeof.md
@@ -23,11 +23,11 @@ typeof foo === "strnig"
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Invalid `typeof` comparison value</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">not a valid type name</span>
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>typeof foo === &quot;strnig&quot;
    <strong>   │ </strong>               <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
   
 </code></pre>{% endraw %}
 
@@ -39,11 +39,11 @@ typeof foo == "undefimed"
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Invalid `typeof` comparison value</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">not a valid type name</span>
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>typeof foo == &quot;undefimed&quot;
    <strong>   │ </strong>              <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
   
 </code></pre>{% endraw %}
 
@@ -55,11 +55,11 @@ typeof bar != "nunber"
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Invalid `typeof` comparison value</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">not a valid type name</span>
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>typeof bar != &quot;nunber&quot;
    <strong>   │ </strong>              <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
   
 </code></pre>{% endraw %}
 
@@ -71,11 +71,11 @@ typeof bar !== "fucntion"
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Invalid `typeof` comparison value</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">not a valid type name</span>
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>typeof bar !== &quot;fucntion&quot;
    <strong>   │ </strong>               <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">not a valid type name</span>
   
 </code></pre>{% endraw %}
 
@@ -87,11 +87,11 @@ typeof foo === undefined
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Invalid `typeof` comparison value</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">not a string literal</span>
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>typeof foo === undefined
    <strong>   │ </strong>               <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">not a string literal</span>
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Compare the result of `typeof` with a valid type name</span>
   
@@ -107,11 +107,11 @@ typeof bar == Object
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Invalid `typeof` comparison value</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">not a string literal</span>
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>typeof bar == Object
    <strong>   │ </strong>              <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">not a string literal</span>
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Compare the result of `typeof` with a valid type name</span>
   
@@ -129,11 +129,11 @@ typeof foo === baz
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Invalid `typeof` comparison value</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">not a string literal</span>
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>typeof foo === baz
    <strong>   │ </strong>               <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">not a string literal</span>
   
 </code></pre>{% endraw %}
 
@@ -145,11 +145,11 @@ typeof foo == 5
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Invalid `typeof` comparison value</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">not a string literal</span>
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>typeof foo == 5
    <strong>   │ </strong>              <strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">not a string literal</span>
   
 </code></pre>{% endraw %}
 
@@ -161,11 +161,11 @@ typeof foo == -5
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Invalid `typeof` comparison value</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">not a string literal</span>
-  
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>typeof foo == -5
    <strong>   │ </strong>              <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">not a string literal</span>
   
 </code></pre>{% endraw %}
 

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -7,7 +7,8 @@ use rome_console::{
     fmt::{Formatter, HTML},
     markup, Markup,
 };
-use rome_diagnostics::{file::FileId, file::SimpleFile, Diagnostic};
+use rome_diagnostics::file::FileId;
+use rome_diagnostics::v2::{Diagnostic, DiagnosticExt, PrintDiagnostic};
 use rome_js_analyze::{analyze, visit_registry};
 use rome_js_syntax::{JsLanguage, Language, LanguageVariant, ModuleKind, SourceType};
 use rome_service::settings::WorkspaceSettings;
@@ -467,12 +468,12 @@ fn assert_lint(
     code: &str,
     content: &mut Vec<u8>,
 ) -> Result<()> {
-    let file = SimpleFile::new(format!("{group}/{rule}.js"), code.into());
+    let file = format!("{group}/{rule}.js");
 
     let mut write = HTML(content);
     let mut diagnostic_count = 0;
 
-    let mut write_diagnostic = |code: &str, diag: Diagnostic| {
+    let mut write_diagnostic = |code: &str, diag: rome_diagnostics::v2::Error| {
         // Fail the test if the analysis returns more diagnostics than expected
         if test.expect_diagnostic {
             ensure!(
@@ -482,14 +483,14 @@ fn assert_lint(
             );
         } else {
             bail!(format!(
-                "analysis returned an unexpected diagnostic, code snippet:\n\n{:?}\n\n{}",
-                diag.code.map_or("", |code| code.name()),
+                "analysis returned an unexpected diagnostic, code `snippet:\n\n{:?}\n\n{}",
+                diag.category().map_or("", |code| code.name()),
                 code
             ));
         }
 
         Formatter::new(&mut write).write_markup(markup! {
-            {diag.display(&file)}
+            {PrintDiagnostic(&diag)}
         })?;
 
         diagnostic_count += 1;
@@ -500,7 +501,10 @@ fn assert_lint(
 
     if parse.has_errors() {
         for diag in parse.into_diagnostics() {
-            write_diagnostic(code, diag)?;
+            let error = diag
+                .with_file_path((file.clone(), FileId::zero()))
+                .with_file_source_code(code);
+            write_diagnostic(code, error)?;
         }
     } else {
         let root = parse.tree();
@@ -515,18 +519,21 @@ fn assert_lint(
 
         let options = AnalyzerOptions::default();
         let result = analyze(FileId::zero(), &root, filter, &options, |signal| {
-            if let Some(diag) = signal.diagnostic() {
-                let category = diag.code().expect("linter diagnostic has no code");
+            if let Some(mut diag) = signal.diagnostic() {
+                let category = diag.category().expect("linter diagnostic has no code");
                 let severity = settings.get_severity_from_rule_code(category).expect(
                     "If you see this error, it means you need to run cargo codegen-configuration",
                 );
-                let mut diag = diag.into_diagnostic(severity);
+                diag.set_severity(severity);
 
                 if let Some(action) = signal.action() {
-                    diag.suggestions.push(action.into());
+                    diag.add_code_suggestion(action.into());
                 }
 
-                let res = write_diagnostic(code, diag);
+                let error = diag
+                    .with_file_path((file.clone(), FileId::zero()))
+                    .with_file_source_code(code);
+                let res = write_diagnostic(code, error);
 
                 // Abort the analysis on error
                 if let Err(err) = res {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR joins the refactored diagnostics of JS parser and analyzer into a single data structure, which `v2::serde::Diagnostics`.

In theory, once this PR is merged, we could start merging the code in `main`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CLI tests passed locally. 

The command `cargo lintdoc` now works

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
