### PR TITLE
fix(ci): fix the version update scripts for pre-releases

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -93,7 +93,7 @@ jobs:
         if: needs.check.outputs.prerelease == 'true'
         run: |
           echo "prerelease=true" >> $GITHUB_ENV
-          node npm/rome/scripts/update-nightly-version.mjs >> $GITHUB_ENV
+          echo "version=$(node npm/rome/scripts/update-nightly-version.mjs)" >> $GITHUB_ENV
       - name: Set release infos
         if: needs.check.outputs.prerelease != 'true'
         run: |

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -56,7 +56,7 @@ jobs:
         if: env.nightly == 'true' || steps.version.outputs.type == 'prerelease' || steps.version.outputs.type == 'prepatch' || steps.version.outputs.type == 'premajor' || steps.version.outputs.type == 'preminor'
         run: |
           echo "prerelease=true" >> $GITHUB_ENV
-          echo "version=$(node ./editors/vscode/scripts/updateVersionForPrerelease.mjs)" >> $GITHUB_ENV
+          node ./editors/vscode/scripts/update-nightly-version.mjs >> $GITHUB_ENV
           echo "rome_version=$(node ./npm/rome/scripts/update-nightly-version.mjs)" >> $GITHUB_ENV
 
       - name: Check version status
@@ -149,7 +149,7 @@ jobs:
         if: needs.check.outputs.prerelease == 'true'
         working-directory: editors/vscode
         run: |
-          node ./scripts/updateVersionForPrerelease.mjs >> $GITHUB_ENV
+          node ./scripts/update-nightly-version.mjs >> $GITHUB_ENV
           echo "prerelease=true" >> $GITHUB_ENV
       - name: Set release infos
         if: needs.check.outputs.prerelease != 'true'

--- a/editors/vscode/scripts/update-nightly-version.mjs
+++ b/editors/vscode/scripts/update-nightly-version.mjs
@@ -1,26 +1,46 @@
-import { resolve } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import * as fs from "node:fs";
+import { resolve } from "node:path";
 
-const ROMECLI_ROOT = resolve(fileURLToPath(import.meta.url), "../");
-const MANIFEST_PATH = resolve(ROMECLI_ROOT, "package.json");
+const EXTENSION_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
+const MANIFEST_PATH = resolve(EXTENSION_ROOT, "package.json");
 
-const rootManifest = JSON.parse(
-	fs.readFileSync(MANIFEST_PATH).toString("utf-8"),
-);
-
-let version = rootManifest["version"];
-if (
-	typeof process.env.GITHUB_SHA !== "string" ||
-	process.env.GITHUB_SHA === ""
-) {
-	throw new Error("GITHUB_SHA environment variable is undefined");
+function pad(date) {
+	if (date < 10) {
+		return `0${date}`;
+	}
+	return `${date}`;
 }
 
-version += `.${process.env.GITHUB_SHA.substring(0, 7)}`;
-rootManifest["version"] = version;
+// read the package.json file
+readFile(MANIFEST_PATH, "utf8")
+	.then(async (value) => {
+		const manifest = JSON.parse(value);
+		const currentVersion = manifest.version;
+		const versionAsSemver = currentVersion.split(".");
+		// first one is the major
+		const currentMajor = parseInt(versionAsSemver[0]);
+		// second one is the minor
+		const currentMinor = parseInt(versionAsSemver[1]);
 
-const content = JSON.stringify(rootManifest);
-fs.writeFileSync(MANIFEST_PATH, content);
-
-console.log(`version=${version}`);
+		const date = new Date();
+		const newMinor = currentMinor + 1;
+		const newPatch = [
+			pad(date.getFullYear()),
+			pad(date.getMonth() + 1),
+			pad(date.getDate()),
+		].join("");
+		// update the version field
+		manifest.version = `${currentMajor}.${newMinor}.${newPatch}`;
+		try {
+			await writeFile(MANIFEST_PATH, JSON.stringify(manifest, null, "\t"));
+			console.log(`version=${manifest.version}`);
+		} catch {
+			console.log(`Could not write the package.json file at ${MANIFEST_PATH}`);
+			process.exit(1);
+		}
+	})
+	.catch(() => {
+		console.log(`Could not read the package.json file at ${MANIFEST_PATH}`);
+		process.exit(1);
+	});

--- a/npm/rome/scripts/update-nightly-version.mjs
+++ b/npm/rome/scripts/update-nightly-version.mjs
@@ -24,4 +24,4 @@ rootManifest["version"] = version;
 const content = JSON.stringify(rootManifest);
 fs.writeFileSync(MANIFEST_PATH, content);
 
-console.log(`version=${version}`);
+console.log(version);


### PR DESCRIPTION
## Summary

The nightly builds for the LSP are failing since it refers to the version update script using an incorrect name, this PR fixes the path this script is accessed with to make the build work.
I also restored this script with the correct logic for the versioning scheme of the VS Marketplace, since it seems it got mixed up with the logic used to generate version numbers for npm (the difference is that npm supports semver pre-release tags while VSCode doesn't).
Finally I also changed the version update script used in the `rome` npm package to only print the version name without prefixing it with an environment variable name, since this value is exported as `version` in the npm release script while it gets exported as `rome_version` in the LSP release script.

## Test Plan

Manually run the `release_cli` and `release_lsp` workflows from this branch
