### PR TITLE
fix(rome_cli): print the correct subcommand in error messages

### DIFF
--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -36,7 +36,10 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
             Some((path, input_code))
         } else {
             // we provided the argument without a piped stdin, we bail
-            return Err(Termination::MissingArgument { argument: "stdin" });
+            return Err(Termination::MissingArgument {
+                subcommand: "format",
+                argument: "stdin",
+            });
         }
     } else {
         None

--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -117,6 +117,15 @@ impl Execution {
             _ => None,
         }
     }
+
+    /// Returns the subcommand of the [traversal mode](TraversalMode) execution
+    pub(crate) fn traversal_mode_subcommand(&self) -> &'static str {
+        match self.traversal_mode {
+            TraversalMode::Check { .. } => "check",
+            TraversalMode::CI { .. } => "ci",
+            TraversalMode::Format { .. } => "format",
+        }
+    }
 }
 
 /// Based on the [mode](ExecutionMode), the function might launch a traversal of the file system

--- a/crates/rome_cli/src/termination.rs
+++ b/crates/rome_cli/src/termination.rs
@@ -27,17 +27,23 @@ pub enum Termination {
 
     /// Returned when the CLI  doesn't recognize a command line argument
     #[error(
-        "unrecognized option {argument:?}. Type '{} format --help' for more information.",
+        "unrecognized option {argument:?}. Type '{} {subcommand} --help' for more information.",
         command_name()
     )]
-    UnexpectedArgument { argument: OsString },
+    UnexpectedArgument {
+        subcommand: &'static str,
+        argument: OsString,
+    },
 
     /// Returned when a required argument is not present in the command line
     #[error(
-        "missing argument '{argument}'. Type '{} format --help' for more information.",
+        "missing argument '{argument}'. Type '{} {subcommand} --help' for more information.",
         command_name()
     )]
-    MissingArgument { argument: &'static str },
+    MissingArgument {
+        subcommand: &'static str,
+        argument: &'static str,
+    },
 
     /// Returned when a subcommand is called without any arguments
     #[error("empty arguments")]

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -47,7 +47,10 @@ pub(crate) fn traverse(execution: Execution, mut session: CliSession) -> Result<
             }
             // `--<some character>` or `-<some character>`
             if without_dashes != input {
-                return Err(Termination::UnexpectedArgument { argument: input });
+                return Err(Termination::UnexpectedArgument {
+                    subcommand: execution.traversal_mode_subcommand(),
+                    argument: input,
+                });
             }
         }
         inputs.push(input);
@@ -55,6 +58,7 @@ pub(crate) fn traverse(execution: Execution, mut session: CliSession) -> Result<
 
     if inputs.is_empty() && execution.as_stdin_file().is_none() {
         return Err(Termination::MissingArgument {
+            subcommand: execution.traversal_mode_subcommand(),
             argument: "<INPUT>",
         });
     }

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -723,7 +723,13 @@ fn format_stdin_with_errors() {
     assert!(result.is_err(), "run_cli returned {result:?}");
 
     match result {
-        Err(Termination::MissingArgument { argument }) => assert_eq!(argument, "stdin"),
+        Err(Termination::MissingArgument {
+            subcommand,
+            argument,
+        }) => {
+            assert_eq!(subcommand, "format");
+            assert_eq!(argument, "stdin")
+        }
         _ => {
             panic!("run_cli returned {result:?} for an unknown command help, expected an error")
         }

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -86,7 +86,11 @@ mod main {
         );
 
         match result {
-            Err(Termination::UnexpectedArgument { argument, .. }) => {
+            Err(Termination::UnexpectedArgument {
+                subcommand,
+                argument,
+            }) => {
+                assert_eq!(subcommand, "format");
                 assert_eq!(argument, OsString::from("--unknown"))
             }
             _ => panic!("run_cli returned {result:?} for an unknown argument, expected an error"),
@@ -122,7 +126,13 @@ mod main {
         );
 
         match result {
-            Err(Termination::MissingArgument { argument }) => assert_eq!(argument, "<INPUT>"),
+            Err(Termination::MissingArgument {
+                subcommand,
+                argument,
+            }) => {
+                assert_eq!(subcommand, "format");
+                assert_eq!(argument, "<INPUT>")
+            }
             _ => panic!("run_cli returned {result:?} for a missing argument, expected an error"),
         }
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

- Resolves the issue that the error messages in `rome check` and `rome ci` incorrectly refer to the `rome format` command
```
❯ cargo run --bin rome ci --quote-style="double" 
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/rome ci --quote-style=double`
Error: missing argument '<INPUT>'. Type 'rome format --help' for more information.
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
- Running `rome check` or `rome ci` with one argument missing or unsupported options and the error message should infer the subcommand
  <img width="739" alt="error_message1" src="https://user-images.githubusercontent.com/30640930/196840471-5c53068c-3f1d-4d58-8555-9c13cd716f01.png">
  <img width="799" alt="error_message2" src="https://user-images.githubusercontent.com/30640930/196840477-55250822-d9de-44ef-bc8f-98cb78ec898c.png">
