### PR TITLE
fix(rome_diagnostics): improve the handling of newline characters in diffs

### DIFF
--- a/crates/rome_js_analyze/tests/specs/correctness/noDebugger.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noDebugger.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 99
 expression: noDebugger.js
 ---
 # Input
@@ -78,8 +79,11 @@ noDebugger.js:9:3 lint/correctness/noDebugger  FIXABLE  ━━━━━━━━
   
   i Suggested fix: Remove debugger statement
   
-    9 │ ··debugger;
-      │ -----------
+     7 7 │   function test() {
+     8 8 │     let a = 3;
+     9   │ - ··debugger;
+    10 9 │   }
+  
 
 ```
 

--- a/crates/rome_js_analyze/tests/specs/correctness/noUnnecessaryContinue.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnnecessaryContinue.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 99
 expression: noUnnecessaryContinue.js
 ---
 # Input
@@ -95,8 +96,12 @@ noUnnecessaryContinue.js:3:2 lint/correctness/noUnnecessaryContinue  FIXABLE  �
   
   i Suggested fix: Delete the unnecessary continue statement
   
-    3 │ → continue·loop;
-      │ ----------------
+     1  1 │   // invalid
+     2  2 │   loop: for (let i = 0; i < 5; i++) {
+     3    │ - → continue·loop;
+     4  3 │   }
+     5  4 │   while (i--) {
+  
 
 ```
 
@@ -114,8 +119,12 @@ noUnnecessaryContinue.js:6:2 lint/correctness/noUnnecessaryContinue  FIXABLE  �
   
   i Suggested fix: Delete the unnecessary continue statement
   
-    6 │ → continue;
-      │ -----------
+     4  4 │   }
+     5  5 │   while (i--) {
+     6    │ - → continue;
+     7  6 │   }
+     8  7 │   while (1) {
+  
 
 ```
 
@@ -133,8 +142,12 @@ noUnnecessaryContinue.js:9:2 lint/correctness/noUnnecessaryContinue  FIXABLE  �
   
   i Suggested fix: Delete the unnecessary continue statement
   
-    9 │ → continue;
-      │ -----------
+     7  7 │   }
+     8  8 │   while (1) {
+     9    │ - → continue;
+    10  9 │   }
+    11 10 │   for (let i = 0; i < 10; i++) {
+  
 
 ```
 
@@ -177,8 +190,12 @@ noUnnecessaryContinue.js:22:2 lint/correctness/noUnnecessaryContinue  FIXABLE  �
   
   i Suggested fix: Delete the unnecessary continue statement
   
-    22 │ → continue;
-       │ -----------
+    20 20 │   }
+    21 21 │   for (let i = 0; i < 9; i++) {
+    22    │ - → continue;
+    23 22 │   }
+    24 23 │   
+  
 
 ```
 
@@ -214,8 +231,12 @@ noUnnecessaryContinue.js:28:2 lint/correctness/noUnnecessaryContinue  FIXABLE  �
   
   i Suggested fix: Delete the unnecessary continue statement
   
-    28 │ → continue·test2;
-       │ -----------------
+    26 26 │   
+    27 27 │   test2: do {
+    28    │ - → continue·test2;
+    29 28 │   } while (true);
+    30 29 │   // valid
+  
 
 ```
 

--- a/crates/rome_js_analyze/tests/specs/nursery/noVoidElementsWithChildren/createElement.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noVoidElementsWithChildren/createElement.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 99
 expression: createElement.js
 ---
 # Input
@@ -51,8 +52,11 @@ createElement.js:7:1 lint/nursery/noVoidElementsWithChildren  FIXABLE  ━━━
   
   i Suggested fix: Remove the dangerouslySetInnerHTML prop.
   
-    8 │ ····dangerouslySetInnerHTML:·"text"
-      │ -----------------------------------
+    6 6 │   
+    7 7 │   React.createElement('img', {
+    8   │ - ····dangerouslySetInnerHTML:·"text"
+    9 8 │   })
+  
 
 ```
 

--- a/website/src/docs/lint/rules/noUnnecessaryContinue.md
+++ b/website/src/docs/lint/rules/noUnnecessaryContinue.md
@@ -31,8 +31,11 @@ loop: for (let i = 0; i < 5; i++) {
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Delete the unnecessary continue statement</span>
   
-<strong>  </strong><strong>  2 │ </strong><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="color: Tomato;">c</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;">t</span><span style="color: Tomato;">i</span><span style="color: Tomato;">n</span><span style="color: Tomato;">u</span><span style="color: Tomato;">e</span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="color: Tomato;">l</span><span style="color: Tomato;">o</span><span style="color: Tomato;">o</span><span style="color: Tomato;">p</span><span style="color: Tomato;">;</span>
-<strong>  </strong><strong>    │ </strong><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>
+    <strong>1</strong> <strong>1</strong><strong> │ </strong>  loop: for (let i = 0; i &lt; 5; i++) {
+    <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>c</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>u</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>l</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>p</strong></span><span style="color: Tomato;"><strong>;</strong></span>
+    <strong>3</strong> <strong>2</strong><strong> │ </strong>  }
+    <strong>4</strong> <strong>3</strong><strong> │ </strong>  
+  
 </code></pre>{% endraw %}
 
 ```jsx
@@ -53,8 +56,11 @@ while (i--) {
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Delete the unnecessary continue statement</span>
   
-<strong>  </strong><strong>  2 │ </strong><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="color: Tomato;">c</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;">t</span><span style="color: Tomato;">i</span><span style="color: Tomato;">n</span><span style="color: Tomato;">u</span><span style="color: Tomato;">e</span><span style="color: Tomato;">;</span>
-<strong>  </strong><strong>    │ </strong><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>
+    <strong>1</strong> <strong>1</strong><strong> │ </strong>  while (i--) {
+    <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>c</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>u</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>;</strong></span>
+    <strong>3</strong> <strong>2</strong><strong> │ </strong>  }
+    <strong>4</strong> <strong>3</strong><strong> │ </strong>  
+  
 </code></pre>{% endraw %}
 
 ```jsx
@@ -75,8 +81,11 @@ while (1) {
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Delete the unnecessary continue statement</span>
   
-<strong>  </strong><strong>  2 │ </strong><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="color: Tomato;">c</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;">t</span><span style="color: Tomato;">i</span><span style="color: Tomato;">n</span><span style="color: Tomato;">u</span><span style="color: Tomato;">e</span><span style="color: Tomato;">;</span>
-<strong>  </strong><strong>    │ </strong><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>
+    <strong>1</strong> <strong>1</strong><strong> │ </strong>  while (1) {
+    <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>c</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>u</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>;</strong></span>
+    <strong>3</strong> <strong>2</strong><strong> │ </strong>  }
+    <strong>4</strong> <strong>3</strong><strong> │ </strong>  
+  
 </code></pre>{% endraw %}
 
 ```jsx
@@ -105,8 +114,12 @@ for (let i = 0; i < 10; i++) {
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Delete the unnecessary continue statement</span>
   
-<strong>  </strong><strong>  4 │ </strong><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="color: Tomato;">c</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;">t</span><span style="color: Tomato;">i</span><span style="color: Tomato;">n</span><span style="color: Tomato;">u</span><span style="color: Tomato;">e</span><span style="color: Tomato;">;</span>
-<strong>  </strong><strong>    │ </strong><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>
+    <strong> 2</strong> <strong> 2</strong><strong> │ </strong>    if (i &gt; 5) {
+    <strong> 3</strong> <strong> 3</strong><strong> │ </strong>      console.log(&quot;foo&quot;);
+    <strong> 4</strong>   <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>c</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>u</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>;</strong></span>
+    <strong> 5</strong> <strong> 4</strong><strong> │ </strong>    } else if (i &gt;= 5 &amp;&amp; i &lt; 8) {
+    <strong> 6</strong> <strong> 5</strong><strong> │ </strong>      console.log(&quot;test&quot;);
+  
 </code></pre>{% endraw %}
 
 ```jsx
@@ -127,8 +140,11 @@ for (let i = 0; i < 9; i++) {
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Delete the unnecessary continue statement</span>
   
-<strong>  </strong><strong>  2 │ </strong><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="color: Tomato;">c</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;">t</span><span style="color: Tomato;">i</span><span style="color: Tomato;">n</span><span style="color: Tomato;">u</span><span style="color: Tomato;">e</span><span style="color: Tomato;">;</span>
-<strong>  </strong><strong>    │ </strong><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>
+    <strong>1</strong> <strong>1</strong><strong> │ </strong>  for (let i = 0; i &lt; 9; i++) {
+    <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>c</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>u</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>;</strong></span>
+    <strong>3</strong> <strong>2</strong><strong> │ </strong>  }
+    <strong>4</strong> <strong>3</strong><strong> │ </strong>  
+  
 </code></pre>{% endraw %}
 
 ```jsx
@@ -149,8 +165,11 @@ test2: do {
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Delete the unnecessary continue statement</span>
   
-<strong>  </strong><strong>  2 │ </strong><span style="opacity: 0.8;"><span style="color: Tomato;">→ </span></span><span style="color: Tomato;">c</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;">t</span><span style="color: Tomato;">i</span><span style="color: Tomato;">n</span><span style="color: Tomato;">u</span><span style="color: Tomato;">e</span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span><span style="color: Tomato;">t</span><span style="color: Tomato;">e</span><span style="color: Tomato;">s</span><span style="color: Tomato;">t</span><span style="color: Tomato;">2</span><span style="color: Tomato;">;</span>
-<strong>  </strong><strong>    │ </strong><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>
+    <strong>1</strong> <strong>1</strong><strong> │ </strong>  test2: do {
+    <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><span style="opacity: 0.8;"><strong>→ </strong></span></span><span style="color: Tomato;"><strong>c</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>u</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>s</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>2</strong></span><span style="color: Tomato;"><strong>;</strong></span>
+    <strong>3</strong> <strong>2</strong><strong> │ </strong>  } while (true);
+    <strong>4</strong> <strong>3</strong><strong> │ </strong>  
+  
 </code></pre>{% endraw %}
 
 ### Valid


### PR DESCRIPTION
## Summary

Fixes #3515

This PR changes how line breaks are handled in diffs, and specifically how individual lines get marked as "modified" when a line break is removed or inserted. It fixes an issue with the rendering of diffs from the formatter, but also changes when diffs are allowed to be rendered in short mode as the removal of an entire line is now shown in full mode (with the surrounding lines of context).

## Test Plan

I've added an additional test case for this and updated the ellipsis case since it was actually being rendered incorrectly. I've also improved how markup assertion mismatches are displayed in the tests to ensure these kinds of issue are easier to notice in the future, and update a few snapshots related to the short mode changes.
