### PR TITLE
chore(rome): remove WASM pacakges from optional dependencies

### DIFF
--- a/npm/rome/scripts/generate-packages.mjs
+++ b/npm/rome/scripts/generate-packages.mjs
@@ -75,14 +75,9 @@ function writeManifest(packagePath) {
 		]),
 	);
 
-	const wasmPackages = WASM_TARGETS.map((target) => [
-		`@rometools/wasm-${target}`,
-		rootManifest.version,
-	]);
-
 	manifestData["version"] = rootManifest.version;
 	manifestData["optionalDependencies"] = Object.fromEntries(
-		nativePackages.concat(wasmPackages),
+		nativePackages,
 	);
 
 	console.log(`Update manifest ${manifestPath}`);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #3482  

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I manually checked that the updated `package.json` doesn't contain optional dependencies to wasm packages.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
