### PR TITLE
fix(rome_js_analyze): fix how control flow edges are generated in for-statements with no test node

### DIFF
--- a/crates/rome_cli/tests/snapshots/main_commands_check/upgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/upgrade_severity.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 223
 expression: content
 ---
 ## `rome.json`
@@ -39,19 +40,25 @@ errors where emitted while running checks
 # Emitted Messages
 
 ```block
-file.js:2:5 lint/nursery/noUnreachable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file.js:4:9 lint/nursery/noUnreachable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This code is unreachable
+  × This code will never be reached ...
+  
+    2 │     for (;;) {
+    3 │         continue;
+  > 4 │         break;
+      │         ^^^^^^
+    5 │     }
+    6 │ }
+  
+  i ... because this statement will continue the loop beforehand
   
     1 │ function f() {
-  > 2 │     for (;;) {
-      │     ^^^^^^^^^^
+    2 │     for (;;) {
   > 3 │         continue;
-  > 4 │         break;
-  > 5 │     }
-      │     ^
-    6 │ }
-    7 │ 
+      │         ^^^^^^^^^
+    4 │         break;
+    5 │     }
   
 
 ```

--- a/crates/rome_js_analyze/src/control_flow/nodes/for_stmt.rs
+++ b/crates/rome_js_analyze/src/control_flow/nodes/for_stmt.rs
@@ -90,6 +90,8 @@ impl NodeVisitor for ForVisitor {
             builder
                 .append_jump(true, loop_block)
                 .with_node(test.syntax().clone());
+        } else {
+            builder.append_jump(false, loop_block);
         }
 
         builder.append_jump(false, break_block);

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnreachable/JsForStatement.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnreachable/JsForStatement.js
@@ -3,3 +3,8 @@ function JsForStatement1() {
         break;
     }
 }
+
+function JsForStatement2() {
+    for (;;) {}
+    afterLoop();
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUnreachable/JsForStatement.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUnreachable/JsForStatement.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 99
 expression: JsForStatement.js
 ---
 # Input
@@ -8,6 +9,11 @@ function JsForStatement1() {
     for (let i = 0; i < 10; ++i) {
         break;
     }
+}
+
+function JsForStatement2() {
+    for (;;) {}
+    afterLoop();
 }
 
 ```
@@ -32,6 +38,21 @@ JsForStatement.js:2:29 lint/nursery/noUnreachable ━━━━━━━━━━
       │         ^^^^^^
     4 │     }
     5 │ }
+  
+
+```
+
+```
+JsForStatement.js:9:5 lint/nursery/noUnreachable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This code is unreachable
+  
+     7 │ function JsForStatement2() {
+     8 │     for (;;) {}
+   > 9 │     afterLoop();
+       │     ^^^^^^^^^^^^
+    10 │ }
+    11 │ 
   
 
 ```


### PR DESCRIPTION
## Summary

Fixes #3511

This PR fixes the control flow graph generation of for-statements with no `test` node by correctly generating an unconditional jump edge from the condition block to the loop block instead of not generating an edge at all.

## Test Plan

I've added an additional test case for the `noUnreachable` rule to check this, and updated a CLI snapshot that was also triggering the rule
