### PR TITLE
doc(website): Show lint groups in TOC

### DIFF
--- a/website/src/credits.md
+++ b/website/src/credits.md
@@ -109,9 +109,9 @@ layout: layouts/page.liquid
 
 {% include ./contributors.md %}
 
-### Acknowledgements
+## Acknowledgements
 
-Rome contains code that is heavily inspired from other projects. They have been adapted to Rome's 
+Rome contains code that is heavily inspired from other projects. They have been adapted to Rome's
 language/infrastructure.
 
 - [Prettier](https://github.com/prettier/prettier/)

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -14,7 +14,7 @@ eleventyNavigation:
 
 ## Correctness
 
-This group should includes those rules that are meant to prevent possible bugs and misuse of the language.
+Rules that detect incorrect or useless code.
 <section class="rule">
 <h3 data-toc-exclude id="noArguments">
 	<a href="/docs/lint/rules/noArguments">noArguments</a>
@@ -219,7 +219,7 @@ initializer and update expressions are not needed
 
 ## Style
 
-Rules that focus mostly on making the code more consistent.
+Rules enforcing a consistent way of writing your code. 
 <section class="rule">
 <h3 data-toc-exclude id="noNegationElse">
 	<a href="/docs/lint/rules/noNegationElse">noNegationElse</a>
@@ -251,12 +251,9 @@ When expressing array types, this rule promotes the usage of <code>T[]</code> sh
 
 ## Nursery
 
-Rules that are being written. Rules under this group are meant to be considered unstable or buggy.
+New rules that are still under development.
 
-Developers can opt-in these rules via configuration. We vehemently appreciate filing issue in case of bugs or performance problems.
-
-Rules can be downgraded to this group in case a patch release is needed. After an arbitrary amount of time, the team can decide
-to promote these rules into an appropriate group. Doing so means that the rule is stable and ready for production.
+All nursery rules require explicit opt-in via configuration. Please file issues in case you encounter any bugs or performance problems.
 <section class="rule">
 <h3 data-toc-exclude id="noArrayIndexKey">
 	<a href="/docs/lint/rules/noArrayIndexKey">noArrayIndexKey</a>

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -11,468 +11,407 @@ eleventyNavigation:
 
 # Rules
 
-<section>
-<h2>Correctness<a class="header-anchor" href="#Correctness" aria-label="Correctness"></a></h2>
+
+## Correctness
 
 This group should includes those rules that are meant to prevent possible bugs and misuse of the language.
-<div class="rule">
+<section class="rule">
 <h3 data-toc-exclude id="noArguments">
-	<a href="/docs/lint/rules/noArguments">noArguments (since v0.7.0)</a>
-	<a class="header-anchor" href="#noArguments"></a>
+	<a href="/docs/lint/rules/noArguments">noArguments</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow the use of <code>arguments</code>
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noAsyncPromiseExecutor">
-	<a href="/docs/lint/rules/noAsyncPromiseExecutor">noAsyncPromiseExecutor (since v0.7.0)</a>
-	<a class="header-anchor" href="#noAsyncPromiseExecutor"></a>
+	<a href="/docs/lint/rules/noAsyncPromiseExecutor">noAsyncPromiseExecutor</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallows using an async function as a Promise executor.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noCatchAssign">
-	<a href="/docs/lint/rules/noCatchAssign">noCatchAssign (since v0.7.0)</a>
-	<a class="header-anchor" href="#noCatchAssign"></a>
+	<a href="/docs/lint/rules/noCatchAssign">noCatchAssign</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow reassigning exceptions in catch clauses
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noCommentText">
-	<a href="/docs/lint/rules/noCommentText">noCommentText (since v0.7.0)</a>
-	<a class="header-anchor" href="#noCommentText"></a>
+	<a href="/docs/lint/rules/noCommentText">noCommentText</a>
 	<span class="recommended">recommended</span>
 </h3>
 Prevent comments from being inserted as text nodes
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noCompareNegZero">
-	<a href="/docs/lint/rules/noCompareNegZero">noCompareNegZero (since v0.7.0)</a>
-	<a class="header-anchor" href="#noCompareNegZero"></a>
+	<a href="/docs/lint/rules/noCompareNegZero">noCompareNegZero</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow comparing against <code>-0</code>
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noDebugger">
-	<a href="/docs/lint/rules/noDebugger">noDebugger (since v0.7.0)</a>
-	<a class="header-anchor" href="#noDebugger"></a>
+	<a href="/docs/lint/rules/noDebugger">noDebugger</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow the use of <code>debugger</code>
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noDelete">
-	<a href="/docs/lint/rules/noDelete">noDelete (since v0.7.0)</a>
-	<a class="header-anchor" href="#noDelete"></a>
+	<a href="/docs/lint/rules/noDelete">noDelete</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow the use of the <code>delete</code> operator
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noDoubleEquals">
-	<a href="/docs/lint/rules/noDoubleEquals">noDoubleEquals (since v0.7.0)</a>
-	<a class="header-anchor" href="#noDoubleEquals"></a>
+	<a href="/docs/lint/rules/noDoubleEquals">noDoubleEquals</a>
 	<span class="recommended">recommended</span>
 </h3>
 Require the use of <code>===</code> and <code>!==</code>
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noDupeArgs">
-	<a href="/docs/lint/rules/noDupeArgs">noDupeArgs (since v0.9.0)</a>
-	<a class="header-anchor" href="#noDupeArgs"></a>
+	<a href="/docs/lint/rules/noDupeArgs">noDupeArgs</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow duplicate function arguments name.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noEmptyPattern">
-	<a href="/docs/lint/rules/noEmptyPattern">noEmptyPattern (since v0.7.0)</a>
-	<a class="header-anchor" href="#noEmptyPattern"></a>
+	<a href="/docs/lint/rules/noEmptyPattern">noEmptyPattern</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallows empty destructuring patterns.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noExtraBooleanCast">
-	<a href="/docs/lint/rules/noExtraBooleanCast">noExtraBooleanCast (since v0.9.0)</a>
-	<a class="header-anchor" href="#noExtraBooleanCast"></a>
+	<a href="/docs/lint/rules/noExtraBooleanCast">noExtraBooleanCast</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow unnecessary boolean casts
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noFunctionAssign">
-	<a href="/docs/lint/rules/noFunctionAssign">noFunctionAssign (since v0.7.0)</a>
-	<a class="header-anchor" href="#noFunctionAssign"></a>
+	<a href="/docs/lint/rules/noFunctionAssign">noFunctionAssign</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow reassigning function declarations.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noImplicitBoolean">
-	<a href="/docs/lint/rules/noImplicitBoolean">noImplicitBoolean (since v0.7.0)</a>
-	<a class="header-anchor" href="#noImplicitBoolean"></a>
+	<a href="/docs/lint/rules/noImplicitBoolean">noImplicitBoolean</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow implicit <code>true</code> values on JSX boolean attributes
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noImportAssign">
-	<a href="/docs/lint/rules/noImportAssign">noImportAssign (since v0.9.0)</a>
-	<a class="header-anchor" href="#noImportAssign"></a>
+	<a href="/docs/lint/rules/noImportAssign">noImportAssign</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow assigning to imported bindings
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noLabelVar">
-	<a href="/docs/lint/rules/noLabelVar">noLabelVar (since v0.7.0)</a>
-	<a class="header-anchor" href="#noLabelVar"></a>
+	<a href="/docs/lint/rules/noLabelVar">noLabelVar</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow labels that share a name with a variable
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noMultipleSpacesInRegularExpressionLiterals">
-	<a href="/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">noMultipleSpacesInRegularExpressionLiterals (since v0.7.0)</a>
-	<a class="header-anchor" href="#noMultipleSpacesInRegularExpressionLiterals"></a>
+	<a href="/docs/lint/rules/noMultipleSpacesInRegularExpressionLiterals">noMultipleSpacesInRegularExpressionLiterals</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow unclear usage of multiple space characters in regular expression literals
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noShadowRestrictedNames">
-	<a href="/docs/lint/rules/noShadowRestrictedNames">noShadowRestrictedNames (since v0.9.0)</a>
-	<a class="header-anchor" href="#noShadowRestrictedNames"></a>
+	<a href="/docs/lint/rules/noShadowRestrictedNames">noShadowRestrictedNames</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow identifiers from shadowing restricted names.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noSparseArray">
-	<a href="/docs/lint/rules/noSparseArray">noSparseArray (since v0.7.0)</a>
-	<a class="header-anchor" href="#noSparseArray"></a>
+	<a href="/docs/lint/rules/noSparseArray">noSparseArray</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow sparse arrays
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noUnnecessaryContinue">
-	<a href="/docs/lint/rules/noUnnecessaryContinue">noUnnecessaryContinue (since v0.7.0)</a>
-	<a class="header-anchor" href="#noUnnecessaryContinue"></a>
+	<a href="/docs/lint/rules/noUnnecessaryContinue">noUnnecessaryContinue</a>
 	<span class="recommended">recommended</span>
 </h3>
 Avoid using unnecessary <code>ContinueStatement</code>.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noUnsafeNegation">
-	<a href="/docs/lint/rules/noUnsafeNegation">noUnsafeNegation (since v0.7.0)</a>
-	<a class="header-anchor" href="#noUnsafeNegation"></a>
+	<a href="/docs/lint/rules/noUnsafeNegation">noUnsafeNegation</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow using unsafe negation.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noUnusedTemplateLiteral">
-	<a href="/docs/lint/rules/noUnusedTemplateLiteral">noUnusedTemplateLiteral (since v0.7.0)</a>
-	<a class="header-anchor" href="#noUnusedTemplateLiteral"></a>
+	<a href="/docs/lint/rules/noUnusedTemplateLiteral">noUnusedTemplateLiteral</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow template literals if interpolation and special-character handling are not needed
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useBlockStatements">
-	<a href="/docs/lint/rules/useBlockStatements">useBlockStatements (since v0.7.0)</a>
-	<a class="header-anchor" href="#useBlockStatements"></a>
+	<a href="/docs/lint/rules/useBlockStatements">useBlockStatements</a>
 	<span class="recommended">recommended</span>
 </h3>
 Requires following curly brace conventions.
 JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to never omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useSimplifiedLogicExpression">
-	<a href="/docs/lint/rules/useSimplifiedLogicExpression">useSimplifiedLogicExpression (since v0.7.0)</a>
-	<a class="header-anchor" href="#useSimplifiedLogicExpression"></a>
+	<a href="/docs/lint/rules/useSimplifiedLogicExpression">useSimplifiedLogicExpression</a>
 	<span class="recommended">recommended</span>
 </h3>
 Discard redundant terms from logical expressions.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useSingleCaseStatement">
-	<a href="/docs/lint/rules/useSingleCaseStatement">useSingleCaseStatement (since v0.7.0)</a>
-	<a class="header-anchor" href="#useSingleCaseStatement"></a>
+	<a href="/docs/lint/rules/useSingleCaseStatement">useSingleCaseStatement</a>
 	<span class="recommended">recommended</span>
 </h3>
 Enforces case clauses have a single statement, emits a quick fix wrapping
 the statements in a block
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useSingleVarDeclarator">
-	<a href="/docs/lint/rules/useSingleVarDeclarator">useSingleVarDeclarator (since v0.7.0)</a>
-	<a class="header-anchor" href="#useSingleVarDeclarator"></a>
+	<a href="/docs/lint/rules/useSingleVarDeclarator">useSingleVarDeclarator</a>
 	<span class="recommended">recommended</span>
 </h3>
 Disallow multiple variable declarations in the same variable statement
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useTemplate">
-	<a href="/docs/lint/rules/useTemplate">useTemplate (since v0.7.0)</a>
-	<a class="header-anchor" href="#useTemplate"></a>
+	<a href="/docs/lint/rules/useTemplate">useTemplate</a>
 	<span class="recommended">recommended</span>
 </h3>
 Template literals are preferred over string concatenation.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useValidTypeof">
-	<a href="/docs/lint/rules/useValidTypeof">useValidTypeof (since v0.7.0)</a>
-	<a class="header-anchor" href="#useValidTypeof"></a>
+	<a href="/docs/lint/rules/useValidTypeof">useValidTypeof</a>
 	<span class="recommended">recommended</span>
 </h3>
 This rule verifies the result of <code>typeof $expr</code> unary expressions is being
 compared to valid values, either string literals containing valid type
 names or other <code>typeof</code> expressions
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useWhile">
-	<a href="/docs/lint/rules/useWhile">useWhile (since v0.7.0)</a>
-	<a class="header-anchor" href="#useWhile"></a>
+	<a href="/docs/lint/rules/useWhile">useWhile</a>
 	<span class="recommended">recommended</span>
 </h3>
 Enforce the use of <code>while</code> loops instead of <code>for</code> loops when the
 initializer and update expressions are not needed
-</div>
 </section>
-<section>
-<h2>Nursery<a class="header-anchor" href="#Nursery" aria-label="Nursery"></a></h2>
+
+## Style
+
+Rules that focus mostly on making the code more consistent.
+<section class="rule">
+<h3 data-toc-exclude id="noNegationElse">
+	<a href="/docs/lint/rules/noNegationElse">noNegationElse</a>
+	<span class="recommended">recommended</span>
+</h3>
+Disallow negation in the condition of an <code>if</code> statement if it has an <code>else</code> clause
+</section>
+<section class="rule">
+<h3 data-toc-exclude id="noShoutyConstants">
+	<a href="/docs/lint/rules/noShoutyConstants">noShoutyConstants</a>
+	<span class="recommended">recommended</span>
+</h3>
+Disallow the use of constants which its value is the upper-case version of its name.
+</section>
+<section class="rule">
+<h3 data-toc-exclude id="useSelfClosingElements">
+	<a href="/docs/lint/rules/useSelfClosingElements">useSelfClosingElements</a>
+	<span class="recommended">recommended</span>
+</h3>
+Prevent extra closing tags for components without children
+</section>
+<section class="rule">
+<h3 data-toc-exclude id="useShorthandArrayType">
+	<a href="/docs/lint/rules/useShorthandArrayType">useShorthandArrayType</a>
+	<span class="recommended">recommended</span>
+</h3>
+When expressing array types, this rule promotes the usage of <code>T[]</code> shorthand instead of <code>Array&lt;T&gt;</code>.
+</section>
+
+## Nursery
 
 Rules that are being written. Rules under this group are meant to be considered unstable or buggy.
 
-Developers can opt-in these rules via configuration. We vehemently appreciate filing issue in case of bugs or performance problems. 
+Developers can opt-in these rules via configuration. We vehemently appreciate filing issue in case of bugs or performance problems.
 
 Rules can be downgraded to this group in case a patch release is needed. After an arbitrary amount of time, the team can decide
 to promote these rules into an appropriate group. Doing so means that the rule is stable and ready for production.
-<div class="rule">
+<section class="rule">
 <h3 data-toc-exclude id="noArrayIndexKey">
-	<a href="/docs/lint/rules/noArrayIndexKey">noArrayIndexKey (since v0.10.0)</a>
-	<a class="header-anchor" href="#noArrayIndexKey"></a>
+	<a href="/docs/lint/rules/noArrayIndexKey">noArrayIndexKey</a>
 </h3>
 Discourage the usage of Array index in keys.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noAutofocus">
-	<a href="/docs/lint/rules/noAutofocus">noAutofocus (since v10.0.0)</a>
-	<a class="header-anchor" href="#noAutofocus"></a>
+	<a href="/docs/lint/rules/noAutofocus">noAutofocus</a>
 </h3>
 Avoid the <code>autoFocus</code> attribute
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noChildrenProp">
-	<a href="/docs/lint/rules/noChildrenProp">noChildrenProp (since v0.10.0)</a>
-	<a class="header-anchor" href="#noChildrenProp"></a>
+	<a href="/docs/lint/rules/noChildrenProp">noChildrenProp</a>
 </h3>
 Prevent passing of <strong>children</strong> as props.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noConstAssign">
-	<a href="/docs/lint/rules/noConstAssign">noConstAssign (since v10.0.0)</a>
-	<a class="header-anchor" href="#noConstAssign"></a>
+	<a href="/docs/lint/rules/noConstAssign">noConstAssign</a>
 </h3>
 Prevents from having <code>const</code> variables being re-assigned.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noDangerouslySetInnerHtml">
-	<a href="/docs/lint/rules/noDangerouslySetInnerHtml">noDangerouslySetInnerHtml (since v0.10.0)</a>
-	<a class="header-anchor" href="#noDangerouslySetInnerHtml"></a>
+	<a href="/docs/lint/rules/noDangerouslySetInnerHtml">noDangerouslySetInnerHtml</a>
 </h3>
 Prevent the usage of dangerous JSX props
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noDangerouslySetInnerHtmlWithChildren">
-	<a href="/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren">noDangerouslySetInnerHtmlWithChildren (since v0.10.0)</a>
-	<a class="header-anchor" href="#noDangerouslySetInnerHtmlWithChildren"></a>
+	<a href="/docs/lint/rules/noDangerouslySetInnerHtmlWithChildren">noDangerouslySetInnerHtmlWithChildren</a>
 </h3>
 Report when a DOM element or a component uses both <code>children</code> and <code>dangerouslySetInnerHTML</code> prop.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noExplicitAny">
-	<a href="/docs/lint/rules/noExplicitAny">noExplicitAny (since v10.0.0)</a>
-	<a class="header-anchor" href="#noExplicitAny"></a>
+	<a href="/docs/lint/rules/noExplicitAny">noExplicitAny</a>
 </h3>
 Disallow the <code>any</code> type usage
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noNewSymbol">
-	<a href="/docs/lint/rules/noNewSymbol">noNewSymbol (since v0.10.0)</a>
-	<a class="header-anchor" href="#noNewSymbol"></a>
+	<a href="/docs/lint/rules/noNewSymbol">noNewSymbol</a>
 </h3>
 Disallow <code>new</code> operators with the <code>Symbol</code> object
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noPositiveTabindex">
-	<a href="/docs/lint/rules/noPositiveTabindex">noPositiveTabindex (since v10.0.0)</a>
-	<a class="header-anchor" href="#noPositiveTabindex"></a>
+	<a href="/docs/lint/rules/noPositiveTabindex">noPositiveTabindex</a>
 </h3>
 Prevent the usage of positive integers on <code>tabIndex</code> property
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noRenderReturnValue">
-	<a href="/docs/lint/rules/noRenderReturnValue">noRenderReturnValue (since v0.10.0)</a>
-	<a class="header-anchor" href="#noRenderReturnValue"></a>
+	<a href="/docs/lint/rules/noRenderReturnValue">noRenderReturnValue</a>
 </h3>
 Prevent the usage of the return value of <code>React.render</code>.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noRestrictedGlobals">
-	<a href="/docs/lint/rules/noRestrictedGlobals">noRestrictedGlobals (since v0.10.0)</a>
-	<a class="header-anchor" href="#noRestrictedGlobals"></a>
+	<a href="/docs/lint/rules/noRestrictedGlobals">noRestrictedGlobals</a>
 </h3>
 This rule allows you to specify global variable names that you don’t want to use in your application.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noUndeclaredVariables">
-	<a href="/docs/lint/rules/noUndeclaredVariables">noUndeclaredVariables (since v0.10.0)</a>
-	<a class="header-anchor" href="#noUndeclaredVariables"></a>
+	<a href="/docs/lint/rules/noUndeclaredVariables">noUndeclaredVariables</a>
 </h3>
 Prevents the usage of variables that haven't been declared inside the document
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noUnreachable">
-	<a href="/docs/lint/rules/noUnreachable">noUnreachable (since v0.7.0)</a>
-	<a class="header-anchor" href="#noUnreachable"></a>
+	<a href="/docs/lint/rules/noUnreachable">noUnreachable</a>
 </h3>
 Disallow unreachable code
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noUnusedVariables">
-	<a href="/docs/lint/rules/noUnusedVariables">noUnusedVariables (since v0.9.0)</a>
-	<a class="header-anchor" href="#noUnusedVariables"></a>
+	<a href="/docs/lint/rules/noUnusedVariables">noUnusedVariables</a>
 </h3>
 Disallow unused variables.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noUselessFragments">
-	<a href="/docs/lint/rules/noUselessFragments">noUselessFragments (since v0.10.0)</a>
-	<a class="header-anchor" href="#noUselessFragments"></a>
+	<a href="/docs/lint/rules/noUselessFragments">noUselessFragments</a>
 </h3>
 Disallow unnecessary fragments
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noVoidElementsWithChildren">
-	<a href="/docs/lint/rules/noVoidElementsWithChildren">noVoidElementsWithChildren (since v0.10.0)</a>
-	<a class="header-anchor" href="#noVoidElementsWithChildren"></a>
+	<a href="/docs/lint/rules/noVoidElementsWithChildren">noVoidElementsWithChildren</a>
 </h3>
 This rules prevents void elements (AKA self-closing elements) from having children.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useAnchorContent">
-	<a href="/docs/lint/rules/useAnchorContent">useAnchorContent (since v10.0.0)</a>
-	<a class="header-anchor" href="#useAnchorContent"></a>
+	<a href="/docs/lint/rules/useAnchorContent">useAnchorContent</a>
 </h3>
 Enforce that anchor elements have content and that the content is accessible to screen readers.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useBlankTarget">
-	<a href="/docs/lint/rules/useBlankTarget">useBlankTarget (since v10.0.0)</a>
-	<a class="header-anchor" href="#useBlankTarget"></a>
+	<a href="/docs/lint/rules/useBlankTarget">useBlankTarget</a>
 </h3>
 Disallow <code>target=&quot;_blank&quot;</code> attribute without <code>rel=&quot;noreferrer&quot;</code>
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useButtonType">
-	<a href="/docs/lint/rules/useButtonType">useButtonType (since v0.10.0)</a>
-	<a class="header-anchor" href="#useButtonType"></a>
+	<a href="/docs/lint/rules/useButtonType">useButtonType</a>
 </h3>
 Enforces the usage of the attribute <code>type</code> for the element <code>button</code>
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useCamelCase">
-	<a href="/docs/lint/rules/useCamelCase">useCamelCase (since v0.8.0)</a>
-	<a class="header-anchor" href="#useCamelCase"></a>
+	<a href="/docs/lint/rules/useCamelCase">useCamelCase</a>
 </h3>
 Enforce camel case naming convention.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useFlatMap">
-	<a href="/docs/lint/rules/useFlatMap">useFlatMap (since v10.0.0)</a>
-	<a class="header-anchor" href="#useFlatMap"></a>
+	<a href="/docs/lint/rules/useFlatMap">useFlatMap</a>
 </h3>
 Promotes the use of <code>.flatMap()</code> when <code>map().flat()</code> are used together.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useFragmentSyntax">
-	<a href="/docs/lint/rules/useFragmentSyntax">useFragmentSyntax (since v0.10.0)</a>
-	<a class="header-anchor" href="#useFragmentSyntax"></a>
+	<a href="/docs/lint/rules/useFragmentSyntax">useFragmentSyntax</a>
 </h3>
 This rule enforces the use of <code>&lt;&gt;...&lt;/&gt;</code> over <code>&lt;Fragment&gt;...&lt;/Fragment&gt;</code>.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useKeyWithClickEvents">
-	<a href="/docs/lint/rules/useKeyWithClickEvents">useKeyWithClickEvents (since v10.0.0)</a>
-	<a class="header-anchor" href="#useKeyWithClickEvents"></a>
+	<a href="/docs/lint/rules/useKeyWithClickEvents">useKeyWithClickEvents</a>
 </h3>
 Enforce to have the <code>onClick</code> mouse event with the <code>onKeyUp</code>, the <code>onKeyDown</code>, or the <code>noKeyPress</code> keyboard event.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useKeyWithMouseEvents">
-	<a href="/docs/lint/rules/useKeyWithMouseEvents">useKeyWithMouseEvents (since v10.0.0)</a>
-	<a class="header-anchor" href="#useKeyWithMouseEvents"></a>
+	<a href="/docs/lint/rules/useKeyWithMouseEvents">useKeyWithMouseEvents</a>
 </h3>
 Enforce that <code>onMouseOver</code>/<code>onMouseOut</code> are accompanied by <code>onFocus</code>/<code>onBlur</code> for keyboard-only users.
 It is important to take into account users with physical disabilities who cannot use a mouse,
 who use assistive technology or screenreader.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useOptionalChain">
-	<a href="/docs/lint/rules/useOptionalChain">useOptionalChain (since v0.10.0)</a>
-	<a class="header-anchor" href="#useOptionalChain"></a>
+	<a href="/docs/lint/rules/useOptionalChain">useOptionalChain</a>
 </h3>
 Enforce using concise optional chain instead of chained logical expressions.
-</div>
-<div class="rule">
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useValidAnchor">
-	<a href="/docs/lint/rules/useValidAnchor">useValidAnchor (since v10.0.0)</a>
-	<a class="header-anchor" href="#useValidAnchor"></a>
+	<a href="/docs/lint/rules/useValidAnchor">useValidAnchor</a>
 </h3>
 Enforce that all anchors are valid, and they are navigable elements.
-</div>
-</section>
-<section>
-<h2>Style<a class="header-anchor" href="#Style" aria-label="Style"></a></h2>
-
-Rules that focus mostly on making the code more consistent.
-<div class="rule">
-<h3 data-toc-exclude id="noNegationElse">
-	<a href="/docs/lint/rules/noNegationElse">noNegationElse (since v0.7.0)</a>
-	<a class="header-anchor" href="#noNegationElse"></a>
-	<span class="recommended">recommended</span>
-</h3>
-Disallow negation in the condition of an <code>if</code> statement if it has an <code>else</code> clause
-</div>
-<div class="rule">
-<h3 data-toc-exclude id="noShoutyConstants">
-	<a href="/docs/lint/rules/noShoutyConstants">noShoutyConstants (since v0.7.0)</a>
-	<a class="header-anchor" href="#noShoutyConstants"></a>
-	<span class="recommended">recommended</span>
-</h3>
-Disallow the use of constants which its value is the upper-case version of its name.
-</div>
-<div class="rule">
-<h3 data-toc-exclude id="useSelfClosingElements">
-	<a href="/docs/lint/rules/useSelfClosingElements">useSelfClosingElements (since v0.7.0)</a>
-	<a class="header-anchor" href="#useSelfClosingElements"></a>
-	<span class="recommended">recommended</span>
-</h3>
-Prevent extra closing tags for components without children
-</div>
-<div class="rule">
-<h3 data-toc-exclude id="useShorthandArrayType">
-	<a href="/docs/lint/rules/useShorthandArrayType">useShorthandArrayType (since v0.7.0)</a>
-	<a class="header-anchor" href="#useShorthandArrayType"></a>
-	<span class="recommended">recommended</span>
-</h3>
-When expressing array types, this rule promotes the usage of <code>T[]</code> shorthand instead of <code>Array&lt;T&gt;</code>.
-</div>
 </section>

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -253,7 +253,8 @@ When expressing array types, this rule promotes the usage of <code>T[]</code> sh
 
 New rules that are still under development.
 
-All nursery rules require explicit opt-in via configuration. Please file issues in case you encounter any bugs or performance problems.
+Nursery rules require explicit opt-in via configuration because they may still have bugs or performance problems.
+Nursery rules get promoted to other groups once they become stable or may be removed.
 <section class="rule">
 <h3 data-toc-exclude id="noArrayIndexKey">
 	<a href="/docs/lint/rules/noArrayIndexKey">noArrayIndexKey</a>

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -125,26 +125,23 @@ fn generate_group(
         "correctness" => (
             "Correctness",
             markup! {
-                "This group should includes those rules that are meant to prevent possible bugs and misuse of the language."
+                "Rules that detect incorrect or useless code."
             },
         ),
 
         "nursery" => (
             "Nursery",
             markup! {
-                "Rules that are being written. Rules under this group are meant to be considered unstable or buggy.
+                "New rules that are still under development.
 
-Developers can opt-in these rules via configuration. We vehemently appreciate filing issue in case of bugs or performance problems.
-
-Rules can be downgraded to this group in case a patch release is needed. After an arbitrary amount of time, the team can decide
-to promote these rules into an appropriate group. Doing so means that the rule is stable and ready for production."
+All nursery rules require explicit opt-in via configuration. Please file issues in case you encounter any bugs or performance problems."
 
             },
         ),
         "style" => (
             "Style",
             markup! {
-                "Rules that focus mostly on making the code more consistent."
+                "Rules enforcing a consistent way of writing your code. "
             },
         ),
         _ => panic!("Unknown group ID {group:?}"),

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -154,7 +154,7 @@ Nursery rules get promoted to other groups once they become stable or may be rem
 
     for (rule, meta) in rules {
         match generate_rule(
-            &root,
+            root,
             group,
             rule,
             meta.docs,

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -153,14 +153,7 @@ Nursery rules get promoted to other groups once they become stable or may be rem
     writeln!(index)?;
 
     for (rule, meta) in rules {
-        match generate_rule(
-            root,
-            group,
-            rule,
-            meta.docs,
-            meta.version,
-            meta.recommended,
-        ) {
+        match generate_rule(root, group, rule, meta.docs, meta.version, meta.recommended) {
             Ok(summary) => {
                 writeln!(index, "<section class=\"rule\">")?;
                 writeln!(index, "<h3 data-toc-exclude id=\"{rule}\">")?;

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -87,79 +87,17 @@ fn main() -> Result<()> {
     let mut visitor = LintRulesVisitor::default();
     visit_registry(&mut visitor);
 
-    let LintRulesVisitor { groups } = visitor;
+    let LintRulesVisitor { mut groups } = visitor;
+
+    let nursery_rules = groups
+        .remove("nursery")
+        .expect("Expected nursery group to exist");
 
     for (group, rules) in groups {
-        let (group_name, description) = match group {
-            "correctness" => (
-                "Correctness",
-                markup! {
-                    "This group should includes those rules that are meant to prevent possible bugs and misuse of the language."
-                },
-            ),
-
-            "nursery" => (
-                "Nursery",
-                markup! {
-                    "Rules that are being written. Rules under this group are meant to be considered unstable or buggy.
-
-Developers can opt-in these rules via configuration. We vehemently appreciate filing issue in case of bugs or performance problems. 
-
-Rules can be downgraded to this group in case a patch release is needed. After an arbitrary amount of time, the team can decide
-to promote these rules into an appropriate group. Doing so means that the rule is stable and ready for production."
-
-                },
-            ),
-            "style" => (
-                "Style",
-                markup! {
-                    "Rules that focus mostly on making the code more consistent."
-                },
-            ),
-            _ => panic!("Unknown group ID {group:?}"),
-        };
-
-        writeln!(index, "<section>")?;
-        writeln!(index, "<h2>{group_name}<a class=\"header-anchor\" href=\"#{group_name}\" aria-label=\"{group_name}\"></a></h2>")?;
-        writeln!(index)?;
-        markup_to_string(&mut index, description)?;
-        writeln!(index)?;
-
-        for (rule, meta) in rules {
-            let version = meta.version;
-            match generate_rule(
-                &root,
-                group,
-                rule,
-                meta.docs,
-                meta.version,
-                meta.recommended,
-            ) {
-                Ok(summary) => {
-                    writeln!(index, "<div class=\"rule\">")?;
-                    writeln!(index, "<h3 data-toc-exclude id=\"{rule}\">")?;
-                    writeln!(
-                        index,
-                        "	<a href=\"/docs/lint/rules/{rule}\">{rule} (since v{version})</a>"
-                    )?;
-                    writeln!(index, "	<a class=\"header-anchor\" href=\"#{rule}\"></a>")?;
-                    if meta.recommended {
-                        writeln!(index, "	<span class=\"recommended\">recommended</span>")?;
-                    }
-                    writeln!(index, "</h3>")?;
-
-                    write_html(&mut index, summary.into_iter())?;
-
-                    writeln!(index, "\n</div>")?;
-                }
-                Err(err) => {
-                    errors.push((rule, err));
-                }
-            }
-        }
-
-        writeln!(index, "</section>")?;
+        generate_group(group, rules, &root, &mut index, &mut errors)?;
     }
+
+    generate_group("nursery", nursery_rules, &root, &mut index, &mut errors)?;
 
     if !errors.is_empty() {
         bail!(
@@ -172,6 +110,79 @@ to promote these rules into an appropriate group. Doing so means that the rule i
     }
 
     fs2::write(root.join("index.md"), index)?;
+
+    Ok(())
+}
+
+fn generate_group(
+    group: &'static str,
+    rules: BTreeMap<&'static str, RuleMetadata>,
+    root: &Path,
+    mut index: &mut dyn io::Write,
+    errors: &mut Vec<(&'static str, Error)>,
+) -> io::Result<()> {
+    let (group_name, description) = match group {
+        "correctness" => (
+            "Correctness",
+            markup! {
+                "This group should includes those rules that are meant to prevent possible bugs and misuse of the language."
+            },
+        ),
+
+        "nursery" => (
+            "Nursery",
+            markup! {
+                "Rules that are being written. Rules under this group are meant to be considered unstable or buggy.
+
+Developers can opt-in these rules via configuration. We vehemently appreciate filing issue in case of bugs or performance problems.
+
+Rules can be downgraded to this group in case a patch release is needed. After an arbitrary amount of time, the team can decide
+to promote these rules into an appropriate group. Doing so means that the rule is stable and ready for production."
+
+            },
+        ),
+        "style" => (
+            "Style",
+            markup! {
+                "Rules that focus mostly on making the code more consistent."
+            },
+        ),
+        _ => panic!("Unknown group ID {group:?}"),
+    };
+
+    writeln!(index, "\n## {group_name}")?;
+    writeln!(index)?;
+    markup_to_string(index, description)?;
+    writeln!(index)?;
+
+    for (rule, meta) in rules {
+        match generate_rule(
+            &root,
+            group,
+            rule,
+            meta.docs,
+            meta.version,
+            meta.recommended,
+        ) {
+            Ok(summary) => {
+                writeln!(index, "<section class=\"rule\">")?;
+                writeln!(index, "<h3 data-toc-exclude id=\"{rule}\">")?;
+                writeln!(index, "	<a href=\"/docs/lint/rules/{rule}\">{rule}</a>")?;
+
+                if meta.recommended {
+                    writeln!(index, "	<span class=\"recommended\">recommended</span>")?;
+                }
+                writeln!(index, "</h3>")?;
+
+                write_html(&mut index, summary.into_iter())?;
+
+                writeln!(index, "\n</section>")?;
+            }
+            Err(err) => {
+                errors.push((rule, err));
+            }
+        }
+    }
 
     Ok(())
 }
@@ -555,7 +566,7 @@ fn assert_lint(
     Ok(())
 }
 
-pub fn markup_to_string(buffer: &mut Vec<u8>, markup: Markup) -> io::Result<()> {
+pub fn markup_to_string(buffer: &mut dyn io::Write, markup: Markup) -> io::Result<()> {
     let mut write = HTML(buffer);
     let mut fmt = Formatter::new(&mut write);
     fmt.write_markup(markup)

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -134,8 +134,8 @@ fn generate_group(
             markup! {
                 "New rules that are still under development.
 
-All nursery rules require explicit opt-in via configuration. Please file issues in case you encounter any bugs or performance problems."
-
+Nursery rules require explicit opt-in via configuration because they may still have bugs or performance problems.
+Nursery rules get promoted to other groups once they become stable or may be removed."
             },
         ),
         "style" => (


### PR DESCRIPTION
## Summary

* Add lint groups to the TOC
* Make `nursery` the last group (likely the least important)
* Removes `since (v...)` from the overview to reduce the noise (available on the details page)