### PR TITLE
fix(rome_cli): state correct command to verify code post `rome init`

### DIFF
--- a/crates/rome_cli/src/commands/init.rs
+++ b/crates/rome_cli/src/commands/init.rs
@@ -13,7 +13,7 @@ pub(crate) fn init(mut session: CliSession) -> Result<(), Termination> {
     "\t1. "<Emphasis>"Setup an editor extension\n"</Emphasis>
             "\t\tGet live errors as you type and format when you save. Learn more:"<Underline>"https://rome.tools/#install-official-rome-vs-code-extension \n"</Underline>
     "\t2. "<Emphasis>"Try a command\n"</Emphasis>
-            <Italic>"\t\trome check"</Italic>" is used to validate your code, verify formatting, and check for lint errors. Run " <Italic>"rome --help"</Italic>" for a full list of commands and flags\n"
+            <Italic>"\t\trome ci"</Italic>" is used to validate your code, verify formatting, and check for lint errors. Run " <Italic>"rome --help"</Italic>" for a full list of commands and flags\n"
     "\t3. "<Emphasis>"Read documentation \n"</Emphasis>
             "\t\tOur website serves as a comprehensive source of guides and documentation: "<Underline>"https://rome.tools/ \n"</Underline>
     "\t4. "<Emphasis>"Get involved in the community\n"</Emphasis>

--- a/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
@@ -27,7 +27,7 @@ What's next?
 	1. Setup an editor extension
 		Get live errors as you type and format when you save. Learn more:https://rome.tools/#install-official-rome-vs-code-extension 
 	2. Try a command
-		rome check is used to validate your code, verify formatting, and check for lint errors. Run rome --help for a full list of commands and flags
+		rome ci is used to validate your code, verify formatting, and check for lint errors. Run rome --help for a full list of commands and flags
 	3. Read documentation 
 		Our website serves as a comprehensive source of guides and documentation: https://rome.tools/ 
 	4. Get involved in the community

--- a/website/src/_includes/docs/cli-screenshots/init.md
+++ b/website/src/_includes/docs/cli-screenshots/init.md
@@ -21,7 +21,7 @@
      <a href="https://rome.tools/#editor-integration">https://rome.tools/#editor-integration</a>
 
   <span style="opacity: 0.8;">2. </span><strong>Try a command</strong>
-     <i>rome check</i> is used to validate your code, verify formatting, and
+     <i>rome ci</i> is used to validate your code, verify formatting, and
      check for lint errors. Run <i>rome --help</i> for a full list of commands
      and flags.
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Short fix for the stated command that should verify formatting _and_ correctness. At the moment, `rome check` does not check the formatting, you'll need to run `rome format .` separately, or just use `rome ci`. That also means `rome check . --apply-suggested` does not fix formatting errors as well. This might be obvious to some but this should avoid some confusion.

Fixes https://github.com/rome/tools/issues/3440

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

```
cargo insta test
...
cargo insta review
```

Approved that one change