### PR TITLE
feat(rome_lsp): add support for incremental document sync in the language server

### DIFF
--- a/crates/rome_lsp/src/capabilities.rs
+++ b/crates/rome_lsp/src/capabilities.rs
@@ -8,7 +8,9 @@ use tower_lsp::lsp_types::{
 /// [`InitializeResult`]: lspower::lsp::InitializeResult
 pub(crate) fn server_capabilities() -> ServerCapabilities {
     ServerCapabilities {
-        text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+        text_document_sync: Some(TextDocumentSyncCapability::Kind(
+            TextDocumentSyncKind::INCREMENTAL,
+        )),
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         document_formatting_provider: Some(OneOf::Left(true)),
         document_range_formatting_provider: Some(OneOf::Left(true)),

--- a/crates/rome_lsp/src/documents.rs
+++ b/crates/rome_lsp/src/documents.rs
@@ -6,6 +6,7 @@ use crate::line_index::LineIndex;
 #[derive(Clone)]
 pub(crate) struct Document {
     pub(crate) version: i32,
+    pub(crate) content: String,
     pub(crate) line_index: LineIndex,
 }
 
@@ -13,6 +14,7 @@ impl Document {
     pub(crate) fn new(version: i32, text: &str) -> Self {
         Self {
             version,
+            content: text.into(),
             line_index: LineIndex::new(text),
         }
     }


### PR DESCRIPTION
## Summary

Historically our LSP implementation has been using full document sync, where the editor sends the entire content of the document on every change notification, since it's easier to get right. However sending the whole buffer is a heavy operation, so VSCode will debounce change notifications or defer them until other language server requests are sent. This has caused [issues](https://github.com/rome/tools/issues/2932) in the past with requests being deferred too much causing the document state to go out of sync between the editor and language server.
This PR implements support for the incremental document sync mode where the editor sends in individual changes as they happen, meaning updates can be processed more frequently and could generally cause the editor experience to feel more reactive.
One downside to this approach is that it may introduce new synchronization issues since `tower_lsp` may schedule requests to be executed in parallel, I haven't seen it happen while testing on a local build of the server but it's hard to be absolutely sure about this kind of concurrency issues.

## Test Plan

I've added a test for a complex update in the tests for the LSP crate, it relies on the `get_syntax_tree` method to check the changes are correctly applied since there are no easy way to peek at the state of the active workspace documents over the language server protocol.
