### PR TITLE
feat(rome_service): add a `max_diagnostics` parameter to `pull_diagnostics`

### DIFF
--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -9,7 +9,7 @@ use rome_diagnostics::{
     v2::{
         self,
         adapters::{IoError, StdError},
-        category, Advices, Category, Diagnostic, DiagnosticExt, Error, FilePath, PrintDescription,
+        category, Advices, Category, DiagnosticExt, Error, FilePath, PrintDescription,
         PrintDiagnostic, Severity, Visit,
     },
     MAXIMUM_DISPLAYABLE_DIAGNOSTICS,
@@ -30,7 +30,10 @@ use std::{
     io,
     panic::catch_unwind,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -75,6 +78,8 @@ pub(crate) fn traverse(execution: Execution, mut session: CliSession) -> Result<
     let console = &mut *session.app.console;
 
     let mut has_errors = None;
+    let remaining_diagnostics = Arc::new(AtomicU64::new(u64::MAX));
+
     let mut duration = None;
     let mut report = None;
     let sender_reports_from_messages = sender_reports_from_traversal.clone();
@@ -90,6 +95,7 @@ pub(crate) fn traverse(execution: Execution, mut session: CliSession) -> Result<
                 recv_files,
                 recv_msgs,
                 sender_reports: sender_reports_from_messages,
+                remaining_diagnostics: Arc::clone(&remaining_diagnostics),
             }));
         });
         s.spawn(|_| {
@@ -107,6 +113,7 @@ pub(crate) fn traverse(execution: Execution, mut session: CliSession) -> Result<
                     skipped: &skipped,
                     messages: send_msgs,
                     sender_reports: sender_reports_from_traversal,
+                    remaining_diagnostics: Arc::clone(&remaining_diagnostics),
                 },
             ));
         })
@@ -207,6 +214,9 @@ struct ProcessMessagesOptions<'ctx> {
     recv_msgs: Receiver<Message>,
     /// Sender of reports
     sender_reports: Sender<ReportKind>,
+    /// The approximate number of diagnostics the console will print before
+    /// folding the rest into the "skipped diagnostics" counter
+    remaining_diagnostics: Arc<AtomicU64>,
 }
 
 #[derive(Debug, v2::Diagnostic)]
@@ -269,7 +279,15 @@ fn process_messages(options: ProcessMessagesOptions) -> bool {
         recv_files,
         recv_msgs,
         sender_reports,
+        remaining_diagnostics,
     } = options;
+
+    // The command `rome check` gives a default value of 20.
+    // In case of other commands that pass here, we limit to 50 to avoid to delay the terminal.
+    // Once `--max-diagnostics` will be a global argument, `unwrap_of_default` should be enough.
+    let max_diagnostics = mode
+        .get_max_diagnostics()
+        .unwrap_or(MAXIMUM_DISPLAYABLE_DIAGNOSTICS);
 
     let mut has_errors = false;
     let mut paths = HashMap::new();
@@ -354,13 +372,10 @@ fn process_messages(options: ProcessMessagesOptions) -> bool {
                 name,
                 content,
                 diagnostics,
+                skipped_diagnostics,
             } => {
-                // The command `rome check` gives a default value of 20.
-                // In case of other commands that pass here, we limit to 50 to avoid to delay the terminal.
-                // Once `--max-diagnostics` will be a global argument, `unwrap_of_default` should be enough.
-                let max_diagnostics = mode
-                    .get_max_diagnostics()
-                    .unwrap_or(MAXIMUM_DISPLAYABLE_DIAGNOSTICS);
+                not_printed_diagnostics += skipped_diagnostics;
+
                 // is CI mode we want to print all the diagnostics
                 if mode.is_ci() {
                     for diag in diagnostics {
@@ -378,6 +393,10 @@ fn process_messages(options: ProcessMessagesOptions) -> bool {
                         let should_print = printed_diagnostics < max_diagnostics;
                         if should_print {
                             printed_diagnostics += 1;
+                            remaining_diagnostics.store(
+                                u64::from(max_diagnostics.saturating_sub(printed_diagnostics)),
+                                Ordering::Relaxed,
+                            );
                         } else {
                             not_printed_diagnostics += 1;
                         }
@@ -504,6 +523,9 @@ struct TraversalOptions<'ctx, 'app> {
     messages: Sender<Message>,
     /// Channel sending reports to the reports thread
     sender_reports: Sender<ReportKind>,
+    /// The approximate number of diagnostics the console will print before
+    /// folding the rest into the "skipped diagnostics" counter
+    remaining_diagnostics: Arc<AtomicU64>,
 }
 
 impl<'ctx, 'app> TraversalOptions<'ctx, 'app> {
@@ -713,16 +735,13 @@ fn process_file(ctx: &TraversalOptions, path: &Path, file_id: FileId) -> FileRes
             RuleCategories::SYNTAX | RuleCategories::LINT
         };
 
+        let max_diagnostics = ctx.remaining_diagnostics.load(Ordering::Relaxed);
         let result = file_guard
-            .pull_diagnostics(categories)
+            .pull_diagnostics(categories, max_diagnostics)
             .with_file_id_and_code(file_id, category!("lint"))?;
 
-        let has_errors = result
-            .diagnostics
-            .iter()
-            .any(|diag| diag.severity() >= Severity::Error);
-
         // In formatting mode, abort immediately if the file has errors
+        let has_errors = result.has_errors;
         match ctx.execution.traversal_mode() {
             TraversalMode::Format { ignore_errors, .. } if has_errors => {
                 return Err(if *ignore_errors {
@@ -732,6 +751,7 @@ fn process_file(ctx: &TraversalOptions, path: &Path, file_id: FileId) -> FileRes
                         name: path.display().to_string(),
                         content: input,
                         diagnostics: result.diagnostics.into_iter().map(Error::from).collect(),
+                        skipped_diagnostics: result.skipped_diagnostics,
                     }
                 });
             }
@@ -749,6 +769,7 @@ fn process_file(ctx: &TraversalOptions, path: &Path, file_id: FileId) -> FileRes
                 name: path.display().to_string(),
                 content: input.clone(),
                 diagnostics: result.diagnostics.into_iter().map(Error::from).collect(),
+                skipped_diagnostics: result.skipped_diagnostics,
             })
         };
 
@@ -825,6 +846,7 @@ enum Message {
         name: String,
         content: String,
         diagnostics: Vec<Error>,
+        skipped_diagnostics: u64,
     },
     Diff {
         file_name: String,

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -147,6 +147,7 @@ impl Session {
             let result = self.workspace.pull_diagnostics(PullDiagnosticsParams {
                 path: rome_path,
                 categories: RuleCategories::SYNTAX | RuleCategories::LINT,
+                max_diagnostics: u64::MAX,
             })?;
 
             result

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -157,13 +157,22 @@ pub(crate) struct DebugCapabilities {
     pub(crate) debug_formatter_ir: Option<DebugFormatterIR>,
 }
 
-type Lint = fn(
-    &RomePath,
-    AnyParse,
-    AnalysisFilter,
-    Option<&Rules>,
-    SettingsHandle,
-) -> Vec<rome_diagnostics::v2::serde::Diagnostic>;
+pub(crate) struct LintParams<'a> {
+    pub(crate) rome_path: &'a RomePath,
+    pub(crate) parse: AnyParse,
+    pub(crate) filter: AnalysisFilter<'a>,
+    pub(crate) rules: Option<&'a Rules>,
+    pub(crate) settings: SettingsHandle<'a>,
+    pub(crate) max_diagnostics: u64,
+}
+
+pub(crate) struct LintResults {
+    pub(crate) diagnostics: Vec<rome_diagnostics::v2::serde::Diagnostic>,
+    pub(crate) has_errors: bool,
+    pub(crate) skipped_diagnostics: u64,
+}
+
+type Lint = fn(LintParams) -> LintResults;
 type CodeActions =
     fn(&RomePath, AnyParse, TextRange, Option<&Rules>, SettingsHandle) -> PullActionsResult;
 type FixAll = fn(FixAllParams) -> Result<FixFileResult, RomeError>;

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -177,12 +177,15 @@ pub struct CloseFileParams {
 pub struct PullDiagnosticsParams {
     pub path: RomePath,
     pub categories: RuleCategories,
+    pub max_diagnostics: u64,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PullDiagnosticsResult {
     pub diagnostics: Vec<v2::serde::Diagnostic>,
+    pub has_errors: bool,
+    pub skipped_diagnostics: u64,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -452,10 +455,12 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
     pub fn pull_diagnostics(
         &self,
         categories: RuleCategories,
+        max_diagnostics: u64,
     ) -> Result<PullDiagnosticsResult, RomeError> {
         self.workspace.pull_diagnostics(PullDiagnosticsParams {
             path: self.path.clone(),
             categories,
+            max_diagnostics,
         })
     }
 

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -255,12 +255,15 @@ export interface GetFormatterIRParams {
 }
 export interface PullDiagnosticsParams {
 	categories: RuleCategories;
+	max_diagnostics: number;
 	path: RomePath;
 }
 export type RuleCategories = RuleCategory[];
 export type RuleCategory = "Syntax" | "Lint" | "Action";
 export interface PullDiagnosticsResult {
 	diagnostics: Diagnostic[];
+	has_errors: boolean;
+	skipped_diagnostics: number;
 }
 /**
  * Serializable representation for a [Diagnostic](super::Diagnostic).

--- a/npm/js-api/src/index.ts
+++ b/npm/js-api/src/index.ts
@@ -259,6 +259,7 @@ export class Rome {
 				const { diagnostics } = await this.backend.workspace.pullDiagnostics({
 					path: file.path,
 					categories: ["Syntax"],
+					max_diagnostics: Number.MAX_SAFE_INTEGER,
 				});
 				return {
 					content: content,

--- a/website/playground/src/romeWorker.ts
+++ b/website/playground/src/romeWorker.ts
@@ -175,6 +175,7 @@ self.addEventListener("message", async (e) => {
 			const diagnostics = workspace.pullDiagnostics({
 				path,
 				categories: ["Syntax", "Lint"],
+				max_diagnostics: Number.MAX_SAFE_INTEGER,
 			});
 
 			const printer = new DiagnosticPrinter(path.path, code);


### PR DESCRIPTION
## Summary

This PR adds a new `max_diagnostics` field to `PullDiagnosticsParams` that limits how many diagnostics are emitted in the `diagnostics` field of `PullDiagnosticsResult`, and maintains a counter of `skipped_diagnostics` as well as an `has_errors` flag to allow checking if any of the skipped diagnostics had a severity of `Error` or higher. The `max_diagnostics` value is not a hard limit, and more diagnostics may be emitted by the parser. This new argument is used in the CLI since it's only printing a limited amount of diagnostics, the console thread now maintains an approximate counter of `remaining_diagnostics` that can still be printed, and the shared value of this counter is used as the value of `max_diagnostics` in the worker threads of the traversal.

## Test Plan

This change is covered by the test suite of the CLI, none of the snapshots have been modified since it should be an internal change only.
