### PR TITLE
fix(rome_js_analyze): don't check double negation in `noNegationElse`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/style/no_negation_else.rs
+++ b/crates/rome_js_analyze/src/analyzers/style/no_negation_else.rs
@@ -136,15 +136,12 @@ impl Rule for NoNegationElse {
 fn is_negation(node: &JsAnyExpression) -> Option<bool> {
     match node {
         JsAnyExpression::JsUnaryExpression(expr) => {
-            let argument = expr.argument().ok()?;
-            if expr.operator().ok()? == JsUnaryOperator::LogicalNot {
-                if !JsUnaryExpression::can_cast(argument.syntax().kind()) {
-                    Some(true)
-                } else {
-                    Some(false)
-                }
-            } else {
-                Some(false)
+            match (expr.operator().ok(), expr.argument().ok()) {
+                (
+                    Some(JsUnaryOperator::LogicalNot),
+                    Some(JsAnyExpression::JsUnaryExpression(_)),
+                ) => Some(false),
+                _ => Some(true),
             }
         }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/3141

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test case from the issue that was filed

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
