### PR TITLE
fix(rome_js_analyze): fix const dependency in react hooks

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
@@ -38,6 +38,14 @@ declare_rule! {
     ///     setName("");
     /// }, [name, setName])
     /// ```
+    /// 
+    /// ```js,expect_diagnostic
+    /// let a = 1;
+    /// const b = a + 1;
+    /// useEffect(() => {
+    ///     console.log(b);
+    /// })
+    /// ```
     ///
     /// ## Valid
     ///
@@ -46,6 +54,13 @@ declare_rule! {
     /// useEffect(() => {
     ///     console.log(a);
     /// }, [a]);
+    /// ```
+    /// 
+    /// ```js
+    /// const a = 1;
+    /// useEffect(() => {
+    ///     console.log(a);
+    /// });
     /// ```
     ///
     /// ```js

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
@@ -38,7 +38,7 @@ declare_rule! {
     ///     setName("");
     /// }, [name, setName])
     /// ```
-    /// 
+    ///
     /// ```js,expect_diagnostic
     /// let a = 1;
     /// const b = a + 1;
@@ -55,7 +55,7 @@ declare_rule! {
     ///     console.log(a);
     /// }, [a]);
     /// ```
-    /// 
+    ///
     /// ```js
     /// const a = 1;
     /// useEffect(() => {

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/extraDependenciesInvalid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/extraDependenciesInvalid.js
@@ -9,3 +9,11 @@ function MyComponent2() {
   let a = 1, b = 1;
   useEffect(() => {}, [a, b]);
 }
+
+// extra const
+
+function MyComponent2() {
+  const a = 1;
+  useEffect(() => {}, [a]);
+}
+

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
@@ -16,6 +16,14 @@ function MyComponent2() {
   useEffect(() => {}, [a, b]);
 }
 
+// extra const
+
+function MyComponent2() {
+  const a = 1;
+  useEffect(() => {}, [a]);
+}
+
+
 ```
 
 # Diagnostics
@@ -72,6 +80,30 @@ extraDependenciesInvalid.js:10:3 lint/nursery/useExhaustiveDependencies ━━�
        │                           ^
     11 │ }
     12 │ 
+  
+
+```
+
+```
+extraDependenciesInvalid.js:17:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook specifies more dependencies than necessary.
+  
+    15 │ function MyComponent2() {
+    16 │   const a = 1;
+  > 17 │   useEffect(() => {}, [a]);
+       │   ^^^^^^^^^
+    18 │ }
+    19 │ 
+  
+  i This dependency can be removed from the list.
+  
+    15 │ function MyComponent2() {
+    16 │   const a = 1;
+  > 17 │   useEffect(() => {}, [a]);
+       │                        ^
+    18 │ }
+    19 │ 
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/missingDependenciesInvalid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/missingDependenciesInvalid.js
@@ -1,7 +1,8 @@
 function MyComponent() {
-    let local = 1;
+    let a = 1;
+    const b = a + 1;
     useEffect(() => {
-      console.log(local);
+      console.log(a, b);
     });
   }
 

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/missingDependenciesInvalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/missingDependenciesInvalid.js.snap
@@ -5,9 +5,10 @@ expression: missingDependenciesInvalid.js
 # Input
 ```js
 function MyComponent() {
-    let local = 1;
+    let a = 1;
+    const b = a + 1;
     useEffect(() => {
-      console.log(local);
+      console.log(a, b);
     });
   }
 
@@ -71,192 +72,192 @@ function MyComponent5() {
 
 # Diagnostics
 ```
-missingDependenciesInvalid.js:3:5 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+missingDependenciesInvalid.js:4:5 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook do not specify all of its dependencies.
   
-    1 │ function MyComponent() {
-    2 │     let local = 1;
-  > 3 │     useEffect(() => {
+    2 │     let a = 1;
+    3 │     const b = a + 1;
+  > 4 │     useEffect(() => {
       │     ^^^^^^^^^
-    4 │       console.log(local);
-    5 │     });
+    5 │       console.log(a, b);
+    6 │     });
   
   i This dependency is not specified in the hook dependency list.
   
-    2 │     let local = 1;
-    3 │     useEffect(() => {
-  > 4 │       console.log(local);
-      │                   ^^^^^
-    5 │     });
-    6 │   }
+    3 │     const b = a + 1;
+    4 │     useEffect(() => {
+  > 5 │       console.log(a, b);
+      │                   ^
+    6 │     });
+    7 │   }
   
 
 ```
 
 ```
-missingDependenciesInvalid.js:17:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+missingDependenciesInvalid.js:4:5 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook do not specify all of its dependencies.
   
-    15 │   const deferredValue = useDeferredValue(value);
-    16 │   const [isPending, startTransition] = useTransition();
-  > 17 │   useEffect(() => {
-       │   ^^^^^^^^^
-    18 │       console.log(name);
-    19 │       setName(1);
+    2 │     let a = 1;
+    3 │     const b = a + 1;
+  > 4 │     useEffect(() => {
+      │     ^^^^^^^^^
+    5 │       console.log(a, b);
+    6 │     });
   
   i This dependency is not specified in the hook dependency list.
   
-    24 │       console.log(memoizedCallback);
-    25 │       console.log(memoizedValue);
-  > 26 │       console.log(deferredValue);
+    3 │     const b = a + 1;
+    4 │     useEffect(() => {
+  > 5 │       console.log(a, b);
+      │                      ^
+    6 │     });
+    7 │   }
+  
+
+```
+
+```
+missingDependenciesInvalid.js:18:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook do not specify all of its dependencies.
+  
+    16 │   const deferredValue = useDeferredValue(value);
+    17 │   const [isPending, startTransition] = useTransition();
+  > 18 │   useEffect(() => {
+       │   ^^^^^^^^^
+    19 │       console.log(name);
+    20 │       setName(1);
+  
+  i This dependency is not specified in the hook dependency list.
+  
+    25 │       console.log(memoizedCallback);
+    26 │       console.log(memoizedValue);
+  > 27 │       console.log(deferredValue);
        │                   ^^^^^^^^^^^^^
-    27 │ 
-    28 │       console.log(isPending);
+    28 │ 
+    29 │       console.log(isPending);
   
 
 ```
 
 ```
-missingDependenciesInvalid.js:17:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+missingDependenciesInvalid.js:18:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook do not specify all of its dependencies.
   
-    15 │   const deferredValue = useDeferredValue(value);
-    16 │   const [isPending, startTransition] = useTransition();
-  > 17 │   useEffect(() => {
+    16 │   const deferredValue = useDeferredValue(value);
+    17 │   const [isPending, startTransition] = useTransition();
+  > 18 │   useEffect(() => {
        │   ^^^^^^^^^
-    18 │       console.log(name);
-    19 │       setName(1);
+    19 │       console.log(name);
+    20 │       setName(1);
   
   i This dependency is not specified in the hook dependency list.
   
-    22 │       dispatch(1);
-    23 │ 
-  > 24 │       console.log(memoizedCallback);
+    23 │       dispatch(1);
+    24 │ 
+  > 25 │       console.log(memoizedCallback);
        │                   ^^^^^^^^^^^^^^^^
-    25 │       console.log(memoizedValue);
-    26 │       console.log(deferredValue);
+    26 │       console.log(memoizedValue);
+    27 │       console.log(deferredValue);
   
 
 ```
 
 ```
-missingDependenciesInvalid.js:17:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+missingDependenciesInvalid.js:18:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook do not specify all of its dependencies.
   
-    15 │   const deferredValue = useDeferredValue(value);
-    16 │   const [isPending, startTransition] = useTransition();
-  > 17 │   useEffect(() => {
+    16 │   const deferredValue = useDeferredValue(value);
+    17 │   const [isPending, startTransition] = useTransition();
+  > 18 │   useEffect(() => {
        │   ^^^^^^^^^
-    18 │       console.log(name);
-    19 │       setName(1);
+    19 │       console.log(name);
+    20 │       setName(1);
   
   i This dependency is not specified in the hook dependency list.
   
-    19 │       setName(1);
-    20 │ 
-  > 21 │       console.log(state);
+    20 │       setName(1);
+    21 │ 
+  > 22 │       console.log(state);
        │                   ^^^^^
-    22 │       dispatch(1);
-    23 │ 
+    23 │       dispatch(1);
+    24 │ 
   
 
 ```
 
 ```
-missingDependenciesInvalid.js:17:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+missingDependenciesInvalid.js:18:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook do not specify all of its dependencies.
   
-    15 │   const deferredValue = useDeferredValue(value);
-    16 │   const [isPending, startTransition] = useTransition();
-  > 17 │   useEffect(() => {
+    16 │   const deferredValue = useDeferredValue(value);
+    17 │   const [isPending, startTransition] = useTransition();
+  > 18 │   useEffect(() => {
        │   ^^^^^^^^^
-    18 │       console.log(name);
-    19 │       setName(1);
+    19 │       console.log(name);
+    20 │       setName(1);
   
   i This dependency is not specified in the hook dependency list.
   
-    16 │   const [isPending, startTransition] = useTransition();
-    17 │   useEffect(() => {
-  > 18 │       console.log(name);
+    17 │   const [isPending, startTransition] = useTransition();
+    18 │   useEffect(() => {
+  > 19 │       console.log(name);
        │                   ^^^^
-    19 │       setName(1);
-    20 │ 
+    20 │       setName(1);
+    21 │ 
   
 
 ```
 
 ```
-missingDependenciesInvalid.js:17:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+missingDependenciesInvalid.js:18:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook do not specify all of its dependencies.
   
-    15 │   const deferredValue = useDeferredValue(value);
-    16 │   const [isPending, startTransition] = useTransition();
-  > 17 │   useEffect(() => {
+    16 │   const deferredValue = useDeferredValue(value);
+    17 │   const [isPending, startTransition] = useTransition();
+  > 18 │   useEffect(() => {
        │   ^^^^^^^^^
-    18 │       console.log(name);
-    19 │       setName(1);
+    19 │       console.log(name);
+    20 │       setName(1);
   
   i This dependency is not specified in the hook dependency list.
   
-    26 │       console.log(deferredValue);
-    27 │ 
-  > 28 │       console.log(isPending);
+    27 │       console.log(deferredValue);
+    28 │ 
+  > 29 │       console.log(isPending);
        │                   ^^^^^^^^^
-    29 │       startTransition();
-    30 │   }, []);
+    30 │       startTransition();
+    31 │   }, []);
   
 
 ```
 
 ```
-missingDependenciesInvalid.js:17:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+missingDependenciesInvalid.js:18:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook do not specify all of its dependencies.
   
-    15 │   const deferredValue = useDeferredValue(value);
-    16 │   const [isPending, startTransition] = useTransition();
-  > 17 │   useEffect(() => {
+    16 │   const deferredValue = useDeferredValue(value);
+    17 │   const [isPending, startTransition] = useTransition();
+  > 18 │   useEffect(() => {
        │   ^^^^^^^^^
-    18 │       console.log(name);
-    19 │       setName(1);
+    19 │       console.log(name);
+    20 │       setName(1);
   
   i This dependency is not specified in the hook dependency list.
   
-    24 │       console.log(memoizedCallback);
-  > 25 │       console.log(memoizedValue);
+    25 │       console.log(memoizedCallback);
+  > 26 │       console.log(memoizedValue);
        │                   ^^^^^^^^^^^^^
-    26 │       console.log(deferredValue);
-    27 │ 
-  
-
-```
-
-```
-missingDependenciesInvalid.js:37:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This hook do not specify all of its dependencies.
-  
-    35 │ function MyComponent3() {
-    36 │   let a = 1;
-  > 37 │   useEffect(() => console.log(a));
-       │   ^^^^^^^^^
-    38 │   useCallback(() => console.log(a));
-    39 │   useMemo(() => console.log(a));
-  
-  i This dependency is not specified in the hook dependency list.
-  
-    35 │ function MyComponent3() {
-    36 │   let a = 1;
-  > 37 │   useEffect(() => console.log(a));
-       │                               ^
-    38 │   useCallback(() => console.log(a));
-    39 │   useMemo(() => console.log(a));
+    27 │       console.log(deferredValue);
+    28 │ 
   
 
 ```
@@ -266,21 +267,21 @@ missingDependenciesInvalid.js:38:3 lint/nursery/useExhaustiveDependencies ━━
 
   ! This hook do not specify all of its dependencies.
   
-    36 │   let a = 1;
-    37 │   useEffect(() => console.log(a));
-  > 38 │   useCallback(() => console.log(a));
-       │   ^^^^^^^^^^^
-    39 │   useMemo(() => console.log(a));
-    40 │   useImperativeHandle(ref, () => console.log(a));
+    36 │ function MyComponent3() {
+    37 │   let a = 1;
+  > 38 │   useEffect(() => console.log(a));
+       │   ^^^^^^^^^
+    39 │   useCallback(() => console.log(a));
+    40 │   useMemo(() => console.log(a));
   
   i This dependency is not specified in the hook dependency list.
   
-    36 │   let a = 1;
-    37 │   useEffect(() => console.log(a));
-  > 38 │   useCallback(() => console.log(a));
-       │                                 ^
-    39 │   useMemo(() => console.log(a));
-    40 │   useImperativeHandle(ref, () => console.log(a));
+    36 │ function MyComponent3() {
+    37 │   let a = 1;
+  > 38 │   useEffect(() => console.log(a));
+       │                               ^
+    39 │   useCallback(() => console.log(a));
+    40 │   useMemo(() => console.log(a));
   
 
 ```
@@ -290,21 +291,21 @@ missingDependenciesInvalid.js:39:3 lint/nursery/useExhaustiveDependencies ━━
 
   ! This hook do not specify all of its dependencies.
   
-    37 │   useEffect(() => console.log(a));
-    38 │   useCallback(() => console.log(a));
-  > 39 │   useMemo(() => console.log(a));
-       │   ^^^^^^^
-    40 │   useImperativeHandle(ref, () => console.log(a));
-    41 │   useLayoutEffect(() => console.log(a));
+    37 │   let a = 1;
+    38 │   useEffect(() => console.log(a));
+  > 39 │   useCallback(() => console.log(a));
+       │   ^^^^^^^^^^^
+    40 │   useMemo(() => console.log(a));
+    41 │   useImperativeHandle(ref, () => console.log(a));
   
   i This dependency is not specified in the hook dependency list.
   
-    37 │   useEffect(() => console.log(a));
-    38 │   useCallback(() => console.log(a));
-  > 39 │   useMemo(() => console.log(a));
-       │                             ^
-    40 │   useImperativeHandle(ref, () => console.log(a));
-    41 │   useLayoutEffect(() => console.log(a));
+    37 │   let a = 1;
+    38 │   useEffect(() => console.log(a));
+  > 39 │   useCallback(() => console.log(a));
+       │                                 ^
+    40 │   useMemo(() => console.log(a));
+    41 │   useImperativeHandle(ref, () => console.log(a));
   
 
 ```
@@ -314,21 +315,21 @@ missingDependenciesInvalid.js:40:3 lint/nursery/useExhaustiveDependencies ━━
 
   ! This hook do not specify all of its dependencies.
   
-    38 │   useCallback(() => console.log(a));
-    39 │   useMemo(() => console.log(a));
-  > 40 │   useImperativeHandle(ref, () => console.log(a));
-       │   ^^^^^^^^^^^^^^^^^^^
-    41 │   useLayoutEffect(() => console.log(a));
-    42 │   useInsertionEffect(() => console.log(a));
+    38 │   useEffect(() => console.log(a));
+    39 │   useCallback(() => console.log(a));
+  > 40 │   useMemo(() => console.log(a));
+       │   ^^^^^^^
+    41 │   useImperativeHandle(ref, () => console.log(a));
+    42 │   useLayoutEffect(() => console.log(a));
   
   i This dependency is not specified in the hook dependency list.
   
-    38 │   useCallback(() => console.log(a));
-    39 │   useMemo(() => console.log(a));
-  > 40 │   useImperativeHandle(ref, () => console.log(a));
-       │                                              ^
-    41 │   useLayoutEffect(() => console.log(a));
-    42 │   useInsertionEffect(() => console.log(a));
+    38 │   useEffect(() => console.log(a));
+    39 │   useCallback(() => console.log(a));
+  > 40 │   useMemo(() => console.log(a));
+       │                             ^
+    41 │   useImperativeHandle(ref, () => console.log(a));
+    42 │   useLayoutEffect(() => console.log(a));
   
 
 ```
@@ -338,21 +339,21 @@ missingDependenciesInvalid.js:41:3 lint/nursery/useExhaustiveDependencies ━━
 
   ! This hook do not specify all of its dependencies.
   
-    39 │   useMemo(() => console.log(a));
-    40 │   useImperativeHandle(ref, () => console.log(a));
-  > 41 │   useLayoutEffect(() => console.log(a));
-       │   ^^^^^^^^^^^^^^^
-    42 │   useInsertionEffect(() => console.log(a));
-    43 │ }
+    39 │   useCallback(() => console.log(a));
+    40 │   useMemo(() => console.log(a));
+  > 41 │   useImperativeHandle(ref, () => console.log(a));
+       │   ^^^^^^^^^^^^^^^^^^^
+    42 │   useLayoutEffect(() => console.log(a));
+    43 │   useInsertionEffect(() => console.log(a));
   
   i This dependency is not specified in the hook dependency list.
   
-    39 │   useMemo(() => console.log(a));
-    40 │   useImperativeHandle(ref, () => console.log(a));
-  > 41 │   useLayoutEffect(() => console.log(a));
-       │                                     ^
-    42 │   useInsertionEffect(() => console.log(a));
-    43 │ }
+    39 │   useCallback(() => console.log(a));
+    40 │   useMemo(() => console.log(a));
+  > 41 │   useImperativeHandle(ref, () => console.log(a));
+       │                                              ^
+    42 │   useLayoutEffect(() => console.log(a));
+    43 │   useInsertionEffect(() => console.log(a));
   
 
 ```
@@ -362,78 +363,102 @@ missingDependenciesInvalid.js:42:3 lint/nursery/useExhaustiveDependencies ━━
 
   ! This hook do not specify all of its dependencies.
   
-    40 │   useImperativeHandle(ref, () => console.log(a));
-    41 │   useLayoutEffect(() => console.log(a));
-  > 42 │   useInsertionEffect(() => console.log(a));
+    40 │   useMemo(() => console.log(a));
+    41 │   useImperativeHandle(ref, () => console.log(a));
+  > 42 │   useLayoutEffect(() => console.log(a));
+       │   ^^^^^^^^^^^^^^^
+    43 │   useInsertionEffect(() => console.log(a));
+    44 │ }
+  
+  i This dependency is not specified in the hook dependency list.
+  
+    40 │   useMemo(() => console.log(a));
+    41 │   useImperativeHandle(ref, () => console.log(a));
+  > 42 │   useLayoutEffect(() => console.log(a));
+       │                                     ^
+    43 │   useInsertionEffect(() => console.log(a));
+    44 │ }
+  
+
+```
+
+```
+missingDependenciesInvalid.js:43:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook do not specify all of its dependencies.
+  
+    41 │   useImperativeHandle(ref, () => console.log(a));
+    42 │   useLayoutEffect(() => console.log(a));
+  > 43 │   useInsertionEffect(() => console.log(a));
        │   ^^^^^^^^^^^^^^^^^^
-    43 │ }
-    44 │ 
+    44 │ }
+    45 │ 
   
   i This dependency is not specified in the hook dependency list.
   
-    40 │   useImperativeHandle(ref, () => console.log(a));
-    41 │   useLayoutEffect(() => console.log(a));
-  > 42 │   useInsertionEffect(() => console.log(a));
+    41 │   useImperativeHandle(ref, () => console.log(a));
+    42 │   useLayoutEffect(() => console.log(a));
+  > 43 │   useInsertionEffect(() => console.log(a));
        │                                        ^
-    43 │ }
-    44 │ 
+    44 │ }
+    45 │ 
   
 
 ```
 
 ```
-missingDependenciesInvalid.js:49:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+missingDependenciesInvalid.js:50:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook do not specify all of its dependencies.
   
-    47 │ function MyComponent4() {
-    48 │   let a = 1;
-  > 49 │   useEffect(() => {
+    48 │ function MyComponent4() {
+    49 │   let a = 1;
+  > 50 │   useEffect(() => {
        │   ^^^^^^^^^
-    50 │       return () => console.log(a)
-    51 │   }, []);
+    51 │       return () => console.log(a)
+    52 │   }, []);
   
   i This dependency is not specified in the hook dependency list.
   
-    48 │   let a = 1;
-    49 │   useEffect(() => {
-  > 50 │       return () => console.log(a)
+    49 │   let a = 1;
+    50 │   useEffect(() => {
+  > 51 │       return () => console.log(a)
        │                                ^
-    51 │   }, []);
-    52 │ }
+    52 │   }, []);
+    53 │ }
   
 
 ```
 
 ```
-missingDependenciesInvalid.js:58:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+missingDependenciesInvalid.js:59:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This hook do not specify all of its dependencies.
   
-    56 │ function MyComponent5() {
-    57 │   let a = 1;
-  > 58 │   useEffect(() => {
+    57 │ function MyComponent5() {
+    58 │   let a = 1;
+  > 59 │   useEffect(() => {
        │   ^^^^^^^^^
-    59 │     console.log(a);
-    60 │     return () => console.log(a);
+    60 │     console.log(a);
+    61 │     return () => console.log(a);
   
   i This dependency is not specified in the hook dependency list.
   
-    57 │   let a = 1;
-    58 │   useEffect(() => {
-  > 59 │     console.log(a);
+    58 │   let a = 1;
+    59 │   useEffect(() => {
+  > 60 │     console.log(a);
        │                 ^
-    60 │     return () => console.log(a);
-    61 │   }, []);
+    61 │     return () => console.log(a);
+    62 │   }, []);
   
   i This dependency is not specified in the hook dependency list.
   
-    58 │   useEffect(() => {
-    59 │     console.log(a);
-  > 60 │     return () => console.log(a);
+    59 │   useEffect(() => {
+    60 │     console.log(a);
+  > 61 │     return () => console.log(a);
        │                              ^
-    61 │   }, []);
-    62 │ }
+    62 │   }, []);
+    63 │ }
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js
@@ -6,12 +6,14 @@ function MyComponent1() {
     });
 }
 
-// All captures in the dependency list
+// All needed captures in the dependency list
 function MyComponent2() {
-    let local = 1;
+    let a = 1;
+    const b = 1;
+    const c = a + 1;
     useEffect(() => {
-        console.log(local);
-    }, [local]);
+        console.log(a, b, c);
+    }, [a, c]);
 }
 
 // capturing declarations

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js.snap
@@ -12,12 +12,14 @@ function MyComponent1() {
     });
 }
 
-// All captures in the dependency list
+// All needed captures in the dependency list
 function MyComponent2() {
-    let local = 1;
+    let a = 1;
+    const b = 1;
+    const c = a + 1;
     useEffect(() => {
-        console.log(local);
-    }, [local]);
+        console.log(a, b, c);
+    }, [a, c]);
 }
 
 // capturing declarations

--- a/crates/rome_js_semantic/src/semantic_model.rs
+++ b/crates/rome_js_semantic/src/semantic_model.rs
@@ -891,7 +891,6 @@ pub struct SemanticModelBuilder {
     declaration_all_references: HashMap<TextRange, Vec<(ReferenceType, TextRange)>>,
     declaration_all_reads: HashMap<TextRange, Vec<(ReferenceType, TextRange)>>,
     declaration_all_writes: HashMap<TextRange, Vec<(ReferenceType, TextRange)>>,
-    reference_type: HashMap<TextRange, ReferenceType>,
     exported: HashSet<TextRange>,
     unresolved_references: Vec<(ReferenceType, TextRange)>,
     global_references: Vec<(ReferenceType, TextRange)>,
@@ -910,7 +909,6 @@ impl SemanticModelBuilder {
             declaration_all_references: HashMap::new(),
             declaration_all_reads: HashMap::new(),
             declaration_all_writes: HashMap::new(),
-            reference_type: HashMap::new(),
             exported: HashSet::new(),
             unresolved_references: Vec::new(),
             global_references: Vec::new(),
@@ -1005,9 +1003,6 @@ impl SemanticModelBuilder {
 
                 let scope = &mut self.scopes[scope_id];
                 scope.read_references.push(ScopeReference { range });
-
-                self.reference_type
-                    .insert(range, ReferenceType::Read { hoisted: false });
             }
             HoistedRead {
                 range,
@@ -1026,9 +1021,6 @@ impl SemanticModelBuilder {
 
                 let scope = &mut self.scopes[scope_id];
                 scope.read_references.push(ScopeReference { range });
-
-                self.reference_type
-                    .insert(range, ReferenceType::Read { hoisted: true });
             }
             Write {
                 range,
@@ -1047,9 +1039,6 @@ impl SemanticModelBuilder {
 
                 let scope = &mut self.scopes[scope_id];
                 scope.write_references.push(ScopeReference { range });
-
-                self.reference_type
-                    .insert(range, ReferenceType::Write { hoisted: false });
             }
             HoistedWrite {
                 range,
@@ -1068,9 +1057,6 @@ impl SemanticModelBuilder {
 
                 let scope = &mut self.scopes[scope_id];
                 scope.write_references.push(ScopeReference { range });
-
-                self.reference_type
-                    .insert(range, ReferenceType::Write { hoisted: true });
             }
             UnresolvedReference { is_read, range } => {
                 let ty = if is_read {
@@ -1087,8 +1073,6 @@ impl SemanticModelBuilder {
                 } else {
                     self.unresolved_references.push((ty, range));
                 }
-
-                self.reference_type.insert(range, ty);
             }
             Exported { range } => {
                 self.exported.insert(range);

--- a/crates/rome_js_semantic/src/semantic_model/is_constant.rs
+++ b/crates/rome_js_semantic/src/semantic_model/is_constant.rs
@@ -1,0 +1,50 @@
+use rome_js_syntax::{JsAnyExpression, JsSyntaxKind};
+use rome_rowan::AstNode;
+
+pub fn is_constant(expr: &JsAnyExpression) -> bool {
+    for node in expr.syntax().descendants() {
+        if matches!(node.kind(), JsSyntaxKind::JS_REFERENCE_IDENTIFIER) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use rome_diagnostics::v2::FileId;
+    use rome_js_syntax::{JsIdentifierBinding, JsVariableDeclarator, SourceType};
+
+    use crate::{semantic_model, SemanticModelOptions};
+
+    fn assert_is_const(code: &str, is_const: bool) {
+        use rome_rowan::AstNode;
+        use rome_rowan::SyntaxNodeCast;
+        let r = rome_js_parser::parse(code, FileId::zero(), SourceType::js_module());
+        let model = semantic_model(&r.tree(), SemanticModelOptions::default());
+
+        let a_reference = r
+            .syntax()
+            .descendants()
+            .filter_map(|x| x.cast::<JsIdentifierBinding>())
+            .find(|x| x.text() == "a")
+            .unwrap();
+        let declarator = a_reference.parent::<JsVariableDeclarator>().unwrap();
+        let initializer = declarator.initializer().unwrap();
+        let expr = initializer.expression().ok().unwrap();
+
+        assert_eq!(model.is_constant(&expr), is_const, "{}", code);
+    }
+
+    #[test]
+    pub fn ok_semantic_model_is_constant() {
+        assert_is_const("const a = 1;", true);
+        assert_is_const("const a = 1 + 1;", true);
+        assert_is_const("const a = \"a\";", true);
+        assert_is_const("const a = b = 1;", true);
+
+        assert_is_const("const a = 1 + f();", false);
+        assert_is_const("const a = `${a}`;", false);
+        assert_is_const("const a = b = 1 + f();", false);
+    }
+}

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -122,6 +122,7 @@ assert_semantics! {
     console.log(3);
 }
 f(1);"#,
+    ok_reference_write_expression, "let a/*#A*/ = 1; let b = a/*WRITE A*/ = 2;",
 }
 
 // Write Hoisting

--- a/website/src/docs/lint/rules/useExhaustiveDependencies.md
+++ b/website/src/docs/lint/rules/useExhaustiveDependencies.md
@@ -93,6 +93,36 @@ useEffect(() => {
   
 </code></pre>{% endraw %}
 
+```jsx
+let a = 1;
+const b = a + 1;
+useEffect(() => {
+    console.log(b);
+})
+```
+
+{% raw %}<pre class="language-text"><code class="language-text">nursery/useExhaustiveDependencies.js:3:1 <a href="https://rome.tools/docs/lint/rules/useExhaustiveDependencies">lint/nursery/useExhaustiveDependencies</a> ━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">This hook do not specify all of its dependencies.</span>
+  
+    <strong>1 │ </strong>let a = 1;
+    <strong>2 │ </strong>const b = a + 1;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>useEffect(() =&gt; {
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>    console.log(b);
+    <strong>5 │ </strong>})
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">This dependency is not specified in the hook dependency list.</span>
+  
+    <strong>2 │ </strong>const b = a + 1;
+    <strong>3 │ </strong>useEffect(() =&gt; {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    console.log(b);
+   <strong>   │ </strong>                <strong><span style="color: Tomato;">^</span></strong>
+    <strong>5 │ </strong>})
+    <strong>6 │ </strong>
+  
+</code></pre>{% endraw %}
+
 ## Valid
 
 ```jsx
@@ -100,6 +130,13 @@ let a = 1;
 useEffect(() => {
     console.log(a);
 }, [a]);
+```
+
+```jsx
+const a = 1;
+useEffect(() => {
+    console.log(a);
+});
 ```
 
 ```jsx


### PR DESCRIPTION
## Summary

This PR extends support of useExhaustiveDependencies to consider constant captures as not needed in the dependency list.

## What is a constant?

The current implementation assumes that every expression without a reference is a constant.  
This bring us some polemic cases:

- {}
- []
- function () {}
- () => {}
- class {}

These are all considered constants, even though

- {} === {} equals false
- [] === [] equals false
- (function () {}) === (function () {}) equals false
- {} === {} equals false
- (class {}) === ( class {}) equals false

I think this is the case because JS decided to test them by reference and not by value. There are libs specially made to implement equality by value, for example: https://www.npmjs.com/package/are-equal and any assert library. I would say that equality by value is stronger than equality by reference when considering constantness. 

Which makes me say that 

> a constant is anything whose value does not depends on values of its "environemnt".

The same cannot be said by its reference, which is implementation detail.  

## how eslint deal with constantness

eslint has some more complex cases for constantness that we can incorporate later.

https://eslint.org/docs/latest/rules/no-constant-condition  
https://eslint.org/docs/latest/rules/no-constant-binary-expression  

- void x (always undefined)
- x &&= false (assignment expression with a logical and with false)
- x ||= true (assignment expression with a logical or with true)
- Boolean(1)
- undefined
-  someObj === {} (always false)
-  someArr === [] (always false)

## Test Plan

```
> cargo test -p rome_js_analyze -- exhaustive 
```
