### PR TITLE
fix(rome_cli): correctly compute file to handle in `rome ci`

### DIFF
--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -543,10 +543,9 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
             TraversalMode::Check { .. } => self.can_lint(rome_path),
             TraversalMode::CI { .. } => self
                 .can_lint(rome_path)
-                .or_else(|_| self.can_format(rome_path)),
+                .and_then(|_| self.can_format(rome_path)),
             TraversalMode::Format { .. } => self.can_format(rome_path),
         };
-
         match result {
             Ok(result) => result.reason.is_none(),
             Err(err) => {

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -835,7 +835,7 @@ fn does_not_format_ignored_directories() {
     );
 
     let ignored_file = Path::new("scripts/test.js");
-    fs.insert(ignored_file.into(), UNFORMATTED.clone().as_bytes());
+    fs.insert(ignored_file.into(), <&str>::clone(&UNFORMATTED).as_bytes());
 
     let file_to_format = Path::new("src/test.js");
     fs.insert(file_to_format.into(), UNFORMATTED.as_bytes());

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -1,6 +1,6 @@
 use crate::configs::{
-    CONFIG_DISABLED_FORMATTER, CONFIG_FORMAT, CONFIG_FORMATTER_IGNORED_FILES, CONFIG_ISSUE_3175_1,
-    CONFIG_ISSUE_3175_2,
+    CONFIG_DISABLED_FORMATTER, CONFIG_FORMAT, CONFIG_FORMATTER_IGNORED_DIRECTORIES,
+    CONFIG_FORMATTER_IGNORED_FILES, CONFIG_ISSUE_3175_1, CONFIG_ISSUE_3175_2,
 };
 use crate::snap_test::{markup_to_string, SnapshotPayload};
 use crate::{
@@ -818,6 +818,64 @@ fn does_not_format_ignored_files() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "does_not_format_ignored_files",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn does_not_format_ignored_directories() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let file_path = Path::new("rome.json");
+    fs.insert(
+        file_path.into(),
+        CONFIG_FORMATTER_IGNORED_DIRECTORIES.as_bytes(),
+    );
+
+    let ignored_file = Path::new("scripts/test.js");
+    fs.insert(ignored_file.into(), UNFORMATTED.clone().as_bytes());
+
+    let file_to_format = Path::new("src/test.js");
+    fs.insert(file_to_format.into(), UNFORMATTED.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("format"),
+            OsString::from("./"),
+            OsString::from("--write"),
+        ]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let mut file = fs
+        .open(ignored_file)
+        .expect("formatting target file was removed by the CLI");
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .expect("failed to read file from memory FS");
+
+    assert_eq!(content, UNFORMATTED, "we test the file is not formatted");
+    drop(file);
+    let mut file = fs
+        .open(file_to_format)
+        .expect("formatting target file was removed by the CLI");
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .expect("failed to read file from memory FS");
+
+    assert_eq!(content, FORMATTED, "we test the file is formatted");
+    drop(file);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_not_format_ignored_directories",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -172,6 +172,13 @@ pub const CONFIG_FORMATTER_IGNORED_FILES: &str = r#"{
 }
 "#;
 
+pub const CONFIG_FORMATTER_IGNORED_DIRECTORIES: &str = r#"{
+  "formatter": {
+    "ignore": ["scripts/*"]
+  }
+}
+"#;
+
 pub const CONFIG_LINTER_IGNORED_FILES: &str = r#"{
   "linter": {
     "enabled": true,

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -147,7 +147,7 @@ impl From<SnapshotPayload<'_>> for CliSnapshot {
                 (file.to_str().unwrap().to_string(), String::from(content))
             })
             .collect();
-        files.sort();
+        files.sort_by_key(|(path, _)| path.to_string());
 
         for (file, content) in files {
             cli_snapshot.files.insert(file, content);

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -3,7 +3,7 @@ use rome_console::fmt::{Formatter, Termcolor};
 use rome_console::{markup, BufferConsole, Markup};
 use rome_diagnostics::termcolor::NoColor;
 use rome_fs::{FileSystemExt, MemoryFileSystem};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::env::current_exe;
 use std::fmt::Write as _;
 use std::path::PathBuf;
@@ -19,7 +19,7 @@ pub(crate) struct CliSnapshot {
     /// the configuration, if set
     pub configuration: Option<String>,
     /// file name -> content
-    pub files: HashMap<String, String>,
+    pub files: BTreeMap<String, String>,
     /// messages written in console
     pub messages: Vec<String>,
     /// possible termination error of the CLI
@@ -31,7 +31,7 @@ impl CliSnapshot {
         Self {
             in_messages: InMessages::default(),
             configuration: None,
-            files: HashMap::default(),
+            files: BTreeMap::default(),
             messages: Vec::new(),
             termination: result.err(),
         }
@@ -138,7 +138,7 @@ impl From<SnapshotPayload<'_>> for CliSnapshot {
             }
         }
 
-        let mut files: Vec<_> = fs
+        let files: Vec<_> = fs
             .files()
             .into_iter()
             .map(|(file, entry)| {
@@ -147,7 +147,6 @@ impl From<SnapshotPayload<'_>> for CliSnapshot {
                 (file.to_str().unwrap().to_string(), String::from(content))
             })
             .collect();
-        files.sort_by_key(|(path, _)| path.to_string());
 
         for (file, content) in files {
             cli_snapshot.files.insert(file, content);

--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -138,13 +138,19 @@ impl From<SnapshotPayload<'_>> for CliSnapshot {
             }
         }
 
-        for (file, entry) in fs.files() {
-            let content = entry.lock();
-            let content = std::str::from_utf8(content.as_slice()).unwrap();
+        let mut files: Vec<_> = fs
+            .files()
+            .into_iter()
+            .map(|(file, entry)| {
+                let content = entry.lock();
+                let content = std::str::from_utf8(content.as_slice()).unwrap();
+                (file.to_str().unwrap().to_string(), String::from(content))
+            })
+            .collect();
+        files.sort();
 
-            cli_snapshot
-                .files
-                .insert(file.to_str().unwrap().to_string(), String::from(content));
+        for (file, content) in files {
+            cli_snapshot.files.insert(file, content);
         }
 
         let in_buffer = &console.in_buffer;

--- a/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
@@ -13,17 +13,17 @@ expression: content
 
 ```
 
-## `scripts/test.js`
-
-```js
-  statement(  )  
-```
-
 ## `src/test.js`
 
 ```js
 statement();
 
+```
+
+## `scripts/test.js`
+
+```js
+  statement(  )  
 ```
 
 # Emitted Messages

--- a/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
@@ -13,17 +13,17 @@ expression: content
 
 ```
 
+## `scripts/test.js`
+
+```js
+  statement(  )  
+```
+
 ## `src/test.js`
 
 ```js
 statement();
 
-```
-
-## `scripts/test.js`
-
-```js
-  statement(  )  
 ```
 
 # Emitted Messages

--- a/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "formatter": {
+    "ignore": ["scripts/*"]
+  }
+}
+
+```
+
+## `scripts/test.js`
+
+```js
+  statement(  )  
+```
+
+## `src/test.js`
+
+```js
+statement();
+
+```
+
+# Emitted Messages
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/write_only_files_in_correct_base.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/write_only_files_in_correct_base.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `scripts/format.js`
+
+```js
+  statement(  )  
+```
+
+## `src/format.js`
+
+```js
+statement();
+
+```
+
+# Emitted Messages
+
+

--- a/crates/rome_fs/src/fs/memory.rs
+++ b/crates/rome_fs/src/fs/memory.rs
@@ -162,8 +162,8 @@ impl<'scope> TraversalScope<'scope> for MemoryTraversalScope<'scope> {
             let files = &self.fs.files.0.read();
             for path in files.keys() {
                 let should_process_file = if base.starts_with(".") || base.starts_with("./") {
-                    // we simulate absolute paths
-                    let absolute_base = PathBuf::from("/");
+                    // we simulate absolute paths, so we can correctly strips out the base path from the path
+                    let absolute_base = PathBuf::from("/").join(&base);
                     let absolute_path = Path::new("/").join(&path);
                     absolute_path.strip_prefix(&absolute_base).is_ok()
                 } else {

--- a/crates/rome_fs/src/fs/memory.rs
+++ b/crates/rome_fs/src/fs/memory.rs
@@ -167,8 +167,9 @@ impl<'scope> TraversalScope<'scope> for MemoryTraversalScope<'scope> {
                     let absolute_path = Path::new("/").join(&path);
                     absolute_path.strip_prefix(&absolute_base).is_ok()
                 } else {
-                    base.strip_prefix(&path).is_ok()
+                    path.strip_prefix(&base).is_ok()
                 };
+
                 if should_process_file {
                     let file_id = ctx.interner().intern_path(path.into());
                     let rome_path = RomePath::new(&path, file_id);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

There was an issue in the `rome ci` command, but we couldn't see it because the `MemoryFileSystem` behaves differently when handling the files, compared to `OsFileSystem`. By default, it was accepting any kind of file and it was using the `strip_prefix` function. This results in two issues:
- couldn't simulate commands like `rome format .` (the dot)
- couldn't replicate 100% how the real traversal behaves

This PR tries to change that behaviour.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

- I added a new test case for ignoring directories, and see if it works as expected.
- Once I added the `can_handle` function,  the test `ci_does_not_run_linter` was failing, because it was wrongly computing when a file is ignored. That's fixed in the `traversal.rs`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
