### PR TITLE
fix(rome_lsp): rename off by default for vscode

### DIFF
--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -23,7 +23,7 @@ rome_flags = { path = "../rome_flags" }
 rome_rowan = { path = "../rome_rowan" }
 rome_console = { path = "../rome_console" }
 rome_text_edit = { path = "../rome_text_edit" }
-tokio = { workspace = true, features = ["io-std"] }
+tokio = { workspace = true, features = ["rt", "io-std"] }
 tower-lsp = { version = "0.17.0" }
 tracing = { workspace = true, features = ["attributes"] }
 futures = "0.3"

--- a/crates/rome_lsp/src/config.rs
+++ b/crates/rome_lsp/src/config.rs
@@ -11,11 +11,14 @@ pub struct WorkspaceSettings {
     /// Unstable features enabled
     #[serde(default)]
     pub unstable: bool,
+
+    /// Enable rename capability
+    pub rename: Option<bool>,
 }
 
 #[derive(Debug)]
 pub(crate) struct Config {
-    settings: WorkspaceSettings,
+    pub(crate) settings: WorkspaceSettings,
 }
 
 impl Config {

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rome",
-	"version": "0.12.0",
+	"version": "0.16.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rome",
-			"version": "0.12.0",
+			"version": "0.16.1",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-languageclient": "^8.0.2"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -82,6 +82,14 @@
 					],
 					"default": null,
 					"markdownDescription": "The rome lsp server executable. If the path is relative, the workspace folder will be used as base path"
+				},
+				"rome.rename": {
+					"type": [
+						"boolean",
+						"null"
+					],
+					"default": null,
+					"markdownDescription": "Enable/Disable Rome handling renames in the workspace. (Experimental)"
 				}
 			}
 		},
@@ -107,7 +115,7 @@
 		"watch": "npm run compile -- --sourcemap --watch",
 		"package": "vsce package -o rome_lsp.vsix",
 		"build": "npm run compile -- --minify && npm run package",
-		"install-extension": "code --install-extension rome_lsp.vsix",
+		"install-extension": "code --install-extension rome_lsp.vsix --force",
 		"format": "cargo run --bin rome format ./src/ ./scripts --write",
 		"pack:dev": "npm run compile && npm run package && npm run install-extension",
 		"tsc": "tsc"

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -31,6 +31,12 @@ export async function activate(context: ExtensionContext) {
 	const command =
 		process.env.DEBUG_SERVER_PATH || (await getServerPath(context));
 
+	if (process.env.DEBUG_SERVER_PATH) {
+		window.showInformationMessage(
+			`Rome DEBUG_SERVER_PATH detected: ${command}`,
+		);
+	}
+
 	if (!command) {
 		await window.showErrorMessage(
 			"The Rome extensions doesn't ship with prebuilt binaries for your platform yet. " +


### PR DESCRIPTION
## Summary

This PR sets renaming as off by default.  

I have not found a way to change Server capability inside ```did_configuration_changed```, so I decided to register the LSP server capable of renaming, but forfeiting the request when the config is ```null``` or ```false```.

I am also notifying the user when ```vscode``` starts and the debug environment variable is being used.

## Test Plan

on Windows

```
> set-item env:/DEBUG_SERVER_PATH "C:\github\tools\target\debug\rome.exe";
> ps rome | stop-process
> cargo build -p rome_cli
```
