### PR TITLE
feat(rome_js_syntax): better api for picking jsx attributes

### DIFF
--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -109,13 +109,13 @@ macro_rules! assert_remove_ok {
 
 #[test]
 pub fn ok_find_attributes_by_name () {
-    let r = rome_js_parser::parse(r#"<a a="A" b="B" c="C"/>"#, 0.into(), SourceType::jsx());
+    let r = rome_js_parser::parse(r#"<a a="A" c="C" b="B" />"#, 0.into(), SourceType::jsx());
     let list = r.syntax()
         .descendants()
         .filter_map(|x| rome_js_syntax::JsxAttributeList::cast(x))
         .next().unwrap();
     let [a, c, d] = list.find_attributes_by_name(["a", "c", "d"]);
     assert_eq!(a.unwrap().initializer().unwrap().value().unwrap().to_string(), "\"A\" ");
-    assert_eq!(c.unwrap().initializer().unwrap().value().unwrap().to_string(), "\"C\"");
+    assert_eq!(c.unwrap().initializer().unwrap().value().unwrap().to_string(), "\"C\" ");
     assert!(d.is_none());
 }

--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -108,14 +108,32 @@ macro_rules! assert_remove_ok {
 }
 
 #[test]
-pub fn ok_find_attributes_by_name () {
+pub fn ok_find_attributes_by_name() {
     let r = rome_js_parser::parse(r#"<a a="A" c="C" b="B" />"#, 0.into(), SourceType::jsx());
-    let list = r.syntax()
+    let list = r
+        .syntax()
         .descendants()
         .filter_map(|x| rome_js_syntax::JsxAttributeList::cast(x))
-        .next().unwrap();
+        .next()
+        .unwrap();
     let [a, c, d] = list.find_attributes_by_name(["a", "c", "d"]);
-    assert_eq!(a.unwrap().initializer().unwrap().value().unwrap().to_string(), "\"A\" ");
-    assert_eq!(c.unwrap().initializer().unwrap().value().unwrap().to_string(), "\"C\" ");
+    assert_eq!(
+        a.unwrap()
+            .initializer()
+            .unwrap()
+            .value()
+            .unwrap()
+            .to_string(),
+        "\"A\" "
+    );
+    assert_eq!(
+        c.unwrap()
+            .initializer()
+            .unwrap()
+            .value()
+            .unwrap()
+            .to_string(),
+        "\"C\" "
+    );
     assert!(d.is_none());
 }

--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -113,7 +113,7 @@ pub fn ok_find_attributes_by_name() {
     let list = r
         .syntax()
         .descendants()
-        .filter_map(|x| rome_js_syntax::JsxAttributeList::cast(x))
+        .filter_map(rome_js_syntax::JsxAttributeList::cast)
         .next()
         .unwrap();
     let [a, c, d] = list.find_attributes_by_name(["a", "c", "d"]);

--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -106,3 +106,16 @@ macro_rules! assert_remove_ok {
         )*
     };
 }
+
+#[test]
+pub fn ok_find_attributes_by_name () {
+    let r = rome_js_parser::parse(r#"<a a="A" b="B" c="C"/>"#, 0.into(), SourceType::jsx());
+    let list = r.syntax()
+        .descendants()
+        .filter_map(|x| rome_js_syntax::JsxAttributeList::cast(x))
+        .next().unwrap();
+    let [a, c, d] = list.find_attributes_by_name(["a", "c", "d"]);
+    assert_eq!(a.unwrap().initializer().unwrap().value().unwrap().to_string(), "\"A\" ");
+    assert_eq!(c.unwrap().initializer().unwrap().value().unwrap().to_string(), "\"C\"");
+    assert!(d.is_none());
+}

--- a/crates/rome_js_syntax/src/jsx_ext.rs
+++ b/crates/rome_js_syntax/src/jsx_ext.rs
@@ -140,7 +140,8 @@ impl JsxSelfClosingElement {
 }
 
 impl JsxAttributeList {
-    /// Find and return the `JsxAttribute` that matches the given name like [find_attribute_by_name].
+    /// Find and return the `JsxAttribute` that matches the given name like [find_attribute_by_name].  
+    /// Only attributes with name as [JsxName] can be returned.   
     ///
     /// Each name of "names_to_lookup" should be unique.
     /// Support maximum of 16 names.

--- a/crates/rome_js_syntax/src/jsx_ext.rs
+++ b/crates/rome_js_syntax/src/jsx_ext.rs
@@ -137,7 +137,6 @@ impl JsxSelfClosingElement {
     ) -> SyntaxResult<Option<JsxAttribute>> {
         find_attribute_by_name(self.attributes(), name_to_lookup)
     }
-
 }
 
 impl JsxAttributeList {
@@ -145,8 +144,10 @@ impl JsxAttributeList {
     ///
     /// Each name of "names_to_lookup" should be unique.
     /// Support maximum of 16 names.
-    pub fn find_attributes_by_name<const N: usize>(&self, names_to_lookup: [&str; N]) -> [Option<JsxAttribute>; N]
-    {
+    pub fn find_attributes_by_name<const N: usize>(
+        &self,
+        names_to_lookup: [&str; N],
+    ) -> [Option<JsxAttribute>; N] {
         // assert there are no duplicates
         debug_assert!(HashSet::<_>::from_iter(names_to_lookup).len() == N);
         debug_assert!(N <= 16);
@@ -158,8 +159,10 @@ impl JsxAttributeList {
 
         'attributes: for att in self.iter() {
             if let Some(attribute) = att.as_jsx_attribute() {
-                if let Some(name) = attribute.name().ok()
-                    .and_then(|x| x.as_jsx_name()?.value_token().ok()) 
+                if let Some(name) = attribute
+                    .name()
+                    .ok()
+                    .and_then(|x| x.as_jsx_name()?.value_token().ok())
                 {
                     let name = name.text_trimmed();
                     for i in 0..N {
@@ -175,7 +178,7 @@ impl JsxAttributeList {
                     }
                 }
             }
-        };
+        }
 
         results
     }

--- a/crates/rome_js_syntax/src/jsx_ext.rs
+++ b/crates/rome_js_syntax/src/jsx_ext.rs
@@ -143,8 +143,12 @@ impl JsxAttributeList {
     /// Find and return the `JsxAttribute` that matches the given name like [find_attribute_by_name].  
     /// Only attributes with name as [JsxName] can be returned.   
     ///
-    /// Each name of "names_to_lookup" should be unique.
-    /// Support maximum of 16 names.
+    /// Each name of "names_to_lookup" should be unique.  
+    /// 
+    /// Supports maximum of 16 names to avoid stack overflow. Eeach attribute will consume:
+    /// 
+    /// - 8 bytes for the [Option<JsxAttribute>] result;
+    /// - plus 16 bytes for the [&str] argument.
     pub fn find_attributes_by_name<const N: usize>(
         &self,
         names_to_lookup: [&str; N],

--- a/crates/rome_js_syntax/src/jsx_ext.rs
+++ b/crates/rome_js_syntax/src/jsx_ext.rs
@@ -1,3 +1,5 @@
+use std::mem::MaybeUninit;
+
 use crate::{
     JsxAttribute, JsxAttributeList, JsxName, JsxOpeningElement, JsxSelfClosingElement, JsxString,
     TextSize,
@@ -134,6 +136,71 @@ impl JsxSelfClosingElement {
         name_to_lookup: &str,
     ) -> SyntaxResult<Option<JsxAttribute>> {
         find_attribute_by_name(self.attributes(), name_to_lookup)
+    }
+
+}
+
+
+macro_rules! init_none_array {
+    (@ALWAYSNONE, $name:literal) => {None};
+    (@NAMECOMPARISON, $captures:expr, $i:expr, $att:expr, $element_name:expr, $head:literal,) => {
+        if $element_name == $head {
+            $captures[$i] = Some($att);
+        }
+    };
+    (@NAMECOMPARISON, $captures:expr, $i:expr, $att:expr, $element_name:expr, $head:literal, $($tail:literal,)*) => {
+        if $element_name == $head {
+            $captures[$i] = Some($att.clone());
+        }
+
+        jsx_attributes!(@NAMECOMPARISON, $captures, $i + 1, $att, $element_name, $($tail,)*);
+    };
+    ($n:expr) => {{
+        use rome_rowan::AstNodeList;
+        let mut captures = [$(jsx_attributes!(@ALWAYSNONE, $names),)*];
+        for att in $attributes.iter() {
+            if let Some(attribute) = $crate::JsxAttribute::cast_ref(att.syntax()) {
+                if let Some(name) = attribute.name().ok()
+                    .and_then(|x| $crate::JsxName::cast_ref(x.syntax())) 
+                    .and_then(|x| x.value_token().ok())
+                {
+                    let name = name.text_trimmed();
+                    jsx_attributes!(@NAMECOMPARISON, captures, 0, attribute, name, $($names,)*);
+                }
+            }
+        };
+        captures
+    }};
+}
+
+impl JsxAttributeList {
+    pub fn find_attributes_by_name<const N: usize>( &self, names_to_lookup: [&str; N]) -> [Option<JsxAttribute>; N]
+    {
+        let mut captures: [Option<JsxAttribute>; N] = unsafe {
+            let mut arr: MaybeUninit<_> = MaybeUninit::uninit();
+            for i in 0..N {
+                (arr.as_mut_ptr() as *mut Option<JsxAttribute>).add(i).write(None);
+            }
+            arr.assume_init()
+        };
+
+        for att in self.iter() {
+            if let Some(attribute) = JsxAttribute::cast_ref(att.syntax()) {
+                if let Some(name) = attribute.name().ok()
+                    .and_then(|x| JsxName::cast_ref(x.syntax())) 
+                    .and_then(|x| x.value_token().ok())
+                {
+                    let name = name.text_trimmed();
+                    for (i, name_to_lookup) in names_to_lookup.iter().enumerate() {
+                        if captures[i].is_none() && *name_to_lookup == name {
+                            captures[i] = Some(attribute.clone());
+                        }
+                    }
+                }
+            }
+        };
+
+        captures
     }
 }
 

--- a/crates/rome_js_syntax/src/jsx_ext.rs
+++ b/crates/rome_js_syntax/src/jsx_ext.rs
@@ -144,9 +144,9 @@ impl JsxAttributeList {
     /// Only attributes with name as [JsxName] can be returned.   
     ///
     /// Each name of "names_to_lookup" should be unique.  
-    /// 
+    ///
     /// Supports maximum of 16 names to avoid stack overflow. Eeach attribute will consume:
-    /// 
+    ///
     /// - 8 bytes for the [Option<JsxAttribute>] result;
     /// - plus 16 bytes for the [&str] argument.
     pub fn find_attributes_by_name<const N: usize>(


### PR DESCRIPTION
## Summary

This PR try to simplify the API for retrieving JSX attributes.  
Unfortunately, to achieve this it needs to use unsafe, because ```JsxAttribute``` is not ```Copy```.

```
let [a, c, d] = list.find_attributes_by_name(["a", "c", "d"]);
```

## Test Plan

```
cargo test -p rome_js_analyze -- find_attributes_by_name 
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
