### PR TITLE
feat(rome_analyze): suppress rule via code actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -1823,6 +1824,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -18,6 +18,7 @@ rustc-hash = { workspace = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["raw_value"]}
 schemars = { version = "0.8.10", optional = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 rome_js_syntax = { path = "../rome_js_syntax" }

--- a/crates/rome_analyze/src/categories.rs
+++ b/crates/rome_analyze/src/categories.rs
@@ -20,6 +20,9 @@ pub enum RuleCategory {
     Action,
 }
 
+/// Actions that suppress rules should start with this string
+pub const SUPPRESSION_ACTION_CATEGORY: &str = "quickfix.rome.suppressRule";
+
 /// The category of a code action, this type maps directly to the
 /// [CodeActionKind] type in the Language Server Protocol specification
 ///

--- a/crates/rome_analyze/src/categories.rs
+++ b/crates/rome_analyze/src/categories.rs
@@ -21,7 +21,7 @@ pub enum RuleCategory {
 }
 
 /// Actions that suppress rules should start with this string
-pub const SUPPRESSION_ACTION_CATEGORY: &str = "quickfix.rome.suppressRule";
+pub const SUPPRESSION_ACTION_CATEGORY: &str = "quickfix.suppressRule";
 
 /// The category of a code action, this type maps directly to the
 /// [CodeActionKind] type in the Language Server Protocol specification

--- a/crates/rome_analyze/src/categories.rs
+++ b/crates/rome_analyze/src/categories.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use bitflags::bitflags;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -35,7 +35,7 @@ pub use crate::registry::{
 };
 pub use crate::rule::{
     CategoryLanguage, GroupCategory, GroupLanguage, Rule, RuleAction, RuleDiagnostic, RuleGroup,
-    RuleMeta, RuleMetadata,
+    RuleMeta, RuleMetadata, SuppressAction,
 };
 pub use crate::services::{FromServices, MissingServicesDiagnostic, ServiceBag};
 use crate::signals::DiagnosticSignal;

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -685,14 +685,18 @@ fn update_suppression<L: Language>(
 }
 
 /// Convenient type that to mark a function that is responsible to create a mutation to add a suppression comment.
-/// - `token_offset`: the possible offset found in the [TextRange] of the emitted diagnostic
-/// - `mutation`: a [BatchMutation] where the consumer can apply the suppression comment
-/// - `suppression_text`: a string equals to "rome-ignore: lint(<RULE_GROUP>/<RULE_NAME>)"
-type SuppressionCommentEmitter<L> = fn(
-    token_offset: TokenAtOffset<SyntaxToken<L>>,
-    mutation: &mut BatchMutation<L>,
-    suppression_text: &str,
-);
+pub struct SuppressionCommentEmitterPayload<'a, L: Language> {
+    /// The possible offset found in the [TextRange] of the emitted diagnostic
+    pub token_offset: TokenAtOffset<SyntaxToken<L>>,
+    /// A [BatchMutation] where the consumer can apply the suppression comment
+    pub mutation: &'a mut BatchMutation<L>,
+    /// A string equals to "rome-ignore: lint(<RULE_GROUP>/<RULE_NAME>)"
+    pub suppression_text: &'a str,
+    /// The original range of the diagnostic where the rule was triggered
+    pub diagnostic_text_range: &'a TextRange,
+}
+
+type SuppressionCommentEmitter<L> = fn(SuppressionCommentEmitterPayload<L>);
 
 type SignalHandler<'a, L, Break> = &'a mut dyn FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<Break>;
 

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -692,7 +692,7 @@ type SuppressionCommentEmitter<L> = fn(
     token_offset: TokenAtOffset<SyntaxToken<L>>,
     mutation: &mut BatchMutation<L>,
     suppression_text: &str,
-) -> ();
+);
 
 type SignalHandler<'a, L, Break> = &'a mut dyn FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<Break>;
 

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -684,7 +684,7 @@ fn update_suppression<L: Language>(
     })
 }
 
-/// Convenient type that to mark a function that is responsible to create a mutation to add a suppression comment.
+/// Payload received by the function responsible to mark a suppression comment
 pub struct SuppressionCommentEmitterPayload<'a, L: Language> {
     /// The possible offset found in the [TextRange] of the emitted diagnostic
     pub token_offset: TokenAtOffset<SyntaxToken<L>>,
@@ -696,6 +696,7 @@ pub struct SuppressionCommentEmitterPayload<'a, L: Language> {
     pub diagnostic_text_range: &'a TextRange,
 }
 
+/// Convenient type that to mark a function that is responsible to create a mutation to add a suppression comment.
 type SuppressionCommentEmitter<L> = fn(SuppressionCommentEmitterPayload<L>);
 
 type SignalHandler<'a, L, Break> = &'a mut dyn FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<Break>;

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -2,7 +2,7 @@ use crate::{
     AnalyzerOptions, AnalyzerSignal, Phases, QueryMatch, Rule, RuleFilter, RuleGroup, ServiceBag,
     SuppressionCommentEmitter,
 };
-use rome_diagnostics::file::FileId;
+use rome_diagnostics::FileId;
 use rome_rowan::{Language, TextRange};
 use std::{cmp::Ordering, collections::BinaryHeap};
 

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -1,11 +1,10 @@
-use std::{cmp::Ordering, collections::BinaryHeap};
-
-use rome_diagnostics::location::FileId;
-use rome_rowan::{Language, TextRange};
-
 use crate::{
     AnalyzerOptions, AnalyzerSignal, Phases, QueryMatch, Rule, RuleFilter, RuleGroup, ServiceBag,
+    SuppressionCommentEmitter,
 };
+use rome_diagnostics::file::FileId;
+use rome_rowan::{Language, TextRange};
+use std::{cmp::Ordering, collections::BinaryHeap};
 
 /// The [QueryMatcher] trait is responsible of running lint rules on
 /// [QueryMatch] instances emitted by the various [Visitor](crate::Visitor)
@@ -24,6 +23,7 @@ pub struct MatchQueryParams<'phase, 'query, L: Language> {
     pub services: &'phase ServiceBag,
     pub signal_queue: &'query mut BinaryHeap<SignalEntry<'phase, L>>,
     pub options: &'query AnalyzerOptions,
+    pub apply_suppression_comment: SuppressionCommentEmitter<L>,
 }
 
 /// Opaque identifier for a group of rule
@@ -330,6 +330,7 @@ mod tests {
             &metadata,
             SuppressionMatcher,
             parse_suppression_comment,
+            |_, _, _| unreachable!(),
             &mut emit_signal,
         );
 

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -330,7 +330,7 @@ mod tests {
             &metadata,
             SuppressionMatcher,
             parse_suppression_comment,
-            |_, _, _| unreachable!(),
+            |_| unreachable!(),
             &mut emit_signal,
         );
 

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -1,9 +1,3 @@
-use std::{borrow, collections::BTreeSet};
-
-use rome_diagnostics::Error;
-use rome_rowan::{AstNode, Language, RawSyntaxKind, SyntaxKind, SyntaxNode};
-use rustc_hash::FxHashSet;
-
 use crate::{
     context::RuleContext,
     matcher::{GroupKey, MatchQueryParams},
@@ -12,6 +6,10 @@ use crate::{
     AnalysisFilter, GroupCategory, QueryMatcher, Rule, RuleGroup, RuleKey, RuleMetadata,
     SignalEntry,
 };
+use rome_diagnostics::Error;
+use rome_rowan::{AstNode, Language, RawSyntaxKind, SyntaxKind, SyntaxNode};
+use rustc_hash::FxHashSet;
+use std::{borrow, collections::BTreeSet};
 
 /// Defines all the phases that the [RuleRegistry] supports.
 #[repr(usize)]
@@ -365,6 +363,7 @@ impl<L: Language + Default> RegistryRule<L> {
                     result,
                     params.services,
                     params.options.clone(),
+                    params.apply_suppression_comment,
                 ));
 
                 params.signal_queue.push(SignalEntry {

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -493,6 +493,7 @@ pub struct RuleAction<L: Language> {
     pub mutation: BatchMutation<L>,
 }
 
+/// An action meant to suppress a lint rule
 pub struct SuppressAction<L: Language>(SyntaxNode<L>);
 
 impl<L: Language> SuppressAction<L> {

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -338,18 +338,19 @@ pub trait Rule: RuleMeta + Sized {
     ) -> Option<SuppressAction<RuleLanguage<Self>>> {
         // if the rule belongs to `Lint`, we auto generate an action to suppress the rule
         if <Self::Group as RuleGroup>::Category::CATEGORY == RuleCategory::Lint {
-            let suppression_text = format!(
-                "rome-ignore: lint/{}/{}",
+            let rule_category = format!(
+                "lint/{}/{}",
                 <Self::Group as RuleGroup>::NAME,
                 Self::METADATA.name
             );
+            let suppression_text = format!("rome-ignore {}", rule_category);
             let mut mutation = ctx.root().begin();
             let token = ctx.root().syntax().token_at_offset(text_range.end());
             apply_suppression_comment(token, &mut mutation, suppression_text.as_str());
 
             Some(SuppressAction {
                 mutation,
-                message: markup! { "Suppress rule " {suppression_text} }.to_owned(),
+                message: markup! { "Suppress rule " {rule_category} }.to_owned(),
             })
         } else {
             None

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -345,7 +345,7 @@ pub trait Rule: RuleMeta + Sized {
             );
             let suppression_text = format!("rome-ignore {}", rule_category);
             let mut mutation = ctx.root().begin();
-            let token = ctx.root().syntax().token_at_offset(text_range.end());
+            let token = ctx.root().syntax().token_at_offset(text_range.start());
             apply_suppression_comment(token, &mut mutation, suppression_text.as_str());
 
             Some(SuppressAction {

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -353,7 +353,7 @@ pub trait Rule: RuleMeta + Sized {
                 suppression_text: suppression_text.as_str(),
                 mutation: &mut mutation,
                 token_offset: token,
-                diagnostic_text_range: &text_range,
+                diagnostic_text_range: text_range,
             });
 
             Some(SuppressAction {

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -1,7 +1,10 @@
 use crate::categories::{ActionCategory, RuleCategory};
 use crate::context::RuleContext;
 use crate::registry::{RegistryVisitor, RuleLanguage, RuleSuppressions};
-use crate::{AnalyzerDiagnostic, Phase, Phases, Queryable, SuppressionCommentEmitter};
+use crate::{
+    AnalyzerDiagnostic, Phase, Phases, Queryable, SuppressionCommentEmitter,
+    SuppressionCommentEmitterPayload,
+};
 use rome_console::fmt::Display;
 use rome_console::{markup, MarkupBuf};
 use rome_diagnostics::advice::CodeSuggestionAdvice;
@@ -346,7 +349,12 @@ pub trait Rule: RuleMeta + Sized {
             let suppression_text = format!("rome-ignore {}", rule_category);
             let mut mutation = ctx.root().begin();
             let token = ctx.root().syntax().token_at_offset(text_range.start());
-            apply_suppression_comment(token, &mut mutation, suppression_text.as_str());
+            apply_suppression_comment(SuppressionCommentEmitterPayload {
+                suppression_text: suppression_text.as_str(),
+                mutation: &mut mutation,
+                token_offset: token,
+                diagnostic_text_range: &text_range,
+            });
 
             Some(SuppressAction {
                 mutation,

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -12,7 +12,7 @@ use rome_diagnostics::{
     Advices, Category, Diagnostic, DiagnosticTags, Location, LogCategory, MessageAndDescription,
     Visit,
 };
-use rome_rowan::{BatchMutation, Language, TextRange};
+use rome_rowan::{BatchMutation, Language, SyntaxNode, TextRange};
 use serde::de::DeserializeOwned;
 
 /// Static metadata containing information about a rule
@@ -328,6 +328,16 @@ pub trait Rule: RuleMeta {
         let (..) = (ctx, state);
         None
     }
+
+    /// Create a code action that allows to suppress the rule. The function
+    /// has to return the node to which the suppression comment needs to be applied.
+    fn can_suppress(
+        ctx: &RuleContext<Self>,
+        state: &Self::State,
+    ) -> Option<SuppressAction<RuleLanguage<Self>>> {
+        let _ = (ctx, state);
+        None
+    }
 }
 
 /// Diagnostic object returned by a single analysis rule
@@ -481,4 +491,18 @@ pub struct RuleAction<L: Language> {
     pub applicability: Applicability,
     pub message: MarkupBuf,
     pub mutation: BatchMutation<L>,
+}
+
+pub struct SuppressAction<L: Language>(SyntaxNode<L>);
+
+impl<L: Language> SuppressAction<L> {
+    pub fn node(&self) -> &SyntaxNode<L> {
+        &self.0
+    }
+}
+
+impl<L: Language> From<SyntaxNode<L>> for SuppressAction<L> {
+    fn from(node: SyntaxNode<L>) -> Self {
+        Self(node)
+    }
 }

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -333,7 +333,7 @@ pub trait Rule: RuleMeta + Sized {
     }
 
     /// Create a code action that allows to suppress the rule. The function
-    /// has to return the node to which the suppression comment needs to be applied.
+    /// returns the node to which the suppression comment is applied.
     fn suppress(
         ctx: &RuleContext<Self>,
         text_range: &TextRange,

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -79,16 +79,6 @@ where
     }
 }
 
-impl<L: Language> AnalyzerSignal<L> for AnalyzerAction<L> {
-    fn diagnostic(&self) -> Option<AnalyzerDiagnostic> {
-        (self.action)()
-    }
-
-    fn actions(&self) -> AnalyzerActionIter<L> {
-        AnalyzerActionIter::new(vec![self.clone()])
-    }
-}
-
 /// Code Action object returned by the analyzer, generated from a [crate::RuleAction]
 /// with additional information about the rule injected by the analyzer
 ///
@@ -245,8 +235,7 @@ pub(crate) struct RuleSignal<'phase, R: Rule> {
     services: &'phase ServiceBag,
     options: AnalyzerOptions,
     /// An optional action to suppress the rule.
-    apply_suppression_comment:
-        SuppressionCommentEmitter<<<R as Rule>::Query as Queryable>::Language>,
+    apply_suppression_comment: SuppressionCommentEmitter<RuleLanguage<R>>,
 }
 
 impl<'phase, R> RuleSignal<'phase, R>

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -76,7 +76,7 @@ where
 
     fn actions(&self) -> AnalyzerActionIter<L> {
         if let Some(action) = (self.action)() {
-            AnalyzerActionIter::new(vec![action])
+            AnalyzerActionIter::new([action])
         } else {
             AnalyzerActionIter::new(vec![])
         }
@@ -141,9 +141,16 @@ impl<L: Language> From<AnalyzerAction<L>> for CodeSuggestionItem {
 }
 
 impl<L: Language> AnalyzerActionIter<L> {
-    pub fn new(actions: Vec<AnalyzerAction<L>>) -> Self {
+    pub fn new<I>(actions: I) -> Self
+    where
+        I: IntoIterator<Item = AnalyzerAction<L>>,
+        I::IntoIter: ExactSizeIterator,
+    {
         Self {
-            analyzer_actions: actions.into_iter(),
+            analyzer_actions: actions
+                .into_iter()
+                .collect::<Vec<AnalyzerAction<L>>>()
+                .into_iter(),
         }
     }
 }

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -1,5 +1,4 @@
-use std::marker::PhantomData;
-
+use crate::categories::SUPPRESSION_ACTION_CATEGORY;
 use crate::{
     categories::ActionCategory,
     context::RuleContext,
@@ -7,18 +6,22 @@ use crate::{
     rule::Rule,
     AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, ServiceBag,
 };
-use rome_console::MarkupBuf;
+use rome_console::{markup, MarkupBuf};
 use rome_diagnostics::{
     advice::CodeSuggestionAdvice, location::FileId, Applicability, CodeSuggestion, Diagnostic,
     Error, FileSpan,
 };
-use rome_rowan::{BatchMutation, Language};
+use rome_rowan::{AstNode, BatchMutation, BatchMutationExt, Language, TriviaPieceKind};
+use std::borrow::Cow;
+use std::iter::FusedIterator;
+use std::marker::PhantomData;
+use std::vec::IntoIter;
 
 /// Event raised by the analyzer when a [Rule](crate::Rule)
 /// emits a diagnostic, a code action, or both
 pub trait AnalyzerSignal<L: Language> {
     fn diagnostic(&self) -> Option<AnalyzerDiagnostic>;
-    fn action(&self) -> Option<AnalyzerAction<L>>;
+    fn actions(&self) -> Option<AnalyzerActionIter<L>>;
 }
 
 /// Simple implementation of [AnalyzerSignal] generating a [AnalyzerDiagnostic]
@@ -70,7 +73,7 @@ where
         Some(AnalyzerDiagnostic::from_error(error))
     }
 
-    fn action(&self) -> Option<AnalyzerAction<L>> {
+    fn actions(&self) -> Option<AnalyzerActionIter<L>> {
         (self.action)()
     }
 }
@@ -80,7 +83,7 @@ where
 ///
 /// This struct can be converted into a [CodeSuggestion] and injected into
 /// a diagnostic emitted by the same signal
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AnalyzerAction<L: Language> {
     pub rule_name: Option<(&'static str, &'static str)>,
     pub file_id: FileId,
@@ -90,13 +93,19 @@ pub struct AnalyzerAction<L: Language> {
     pub mutation: BatchMutation<L>,
 }
 
-impl<L> From<AnalyzerAction<L>> for CodeSuggestionAdvice<MarkupBuf>
-where
-    L: Language,
-{
+impl<L: Language> AnalyzerAction<L> {
+    pub fn is_suppression(&self) -> bool {
+        self.category.matches("quickfix.rome.suppressRule")
+    }
+}
+
+pub struct AnalyzerActionIter<L: Language> {
+    analyzer_actions: IntoIter<AnalyzerAction<L>>,
+}
+
+impl<L: Language> From<AnalyzerAction<L>> for CodeSuggestionAdvice<MarkupBuf> {
     fn from(action: AnalyzerAction<L>) -> Self {
         let (_, suggestion) = action.mutation.as_text_edits().unwrap_or_default();
-
         CodeSuggestionAdvice {
             applicability: action.applicability,
             msg: action.message,
@@ -105,22 +114,121 @@ where
     }
 }
 
-impl<L> From<AnalyzerAction<L>> for CodeSuggestion
-where
-    L: Language,
-{
+impl<'a, L: Language> From<AnalyzerAction<L>> for CodeSuggestionItem<'a> {
     fn from(action: AnalyzerAction<L>) -> Self {
         let (range, suggestion) = action.mutation.as_text_edits().unwrap_or_default();
 
-        CodeSuggestion {
-            span: FileSpan {
-                file: action.file_id,
-                range,
+        CodeSuggestionItem {
+            rule_name: action.rule_name,
+            category: action.category,
+            group_name: action.group_name,
+            suggestion: CodeSuggestion {
+                span: FileSpan {
+                    file: action.file_id,
+                    range,
+                },
+                applicability: action.applicability,
+                msg: action.message,
+                suggestion,
+                labels: vec![],
             },
-            applicability: action.applicability,
-            msg: action.message,
-            suggestion,
-            labels: vec![],
+        }
+    }
+}
+
+impl<L: Language> AnalyzerActionIter<L> {
+    pub fn new(actions: Vec<AnalyzerAction<L>>) -> Self {
+        Self {
+            analyzer_actions: actions.into_iter(),
+        }
+    }
+}
+
+impl<L: Language> Iterator for AnalyzerActionIter<L> {
+    type Item = AnalyzerAction<L>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.analyzer_actions.next()
+    }
+}
+
+impl<L: Language> FusedIterator for AnalyzerActionIter<L> {}
+
+impl<L: Language> ExactSizeIterator for AnalyzerActionIter<L> {
+    fn len(&self) -> usize {
+        self.analyzer_actions.len()
+    }
+}
+
+#[derive(Debug)]
+pub struct AnalyzerMutation<L: Language> {
+    pub message: MarkupBuf,
+    pub mutation: BatchMutation<L>,
+    pub category: ActionCategory,
+    pub rule_name: String,
+}
+
+pub struct CodeSuggestionAdviceIter<L: Language> {
+    iter: IntoIter<AnalyzerAction<L>>,
+}
+
+impl<L: Language> Iterator for CodeSuggestionAdviceIter<L> {
+    type Item = CodeSuggestionAdvice<MarkupBuf>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let action = self.iter.next()?;
+        Some(action.into())
+    }
+}
+
+impl<L: Language> FusedIterator for CodeSuggestionAdviceIter<L> {}
+
+impl<L: Language> ExactSizeIterator for CodeSuggestionAdviceIter<L> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+pub struct CodeActionIter<L: Language> {
+    iter: IntoIter<AnalyzerAction<L>>,
+}
+
+pub struct CodeSuggestionItem<'a> {
+    pub category: ActionCategory,
+    pub suggestion: CodeSuggestion,
+    pub rule_name: &'a str,
+    pub group_name: &'a str,
+}
+
+impl<L: Language> Iterator for CodeActionIter<L> {
+    type Item = CodeSuggestionItem<'static>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let action = self.iter.next()?;
+        Some(action.into())
+    }
+}
+
+impl<L: Language> FusedIterator for CodeActionIter<L> {}
+
+impl<L: Language> ExactSizeIterator for CodeActionIter<L> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<L: Language> AnalyzerActionIter<L> {
+    /// Returns an iterator that yields [CodeSuggestionAdvice]
+    pub fn into_code_suggestion_advices(self) -> CodeSuggestionAdviceIter<L> {
+        CodeSuggestionAdviceIter {
+            iter: self.analyzer_actions,
+        }
+    }
+
+    /// Returns an iterator that yields [CodeAction]
+    pub fn into_code_action_iter(self) -> CodeActionIter<L> {
+        CodeActionIter {
+            iter: self.analyzer_actions,
         }
     }
 }
@@ -169,17 +277,77 @@ where
         R::diagnostic(&ctx, &self.state).map(|diag| diag.into_analyzer_diagnostic(self.file_id))
     }
 
-    fn action(&self) -> Option<AnalyzerAction<RuleLanguage<R>>> {
+    fn actions(&self) -> Option<AnalyzerActionIter<RuleLanguage<R>>> {
         let ctx =
             RuleContext::new(&self.query_result, self.root, self.services, &self.options).ok()?;
+        let mut actions = Vec::new();
+        if let Some(action) = R::action(&ctx, &self.state) {
+            actions.push(AnalyzerAction {
+                rule_name: Some((<R::Group as RuleGroup>::NAME, R::METADATA.name)),
+                file_id: self.file_id,
+                category: action.category,
+                applicability: action.applicability,
+                mutation: action.mutation,
+                message: action.message,
+            });
+        };
+        let node_to_suppress = R::can_suppress(&ctx, &self.state);
+        let suppression_node = node_to_suppress.and_then(|suppression_node| {
+            let ancestor = suppression_node.node().ancestors().find_map(|node| {
+                if node
+                    .first_token()
+                    .map(|token| {
+                        token
+                            .leading_trivia()
+                            .pieces()
+                            .any(|trivia| trivia.is_newline())
+                    })
+                    .unwrap_or(false)
+                {
+                    Some(node)
+                } else {
+                    None
+                }
+            });
+            if ancestor.is_some() {
+                ancestor
+            } else {
+                Some(ctx.root().syntax().clone())
+            }
+        });
+        let suppression_action = suppression_node.and_then(|suppression_node| {
+            let first_token = suppression_node.first_token();
+            let rule = format!(
+                "lint({}/{})",
+                <R::Group as RuleGroup>::NAME,
+                R::METADATA.name
+            );
+            let mes = format!("// rome-ignore {}: suppressed", rule);
 
-        R::action(&ctx, &self.state).map(|action| AnalyzerAction {
-            rule_name: Some((<R::Group as RuleGroup>::NAME, R::METADATA.name)),
-            file_id: self.file_id,
-            category: action.category,
-            applicability: action.applicability,
-            message: action.message,
-            mutation: action.mutation,
-        })
+            first_token.map(|first_token| {
+                let trivia = vec![
+                    (TriviaPieceKind::Newline, "\n"),
+                    (TriviaPieceKind::SingleLineComment, mes.as_str()),
+                    (TriviaPieceKind::Newline, "\n"),
+                ];
+                let mut mutation = ctx.root().begin();
+                let new_token = first_token.with_leading_trivia(trivia.clone());
+
+                mutation.replace_token_discard_trivia(first_token, new_token);
+                AnalyzerAction {
+                    group_name: <R::Group as RuleGroup>::NAME,
+                    rule_name: R::METADATA.name,
+                    file_id: self.file_id,
+                    category: ActionCategory::Other(Cow::Borrowed(SUPPRESSION_ACTION_CATEGORY)),
+                    applicability: Applicability::Always,
+                    mutation,
+                    message: markup! { "Suppress rule " {rule} }.to_owned(),
+                }
+            })
+        });
+        if let Some(suppression_action) = suppression_action {
+            actions.push(suppression_action);
+        }
+        Some(AnalyzerActionIter::new(actions))
     }
 }

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -110,7 +110,7 @@ mod tests {
             &metadata,
             &mut matcher,
             |_| unreachable!(),
-            |_, _, _| unreachable!(),
+            |_| unreachable!(),
             &mut emit_signal,
         );
 

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -110,6 +110,7 @@ mod tests {
             &metadata,
             &mut matcher,
             |_| unreachable!(),
+            |_, _, _| unreachable!(),
             &mut emit_signal,
         );
 

--- a/crates/rome_analyze/src/visitor.rs
+++ b/crates/rome_analyze/src/visitor.rs
@@ -7,6 +7,7 @@ use crate::{
     matcher::MatchQueryParams,
     registry::{NodeLanguage, Phases},
     AnalyzerOptions, LanguageRoot, QueryMatch, QueryMatcher, ServiceBag, SignalEntry,
+    SuppressionCommentEmitter,
 };
 
 /// Mutable context objects shared by all visitors
@@ -19,6 +20,7 @@ pub struct VisitorContext<'phase, 'query, L: Language> {
     pub(crate) query_matcher: &'query mut dyn QueryMatcher<L>,
     pub(crate) signal_queue: &'query mut BinaryHeap<SignalEntry<'phase, L>>,
     pub options: &'query AnalyzerOptions,
+    pub apply_suppression_comment: SuppressionCommentEmitter<L>,
 }
 
 impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
@@ -31,6 +33,7 @@ impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
             services: self.services,
             signal_queue: self.signal_queue,
             options: self.options,
+            apply_suppression_comment: self.apply_suppression_comment,
         })
     }
 }

--- a/crates/rome_diagnostics/src/suggestion.rs
+++ b/crates/rome_diagnostics/src/suggestion.rs
@@ -25,7 +25,7 @@ pub enum Applicability {
     MaybeIncorrect,
 }
 
-/// A Suggestion that is provided by rslint, and
+/// A Suggestion that is provided by Rome's linter, and
 /// can be reported to the user, and can be automatically
 /// applied if it has the right [`Applicability`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/rome_js_analyze/src/analyzers/a11y/use_alt_text.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/use_alt_text.rs
@@ -1,4 +1,3 @@
-use crate::JsSuppressAction;
 use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{
@@ -142,10 +141,6 @@ impl Rule for UseAltText {
             readers to understand content's purpose within a page."
             }),
         )
-    }
-
-    fn can_suppress(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsSuppressAction> {
-        Some(ctx.query().syntax().clone().into())
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/a11y/use_alt_text.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/use_alt_text.rs
@@ -1,3 +1,4 @@
+use crate::JsSuppressAction;
 use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{
@@ -141,6 +142,10 @@ impl Rule for UseAltText {
             readers to understand content's purpose within a page."
             }),
         )
+    }
+
+    fn can_suppress(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsSuppressAction> {
+        Some(ctx.query().syntax().clone().into())
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/complexity/use_simplified_logic_expression.rs
+++ b/crates/rome_js_analyze/src/analyzers/complexity/use_simplified_logic_expression.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::{
 };
 use rome_rowan::{AstNode, AstNodeExt, BatchMutationExt};
 
-use crate::JsRuleAction;
+use crate::{JsRuleAction, JsSuppressAction};
 
 declare_rule! {
     /// Discard redundant terms from logical expressions.
@@ -157,6 +157,10 @@ impl Rule for UseSimplifiedLogicExpression {
             message: markup! { ""{message}"" }.to_owned(),
             mutation,
         })
+    }
+
+    fn can_suppress(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsSuppressAction> {
+        Some(ctx.query().syntax().clone().into())
     }
 }
 

--- a/crates/rome_js_analyze/src/analyzers/complexity/use_simplified_logic_expression.rs
+++ b/crates/rome_js_analyze/src/analyzers/complexity/use_simplified_logic_expression.rs
@@ -1,3 +1,4 @@
+use crate::JsRuleAction;
 use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
@@ -7,8 +8,6 @@ use rome_js_syntax::{
     JsUnaryExpression, JsUnaryOperator, T,
 };
 use rome_rowan::{AstNode, AstNodeExt, BatchMutationExt};
-
-use crate::{JsRuleAction, JsSuppressAction};
 
 declare_rule! {
     /// Discard redundant terms from logical expressions.
@@ -157,10 +156,6 @@ impl Rule for UseSimplifiedLogicExpression {
             message: markup! { ""{message}"" }.to_owned(),
             mutation,
         })
-    }
-
-    fn can_suppress(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsSuppressAction> {
-        Some(ctx.query().syntax().clone().into())
     }
 }
 

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -2,7 +2,7 @@ use control_flow::make_visitor;
 use rome_analyze::{
     AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, ControlFlow,
     InspectMatcher, LanguageRoot, MatchQueryParams, MetadataRegistry, Phases, RuleAction,
-    RuleRegistry, ServiceBag, SuppressionKind, SyntaxVisitor,
+    RuleRegistry, ServiceBag, SuppressAction, SyntaxVisitor,
 };
 use rome_diagnostics::category;
 use rome_diagnostics::location::FileId;
@@ -26,6 +26,7 @@ pub use crate::registry::visit_registry;
 use crate::semantic_services::{SemanticModelBuilderVisitor, SemanticModelVisitor};
 
 pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
+pub(crate) type JsSuppressAction = SuppressAction<JsLanguage>;
 
 /// Return the static [MetadataRegistry] for the JS analyzer rules
 pub fn metadata() -> &'static MetadataRegistry {
@@ -161,9 +162,11 @@ mod tests {
                 if let Some(mut diag) = signal.diagnostic() {
                     diag.set_severity(Severity::Warning);
                     error_ranges.push(diag.location().unwrap().span.unwrap());
-                    if let Some(action) = signal.action() {
-                        let new_code = action.mutation.commit();
-                        eprintln!("{new_code}");
+                    if let Some(actions) = signal.actions() {
+                        for action in actions {
+                            let new_code = action.mutation.commit();
+                            eprintln!("{new_code}");
+                        }
                     }
                     let error = diag.with_file_path("ahahah").with_file_source_code(SOURCE);
                     let text = markup_to_string(markup! {

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -2,13 +2,12 @@ use control_flow::make_visitor;
 use rome_analyze::{
     AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, ControlFlow,
     InspectMatcher, LanguageRoot, MatchQueryParams, MetadataRegistry, Phases, RuleAction,
-    RuleRegistry, ServiceBag, SuppressionCommentEmitterPayload, SyntaxVisitor,
+    RuleRegistry, ServiceBag, SuppressionCommentEmitterPayload, SuppressionKind, SyntaxVisitor,
 };
-use rome_diagnostics::file::FileId;
+use rome_diagnostics::{category, FileId};
 use rome_js_factory::make::{jsx_expression_child, token};
 use rome_js_syntax::{
-    suppression::{parse_suppression_comment, SuppressionCategory},
-    JsLanguage, JsSyntaxToken, JsxAnyChild, T,
+    suppression::parse_suppression_comment, JsLanguage, JsSyntaxToken, JsxAnyChild, T,
 };
 use rome_rowan::{AstNode, TokenAtOffset, TriviaPieceKind};
 use serde::{Deserialize, Serialize};
@@ -264,7 +263,7 @@ mod tests {
                     }
 
                     if code == category!("suppressions/deprecatedSyntax") {
-                        assert!(signal.action().is_some());
+                        assert!(signal.actions().len() > 0);
                         warn_ranges.push(span.unwrap());
                     }
                 }

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -2,11 +2,15 @@ use control_flow::make_visitor;
 use rome_analyze::{
     AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, ControlFlow,
     InspectMatcher, LanguageRoot, MatchQueryParams, MetadataRegistry, Phases, RuleAction,
-    RuleRegistry, ServiceBag, SuppressAction, SyntaxVisitor,
+    RuleRegistry, ServiceBag, SyntaxVisitor,
 };
-use rome_diagnostics::category;
-use rome_diagnostics::location::FileId;
-use rome_js_syntax::{suppression::parse_suppression_comment, JsLanguage};
+use rome_diagnostics::file::FileId;
+use rome_js_factory::make::{jsx_expression_child, token};
+use rome_js_syntax::{
+    suppression::{parse_suppression_comment, SuppressionCategory},
+    JsLanguage, JsSyntaxToken, JsxAnyChild, T,
+};
+use rome_rowan::{AstNode, BatchMutation, TokenAtOffset, TriviaPieceKind};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, error::Error};
 
@@ -24,9 +28,9 @@ pub mod utils;
 
 pub use crate::registry::visit_registry;
 use crate::semantic_services::{SemanticModelBuilderVisitor, SemanticModelVisitor};
+use crate::utils::batch::JsBatchMutation;
 
 pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
-pub(crate) type JsSuppressAction = SuppressAction<JsLanguage>;
 
 /// Return the static [MetadataRegistry] for the JS analyzer rules
 pub fn metadata() -> &'static MetadataRegistry {
@@ -85,6 +89,7 @@ where
         metadata(),
         InspectMatcher::new(registry.build(), inspect_matcher),
         parse_linter_suppression_comment,
+        apply_suppression_comment,
         &mut emit_signal,
     );
     analyzer.add_visitor(Phases::Syntax, make_visitor());
@@ -122,8 +127,7 @@ where
 
 #[cfg(test)]
 mod tests {
-
-    use rome_analyze::{AnalyzerOptions, Never, RuleCategories};
+    use rome_analyze::{AnalyzerOptions, Never, RuleCategories, RuleFilter};
     use rome_console::fmt::{Formatter, Termcolor};
     use rome_console::{markup, Markup};
     use rome_diagnostics::termcolor::NoColor;
@@ -131,6 +135,7 @@ mod tests {
     use rome_diagnostics::{Diagnostic, DiagnosticExt, PrintDiagnostic, Severity};
     use rome_js_parser::parse;
     use rome_js_syntax::{SourceType, TextRange, TextSize};
+    use std::slice;
 
     use crate::{analyze, AnalysisFilter, ControlFlow};
 
@@ -146,33 +151,37 @@ mod tests {
             String::from_utf8(buffer).unwrap()
         }
 
-        const SOURCE: &str = r#"<img src="image.png" aria-label="alt text" />
+        const SOURCE: &str = r#"if (a < b) {
+}
         "#;
 
         let parsed = parse(SOURCE, FileId::zero(), SourceType::jsx());
 
         let mut error_ranges: Vec<TextRange> = Vec::new();
         let options = AnalyzerOptions::default();
+        let rule_filter = RuleFilter::Rule("correctness", "flipBinExp");
         analyze(
             FileId::zero(),
             &parsed.tree(),
-            AnalysisFilter::default(),
+            AnalysisFilter {
+                enabled_rules: Some(slice::from_ref(&rule_filter)),
+                ..AnalysisFilter::default()
+            },
             &options,
             |signal| {
                 if let Some(mut diag) = signal.diagnostic() {
                     diag.set_severity(Severity::Warning);
                     error_ranges.push(diag.location().unwrap().span.unwrap());
-                    if let Some(actions) = signal.actions() {
-                        for action in actions {
-                            let new_code = action.mutation.commit();
-                            eprintln!("{new_code}");
-                        }
-                    }
                     let error = diag.with_file_path("ahahah").with_file_source_code(SOURCE);
                     let text = markup_to_string(markup! {
                         {PrintDiagnostic(&error)}
                     });
                     eprintln!("{text}");
+                }
+
+                for action in signal.actions() {
+                    let new_code = action.mutation.commit();
+                    eprintln!("{new_code}");
                 }
 
                 ControlFlow::<Never>::Continue(())
@@ -344,3 +353,70 @@ impl std::fmt::Display for RuleError {
 }
 
 impl Error for RuleError {}
+
+/// We now try to "guess" the token where to apply the suppression comment.
+/// Considering that the detection of suppression comments in the linter is "line based", we start
+/// querying the node covered by the text range of the diagnostic, until we find the first token that has a newline
+/// among its leading trivia.
+///
+/// If we're not able to find any token, it means that the range is
+/// placed at row 1, so we take the root itself.
+fn apply_suppression_comment(
+    current_token: TokenAtOffset<JsSyntaxToken>,
+    mutation: &mut BatchMutation<JsLanguage>,
+    suppression_text: &str,
+) {
+    let current_token = match current_token {
+        TokenAtOffset::None => None,
+        TokenAtOffset::Single(token) => find_token_with_newline(token),
+        TokenAtOffset::Between(token, _) => find_token_with_newline(token),
+    };
+    if let Some(current_token) = current_token {
+        if let Some(element) = current_token.ancestors().find_map(|node| {
+            if node
+                .first_token()
+                .map(|token| token.text_trimmed().contains('\n'))
+                .is_some()
+            {
+                JsxAnyChild::cast(node)
+            } else {
+                None
+            }
+        }) {
+            let jsx_comment = jsx_expression_child(
+                token(T!['{']).with_trailing_trivia([(
+                    TriviaPieceKind::SingleLineComment,
+                    format!("/* {} */", suppression_text).as_str(),
+                )]),
+                token(T!['}']),
+            );
+            mutation.add_jsx_element_after_element(
+                &element,
+                &JsxAnyChild::JsxExpressionChild(jsx_comment.build()),
+            );
+        } else {
+            let new_token = current_token.with_leading_trivia(vec![
+                (TriviaPieceKind::Newline, "\n"),
+                (
+                    TriviaPieceKind::SingleLineComment,
+                    format!("// {} ", suppression_text).as_str(),
+                ),
+                (TriviaPieceKind::Newline, "\n"),
+            ]);
+            mutation.replace_token_discard_trivia(current_token, new_token);
+        }
+    }
+}
+
+/// It checks if the current token has leading trivia newline. If not, it
+/// it peeks the previous token and recursively call itself
+fn find_token_with_newline(token: JsSyntaxToken) -> Option<JsSyntaxToken> {
+    let trivia = token.leading_trivia();
+    if trivia.pieces().any(|trivia| trivia.is_newline()) || token.text_trimmed().contains('\n') {
+        Some(token)
+    } else if let Some(token) = token.prev_token() {
+        find_token_with_newline(token)
+    } else {
+        None
+    }
+}

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -402,7 +402,7 @@ fn apply_suppression_comment(payload: SuppressionCommentEmitterPayload<JsLanguag
                 &JsxAnyChild::JsxExpressionChild(jsx_comment.build()),
             );
         } else {
-            let new_token = current_token.with_leading_trivia(vec![
+            let new_token = current_token.with_leading_trivia([
                 (TriviaPieceKind::Newline, "\n"),
                 (
                     TriviaPieceKind::SingleLineComment,

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -390,7 +390,6 @@ fn apply_suppression_comment(payload: SuppressionCommentEmitterPayload<JsLanguag
         }
     };
     if let Some(current_token) = current_token {
-        dbg!(current_token.parent());
         if let Some(element) = current_token.ancestors().find_map(JsxAnyChild::cast) {
             let jsx_comment = jsx_expression_child(
                 token(T!['{']).with_trailing_trivia([(

--- a/crates/rome_js_analyze/src/utils/batch.rs
+++ b/crates/rome_js_analyze/src/utils/batch.rs
@@ -27,6 +27,13 @@ pub trait JsBatchMutation {
         after_element: &JsxAnyChild,
         new_element: &JsxAnyChild,
     ) -> bool;
+
+    /// It attempts to add a new element before the given element
+    fn add_jsx_element_before_element(
+        &mut self,
+        after_element: &JsxAnyChild,
+        new_element: &JsxAnyChild,
+    ) -> bool;
 }
 
 fn remove_js_formal_parameter_from_js_parameter_list(
@@ -220,6 +227,41 @@ impl JsBatchMutation for BatchMutation<JsLanguage> {
                         if element == *after_element {
                             new_items.push(new_element.clone());
                         }
+                    }
+
+                    Some(jsx_child_list(new_items))
+                })
+                .unwrap_or(None);
+
+            if let Some(jsx_child_list) = jsx_child_list {
+                self.replace_node(old_list, jsx_child_list);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    fn add_jsx_element_before_element(
+        &mut self,
+        after_element: &JsxAnyChild,
+        new_element: &JsxAnyChild,
+    ) -> bool {
+        let old_list = after_element.syntax().parent().and_then(JsxChildList::cast);
+        if let Some(old_list) = old_list {
+            let jsx_child_list = after_element
+                .syntax()
+                .parent()
+                .map(|parent| {
+                    let list = JsxChildList::cast(parent)?;
+                    let mut new_items = vec![];
+                    for element in list {
+                        if element == *after_element {
+                            new_items.push(new_element.clone());
+                        }
+                        new_items.push(element.clone());
                     }
 
                     Some(jsx_child_list(new_items))

--- a/crates/rome_js_analyze/src/utils/batch.rs
+++ b/crates/rome_js_analyze/src/utils/batch.rs
@@ -214,31 +214,22 @@ impl JsBatchMutation for BatchMutation<JsLanguage> {
         after_element: &JsxAnyChild,
         new_element: &JsxAnyChild,
     ) -> bool {
-        let old_list = after_element.syntax().parent().and_then(JsxChildList::cast);
-        if let Some(old_list) = old_list {
-            let jsx_child_list = after_element
-                .syntax()
-                .parent()
-                .map(|parent| {
-                    let list = JsxChildList::cast(parent)?;
-                    let mut new_items = vec![];
-                    for element in list {
-                        new_items.push(element.clone());
-                        if element == *after_element {
-                            new_items.push(new_element.clone());
-                        }
+        let old_list = after_element.parent::<JsxChildList>();
+        if let Some(old_list) = &old_list {
+            let jsx_child_list = {
+                let mut new_items = vec![];
+                for element in old_list {
+                    new_items.push(element.clone());
+                    if element == *after_element {
+                        new_items.push(new_element.clone());
                     }
+                }
 
-                    Some(jsx_child_list(new_items))
-                })
-                .unwrap_or(None);
+                jsx_child_list(new_items)
+            };
 
-            if let Some(jsx_child_list) = jsx_child_list {
-                self.replace_node(old_list, jsx_child_list);
-                true
-            } else {
-                false
-            }
+            self.replace_node(old_list.clone(), jsx_child_list);
+            true
         } else {
             false
         }
@@ -250,30 +241,21 @@ impl JsBatchMutation for BatchMutation<JsLanguage> {
         new_element: &JsxAnyChild,
     ) -> bool {
         let old_list = after_element.syntax().parent().and_then(JsxChildList::cast);
-        if let Some(old_list) = old_list {
-            let jsx_child_list = after_element
-                .syntax()
-                .parent()
-                .map(|parent| {
-                    let list = JsxChildList::cast(parent)?;
-                    let mut new_items = vec![];
-                    for element in list {
-                        if element == *after_element {
-                            new_items.push(new_element.clone());
-                        }
-                        new_items.push(element.clone());
+        if let Some(old_list) = &old_list {
+            let jsx_child_list = {
+                let mut new_items = vec![];
+                for element in old_list {
+                    if element == *after_element {
+                        new_items.push(new_element.clone());
                     }
+                    new_items.push(element.clone());
+                }
 
-                    Some(jsx_child_list(new_items))
-                })
-                .unwrap_or(None);
+                jsx_child_list(new_items)
+            };
 
-            if let Some(jsx_child_list) = jsx_child_list {
-                self.replace_node(old_list, jsx_child_list);
-                true
-            } else {
-                false
-            }
+            self.replace_node(old_list.clone(), jsx_child_list);
+            true
         } else {
             false
         }

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -7,9 +7,9 @@ use rome_console::{
     fmt::{Formatter, Termcolor},
     markup, Markup,
 };
+use rome_diagnostics::advice::CodeSuggestionAdvice;
 use rome_diagnostics::location::FileId;
 use rome_diagnostics::termcolor::NoColor;
-use rome_diagnostics::v2::advice::CodeSuggestionAdvice;
 use rome_diagnostics::{DiagnosticExt, PrintDiagnostic, Severity};
 use rome_js_parser::{
     parse,

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -92,12 +92,10 @@ fn write_analysis_to_snapshot(
     rome_js_analyze::analyze(FileId::zero(), &root, filter, &options, |event| {
         if let Some(mut diag) = event.diagnostic() {
             diag.set_severity(Severity::Warning);
-            if let Some(actions) = event.actions() {
-                for action in actions {
-                    if !action.is_suppression() {
-                        check_code_action(input_file, input_code, source_type, &action);
-                        diag = diag.add_code_suggestion(CodeSuggestionAdvice::from(action));
-                    }
+            for action in event.actions() {
+                if !action.is_suppression() {
+                    check_code_action(input_file, input_code, source_type, &action);
+                    diag = diag.add_code_suggestion(CodeSuggestionAdvice::from(action));
                 }
             }
 
@@ -105,11 +103,9 @@ fn write_analysis_to_snapshot(
             return ControlFlow::Continue(());
         }
 
-        if let Some(actions) = event.actions() {
-            for action in actions {
-                check_code_action(input_file, input_code, source_type, &action);
-                code_fixes.push(code_fix_to_string(input_code, action));
-            }
+        for action in event.actions() {
+            check_code_action(input_file, input_code, source_type, &action);
+            code_fixes.push(code_fix_to_string(input_code, action));
         }
 
         ControlFlow::<Never>::Continue(())

--- a/crates/rome_lsp/src/handlers/analysis.rs
+++ b/crates/rome_lsp/src/handlers/analysis.rs
@@ -23,14 +23,6 @@ fn fix_all_kind() -> CodeActionKind {
         Cow::Owned(kind) => CodeActionKind::from(kind),
     }
 }
-
-/// Checks
-fn is_suppression_action_kind(action_kind: &CodeActionKind) -> bool {
-    action_kind
-        .as_str()
-        .starts_with("quickfix.rome.suppressRule")
-}
-
 /// Queries the [`AnalysisServer`] for code actions of the file matching [FileId]
 ///
 /// If the AnalysisServer has no matching file, results in error.
@@ -116,13 +108,7 @@ pub(crate) fn code_actions(
     if has_fixes {
         actions.retain(|action| {
             if let CodeActionOrCommand::CodeAction(action) = action {
-                action.kind.as_ref() == Some(&fix_all_kind())
-                    || action
-                        .kind
-                        .as_ref()
-                        .map(is_suppression_action_kind)
-                        .unwrap_or(false)
-                    || action.diagnostics.is_some()
+                action.kind.as_ref() == Some(&fix_all_kind()) || action.diagnostics.is_some()
             } else {
                 true
             }

--- a/crates/rome_lsp/src/handlers/analysis.rs
+++ b/crates/rome_lsp/src/handlers/analysis.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
-use std::collections::HashMap;
-
+use crate::line_index::LineIndex;
+use crate::session::Session;
+use crate::utils;
 use anyhow::{Context, Result};
 use rome_analyze::{ActionCategory, SourceActionKind};
 use rome_fs::RomePath;
@@ -8,13 +8,12 @@ use rome_service::workspace::{
     FeatureName, FixFileMode, FixFileParams, PullActionsParams, SupportsFeatureParams,
 };
 use rome_service::RomeError;
+use std::borrow::Cow;
+use std::collections::HashMap;
 use tower_lsp::lsp_types::{
     self as lsp, CodeActionKind, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
 };
-
-use crate::line_index::LineIndex;
-use crate::session::Session;
-use crate::utils;
+use tracing::debug;
 
 const FIX_ALL_CATEGORY: ActionCategory = ActionCategory::Source(SourceActionKind::FixAll);
 
@@ -25,10 +24,17 @@ fn fix_all_kind() -> CodeActionKind {
     }
 }
 
+/// Checks
+fn is_suppression_action_kind(action_kind: &CodeActionKind) -> bool {
+    action_kind
+        .as_str()
+        .starts_with("quickfix.rome.suppressRule")
+}
+
 /// Queries the [`AnalysisServer`] for code actions of the file matching [FileId]
 ///
 /// If the AnalysisServer has no matching file, results in error.
-#[tracing::instrument(level = "trace", skip_all, fields(uri = display(&params.text_document.uri), range = debug(params.range), only = debug(&params.context.only), diagnostics = debug(&params.context.diagnostics)), err)]
+#[tracing::instrument(level = "debug", skip_all, fields(uri = display(&params.text_document.uri), range = debug(params.range), only = debug(&params.context.only), diagnostics = debug(&params.context.diagnostics)), err)]
 pub(crate) fn code_actions(
     session: &Session,
     params: CodeActionParams,
@@ -110,18 +116,26 @@ pub(crate) fn code_actions(
     if has_fixes {
         actions.retain(|action| {
             if let CodeActionOrCommand::CodeAction(action) = action {
-                action.kind.as_ref() == Some(&fix_all_kind()) || action.diagnostics.is_some()
+                action.kind.as_ref() == Some(&fix_all_kind())
+                    || action
+                        .kind
+                        .as_ref()
+                        .map(is_suppression_action_kind)
+                        .unwrap_or(false)
+                    || action.diagnostics.is_some()
             } else {
                 true
             }
         });
     }
 
+    debug!("Suggested actions: \n{:?}", &actions);
+
     Ok(Some(actions))
 }
 
 /// Generate a "fix all" code action for the given document
-#[tracing::instrument(level = "trace", skip(session), err)]
+#[tracing::instrument(level = "debug", skip(session), err)]
 fn fix_all(
     session: &Session,
     url: &lsp::Url,

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -50,7 +50,7 @@ pub(crate) fn format(
     Ok(Some(edits))
 }
 
-#[tracing::instrument(level = "trace", skip(session), err)]
+#[tracing::instrument(level = "debug", skip(session), err)]
 pub(crate) fn format_range(
     session: &Session,
     params: DocumentRangeFormattingParams,
@@ -111,7 +111,7 @@ pub(crate) fn format_range(
     }]))
 }
 
-#[tracing::instrument(level = "trace", skip(session), err)]
+#[tracing::instrument(level = "debug", skip(session), err)]
 pub(crate) fn format_on_type(
     session: &Session,
     params: DocumentOnTypeFormattingParams,

--- a/crates/rome_lsp/src/handlers/rename.rs
+++ b/crates/rome_lsp/src/handlers/rename.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use tower_lsp::lsp_types::{RenameParams, WorkspaceEdit};
 use tracing::trace;
 
-#[tracing::instrument(level = "trace", skip(session), err)]
+#[tracing::instrument(level = "debug", skip(session), err)]
 pub(crate) fn rename(session: &Session, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
     let url = params.text_document_position.text_document.uri;
     let rome_path = session.file_path(&url);

--- a/crates/rome_lsp/src/handlers/text_document.rs
+++ b/crates/rome_lsp/src/handlers/text_document.rs
@@ -8,7 +8,7 @@ use tracing::{error, field};
 use crate::{documents::Document, session::Session, utils};
 
 /// Handler for `textDocument/didOpen` LSP notification
-#[tracing::instrument(level = "trace", skip(session), err)]
+#[tracing::instrument(level = "debug", skip(session), err)]
 pub(crate) async fn did_open(
     session: &Session,
     params: lsp_types::DidOpenTextDocumentParams,
@@ -38,7 +38,7 @@ pub(crate) async fn did_open(
 }
 
 /// Handler for `textDocument/didChange` LSP notification
-#[tracing::instrument(level = "trace", skip_all, fields(url = field::display(&params.text_document.uri), version = params.text_document.version), err)]
+#[tracing::instrument(level = "debug", skip_all, fields(url = field::display(&params.text_document.uri), version = params.text_document.version), err)]
 pub(crate) async fn did_change(
     session: &Session,
     params: lsp_types::DidChangeTextDocumentParams,
@@ -87,7 +87,7 @@ pub(crate) async fn did_change(
 }
 
 /// Handler for `textDocument/didClose` LSP notification
-#[tracing::instrument(level = "trace", skip(session), err)]
+#[tracing::instrument(level = "debug", skip(session), err)]
 pub(crate) async fn did_close(
     session: &Session,
     params: lsp_types::DidCloseTextDocumentParams,

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -58,7 +58,7 @@ impl LSPServer {
         requests::syntax_tree::syntax_tree(&self.session, &url).map_err(into_lsp_error)
     }
 
-    #[tracing::instrument(skip(self), name = "rome/rage", level = "trace")]
+    #[tracing::instrument(skip(self), name = "rome/rage", level = "debug")]
     async fn rage(&self, params: RageParams) -> LspResult<RageResult> {
         let mut entries = vec![
             RageEntry::section("Server"),
@@ -185,7 +185,7 @@ impl LSPServer {
 
 #[tower_lsp::async_trait]
 impl LanguageServer for LSPServer {
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn initialize(&self, params: InitializeParams) -> LspResult<InitializeResult> {
         info!("Starting Rome Language Server...");
         self.is_initialized.store(true, Ordering::Relaxed);
@@ -219,7 +219,7 @@ impl LanguageServer for LSPServer {
         Ok(init)
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn initialized(&self, params: InitializedParams) {
         let _ = params;
 
@@ -244,14 +244,14 @@ impl LanguageServer for LSPServer {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
         let _ = params;
         self.session.fetch_client_configuration().await;
         self.setup_capabilities().await;
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
         let file_paths = params
             .changes

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -135,7 +135,7 @@ impl Session {
     /// Computes diagnostics for the file matching the provided url and publishes
     /// them to the client. Called from [`handlers::text_document`] when a file's
     /// contents changes.
-    #[tracing::instrument(level = "trace", skip_all, fields(url = display(&url), diagnostic_count), err)]
+    #[tracing::instrument(level = "debug", skip_all, fields(url = display(&url), diagnostic_count), err)]
     pub(crate) async fn update_diagnostics(&self, url: lsp_types::Url) -> anyhow::Result<()> {
         let rome_path = self.file_path(&url);
         let doc = self.document(&url)?;

--- a/crates/rome_lsp/src/utils.rs
+++ b/crates/rome_lsp/src/utils.rs
@@ -175,7 +175,9 @@ pub(crate) fn code_fix_to_lsp(
         },
         edit: Some(edit),
         command: None,
-        is_preferred: if matches!(suggestion.applicability, Applicability::Always) {
+        is_preferred: if matches!(suggestion.applicability, Applicability::Always)
+            && !action.category.matches("quickfix.suppressRule")
+        {
             Some(true)
         } else {
             None

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -693,7 +693,22 @@ async fn pull_quick_fixes() -> Result<()> {
     });
 
     let mut suppression_changes = HashMap::default();
-    suppression_changes.insert(lsp::Url::parse("test://workspace/document.js")?, vec![]);
+    suppression_changes.insert(
+        lsp::Url::parse("test://workspace/document.js")?,
+        vec![lsp::TextEdit {
+            range: lsp::Range {
+                start: lsp::Position {
+                    line: 0,
+                    character: 2,
+                },
+                end: lsp::Position {
+                    line: 0,
+                    character: 2,
+                },
+            },
+            new_text: String::from("\n// rome-ignore lint/correctness/noCompareNegZero \n"),
+        }],
+    );
 
     let expected_suppression_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
         title: String::from("Suppress rule lint/correctness/noCompareNegZero"),
@@ -707,7 +722,7 @@ async fn pull_quick_fixes() -> Result<()> {
             change_annotations: None,
         }),
         command: None,
-        is_preferred: Some(true),
+        is_preferred: None,
         disabled: None,
         data: None,
     });

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -699,11 +699,11 @@ async fn pull_quick_fixes() -> Result<()> {
             range: lsp::Range {
                 start: lsp::Position {
                     line: 0,
-                    character: 2,
+                    character: 3,
                 },
                 end: lsp::Position {
                     line: 0,
-                    character: 2,
+                    character: 3,
                 },
             },
             new_text: String::from("\n// rome-ignore lint/correctness/noCompareNegZero \n"),

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -692,7 +692,27 @@ async fn pull_quick_fixes() -> Result<()> {
         data: None,
     });
 
-    assert_eq!(res, vec![expected_code_action]);
+    let mut suppression_changes = HashMap::default();
+    suppression_changes.insert(lsp::Url::parse("test://workspace/document.js")?, vec![]);
+
+    let expected_suppression_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+        title: String::from("Suppress rule lint/correctness/noCompareNegZero"),
+        kind: Some(lsp::CodeActionKind::new(
+            "quickfix.suppressRule.rome.correctness.noCompareNegZero",
+        )),
+        diagnostics: Some(vec![fixable_diagnostic(0)?]),
+        edit: Some(lsp::WorkspaceEdit {
+            changes: Some(suppression_changes),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: Some(true),
+        disabled: None,
+        data: None,
+    });
+
+    assert_eq!(res, vec![expected_code_action, expected_suppression_action]);
 
     server.close_document().await?;
 

--- a/crates/rome_rowan/Cargo.toml
+++ b/crates/rome_rowan/Cargo.toml
@@ -18,6 +18,7 @@ countme = { workspace = true }
 serde = { version = "1.0.133", optional = true, default-features = false }
 rome_text_edit = { path = "../rome_text_edit" }
 schemars = { version = "0.8.10", optional = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -1,5 +1,6 @@
 use rome_text_edit::TextEdit;
 use rome_text_size::TextRange;
+use tracing::debug;
 
 use crate::{AstNode, Language, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxSlot, SyntaxToken};
 use std::{
@@ -261,6 +262,7 @@ where
         });
         let parent_depth = parent.as_ref().map(|p| p.ancestors().count()).unwrap_or(0);
 
+        debug!("pushing change...");
         self.changes.push(CommitChange {
             parent_depth,
             parent,
@@ -275,6 +277,8 @@ where
     /// [None] if the mutation is empty
     pub fn as_text_edits(&self) -> Option<(TextRange, TextEdit)> {
         let mut range = None;
+
+        debug!(" changes {:?}", &self.changes);
 
         for change in &self.changes {
             let parent = change.parent.as_ref().unwrap_or(&self.root);
@@ -398,6 +402,10 @@ where
         }
 
         root
+    }
+
+    pub fn root(&self) -> &SyntaxNode<L> {
+        &self.root
     }
 }
 

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -218,7 +218,10 @@ where
 
     /// Push a change to replace the "prev_token" with "next_token".
     ///
-    /// Changes to take effect must be committed.
+    /// - leading trivia of `prev_token`
+    /// - leading trivia of `next_token`
+    /// - trailing trivia of `prev_token`
+    /// - trailing trivia of `next_token`
     pub fn replace_token_transfer_trivia(
         &mut self,
         prev_token: SyntaxToken<L>,
@@ -262,14 +265,14 @@ where
 
     /// Push a change to remove the specified token.
     ///
-    /// Changes to take effect must be commited.
+    /// Changes to take effect must be committed.
     pub fn remove_token(&mut self, prev_token: SyntaxToken<L>) {
         self.remove_element(prev_token.into())
     }
 
     /// Push a change to remove the specified node.
     ///
-    /// Changes to take effect must be commited.
+    /// Changes to take effect must be committed.
     pub fn remove_node<T>(&mut self, prev_node: T)
     where
         T: AstNode<Language = L>,
@@ -279,7 +282,7 @@ where
 
     /// Push a change to remove the specified element.
     ///
-    /// Changes to take effect must be commited.
+    /// Changes to take effect must be committed.
     pub fn remove_element(&mut self, prev_element: SyntaxElement<L>) {
         self.push_change(prev_element, None)
     }
@@ -343,10 +346,10 @@ where
     /// 2 - Insert them into a heap (priority queue) by depth. Deeper changes are done first;
     /// 3 - Loop popping requested changes from the heap, taking the deepest change we have for the moment;
     /// 4 - Each requested change has a "parent", an "index" and the "new node" (or None);
-    /// 5 - Clone the current parent's "parent", the "greatparent";
+    /// 5 - Clone the current parent's "parent", the "grandparent";
     /// 6 - Detach the current "parent" from the tree;
     /// 7 - Replace the old node at "index" at the current "parent" with the current "new node";
-    /// 8 - Insert into the heap the greatparent as the parent and the current "parent" as the "new node";
+    /// 8 - Insert into the heap the grandparent as the parent and the current "parent" as the "new node";
     ///
     /// This is the simple case. The algorithm also has a more complex case when to changes have a common ancestor,
     /// which can actually be one of the changed nodes.
@@ -369,7 +372,7 @@ where
                     let range = g.text_range();
                     (range.start().into(), range.end().into())
                 });
-                let currentparent_slot = current_parent.index();
+                let current_parent_slot = current_parent.index();
 
                 // Aggregate all modifications to the current parent
                 // This works because of the Ord we defined in the [CommitChange] struct
@@ -422,7 +425,7 @@ where
                     parent_depth: item.parent_depth - 1,
                     parent: grandparent,
                     parent_range: grandparent_range,
-                    new_node_slot: currentparent_slot,
+                    new_node_slot: current_parent_slot,
                     new_node: Some(SyntaxElement::Node(current_parent)),
                 });
             } else {

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -214,6 +214,17 @@ where
         self.replace_element_discard_trivia(prev_token.into(), next_token.into())
     }
 
+    /// Push a change to replace the "prev_token" with "next_token".
+    ///
+    /// Changes to take effect must be committed.
+    pub fn replace_token_transfer_trivia(
+        &mut self,
+        prev_token: SyntaxToken<L>,
+        next_token: SyntaxToken<L>,
+    ) {
+        self.replace_element_discard_trivia(prev_token.into(), next_token.into())
+    }
+
     /// Push a change to replace the "prev_element" with "next_element".
     ///
     /// Changes to take effect must be committed.

--- a/crates/rome_rowan/src/syntax.rs
+++ b/crates/rome_rowan/src/syntax.rs
@@ -3,26 +3,21 @@ mod node;
 mod token;
 mod trivia;
 
-use std::fmt::Debug;
-
-pub use trivia::{
-    SyntaxTrivia, SyntaxTriviaPiece, SyntaxTriviaPieceComments, SyntaxTriviaPieceNewline,
-    SyntaxTriviaPieceSkipped, SyntaxTriviaPieceWhitespace, SyntaxTriviaPiecesIterator, TriviaPiece,
-    TriviaPieceKind,
-};
-
+use crate::{AstNode, RawSyntaxKind};
 pub use element::{SyntaxElement, SyntaxElementKey};
 pub(crate) use node::SyntaxSlots;
 pub use node::{
     Preorder, PreorderWithTokens, SendNode, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren,
     SyntaxNodeOptionExt, SyntaxSlot,
 };
-
-pub use token::SyntaxToken;
-
 use std::fmt;
-
-use crate::{AstNode, RawSyntaxKind};
+use std::fmt::Debug;
+pub use token::SyntaxToken;
+pub use trivia::{
+    SyntaxTrivia, SyntaxTriviaPiece, SyntaxTriviaPieceComments, SyntaxTriviaPieceNewline,
+    SyntaxTriviaPieceSkipped, SyntaxTriviaPieceWhitespace, SyntaxTriviaPiecesIterator, TriviaPiece,
+    TriviaPieceKind,
+};
 
 /// Type tag for each node or token of a language
 pub trait SyntaxKind: fmt::Debug + PartialEq + Copy {

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -776,7 +776,7 @@ export type ActionCategory =
 	| { Source: SourceActionKind }
 	| { Other: string };
 /**
- * A Suggestion that is provided by rslint, and can be reported to the user, and can be automatically applied if it has the right [`Applicability`].
+ * A Suggestion that is provided by Rome's linter, and can be reported to the user, and can be automatically applied if it has the right [`Applicability`].
  */
 export interface CodeSuggestion {
 	applicability: Applicability;

--- a/xtask/bench/src/features/analyzer.rs
+++ b/xtask/bench/src/features/analyzer.rs
@@ -31,7 +31,7 @@ pub fn run_analyzer(root: &JsAnyRoot) {
     let options = AnalyzerOptions::default();
     analyze(FileId::zero(), root, filter, &options, |event| {
         black_box(event.diagnostic());
-        black_box(event.action());
+        black_box(event.actions());
         ControlFlow::<Never>::Continue(())
     });
 }

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -541,11 +541,9 @@ fn assert_lint(
                 );
                 diag.set_severity(severity);
 
-                if let Some(actions) = signal.actions() {
-                    for action in actions {
-                        if !action.is_suppression() {
-                            diag = diag.add_code_suggestion(action.into());
-                        }
+                for action in signal.actions() {
+                    if !action.is_suppression() {
+                        diag = diag.add_code_suggestion(action.into());
                     }
                 }
 

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -541,8 +541,12 @@ fn assert_lint(
                 );
                 diag.set_severity(severity);
 
-                if let Some(action) = signal.action() {
-                    diag = diag.add_code_suggestion(action.into());
+                if let Some(actions) = signal.actions() {
+                    for action in actions {
+                        if !action.is_suppression() {
+                            diag = diag.add_code_suggestion(action.into());
+                        }
+                    }
                 }
 
                 let error = diag


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to the changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR introduces some infrastructure changes to the analyzer. Before the `AnalyzerSignal` was returning only one action but now is able to return an iterator of actions. 

Doing so allows us to create other actions, and in this PR we create actions to suppress lint rules via LSP. This feature will give us some other perks, like the ability to choose the suppression action when will have commands like `rome check --review`, where the user can choose different actions. 

> **Note**: Another perk will be the ability to create **different fixes** from the rules, although this is not supported now because it would require some more changes to the `Rule` trait and the `RuleDiagnostic` struct, this is something that we have access to.

### Suppression action

The suppression of the rules **opt-out**. 

Suppression actions are automatically generated for rules that belong to the category `RuleCategory::LINT`.

A new API has been introduced, called `suppress` which returns a small wrapper called `SuppressAction`.

### Heuristic of the suppression comment

The heuristic for suppression comments is languages specific, so I had to create a new generic `apply_suppression_comment` closure that it's passed down to the specific implementation of the analyzer. The function accepts the token offset of where the diagnostic occurred, and a mutation and string that contains the `rome-ignore ..` comment.


## Test Plan

Run the feature locally, here's a small video:

https://user-images.githubusercontent.com/602478/201928280-b5187d92-434a-450d-b304-c505cbd334d4.mov


The current tests should stay the same because we should not show suppression actions in the CLI.


**I will implement tests for automatically generated actions in another PR**.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
