### PR TITLE
fix(rome_cli): remove unsupported options in the `ci` help text

### DIFF
--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -60,8 +60,14 @@ const CI: Markup = markup! {
 
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
 
-"<Emphasis>"OPTIONS:"</Emphasis>
-    {FORMAT_OPTIONS}
+"<Emphasis>"OPTIONS:"</Emphasis>"
+	"<Dim>"--indent-style <tabs|space>"</Dim>"              Change the indention character (default: tabs)
+	"<Dim>"--indent-size <number>"</Dim>"                   If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
+	"<Dim>"--line-width <number>"</Dim>"                    Change how many characters the formatter is allowed to print in a single line (default: 80)
+	"<Dim>"--quote-style <single|double>"</Dim>"            Changes the quotation character for strings (default: \")
+	"<Dim>"--quote-properties <as-needed|preserve>"</Dim>"  Changes when properties in object should be quoted (default: as-needed)
+	"<Dim>"--trailing-comma <all|es5>"</Dim>"               Changes trailing commas in multi-line comma-separated syntactic structures (default: all)
+"
 };
 
 const FORMAT: Markup = markup! {

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -40,15 +40,12 @@ const CHECK: Markup = markup! {
 
 const FORMAT_OPTIONS: Markup = markup! {
     "
-    "<Dim>"--write"</Dim>"                                  Edit the files in place (beware!) instead of printing the diff to the console
-    "<Dim>"--skip-errors"</Dim>"                            Skip over files containing syntax errors instead of emitting an error diagnostic.
     "<Dim>"--indent-style <tabs|space>"</Dim>"              Change the indention character (default: tabs)
     "<Dim>"--indent-size <number>"</Dim>"                   If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
     "<Dim>"--line-width <number>"</Dim>"                    Change how many characters the formatter is allowed to print in a single line (default: 80)
     "<Dim>"--quote-style <single|double>"</Dim>"            Changes the quotation character for strings (default: \")
     "<Dim>"--quote-properties <as-needed|preserve>"</Dim>"  Changes when properties in object should be quoted (default: as-needed)
     "<Dim>"--trailing-comma <all|es5>"</Dim>"               Changes trailing commas in multi-line comma-separated syntactic structures (default: all)
-    "<Dim>"--stdin-file-path <string>"</Dim>"               A file name with its extension to pass when reading from standard in, e.g. echo 'let a;' | rome format --stdin-file-path file.js
     "
 };
 
@@ -60,14 +57,8 @@ const CI: Markup = markup! {
 
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
 
-"<Emphasis>"OPTIONS:"</Emphasis>"
-	"<Dim>"--indent-style <tabs|space>"</Dim>"              Change the indention character (default: tabs)
-	"<Dim>"--indent-size <number>"</Dim>"                   If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
-	"<Dim>"--line-width <number>"</Dim>"                    Change how many characters the formatter is allowed to print in a single line (default: 80)
-	"<Dim>"--quote-style <single|double>"</Dim>"            Changes the quotation character for strings (default: \")
-	"<Dim>"--quote-properties <as-needed|preserve>"</Dim>"  Changes when properties in object should be quoted (default: as-needed)
-	"<Dim>"--trailing-comma <all|es5>"</Dim>"               Changes trailing commas in multi-line comma-separated syntactic structures (default: all)
-"
+"<Emphasis>"OPTIONS:"</Emphasis>""
+    {FORMAT_OPTIONS}
 };
 
 const FORMAT: Markup = markup! {
@@ -78,8 +69,12 @@ const FORMAT: Markup = markup! {
 
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
 
-"<Emphasis>"OPTIONS:"</Emphasis>""
+"<Emphasis>"OPTIONS:"</Emphasis>"
+    "<Dim>"--write"</Dim>"                                  Edit the files in place (beware!) instead of printing the diff to the console
+    "<Dim>"--skip-errors"</Dim>"                            Skip over files containing syntax errors instead of emitting an error diagnostic."
     {FORMAT_OPTIONS}
+   ""<Dim>"--stdin-file-path <string>"</Dim>"               A file name with its extension to pass when reading from standard in, e.g. echo 'let a;' | rome format --stdin-file-path file.js
+"
 };
 
 const INIT: Markup = markup! {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

- Resolves #3456

- Per `apply_format_settings_from_cli`
https://github.com/rome/tools/blob/745464fb69d048de348b31b0b28e265b9e9fe0a8/crates/rome_cli/src/commands/ci.rs#L10
  `rome ci` supports the following options:

  ```
    --indent-style <tabs|space>              Change the indention character (default: tabs)
    --indent-size <number>                   If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
    --line-width <number>                    Change how many characters the formatter is allowed to print in a single line (default: 80)
    --quote-style <single|double>            Changes the quotation character for strings (default: ")
    --quote-properties <as-needed|preserve>  Changes when properties in object should be quoted (default: as-needed)
    --trailing-comma <all|es5>               Changes trailing commas in multi-line comma-separated syntactic structures (default: all)
   ```


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

- Running `cargo run --bin rome ci --help` should print out the supported options
  <img width="1541" alt="options" src="https://user-images.githubusercontent.com/30640930/196741684-e02bfd0a-aee9-4bf0-b333-e061501cd6fb.png">

