### PR TITLE
refactor(rome_cli): refactor the threading of parallel traversal to increase occupancy

### DIFF
--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -9,7 +9,6 @@ use rome_service::workspace::{
 use std::path::PathBuf;
 
 /// Useful information during the traversal of files and virtual content
-#[derive(Clone)]
 pub(crate) struct Execution {
     /// How the information should be collected and reported
     report_mode: ReportMode,
@@ -18,7 +17,6 @@ pub(crate) struct Execution {
     traversal_mode: TraversalMode,
 }
 
-#[derive(Clone)]
 pub(crate) enum TraversalMode {
     /// This mode is enabled when running the command `rome check`
     Check {
@@ -47,7 +45,7 @@ pub(crate) enum TraversalMode {
 }
 
 /// Tells to the execution of the traversal how the information should be reported
-#[derive(Clone, Default)]
+#[derive(Copy, Clone, Default)]
 pub(crate) enum ReportMode {
     /// Reports information straight to the console, it's the default mode
     #[default]


### PR DESCRIPTION
## Summary

This PR changes how threads are spawned during parallel traversal operations: it merges the console and report tasks into a single dedicated thread running outside of the Rayon thread pool, so that all threads in the pool are now available to process files.

I've also made the initial setup of input tasks run on the main thread (to avoid allocating an extraneous thread for this), and replaced some redundant cloning operations of the traversal state with shared references (this is made possible by using the scoped thread API of the standard library from Rust 1.63)

## Test Plan

This is purely an internal change, it should have no noticeable side effect other than possibly improving traversal performance on multi-core systems, and the existing test suite of the CLI should ensure this is actually the case.
