### PR TITLE
fix(rome_js_parser): Ignore bindings in desctructuring initializers

### DIFF
--- a/crates/rome_js_parser/src/syntax/binding.rs
+++ b/crates/rome_js_parser/src/syntax/binding.rs
@@ -283,7 +283,11 @@ impl ParseObjectPattern for ObjectBindingPattern {
             JS_OBJECT_BINDING_PATTERN_PROPERTY
         };
 
+        // test destructuring_initializer_binding
+        // const { value, f = (value) => value } = item
+        let parent = p.state.duplicate_binding_parent.take();
         parse_initializer_clause(p, ExpressionContext::default()).ok();
+        p.state.duplicate_binding_parent = parent;
 
         Present(m.complete(p, kind))
     }

--- a/crates/rome_js_parser/src/tests.rs
+++ b/crates/rome_js_parser/src/tests.rs
@@ -14,9 +14,7 @@ use std::path::{Path, PathBuf};
 #[test]
 fn parser_smoke_test() {
     let src = r#"
-let
-// comment
-a;
+const { value, f = (value) => value } = item
 "#;
 
     let module = parse(src, FileId::zero(), SourceType::tsx());

--- a/crates/rome_js_parser/src/tests.rs
+++ b/crates/rome_js_parser/src/tests.rs
@@ -14,7 +14,9 @@ use std::path::{Path, PathBuf};
 #[test]
 fn parser_smoke_test() {
     let src = r#"
-const { value, f = (value) => value } = item
+let
+// comment
+a;
 "#;
 
     let module = parse(src, FileId::zero(), SourceType::tsx());

--- a/crates/rome_js_parser/test_data/inline/ok/destructuring_initializer_binding.js
+++ b/crates/rome_js_parser/test_data/inline/ok/destructuring_initializer_binding.js
@@ -1,0 +1,1 @@
+const { value, f = (value) => value } = item

--- a/crates/rome_js_parser/test_data/inline/ok/destructuring_initializer_binding.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/destructuring_initializer_binding.rast
@@ -1,0 +1,122 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                kind: CONST_KW@0..6 "const" [] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsObjectBindingPattern {
+                            l_curly_token: L_CURLY@6..8 "{" [] [Whitespace(" ")],
+                            properties: JsObjectBindingPatternPropertyList [
+                                JsObjectBindingPatternShorthandProperty {
+                                    identifier: JsIdentifierBinding {
+                                        name_token: IDENT@8..13 "value" [] [],
+                                    },
+                                    init: missing (optional),
+                                },
+                                COMMA@13..15 "," [] [Whitespace(" ")],
+                                JsObjectBindingPatternShorthandProperty {
+                                    identifier: JsIdentifierBinding {
+                                        name_token: IDENT@15..17 "f" [] [Whitespace(" ")],
+                                    },
+                                    init: JsInitializerClause {
+                                        eq_token: EQ@17..19 "=" [] [Whitespace(" ")],
+                                        expression: JsArrowFunctionExpression {
+                                            async_token: missing (optional),
+                                            type_parameters: missing (optional),
+                                            parameters: JsParameters {
+                                                l_paren_token: L_PAREN@19..20 "(" [] [],
+                                                items: JsParameterList [
+                                                    JsFormalParameter {
+                                                        binding: JsIdentifierBinding {
+                                                            name_token: IDENT@20..25 "value" [] [],
+                                                        },
+                                                        question_mark_token: missing (optional),
+                                                        type_annotation: missing (optional),
+                                                        initializer: missing (optional),
+                                                    },
+                                                ],
+                                                r_paren_token: R_PAREN@25..27 ")" [] [Whitespace(" ")],
+                                            },
+                                            return_type_annotation: missing (optional),
+                                            fat_arrow_token: FAT_ARROW@27..30 "=>" [] [Whitespace(" ")],
+                                            body: JsIdentifierExpression {
+                                                name: JsReferenceIdentifier {
+                                                    value_token: IDENT@30..36 "value" [] [Whitespace(" ")],
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                            r_curly_token: R_CURLY@36..38 "}" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@38..40 "=" [] [Whitespace(" ")],
+                            expression: JsIdentifierExpression {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@40..44 "item" [] [],
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@44..45 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..45
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..44
+    0: JS_VARIABLE_STATEMENT@0..44
+      0: JS_VARIABLE_DECLARATION@0..44
+        0: CONST_KW@0..6 "const" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATOR_LIST@6..44
+          0: JS_VARIABLE_DECLARATOR@6..44
+            0: JS_OBJECT_BINDING_PATTERN@6..38
+              0: L_CURLY@6..8 "{" [] [Whitespace(" ")]
+              1: JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST@8..36
+                0: JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY@8..13
+                  0: JS_IDENTIFIER_BINDING@8..13
+                    0: IDENT@8..13 "value" [] []
+                  1: (empty)
+                1: COMMA@13..15 "," [] [Whitespace(" ")]
+                2: JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY@15..36
+                  0: JS_IDENTIFIER_BINDING@15..17
+                    0: IDENT@15..17 "f" [] [Whitespace(" ")]
+                  1: JS_INITIALIZER_CLAUSE@17..36
+                    0: EQ@17..19 "=" [] [Whitespace(" ")]
+                    1: JS_ARROW_FUNCTION_EXPRESSION@19..36
+                      0: (empty)
+                      1: (empty)
+                      2: JS_PARAMETERS@19..27
+                        0: L_PAREN@19..20 "(" [] []
+                        1: JS_PARAMETER_LIST@20..25
+                          0: JS_FORMAL_PARAMETER@20..25
+                            0: JS_IDENTIFIER_BINDING@20..25
+                              0: IDENT@20..25 "value" [] []
+                            1: (empty)
+                            2: (empty)
+                            3: (empty)
+                        2: R_PAREN@25..27 ")" [] [Whitespace(" ")]
+                      3: (empty)
+                      4: FAT_ARROW@27..30 "=>" [] [Whitespace(" ")]
+                      5: JS_IDENTIFIER_EXPRESSION@30..36
+                        0: JS_REFERENCE_IDENTIFIER@30..36
+                          0: IDENT@30..36 "value" [] [Whitespace(" ")]
+              2: R_CURLY@36..38 "}" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@38..44
+              0: EQ@38..40 "=" [] [Whitespace(" ")]
+              1: JS_IDENTIFIER_EXPRESSION@40..44
+                0: JS_REFERENCE_IDENTIFIER@40..44
+                  0: IDENT@40..44 "item" [] []
+      1: (empty)
+  3: EOF@44..45 "" [Newline("\n")] []


### PR DESCRIPTION
Rome's parser implements a very limited check for duplicated bindings by testing if there are no duplicate bindings in the same variable declaration.

This PR fixes an issue where the parser flagged a binding with the same name inside a destructuring initializer as a duplicated binding which is incorrect.

Fixes #3521  #2960
