### PR TITLE
docs(website): fix an invalid diagnostic example for `useAnchorContent`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/a11y/use_anchor_content.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/use_anchor_content.rs
@@ -33,7 +33,7 @@ declare_rule! {
     /// ```
     ///
     /// ```jsx,expect_diagnostic
-    /// <a><span aria-hidden="true">content</span></a
+    /// <a><span aria-hidden="true">content</span></a>
     /// ```
     ///
     /// ## Valid
@@ -50,11 +50,11 @@ declare_rule! {
     /// ```
     ///
     /// ```jsx
-    /// <a><TextWrapper aria-hidden={true} /> content</a>
+    /// <a><TextWrapper aria-hidden={true} />content</a>
     /// ```
     ///
     /// ```jsx
-    /// <a><div aria-hidden="true"></div> content</a>
+    /// <a><div aria-hidden="true"></div>content</a>
     /// ```
     pub(crate) UseAnchorContent {
         version: "10.0.0",

--- a/website/src/docs/lint/rules/useAnchorContent.md
+++ b/website/src/docs/lint/rules/useAnchorContent.md
@@ -80,22 +80,18 @@ Accessible means that the content is not hidden using the `aria-hidden` attribut
 </code></pre>{% endraw %}
 
 ```jsx
-<a><span aria-hidden="true">content</span></a
+<a><span aria-hidden="true">content</span></a>
 ```
 
-{% raw %}<pre class="language-text"><code class="language-text">a11y/useAnchorContent.js:2:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{% raw %}<pre class="language-text"><code class="language-text">a11y/useAnchorContent.js:1:1 <a href="https://rome.tools/docs/lint/rules/useAnchorContent">lint/a11y/useAnchorContent</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">expected `&gt;` but instead the file ends</span>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Provide screen reader accessible content when using </span><span style="color: Tomato;"><strong>`a`</strong></span><span style="color: Tomato;"> elements.</span>
   
-    <strong>1 │ </strong>&lt;a&gt;&lt;span aria-hidden=&quot;true&quot;&gt;content&lt;/span&gt;&lt;/a
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>
-   <strong>   │ </strong>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;a&gt;&lt;span aria-hidden=&quot;true&quot;&gt;content&lt;/span&gt;&lt;/a&gt;
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">the file ends here</span>
-  
-    <strong>1 │ </strong>&lt;a&gt;&lt;span aria-hidden=&quot;true&quot;&gt;content&lt;/span&gt;&lt;/a
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>
-   <strong>   │ </strong>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">All links on a page should have content that is accessible to screen readers.</span>
   
 </code></pre>{% endraw %}
 
@@ -113,10 +109,10 @@ function html() {
 ```
 
 ```jsx
-<a><TextWrapper aria-hidden={true} /> content</a>
+<a><TextWrapper aria-hidden={true} />content</a>
 ```
 
 ```jsx
-<a><div aria-hidden="true"></div> content</a>
+<a><div aria-hidden="true"></div>content</a>
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

There is an invalid diagnostic example for [`useAnchorContent`](https://rome.tools/docs/lint/rules/useanchorcontent/). This PR fixes the issue.
<img width="867" alt="issue" src="https://user-images.githubusercontent.com/30640930/199265780-05c2b1d3-2453-4f99-b179-fe0872e9d677.png">

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
PR checks