### PR TITLE
fix(rome_cli): Fix private `open_socket`

### DIFF
--- a/crates/rome_cli/src/service/mod.rs
+++ b/crates/rome_cli/src/service/mod.rs
@@ -43,9 +43,7 @@ use tokio::{
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-use self::windows::open_socket;
-#[cfg(windows)]
-pub(crate) use self::windows::{ensure_daemon, print_socket, run_daemon};
+pub(crate) use self::windows::{ensure_daemon, print_socket, run_daemon, open_socket};
 
 #[cfg(unix)]
 mod unix;

--- a/crates/rome_cli/src/service/mod.rs
+++ b/crates/rome_cli/src/service/mod.rs
@@ -43,7 +43,7 @@ use tokio::{
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-pub(crate) use self::windows::{ensure_daemon, print_socket, run_daemon, open_socket};
+pub(crate) use self::windows::{ensure_daemon, open_socket, print_socket, run_daemon};
 
 #[cfg(unix)]
 mod unix;


### PR DESCRIPTION
Makes the `open_socket` public for builds targeting windows to fix a build failure and align with builds targeting `unix`.

