### PR TITLE
doc(rome_cli): Use permalinks in `rome init`

### DIFF
--- a/crates/rome_cli/src/commands/init.rs
+++ b/crates/rome_cli/src/commands/init.rs
@@ -1,27 +1,33 @@
 use crate::{CliSession, Termination};
-use rome_console::{markup, ConsoleExt};
+use rome_console::{markup, ConsoleExt, HorizontalLine};
 use rome_service::configuration::Configuration;
 use rome_service::create_config;
 
 pub(crate) fn init(mut session: CliSession) -> Result<(), Termination> {
     let fs = &mut session.app.fs;
     create_config(fs, Configuration::default())?;
-    let message = markup! {
-    <Info><Emphasis>"Files created:"</Emphasis></Info>"
-\t"<Emphasis>"- rome.json: "</Emphasis>"Your project configuration. Documentation: "<Underline>"https://rome.tools/docs/configuration"</Underline>"
 
-"<Info><Emphasis>"Next Steps:"</Emphasis></Info>"
-\t1. "<Emphasis>"Setup your editor:"</Emphasis>"
-\t\tGet live errors as you type and format when you save. Learn more: "<Underline>"https://rome.tools/editors"</Underline>"
-\t2. "<Emphasis>"Try a command"</Emphasis>"
-\t\t"<Italic>"rome ci"</Italic>" is used to validate your code, verify formatting, and check for lint errors. Run " <Italic>"rome --help"</Italic>" for a full list of commands and flags
-\t3. "<Emphasis>"Read the documentation"</Emphasis>"
-\t\tOur website serves as a comprehensive source of guides and documentation: "<Underline>"https://rome.tools/docs"</Underline>"
-\t4. "<Emphasis>"Get involved in the community"</Emphasis>"
-\t\tAsk questions, get support, or contribute by participating on GitHub ("<Underline>"https://github.com/rome/tools"</Underline>"), or our community Discord ("<Underline>"https://discord.gg/rome"</Underline>")"
-        };
+    session.app.console.log(markup! {
+"\n"<Inverse>"Welcome to Rome! Let's get you started..."</Inverse>"
 
-    session.app.console.log(message);
+"<Info><Emphasis>"Files created "</Emphasis></Info>{HorizontalLine::new(136)}"
+
+  "<Dim>"- "</Dim><Emphasis>"rome.json: "</Emphasis>"Your project configuration. Documentation: https://rome.tools/configuration
+
+"<Info><Emphasis>"Next Steps "</Emphasis></Info>{HorizontalLine::new(139)}"
+
+  "<Dim>"1."</Dim>" "<Emphasis>"Setup an editor extension"</Emphasis>"
+     Get live errors as you type and format when you save. Learn more: https://rome.tools/editors
+
+  "<Dim>"2."</Dim>" "<Emphasis>"Try a command"</Emphasis>"
+     "<Italic>"rome ci"</Italic>" checks for lint errors and verifies formatting. Run " <Italic>"rome --help"</Italic>" for a full list of commands and options.
+
+  "<Dim>"3."</Dim>" "<Emphasis>"Read the documentation"</Emphasis>"
+     Our website serves as a comprehensive source of guides and documentation: https://rome.tools/docs
+
+  "<Dim>"4."</Dim>" "<Emphasis>"Get involved in the community"</Emphasis>"
+     Ask questions, get support, or contribute by participating on GitHub (https://github.com/rome/tools), or join our community Discord (https://discord.gg/rome)"
+        });
 
     Ok(())
 }

--- a/crates/rome_cli/src/commands/init.rs
+++ b/crates/rome_cli/src/commands/init.rs
@@ -12,21 +12,21 @@ pub(crate) fn init(mut session: CliSession) -> Result<(), Termination> {
 
 "<Info><Emphasis>"Files created "</Emphasis></Info>{HorizontalLine::new(136)}"
 
-  "<Dim>"- "</Dim><Emphasis>"rome.json: "</Emphasis>"Your project configuration. Documentation: https://rome.tools/configuration
+  "<Dim>"- "</Dim><Emphasis>"rome.json: "</Emphasis>"Your project configuration ("<Hyperlink href="https://rome.tools/configuration">"Documentation"</Hyperlink>").
 
 "<Info><Emphasis>"Next Steps "</Emphasis></Info>{HorizontalLine::new(139)}"
 
   "<Dim>"1."</Dim>" "<Emphasis>"Setup an editor extension"</Emphasis>"
-     Get live errors as you type and format when you save. Learn more: https://rome.tools/editors
+     Get live errors as you type and format when you save. "<Hyperlink href="https://rome.tools/editors">"Learn more"</Hyperlink>".
 
   "<Dim>"2."</Dim>" "<Emphasis>"Try a command"</Emphasis>"
      "<Italic>"rome ci"</Italic>" checks for lint errors and verifies formatting. Run " <Italic>"rome --help"</Italic>" for a full list of commands and options.
 
   "<Dim>"3."</Dim>" "<Emphasis>"Read the documentation"</Emphasis>"
-     Our website serves as a comprehensive source of guides and documentation: https://rome.tools/docs
+     Our "<Hyperlink href="https://rome.tools/docs">"website"</Hyperlink>" serves as a comprehensive source of guides and documentation.
 
   "<Dim>"4."</Dim>" "<Emphasis>"Get involved in the community"</Emphasis>"
-     Ask questions, get support, or contribute by participating on GitHub (https://github.com/rome/tools), or join our community Discord (https://discord.gg/rome)"
+     Ask questions, get support, or contribute by participating on "<Hyperlink href="https://github.com/rome/tools">"GitHub"</Hyperlink>", or join our community "<Hyperlink href="https://discord.gg/rome">"Discord"</Hyperlink>"."
         });
 
     Ok(())

--- a/crates/rome_cli/src/commands/init.rs
+++ b/crates/rome_cli/src/commands/init.rs
@@ -8,11 +8,11 @@ pub(crate) fn init(mut session: CliSession) -> Result<(), Termination> {
     create_config(fs, Configuration::default())?;
     let message = markup! {
     <Info><Emphasis>"Files created:"</Emphasis></Info>"
-\t"<Emphasis>"- rome.json: "</Emphasis>"Your project configuration. Documentation: "<Underline>"https://rome.tools/docs/#configuration"</Underline>"
+\t"<Emphasis>"- rome.json: "</Emphasis>"Your project configuration. Documentation: "<Underline>"https://rome.tools/docs/configuration"</Underline>"
 
 "<Info><Emphasis>"Next Steps:"</Emphasis></Info>"
 \t1. "<Emphasis>"Setup your editor:"</Emphasis>"
-\t\tGet live errors as you type and format when you save. Learn more: "<Underline>"https://rome.tools/#editor-setup"</Underline>"
+\t\tGet live errors as you type and format when you save. Learn more: "<Underline>"https://rome.tools/editors"</Underline>"
 \t2. "<Emphasis>"Try a command"</Emphasis>"
 \t\t"<Italic>"rome ci"</Italic>" is used to validate your code, verify formatting, and check for lint errors. Run " <Italic>"rome --help"</Italic>" for a full list of commands and flags
 \t3. "<Emphasis>"Read the documentation"</Emphasis>"

--- a/crates/rome_cli/src/commands/init.rs
+++ b/crates/rome_cli/src/commands/init.rs
@@ -10,24 +10,25 @@ pub(crate) fn init(mut session: CliSession) -> Result<(), Termination> {
     session.app.console.log(markup! {
 "\n"<Inverse>"Welcome to Rome! Let's get you started..."</Inverse>"
 
-"<Info><Emphasis>"Files created "</Emphasis></Info>{HorizontalLine::new(136)}"
+"<Info><Emphasis>"Files created "</Emphasis></Info>{HorizontalLine::new(106)}"
 
-  "<Dim>"- "</Dim><Emphasis>"rome.json: "</Emphasis>"Your project configuration ("<Hyperlink href="https://rome.tools/configuration">"Documentation"</Hyperlink>").
+  "<Dim>"- "</Dim><Emphasis>"rome.json: "</Emphasis>"Your project configuration. Documentation: "<Hyperlink href="https://rome.tools/configuration">"https://rome.tools/configuration"</Hyperlink>"
 
-"<Info><Emphasis>"Next Steps "</Emphasis></Info>{HorizontalLine::new(139)}"
+"<Info><Emphasis>"Next Steps "</Emphasis></Info>{HorizontalLine::new(109)}"
 
   "<Dim>"1."</Dim>" "<Emphasis>"Setup an editor extension"</Emphasis>"
-     Get live errors as you type and format when you save. "<Hyperlink href="https://rome.tools/editors">"Learn more"</Hyperlink>".
+     Get live errors as you type and format when you save. Learn more: "<Hyperlink href="https://rome.tools/editors">"https://rome.tools/editors"</Hyperlink>"
 
   "<Dim>"2."</Dim>" "<Emphasis>"Try a command"</Emphasis>"
      "<Italic>"rome ci"</Italic>" checks for lint errors and verifies formatting. Run " <Italic>"rome --help"</Italic>" for a full list of commands and options.
 
   "<Dim>"3."</Dim>" "<Emphasis>"Read the documentation"</Emphasis>"
-     Our "<Hyperlink href="https://rome.tools/docs">"website"</Hyperlink>" serves as a comprehensive source of guides and documentation.
+     Our website serves as a comprehensive source of guides and documentation: "<Hyperlink href="https://rome.tools/docs">"https://rome.tools/docs"</Hyperlink>"
 
   "<Dim>"4."</Dim>" "<Emphasis>"Get involved in the community"</Emphasis>"
-     Ask questions, get support, or contribute by participating on "<Hyperlink href="https://github.com/rome/tools">"GitHub"</Hyperlink>", or join our community "<Hyperlink href="https://discord.gg/rome">"Discord"</Hyperlink>"."
-        });
+     Ask questions, get support, or contribute by participating on GitHub ("<Hyperlink href="https://github.com/rome/tools">"https://github.com/rome/tools"</Hyperlink>"),
+     or join our community Discord ("<Hyperlink href="https://discord.gg/rome">"https://discord.gg/rome"</Hyperlink>")"
+    });
 
     Ok(())
 }

--- a/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 223
 expression: content
 ---
 ## `rome.json`
@@ -24,21 +23,21 @@ Welcome to Rome! Let's get you started...
 
 Files created ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  - rome.json: Your project configuration. Documentation: https://rome.tools/configuration
+  - rome.json: Your project configuration (Documentation).
 
 Next Steps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   1. Setup an editor extension
-     Get live errors as you type and format when you save. Learn more: https://rome.tools/editors
+     Get live errors as you type and format when you save. Learn more.
 
   2. Try a command
      rome ci checks for lint errors and verifies formatting. Run rome --help for a full list of commands and options.
 
   3. Read the documentation
-     Our website serves as a comprehensive source of guides and documentation: https://rome.tools/docs
+     Our website serves as a comprehensive source of guides and documentation.
 
   4. Get involved in the community
-     Ask questions, get support, or contribute by participating on GitHub (https://github.com/rome/tools), or join our community Discord (https://discord.gg/rome)
+     Ask questions, get support, or contribute by participating on GitHub, or join our community Discord.
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 218
+assertion_line: 223
 expression: content
 ---
 ## `rome.json`
@@ -19,18 +19,26 @@ expression: content
 # Emitted Messages
 
 ```block
-Files created:
-	- rome.json: Your project configuration. Documentation: https://rome.tools/docs/#configuration
 
-Next Steps:
-	1. Setup your editor:
-		Get live errors as you type and format when you save. Learn more: https://rome.tools/#editor-setup
-	2. Try a command
-		rome ci is used to validate your code, verify formatting, and check for lint errors. Run rome --help for a full list of commands and flags
-	3. Read the documentation
-		Our website serves as a comprehensive source of guides and documentation: https://rome.tools/docs
-	4. Get involved in the community
-		Ask questions, get support, or contribute by participating on GitHub (https://github.com/rome/tools), or our community Discord (https://discord.gg/rome)
+Welcome to Rome! Let's get you started...
+
+Files created ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  - rome.json: Your project configuration. Documentation: https://rome.tools/configuration
+
+Next Steps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  1. Setup an editor extension
+     Get live errors as you type and format when you save. Learn more: https://rome.tools/editors
+
+  2. Try a command
+     rome ci checks for lint errors and verifies formatting. Run rome --help for a full list of commands and options.
+
+  3. Read the documentation
+     Our website serves as a comprehensive source of guides and documentation: https://rome.tools/docs
+
+  4. Get involved in the community
+     Ask questions, get support, or contribute by participating on GitHub (https://github.com/rome/tools), or join our community Discord (https://discord.gg/rome)
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
@@ -21,23 +21,24 @@ expression: content
 
 Welcome to Rome! Let's get you started...
 
-Files created ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Files created ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  - rome.json: Your project configuration (Documentation).
+  - rome.json: Your project configuration. Documentation: https://rome.tools/configuration
 
-Next Steps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Next Steps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   1. Setup an editor extension
-     Get live errors as you type and format when you save. Learn more.
+     Get live errors as you type and format when you save. Learn more: https://rome.tools/editors
 
   2. Try a command
      rome ci checks for lint errors and verifies formatting. Run rome --help for a full list of commands and options.
 
   3. Read the documentation
-     Our website serves as a comprehensive source of guides and documentation.
+     Our website serves as a comprehensive source of guides and documentation: https://rome.tools/docs
 
   4. Get involved in the community
-     Ask questions, get support, or contribute by participating on GitHub, or join our community Discord.
+     Ask questions, get support, or contribute by participating on GitHub (https://github.com/rome/tools),
+     or join our community Discord (https://discord.gg/rome)
 ```
 
 

--- a/website/src/_includes/docs/configuration.md
+++ b/website/src/_includes/docs/configuration.md
@@ -1,3 +1,4 @@
+<!-- Make sure to update the redirect in `static/_redirects` when changing the configuration title -->
 ## Configuration
 
 The configuration file is considered **optional**, Rome has good defaults. Use the configuration

--- a/website/src/_includes/docs/formatter.md
+++ b/website/src/_includes/docs/formatter.md
@@ -9,7 +9,7 @@ The language agnostic options supported by Rome are:
 
 - indent style (default: `tabs`): Use spaces or tabs for indention
 - tab width (default: `2`): The number of spaces per indention level
-- line width (default: `80)`: The column width at which Rome wraps code
+- line width (default: `80`): The column width at which Rome wraps code
 
 ### Use the formatter with the CLI
 

--- a/website/src/_includes/docs/getting-started.md
+++ b/website/src/_includes/docs/getting-started.md
@@ -109,7 +109,7 @@ yarn run rome format <files> --write
 ```
 
 
-
+<!-- Make sure to update the redirect in `static/_redirects` when changing the editors title -->
 ### Editor Setup
 
 We recommend installing our editor integration to get the most out of Rome. The Rome editor integration allows you to:

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,0 +1,3 @@
+# URLs used in the CLI `init` command.
+/editors						/docs/#editor-setup
+/configuration 			/docs/#configuration-1


### PR DESCRIPTION
## Summary

This PR sets up static permalinks for the URLs used by the CLI so that changes to the website structure no longer require updating the CLI. 

This PR also slightly improves the rendering of the `rome init` command.

## Test Plan

* I opened the permalinks from my browser and verified that they redirect me to the correct sections

![Output of rome init](https://user-images.githubusercontent.com/1203881/199454848-d04acd59-0ca7-456b-be2c-79b0c6a85f72.png)


