### PR TITLE
feat(rome_js_formatter): trailing comma none

### DIFF
--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -46,7 +46,7 @@ const FORMAT_OPTIONS: Markup = markup! {
     "<Dim>"--line-width <number>"</Dim>"                    Change how many characters the formatter is allowed to print in a single line (default: 80)
     "<Dim>"--quote-style <single|double>"</Dim>"            Changes the quotation character for strings (default: \")
     "<Dim>"--quote-properties <as-needed|preserve>"</Dim>"  Changes when properties in object should be quoted (default: as-needed)
-    "<Dim>"--trailing-comma <all|es5>"</Dim>"               Changes trailing commas in multi-line comma-separated syntactic structures (default: all)
+    "<Dim>"--trailing-comma <all|es5|none>"</Dim>"          Changes trailing commas in multi-line comma-separated syntactic structures (default: all)
     "
 };
 

--- a/crates/rome_js_formatter/src/context/trailing_comma.rs
+++ b/crates/rome_js_formatter/src/context/trailing_comma.rs
@@ -19,6 +19,10 @@ pub(crate) enum FormatTrailingComma {
 impl FormatTrailingComma {
     /// This function returns corresponding [TrailingSeparator] for [format_separated] function.
     pub fn trailing_separator(&self, options: &JsFormatOptions) -> TrailingSeparator {
+        if options.trailing_comma.is_none() {
+            return TrailingSeparator::Omit;
+        }
+
         match self {
             FormatTrailingComma::All => {
                 if options.trailing_comma.is_all() {
@@ -34,6 +38,10 @@ impl FormatTrailingComma {
 
 impl Format<JsFormatContext> for FormatTrailingComma {
     fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
+        if f.options().trailing_comma.is_none() {
+            return Ok(());
+        }
+
         if matches!(self, FormatTrailingComma::ES5) || f.options().trailing_comma().is_all() {
             write!(f, [if_group_breaks(&text(","))])?
         }
@@ -54,6 +62,8 @@ pub enum TrailingComma {
     All,
     /// Trailing commas where valid in ES5 (objects, arrays, etc.). No trailing commas in type parameters in TypeScript.
     ES5,
+    /// No trailing commas.
+    None,
 }
 
 impl TrailingComma {
@@ -62,6 +72,9 @@ impl TrailingComma {
     }
     pub const fn is_all(&self) -> bool {
         matches!(self, TrailingComma::All)
+    }
+    pub const fn is_none(&self) -> bool {
+        matches!(self, TrailingComma::None)
     }
 }
 
@@ -72,6 +85,7 @@ impl FromStr for TrailingComma {
         match s {
             "es5" | "ES5" => Ok(Self::ES5),
             "all" | "All" => Ok(Self::All),
+            "none" | "None" => Ok(Self::None),
             // TODO: replace this error with a diagnostic
             _ => Err("Value not supported for TrailingComma"),
         }
@@ -83,6 +97,7 @@ impl fmt::Display for TrailingComma {
         match self {
             TrailingComma::ES5 => std::write!(f, "ES5"),
             TrailingComma::All => std::write!(f, "All"),
+            TrailingComma::None => std::write!(f, "None"),
         }
     }
 }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -862,20 +862,17 @@ function() {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-class C {
-  one(
-    AAAAAAAAAAAAAAAAAAAAAAAAAA,
-    BBBBBBBBBBBBBBBBBBBBBBBBB,
-    BBBBBBBBBBBBBBBBBBBBBB,
-    c,
-  ) {}
-}
+const a = [
+	longlonglonglongItem1longlonglonglongItem1,
+	longlonglonglongItem1longlonglonglongItem2,
+	longlonglonglongItem1longlonglonglongItem3,
+];
 
 "#;
         let syntax = SourceType::tsx();
         let tree = parse(src, FileId::zero(), syntax);
         let options = JsFormatOptions::new(syntax);
-        let options = options.with_trailing_comma(TrailingComma::ES5);
+        let options = options.with_trailing_comma(TrailingComma::None);
         let result = format_node(options.clone(), &tree.syntax())
             .unwrap()
             .print()

--- a/crates/rome_js_formatter/src/utils/array.rs
+++ b/crates/rome_js_formatter/src/utils/array.rs
@@ -15,6 +15,8 @@ where
     N: AstSeparatedList<Language = JsLanguage, Node = I>,
     for<'a> I: ArrayNodeElement + AsFormat<'a>,
 {
+    let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
+
     // Specifically do not use format_separated as arrays need separators
     // inserted after holes regardless of the formatting since this makes a
     // semantic difference
@@ -46,7 +48,14 @@ where
                         None => text(",").fmt(f)?,
                     };
                 } else if let Some(separator) = element.trailing_separator()? {
-                    write!(f, [format_only_if_breaks(separator, &separator.format())])?;
+                    match trailing_separator {
+                        TrailingSeparator::Omit => {
+                            write!(f, [format_removed(separator)])?;
+                        }
+                        _ => {
+                            write!(f, [format_only_if_breaks(separator, &separator.format())])?;
+                        }
+                    }
                 } else {
                     write!(f, [FormatTrailingComma::ES5])?;
                 };

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -70,6 +70,7 @@ impl From<SerializableQuoteProperties> for QuoteProperties {
 pub enum SerializableTrailingComma {
     All,
     ES5,
+    None,
 }
 
 impl From<SerializableTrailingComma> for TrailingComma {
@@ -77,6 +78,7 @@ impl From<SerializableTrailingComma> for TrailingComma {
         match test {
             SerializableTrailingComma::All => TrailingComma::All,
             SerializableTrailingComma::ES5 => TrailingComma::ES5,
+            SerializableTrailingComma::None => TrailingComma::None,
         }
     }
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
@@ -74,4 +74,29 @@ const a = [
 ] = [1, 2, 10];
 ```
 
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: None
+-----
+
+```js
+const a = [
+	longlonglonglongItem1longlonglonglongItem1,
+	longlonglonglongItem1longlonglonglongItem2,
+	longlonglonglongItem1longlonglonglongItem3
+];
+
+// destructuring
+[
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+] = [1, 2, 10];
+```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/options.json
@@ -2,6 +2,9 @@
 	"cases": [
 		{
 			"trailing_comma": "ES5"
+		},
+		{
+			"trailing_comma": "None"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
@@ -55,4 +55,22 @@ export {
 };
 ```
 
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: None
+-----
+
+```js
+export {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+};
+```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/options.json
@@ -2,6 +2,9 @@
 	"cases": [
 		{
 			"trailing_comma": "ES5"
+		},
+		{
+			"trailing_comma": "None"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
@@ -72,4 +72,28 @@ import {
 } from "W";
 ```
 
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: None
+-----
+
+```js
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+} from "D";
+
+import {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+} from "W";
+```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/options.json
@@ -2,6 +2,9 @@
 	"cases": [
 		{
 			"trailing_comma": "ES5"
+		},
+		{
+			"trailing_comma": "None"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
@@ -71,4 +71,28 @@ const {
 } = o;
 ```
 
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: None
+-----
+
+```js
+const b = {
+	longlonglonglongField1,
+	longlonglonglongField2,
+	longlonglonglongField3
+};
+
+const {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+} = o;
+```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/options.json
@@ -2,6 +2,9 @@
 	"cases": [
 		{
 			"trailing_comma": "ES5"
+		},
+		{
+			"trailing_comma": "None"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
@@ -101,4 +101,42 @@ class C<
 }
 ```
 
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: None
+-----
+
+```js
+// class method
+class C<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+> {
+	one<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {}
+	two<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {}
+}
+```
+
 

--- a/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/options.json
@@ -2,6 +2,9 @@
 	"cases": [
 		{
 			"trailing_comma": "ES5"
+		},
+		{
+			"trailing_comma": "None"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
@@ -55,4 +55,22 @@ enum A {
 }
 ```
 
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: None
+-----
+
+```js
+enum A {
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+}
+```
+
 

--- a/crates/rome_js_formatter/tests/specs/ts/enum/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/enum/options.json
@@ -2,6 +2,9 @@
 	"cases": [
 		{
 			"trailing_comma": "ES5"
+		},
+		{
+			"trailing_comma": "None"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/ts/function/function_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/function/function_trailing_comma.ts.snap
@@ -155,4 +155,56 @@ connect(
 )(Component);
 ```
 
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: None
+-----
+
+```js
+function test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+) {}
+const test1 = <
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+) => {};
+test<
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+>(
+	longlonglonglonglonglonglongItem1,
+	longlonglonglonglonglonglongItem2,
+	longlonglonglonglonglonglongItem3
+);
+
+this.test(
+	longlonglonglonglonglonglongT1,
+	longlonglonglonglonglonglongT2,
+	longlonglonglonglonglonglongT3
+);
+
+connect(
+	mapStateToPropsmapStateToProps,
+	mapDispatchToPropsmapDispatchToProps,
+	mergePropsmergeProps
+)(Component);
+```
+
 

--- a/crates/rome_js_formatter/tests/specs/ts/function/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/function/options.json
@@ -2,6 +2,9 @@
 	"cases": [
 		{
 			"trailing_comma": "ES5"
+		},
+		{
+			"trailing_comma": "None"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
@@ -104,4 +104,38 @@ const obj = {
 };
 ```
 
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: None
+-----
+
+```js
+// object method
+const obj = {
+	one<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {},
+	two<
+		longlonglonglonglonglonglongT1,
+		longlonglonglonglonglonglongT2,
+		longlonglonglonglonglonglongT3
+	>(
+		adsadasdasdasdasdasdasdasdasdasdas1,
+		dsadsadasdasdasdasdasdasdasd2,
+		dsadsadasdasdasdasdasdasdasd
+	) {}
+};
+```
+
 

--- a/crates/rome_js_formatter/tests/specs/ts/object/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/object/options.json
@@ -2,6 +2,9 @@
 	"cases": [
 		{
 			"trailing_comma": "ES5"
+		},
+		{
+			"trailing_comma": "None"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/options.json
@@ -2,6 +2,9 @@
 	"cases": [
 		{
 			"trailing_comma": "ES5"
+		},
+		{
+			"trailing_comma": "None"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
@@ -74,4 +74,28 @@ interface C<
 > {}
 ```
 
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: None
+-----
+
+```js
+type A = [
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+];
+
+interface C<
+	adsadasdasdasdasdasdasdasdasdasdas,
+	dsadsadasdasdasdasdasdasdasd,
+	dsadsadasdasdasdasdasdasdasd
+> {}
+```
+
 

--- a/crates/rome_service/src/configuration/javascript.rs
+++ b/crates/rome_service/src/configuration/javascript.rs
@@ -69,4 +69,5 @@ pub enum PlainTrailingComma {
     #[default]
     All,
     ES5,
+    None,
 }

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -912,7 +912,8 @@
       "type": "string",
       "enum": [
         "all",
-        "es5"
+        "es5",
+        "none"
       ]
     }
   }

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -118,7 +118,7 @@ export interface Rules {
 }
 export type QuoteProperties = "asNeeded" | "preserve";
 export type QuoteStyle = "double" | "single";
-export type TrailingComma = "all" | "es5";
+export type TrailingComma = "all" | "es5" | "none";
 /**
  * A list of rules that belong to this group
  */

--- a/website/playground/src/TrailingCommaSelect.tsx
+++ b/website/playground/src/TrailingCommaSelect.tsx
@@ -27,7 +27,7 @@ export default function TrailingCommaSelect({
 						<select
 							id="trailingComma"
 							aria-describedby="quote-style-description"
-							name="quoteStyle"
+							name="trailingComma"
 							value={trailingComma ?? "all"}
 							onChange={(e) =>
 								setTrailingComma(e.target.value as TrailingComma)}

--- a/website/playground/src/TrailingCommaSelect.tsx
+++ b/website/playground/src/TrailingCommaSelect.tsx
@@ -35,6 +35,7 @@ export default function TrailingCommaSelect({
 						>
 							<option value={TrailingComma.All}>All</option>
 							<option value={TrailingComma.ES5}>ES5</option>
+							<option value={TrailingComma.None}>None</option>
 						</select>
 					</div>
 				</div>

--- a/website/playground/src/types.ts
+++ b/website/playground/src/types.ts
@@ -20,6 +20,7 @@ export enum QuoteProperties {
 export enum TrailingComma {
 	All = "all",
 	ES5 = "es5",
+	None = "none",
 }
 export enum LoadingState {
 	Loading,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Add `none` option for `TrailingComma`.

## Test Plan

`cargo test -p rome_js_formatter`
