### PR TITLE
feat(rome_cli): allow to skip checks in `rome ci` command

### DIFF
--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -58,7 +58,9 @@ const CI: Markup = markup! {
 
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
 
-"<Emphasis>"OPTIONS:"</Emphasis>""
+"<Emphasis>"OPTIONS:"</Emphasis>"
+    "<Dim>"--formatter-enabled"</Dim>"                      Allow to enable or disable the formatter check. (default: true)
+    "<Dim>"--linter-enabled"</Dim>"                         Allow to enable or disable the linter check. (default: true)"
     {FORMAT_OPTIONS}
 };
 

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_via_cli.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_formatter_via_cli.snap
@@ -2,17 +2,6 @@
 source: crates/rome_cli/tests/snap_test.rs
 expression: content
 ---
-## `rome.json`
-
-```json
-{
-  "formatter": {
-    "enabled": false
-  }
-}
-
-```
-
 ## `file.js`
 
 ```js

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter_via_cli.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/ci_does_not_run_linter_via_cli.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+statement(    ) ; let a = !b || !c;
+```
+
+# Termination Message
+
+```block
+errors where emitted while running checks
+```
+
+# Emitted Messages
+
+```block
+file.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × File content differs from formatting output
+  
+    1   │ - statement(····)·;·let·a·=·!b·||·!c;
+      1 │ + statement();
+      2 │ + let·a·=·!b·||·!c;
+      3 │ + 
+  
+
+```
+
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR introduces two new arguments to the `rome ci` command: `--format-enabled` and `--format-enabled`. This two arguments allow to skip specific checks during the traversal of files, allowing using `rome ci` without the usage of the `rome.json` file.

This should increase the DX in CI environments.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added two new test cases. 

I updated an existing text case, because it was using some source code that didn't fit the test case.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
