### PR TITLE
fix(rome_js_formatter): make empty line after hashbang optional

### DIFF
--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -31,8 +31,7 @@ pub(crate) use object_like::JsObjectLike;
 pub(crate) use object_pattern_like::JsObjectPatternLike;
 use rome_formatter::{format_args, write, Buffer};
 use rome_js_syntax::{
-    JsAnyExpression, JsAnyStatement, JsCallExpression, JsInitializerClause, JsLanguage,
-    JsSyntaxKind, Modifiers,
+    JsAnyExpression, JsAnyStatement, JsCallExpression, JsInitializerClause, JsLanguage, Modifiers,
 };
 use rome_js_syntax::{JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, AstNodeList};
@@ -125,10 +124,15 @@ impl<'a> FormatInterpreterToken<'a> {
 impl Format<JsFormatContext> for FormatInterpreterToken<'_> {
     fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
         if let Some(interpreter) = self.token {
-            if interpreter.kind() == JsSyntaxKind::JS_SHEBANG {
-                write!(f, [interpreter.format(), hard_line_break()])
+            if let Some(token) = interpreter.next_token() {
+                // the interpreter line + empty line = 2
+                if get_lines_before_token(&token) >= 2 {
+                    write!(f, [interpreter.format(), empty_line()])
+                } else {
+                    write!(f, [interpreter.format(), hard_line_break()])
+                }
             } else {
-                write!(f, [interpreter.format(), empty_line()])
+                Ok(())
             }
         } else {
             Ok(())

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -124,15 +124,14 @@ impl<'a> FormatInterpreterToken<'a> {
 impl Format<JsFormatContext> for FormatInterpreterToken<'_> {
     fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
         if let Some(interpreter) = self.token {
-            if let Some(token) = interpreter.next_token() {
-                // the interpreter line + empty line = 2
-                if get_lines_before_token(&token) >= 2 {
-                    write!(f, [interpreter.format(), empty_line()])
-                } else {
-                    write!(f, [interpreter.format(), hard_line_break()])
-                }
-            } else {
-                Ok(())
+            write!(f, [interpreter.format()])?;
+
+            match interpreter
+                .next_token()
+                .map_or(0, |next_token| get_lines_before_token(&next_token))
+            {
+                0 | 1 => write!(f, [hard_line_break()]),
+                _ => write!(f, [empty_line()]),
             }
         } else {
             Ok(())

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use object_like::JsObjectLike;
 pub(crate) use object_pattern_like::JsObjectPatternLike;
 use rome_formatter::{format_args, write, Buffer};
 use rome_js_syntax::{
-    JsAnyExpression, JsAnyStatement, JsCallExpression, JsInitializerClause, JsLanguage, Modifiers,
+    JsAnyExpression, JsAnyStatement, JsCallExpression, JsInitializerClause, JsLanguage, Modifiers, JsSyntaxKind,
 };
 use rome_js_syntax::{JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, AstNodeList};
@@ -124,7 +124,11 @@ impl<'a> FormatInterpreterToken<'a> {
 impl Format<JsFormatContext> for FormatInterpreterToken<'_> {
     fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
         if let Some(interpreter) = self.token {
-            write!(f, [interpreter.format(), empty_line()])
+            if interpreter.kind() == JsSyntaxKind::JS_SHEBANG {
+                write!(f, [interpreter.format(), hard_line_break()])
+            } else {
+                write!(f, [interpreter.format(), empty_line()])
+            }
         } else {
             Ok(())
         }

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -31,7 +31,8 @@ pub(crate) use object_like::JsObjectLike;
 pub(crate) use object_pattern_like::JsObjectPatternLike;
 use rome_formatter::{format_args, write, Buffer};
 use rome_js_syntax::{
-    JsAnyExpression, JsAnyStatement, JsCallExpression, JsInitializerClause, JsLanguage, Modifiers, JsSyntaxKind,
+    JsAnyExpression, JsAnyStatement, JsCallExpression, JsInitializerClause, JsLanguage,
+    JsSyntaxKind, Modifiers,
 };
 use rome_js_syntax::{JsSyntaxNode, JsSyntaxToken};
 use rome_rowan::{AstNode, AstNodeList};

--- a/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
@@ -29,7 +29,6 @@ Trailing comma: All
 
 ```js
 #!/usr/bin/env node
-
 console.log(1);
 
 console.log(1);

--- a/crates/rome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+
+console.log(1)

--- a/crates/rome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: interpreter_with_empty_line.js
+---
+
+# Input
+
+```js
+#!/usr/bin/env node
+
+
+console.log(1)
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+-----
+
+```js
+#!/usr/bin/env node
+
+console.log(1);
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
@@ -30,7 +30,6 @@ Trailing comma: All
 
 ```js
 #!/usr/bin/env node
-
 "use strict";
 "use asm";
 var express = require("express");

--- a/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
@@ -30,7 +30,6 @@ Trailing comma: All
 
 ```js
 #!/usr/bin/env node
-
 "use strict";
 "use asm";
 var express = require("express");


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
Closes #3497

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
I updated snapshot results by `cargo insta review`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
