### PR TITLE
ci: Fix version on windows build

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -35,16 +35,20 @@ jobs:
           file-name: npm/rome/package.json
 
       - name: Set version name
-        run: echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          echo "Version change found! New version: ${{ steps.version.outputs.version }} (${{ steps.version.outputs.version_type }})"
+          echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
+      - name: Set version name
+        if: steps.version.outputs.changed != 'true'
+        run: |
+          echo "version=$(node npm/rome/scripts/update-nightly-version.mjs)" >> $GITHUB_ENV
 
       - name: Check prerelease status
         id: prerelease
         if: env.nightly == 'true'
-        run: echo "prerelease=true" >> $GITHUB_ENV
-
-      - name: Check version status
-        if: steps.version.outputs.changed == 'true'
-        run: 'echo "Version change found! New version: ${{ steps.version.outputs.version }} (${{ steps.version.outputs.version_type }})"'
+        env:
+            prerelease: true
 
   build:
     strategy:
@@ -89,16 +93,10 @@ jobs:
         with:
           node-version: 14.x
 
-      - name: Set release infos
+      - name: Update Package.json
         if: needs.check.outputs.prerelease == 'true'
         run: |
-          echo "prerelease=true" >> $GITHUB_ENV
-          echo "version=$(node npm/rome/scripts/update-nightly-version.mjs)" >> $GITHUB_ENV
-      - name: Set release infos
-        if: needs.check.outputs.prerelease != 'true'
-        run: |
-          echo "prerelease=false" >> $GITHUB_ENV
-          echo "version=${{ needs.check.outputs.version }}" >> $GITHUB_ENV
+          node npm/rome/scripts/update-nightly-version.mjs
 
       - name: Install Rust toolchain
         run: rustup target add ${{ matrix.target }}

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -49,6 +49,7 @@ jobs:
         if: env.nightly == 'true'
         env:
             prerelease: true
+        run: echo "Create pre-release"
 
   build:
     strategy:
@@ -78,9 +79,11 @@ jobs:
 
     needs: check
     if: needs.check.outputs.version_changed == 'true' || needs.check.outputs.nightly == 'true'
+    env:
+        version: ${{ needs.check.outputs.version }}
     outputs:
       version: ${{ env.version }}
-      prerelease: ${{ env.prerelease }}
+      prerelease: ${{ needs.check.outputs.prerelease }}
 
     steps:
       - name: Checkout repository
@@ -92,11 +95,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 14.x
-
-      - name: Update Package.json
-        if: needs.check.outputs.prerelease == 'true'
-        run: |
-          node npm/rome/scripts/update-nightly-version.mjs
 
       - name: Install Rust toolchain
         run: rustup target add ${{ matrix.target }}

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -94,6 +94,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     needs: check
+    env:
+      version: ${{ needs.check.outputs.version }}
+      prerelease: ${{ needs.check.outputs.prerelease }}
+
     if: needs.check.outputs.version_changed == 'true' || needs.check.outputs.nightly == 'true'
     outputs:
       version: ${{ env.version }}

--- a/.github/workflows/release_lsp.yml
+++ b/.github/workflows/release_lsp.yml
@@ -150,12 +150,6 @@ jobs:
         working-directory: editors/vscode
         run: |
           node ./scripts/update-nightly-version.mjs >> $GITHUB_ENV
-          echo "prerelease=true" >> $GITHUB_ENV
-      - name: Set release infos
-        if: needs.check.outputs.prerelease != 'true'
-        run: |
-          echo "version=${{ needs.check.outputs.version }}" >> $GITHUB_ENV
-          echo "prerelease=${{ needs.check.outputs.prerelease }}" >> $GITHUB_ENV
 
       - name: Package extension
         run: |

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,9 +1,7 @@
 **
 !icon.png
 !LICENSE
-!node_modules/
 !out/main.js
-!package-lock.json
 !package.json
 !server/rome
 !server/rome.exe

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -8,16 +8,14 @@
 			"name": "rome",
 			"version": "0.16.1",
 			"license": "MIT",
-			"dependencies": {
-				"vscode-languageclient": "^8.0.2"
-			},
 			"devDependencies": {
 				"@types/node": "^18.0.0",
 				"@types/vscode": "^1.70.0",
 				"esbuild": "^0.14.47",
 				"rome": "next",
 				"typescript": "^4.8.2",
-				"vsce": "^2.11.0"
+				"vsce": "^2.11.0",
+				"vscode-languageclient": "^8.0.2"
 			},
 			"engines": {
 				"npm": "^8",
@@ -170,7 +168,8 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -227,6 +226,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -371,7 +371,8 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"node_modules/console-control-strings": {
 			"version": "1.1.0",
@@ -1144,6 +1145,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -1210,6 +1212,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -1824,6 +1827,7 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
 			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -1832,6 +1836,7 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
 			"integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+			"dev": true,
 			"dependencies": {
 				"minimatch": "^3.0.4",
 				"semver": "^7.3.5",
@@ -1845,6 +1850,7 @@
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
 			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -1859,6 +1865,7 @@
 			"version": "3.17.2",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
 			"integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+			"dev": true,
 			"dependencies": {
 				"vscode-jsonrpc": "8.0.2",
 				"vscode-languageserver-types": "3.17.2"
@@ -1867,7 +1874,8 @@
 		"node_modules/vscode-languageserver-types": {
 			"version": "3.17.2",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+			"dev": true
 		},
 		"node_modules/wide-align": {
 			"version": "1.1.5",
@@ -1909,7 +1917,8 @@
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/yauzl": {
 			"version": "2.10.0",
@@ -2036,7 +2045,8 @@
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
 		},
 		"base64-js": {
 			"version": "1.5.1",
@@ -2078,6 +2088,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2184,7 +2195,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"console-control-strings": {
 			"version": "1.1.0",
@@ -2670,6 +2682,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
 			}
@@ -2717,6 +2730,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -3202,12 +3216,14 @@
 		"vscode-jsonrpc": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
+			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+			"dev": true
 		},
 		"vscode-languageclient": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
 			"integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+			"dev": true,
 			"requires": {
 				"minimatch": "^3.0.4",
 				"semver": "^7.3.5",
@@ -3218,6 +3234,7 @@
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
 					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -3228,6 +3245,7 @@
 			"version": "3.17.2",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
 			"integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+			"dev": true,
 			"requires": {
 				"vscode-jsonrpc": "8.0.2",
 				"vscode-languageserver-types": "3.17.2"
@@ -3236,7 +3254,8 @@
 		"vscode-languageserver-types": {
 			"version": "3.17.2",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+			"dev": true
 		},
 		"wide-align": {
 			"version": "1.1.5",
@@ -3272,7 +3291,8 @@
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"yauzl": {
 			"version": "2.10.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -125,15 +125,13 @@
 		"pack:dev": "npm run compile && npm run package && npm run install-extension",
 		"tsc": "tsc"
 	},
-	"dependencies": {
-		"vscode-languageclient": "^8.0.2"
-	},
 	"devDependencies": {
 		"@types/node": "^18.0.0",
 		"@types/vscode": "^1.70.0",
 		"typescript": "^4.8.2",
 		"vsce": "^2.11.0",
 		"esbuild": "^0.14.47",
-		"rome": "next"
+		"rome": "next",
+		"vscode-languageclient": "^8.0.2"
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #3541 

This PR fixes an issue with our CI pipeline where it didn't set the ROME_VERSION env variable correctly. 

It took me a while to figure out the issue but the problem is that `"var=value" >> $GITHUB_ENV` doesn't work on windows builds where you must use `$Env::GITHUB_ENV` instead. 

I fixed it by:

* Moving the part where we write the version number to the *Check Version* job that always runs on linux builds
* Later only rely on `env` that works on all runners. 

This PR also removes the `node_moduels` folder from the published VS Code extension. It isn't necessary to publish `node_modules` because we pre-built the javascript file with `esbuild`. 

## Test Plan

Downloaded the artefacts from nightly builds and installed them locally. 

* Installed the VS Code extension and verified that formatting is working
* Ran `rome --version` and verified that it prints the version number

- [CLI Pipeline](https://github.com/rome/tools/actions/runs/3368219416)
- [LSP Pipeline](https://github.com/rome/tools/actions/runs/3368298838)
