### PR TITLE
fix(ci): run the version update script in the publish job of the js-api release workflow

### DIFF
--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -134,6 +134,10 @@ jobs:
           node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Set release infos
+        if: needs.build.outputs.prerelease == 'true'
+        run: node npm/js-api/scripts/update-nightly-version.mjs
+
       - name: Publish npm package as latest
         run: npm publish @rometools/js-api --tag latest --access public
         if: needs.build.outputs.prerelease != 'true'


### PR DESCRIPTION
## Summary

The `update-nightly-version` script needs to be run in the `publish` job to ensure the version is correctly set in the `package.json` manifest of the `@rometools/js-api` package before it gets pushed to npm

## Test Plan

Publish a nightly / pre-release version of the JS API
