### PR TITLE
feat(rome_service): add a configuration option to set the file size limit of the workspace

### DIFF
--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -1,12 +1,13 @@
 use crate::commands::format::apply_format_settings_from_cli;
+use crate::configuration::load_configuration;
 use crate::{execute_mode, CliSession, Execution, Termination, TraversalMode};
 use rome_diagnostics::MAXIMUM_DISPLAYABLE_DIAGNOSTICS;
-use rome_service::load_config;
 use rome_service::workspace::{FixFileMode, UpdateSettingsParams};
 
 /// Handler for the "check" command of the Rome CLI
 pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
-    let configuration = load_config(&session.app.fs, None)?;
+    let mut configuration = load_configuration(&mut session)?;
+
     let max_diagnostics: Option<u16> = session
         .args
         .opt_value_from_str("--max-diagnostics")
@@ -14,6 +15,7 @@ pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
             argument: "--max-diagnostics",
             source,
         })?;
+
     let max_diagnostics = if let Some(max_diagnostics) = max_diagnostics {
         if max_diagnostics > MAXIMUM_DISPLAYABLE_DIAGNOSTICS {
             return Err(Termination::OverflowNumberArgument(
@@ -28,7 +30,8 @@ pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
         20
     };
 
-    let configuration = apply_format_settings_from_cli(&mut session, configuration)?;
+    apply_format_settings_from_cli(&mut session, &mut configuration)?;
+
     session
         .app
         .workspace

--- a/crates/rome_cli/src/commands/ci.rs
+++ b/crates/rome_cli/src/commands/ci.rs
@@ -1,13 +1,15 @@
-use crate::{execute_mode, CliSession, Execution, Termination, TraversalMode};
-use rome_service::load_config;
+use crate::{
+    configuration::load_configuration, execute_mode, CliSession, Execution, Termination,
+    TraversalMode,
+};
 use rome_service::workspace::UpdateSettingsParams;
 
 use super::format::apply_format_settings_from_cli;
 
 /// Handler for the "ci" command of the Rome CLI
 pub(crate) fn ci(mut session: CliSession) -> Result<(), Termination> {
-    let configuration = load_config(&session.app.fs, None)?;
-    let configuration = apply_format_settings_from_cli(&mut session, configuration)?;
+    let mut configuration = load_configuration(&mut session)?;
+    apply_format_settings_from_cli(&mut session, &mut configuration)?;
 
     session
         .app

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -2,16 +2,17 @@ use rome_formatter::IndentStyle;
 use rome_service::configuration::{
     FormatterConfiguration, JavascriptConfiguration, JavascriptFormatter, PlainIndentStyle,
 };
-use rome_service::{load_config, workspace::UpdateSettingsParams, Configuration};
+use rome_service::{workspace::UpdateSettingsParams, Configuration};
 use std::path::PathBuf;
 
+use crate::configuration::load_configuration;
 use crate::execute::ReportMode;
 use crate::{execute_mode, CliSession, Execution, Termination, TraversalMode};
 
 /// Handler for the "format" command of the Rome CLI
 pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
-    let configuration = load_config(&session.app.fs, None)?;
-    let configuration = apply_format_settings_from_cli(&mut session, configuration)?;
+    let mut configuration = load_configuration(&mut session)?;
+    apply_format_settings_from_cli(&mut session, &mut configuration)?;
 
     session
         .app
@@ -69,13 +70,8 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
 /// into the workspace settings
 pub(crate) fn apply_format_settings_from_cli(
     session: &mut CliSession,
-    configuration: Option<Configuration>,
-) -> Result<Configuration, Termination> {
-    let mut configuration = if let Some(configuration) = configuration {
-        configuration
-    } else {
-        Configuration::default()
-    };
+    configuration: &mut Configuration,
+) -> Result<(), Termination> {
     let formatter = configuration
         .formatter
         .get_or_insert_with(FormatterConfiguration::default);
@@ -162,5 +158,5 @@ pub(crate) fn apply_format_settings_from_cli(
         javascript_formatter.trailing_comma = trailing_comma;
     }
 
-    Ok(configuration)
+    Ok(())
 }

--- a/crates/rome_cli/src/configuration.rs
+++ b/crates/rome_cli/src/configuration.rs
@@ -1,0 +1,24 @@
+use rome_service::{load_config, Configuration};
+
+use crate::{CliSession, Termination};
+
+/// Load the configuration for this session of the CLI, merging the content of
+/// the `rome.json` file if it exists on disk with common command line options
+pub(crate) fn load_configuration(session: &mut CliSession) -> Result<Configuration, Termination> {
+    let mut configuration = load_config(&session.app.fs, None)?.unwrap_or_default();
+
+    let files_max_size = session
+        .args
+        .opt_value_from_str("--files-max-size")
+        .map_err(|source| Termination::ParseError {
+            argument: "--files-max-size",
+            source,
+        })?;
+
+    if let Some(files_max_size) = files_max_size {
+        let files = configuration.files.get_or_insert_with(Default::default);
+        files.max_size = Some(files_max_size);
+    }
+
+    Ok(configuration)
+}

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -13,6 +13,7 @@ use rome_fs::OsFileSystem;
 use rome_service::{App, DynRef, Workspace, WorkspaceRef};
 
 mod commands;
+mod configuration;
 mod execute;
 mod metrics;
 mod panic;

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -703,7 +703,7 @@ fn file_too_large() {
 }
 
 #[test]
-fn file_too_large_custom_limit() {
+fn file_too_large_config_limit() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
@@ -722,7 +722,70 @@ fn file_too_large_custom_limit() {
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
-        "file_too_large_custom_limit",
+        "file_too_large_config_limit",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn file_too_large_cli_limit() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("check.js");
+    fs.insert(file_path.into(), "statement1();\nstatement2();");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("check"),
+            OsString::from("--files-max-size"),
+            OsString::from("16"),
+            file_path.as_os_str().into(),
+        ]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "file_too_large_cli_limit",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn files_max_size_parse_error() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("check.js");
+    fs.insert(file_path.into(), "statement1();\nstatement2();");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("check"),
+            OsString::from("--files-max-size"),
+            OsString::from("-1"),
+            file_path.as_os_str().into(),
+        ]),
+    );
+
+    match result {
+        Err(Termination::ParseError { argument, .. }) => assert_eq!(argument, "--files-max-size"),
+        _ => panic!("run_cli returned {result:?} for an invalid argument value, expected an error"),
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "files_max_size_parse_error",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -4,8 +4,8 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use crate::configs::{
-    CONFIG_LINTER_DISABLED, CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC, CONFIG_LINTER_IGNORED_FILES,
-    CONFIG_LINTER_SUPPRESSED_GROUP, CONFIG_LINTER_SUPPRESSED_RULE,
+    CONFIG_FILE_SIZE_LIMIT, CONFIG_LINTER_DISABLED, CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC,
+    CONFIG_LINTER_IGNORED_FILES, CONFIG_LINTER_SUPPRESSED_GROUP, CONFIG_LINTER_SUPPRESSED_RULE,
     CONFIG_LINTER_UPGRADE_DIAGNOSTIC,
 };
 use crate::snap_test::SnapshotPayload;
@@ -696,6 +696,33 @@ fn file_too_large() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "file_too_large",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn file_too_large_custom_limit() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(PathBuf::from("rome.json"), CONFIG_FILE_SIZE_LIMIT);
+
+    let file_path = Path::new("check.js");
+    fs.insert(file_path.into(), "statement1();\nstatement2();");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("check"), file_path.as_os_str().into()]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "file_too_large_custom_limit",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -1,6 +1,7 @@
 use crate::configs::{
-    CONFIG_DISABLED_FORMATTER, CONFIG_FORMAT, CONFIG_FORMATTER_IGNORED_DIRECTORIES,
-    CONFIG_FORMATTER_IGNORED_FILES, CONFIG_ISSUE_3175_1, CONFIG_ISSUE_3175_2,
+    CONFIG_DISABLED_FORMATTER, CONFIG_FILE_SIZE_LIMIT, CONFIG_FORMAT,
+    CONFIG_FORMATTER_IGNORED_DIRECTORIES, CONFIG_FORMATTER_IGNORED_FILES, CONFIG_ISSUE_3175_1,
+    CONFIG_ISSUE_3175_2,
 };
 use crate::snap_test::{markup_to_string, SnapshotPayload};
 use crate::{
@@ -12,7 +13,7 @@ use rome_console::{markup, BufferConsole};
 use rome_fs::{FileSystemExt, MemoryFileSystem};
 use rome_service::DynRef;
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // six spaces
 const CUSTOM_FORMAT_AFTER: &str = r#"function f() {
@@ -1057,6 +1058,33 @@ fn file_too_large() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "file_too_large",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn file_too_large_custom_limit() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(PathBuf::from("rome.json"), CONFIG_FILE_SIZE_LIMIT);
+
+    let file_path = Path::new("format.js");
+    fs.insert(file_path.into(), "statement1();\nstatement2();");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("format"), file_path.as_os_str().into()]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "file_too_large_custom_limit",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -1065,7 +1065,7 @@ fn file_too_large() {
 }
 
 #[test]
-fn file_too_large_custom_limit() {
+fn file_too_large_config_limit() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
@@ -1084,7 +1084,70 @@ fn file_too_large_custom_limit() {
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
-        "file_too_large_custom_limit",
+        "file_too_large_config_limit",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn file_too_large_cli_limit() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("format.js");
+    fs.insert(file_path.into(), "statement1();\nstatement2();");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("format"),
+            OsString::from("--files-max-size"),
+            OsString::from("16"),
+            file_path.as_os_str().into(),
+        ]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "file_too_large_cli_limit",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn files_max_size_parse_error() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("format.js");
+    fs.insert(file_path.into(), "statement1();\nstatement2();");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("format"),
+            OsString::from("--files-max-size"),
+            OsString::from("-1"),
+            file_path.as_os_str().into(),
+        ]),
+    );
+
+    match result {
+        Err(Termination::ParseError { argument, .. }) => assert_eq!(argument, "--files-max-size"),
+        _ => panic!("run_cli returned {result:?} for an invalid argument value, expected an error"),
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "files_max_size_parse_error",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -186,3 +186,9 @@ pub const CONFIG_LINTER_IGNORED_FILES: &str = r#"{
   }
 }
 "#;
+
+pub const CONFIG_FILE_SIZE_LIMIT: &str = r#"{
+  "files": {
+    "maxSize": 16
+  }
+}"#;

--- a/crates/rome_cli/tests/snapshots/main_commands_check/file_too_large.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/file_too_large.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 223
 expression: content
 ---
 # Emitted Messages
@@ -7,7 +8,7 @@ expression: content
 ```block
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The file check.js could not be parsed because it's too large (the file is 1.0 MiB long, but the size limit is 1.0 MiB)
+  × Size of check.js is 1.0 MiB which exceeds the project maximum of 1.0 MiB. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_check/file_too_large_cli_limit.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/file_too_large_cli_limit.snap
@@ -3,12 +3,19 @@ source: crates/rome_cli/tests/snap_test.rs
 assertion_line: 223
 expression: content
 ---
+## `check.js`
+
+```js
+statement1();
+statement2();
+```
+
 # Emitted Messages
 
 ```block
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_check/file_too_large_config_limit.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/file_too_large_config_limit.snap
@@ -3,12 +3,29 @@ source: crates/rome_cli/tests/snap_test.rs
 assertion_line: 223
 expression: content
 ---
+## `rome.json`
+
+```json
+{
+  "files": {
+    "maxSize": 16
+  }
+}
+```
+
+## `check.js`
+
+```js
+statement1();
+statement2();
+```
+
 # Emitted Messages
 
 ```block
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of check.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of check.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_check/files_max_size_parse_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/files_max_size_parse_error.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 223
+expression: content
+---
+## `check.js`
+
+```js
+statement1();
+statement2();
+```
+
+# Termination Message
+
+```block
+failed to parse argument '--files-max-size': failed to parse '-1': invalid digit found in string
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/file_too_large.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/file_too_large.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 223
 expression: content
 ---
 # Emitted Messages
@@ -7,7 +8,7 @@ expression: content
 ```block
 ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The file ci.js could not be parsed because it's too large (the file is 1.0 MiB long, but the size limit is 1.0 MiB)
+  × Size of ci.js is 1.0 MiB which exceeds the project maximum of 1.0 MiB. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/file_too_large_cli_limit.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/file_too_large_cli_limit.snap
@@ -3,12 +3,19 @@ source: crates/rome_cli/tests/snap_test.rs
 assertion_line: 223
 expression: content
 ---
+## `ci.js`
+
+```js
+statement1();
+statement2();
+```
+
 # Emitted Messages
 
 ```block
 ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/file_too_large_config_limit.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/file_too_large_config_limit.snap
@@ -3,12 +3,29 @@ source: crates/rome_cli/tests/snap_test.rs
 assertion_line: 223
 expression: content
 ---
+## `rome.json`
+
+```json
+{
+  "files": {
+    "maxSize": 16
+  }
+}
+```
+
+## `ci.js`
+
+```js
+statement1();
+statement2();
+```
+
 # Emitted Messages
 
 ```block
 ci.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of ci.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of ci.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/files_max_size_parse_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/files_max_size_parse_error.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 223
+expression: content
+---
+## `ci.js`
+
+```js
+statement1();
+statement2();
+```
+
+# Termination Message
+
+```block
+failed to parse argument '--files-max-size': failed to parse '-1': invalid digit found in string
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/file_too_large.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/file_too_large.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 223
 expression: content
 ---
 # Emitted Messages
@@ -7,7 +8,7 @@ expression: content
 ```block
 format.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The file format.js could not be parsed because it's too large (the file is 1.0 MiB long, but the size limit is 1.0 MiB)
+  × Size of format.js is 1.0 MiB which exceeds the project maximum of 1.0 MiB. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_format/file_too_large_cli_limit.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/file_too_large_cli_limit.snap
@@ -3,12 +3,19 @@ source: crates/rome_cli/tests/snap_test.rs
 assertion_line: 223
 expression: content
 ---
+## `format.js`
+
+```js
+statement1();
+statement2();
+```
+
 # Emitted Messages
 
 ```block
 format.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of format.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of format.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_format/file_too_large_config_limit.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/file_too_large_config_limit.snap
@@ -3,12 +3,29 @@ source: crates/rome_cli/tests/snap_test.rs
 assertion_line: 223
 expression: content
 ---
+## `rome.json`
+
+```json
+{
+  "files": {
+    "maxSize": 16
+  }
+}
+```
+
+## `format.js`
+
+```js
+statement1();
+statement2();
+```
+
 # Emitted Messages
 
 ```block
 format.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Size of format.js is 1.0 MiB which exceeds configured maximum of 1.0 MiB for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  × Size of format.js is 27 B which exceeds configured maximum of 16 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_format/files_max_size_parse_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/files_max_size_parse_error.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 223
+expression: content
+---
+## `format.js`
+
+```js
+statement1();
+statement2();
+```
+
+# Termination Message
+
+```block
+failed to parse argument '--files-max-size': failed to parse '-1': invalid digit found in string
+```
+
+

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -327,6 +327,7 @@ where
 ///  )
 /// ```
 ///
+/// [WorkspaceSettings]: crate::settings::WorkspaceSettings
 /// [metadata]: rome_analyze::RegistryRuleMetadata
 /// [configuration for the analyzer]: AnalyzerConfiguration
 pub fn to_analyzer_configuration<ToGlobals>(

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -176,7 +176,7 @@ impl Display for RomeError {
                 write!(f, "The file {} was ignored", path.display())
             }
             RomeError::FileTooLarge { path, size, limit } => {
-                write!(f, "Size of {} is {} which exceeds the project maximum of {}. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.", path.display(), Bytes(*size), Bytes(*limit))
+                write!(f, "Size of {} is {} which exceeds configured maximum of {} for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.", path.display(), Bytes(*size), Bytes(*limit))
             }
         }
     }

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -176,7 +176,7 @@ impl Display for RomeError {
                 write!(f, "The file {} was ignored", path.display())
             }
             RomeError::FileTooLarge { path, size, limit } => {
-                write!(f, "The file {} could not be parsed because it's too large (the file is {} long, but the size limit is {})", path.display(), Bytes(*size), Bytes(*limit))
+                write!(f, "Size of {} is {} which exceeds the project maximum of {}. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.", path.display(), Bytes(*size), Bytes(*limit))
             }
         }
     }

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -191,6 +191,7 @@ pub struct FilesSettings {
     pub max_size: NonZeroU64,
 }
 
+/// Limit the size of files to 1.0 MiB by default
 const DEFAULT_FILE_SIZE_LIMIT: NonZeroU64 =
     // SAFETY: This constant is initialized with a non-zero value
     unsafe { NonZeroU64::new_unchecked(1024 * 1024) };

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -177,15 +177,19 @@ impl WorkspaceServer {
                     .parse
                     .ok_or_else(self.build_capability_error(rome_path))?;
 
-                /// Limit the size of files to 1.0 MiB
-                const SIZE_LIMIT_IN_BYTES: usize = 1024 * 1024;
+                let size_limit = {
+                    let settings = self.settings();
+                    let settings = settings.as_ref();
+                    let limit = settings.files.max_size.get();
+                    usize::try_from(limit).unwrap_or(usize::MAX)
+                };
 
                 let size = document.content.as_bytes().len();
-                if size >= SIZE_LIMIT_IN_BYTES {
+                if size >= size_limit {
                     return Err(RomeError::FileTooLarge {
                         path: rome_path.to_path_buf(),
                         size,
-                        limit: SIZE_LIMIT_IN_BYTES,
+                        limit: size_limit,
                     });
                 }
 

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -4,6 +4,17 @@
   "description": "The configuration that is contained inside the file `rome.json`",
   "type": "object",
   "properties": {
+    "files": {
+      "description": "The configuration of the filesystem",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FilesConfiguration"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "formatter": {
       "description": "The configuration of the formatter",
       "anyOf": [
@@ -332,6 +343,23 @@
           ]
         }
       }
+    },
+    "FilesConfiguration": {
+      "description": "The configuration of the filesystem",
+      "type": "object",
+      "properties": {
+        "maxSize": {
+          "description": "The maximum allowed size for source code files in bytes. Files above this limit will be ignore for performance reason. Defaults to 1 MiB",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      },
+      "additionalProperties": false
     },
     "FormatterConfiguration": {
       "type": "object",

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -28,6 +28,10 @@ export interface UpdateSettingsParams {
  */
 export interface Configuration {
 	/**
+	 * The configuration of the filesystem
+	 */
+	files?: FilesConfiguration;
+	/**
 	 * The configuration of the formatter
 	 */
 	formatter?: FormatterConfiguration;
@@ -39,6 +43,15 @@ export interface Configuration {
 	 * The configuration for the linter
 	 */
 	linter?: LinterConfiguration;
+}
+/**
+ * The configuration of the filesystem
+ */
+export interface FilesConfiguration {
+	/**
+	 * The maximum allowed size for source code files in bytes. Files above this limit will be ignore for performance reason. Defaults to 1 MiB
+	 */
+	maxSize?: number;
 }
 export interface FormatterConfiguration {
 	enabled?: boolean;


### PR DESCRIPTION
## Summary

This PR introduces a `files.maxSize` configuration to set the maximum allowed file size for the workspace. I've also reworded the error message that's emitted for skipped files to use the same messaging as Rome JS, that focuses on performance and doesn't mention parsing.

## Test Plan

I've added additional test cases for the CLI to check that the option is correctly applied, and update existing snapshots for the tests of the default limit with the new error message.
