### PR TITLE
fix(ci): fix the pre-release tag for nightly versions

### DIFF
--- a/npm/js-api/scripts/update-nightly-version.mjs
+++ b/npm/js-api/scripts/update-nightly-version.mjs
@@ -18,7 +18,7 @@ if (
 	throw new Error("GITHUB_SHA environment variable is undefined");
 }
 
-version += `.${process.env.GITHUB_SHA.substring(0, 7)}`;
+version += `-nightly.${process.env.GITHUB_SHA.substring(0, 7)}`;
 rootManifest["version"] = version;
 
 const content = JSON.stringify(rootManifest);

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rome",
-    "version": "0.10.1-next",
+    "version": "0.10.1",
     "bin": "bin/rome",
     "scripts": {
         "postinstall": "node scripts/postinstall.js"

--- a/npm/rome/scripts/update-nightly-version.mjs
+++ b/npm/rome/scripts/update-nightly-version.mjs
@@ -18,7 +18,7 @@ if (
 	throw new Error("GITHUB_SHA environment variable is undefined");
 }
 
-version += `.${process.env.GITHUB_SHA.substring(0, 7)}`;
+version += `-nightly.${process.env.GITHUB_SHA.substring(0, 7)}`;
 rootManifest["version"] = version;
 
 const content = JSON.stringify(rootManifest);


### PR DESCRIPTION
## Summary

This PR changes the prefix of the pre-release tag applied to nightly versions from `-next` to `-nightly`

## Test Plan

Publish a nightly version of `@rometools/js-api` and check it has the correct tag
