### PR TITLE
fix(ci): fix the release workflows for the stable release

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -39,17 +39,12 @@ jobs:
         run: |
           echo "Version change found! New version: ${{ steps.version.outputs.version }} (${{ steps.version.outputs.version_type }})"
           echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
-      - name: Set version name
-        if: steps.version.outputs.changed != 'true'
-        run: |
-          echo "version=$(node npm/rome/scripts/update-nightly-version.mjs)" >> $GITHUB_ENV
 
-      - name: Check prerelease status
-        id: prerelease
+      - name: Set prerelease status
         if: env.nightly == 'true'
-        env:
-            prerelease: true
-        run: echo "Create pre-release"
+        run: |
+          echo "prerelease=true" >> $GITHUB_ENV
+          echo "version=$(node npm/rome/scripts/update-nightly-version.mjs)" >> $GITHUB_ENV
 
   build:
     strategy:
@@ -201,8 +196,8 @@ jobs:
       - name: Generate npm packages
         run: node npm/rome/scripts/generate-packages.mjs
 
-      - name: Publish npm packages as next
-        run: for package in npm/*; do if [ $package != "npm/js-api" ]; then npm publish $package --tag next --access public; fi; done
+      - name: Publish npm packages as latest
+        run: for package in npm/*; do if [ $package != "npm/js-api" ]; then npm publish $package --tag latest --access public; fi; done
         if: needs.build.outputs.prerelease != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -139,12 +139,12 @@ jobs:
         run: node npm/js-api/scripts/update-nightly-version.mjs
 
       - name: Publish npm package as latest
-        run: npm publish @rometools/js-api --tag latest --access public
+        run: npm publish npm/js-api --tag latest --access public
         if: needs.build.outputs.prerelease != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish npm package as nightly
-        run: npm publish @rometools/js-api --tag nightly --access public
+        run: npm publish npm/js-api --tag nightly --access public
         if: needs.build.outputs.prerelease == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

This PR makes a few changes to the release workflows before the stable release:
- Publish releases to the `rome` npm package under the `latest` tag instead of `next`
- Ensure the `prerelease` environment variable is correctly exported in CLI nightly builds
- Publish the `js-api` using its path instead of package name

## Test Plan

Test run of the `release_cli` workflow: https://github.com/rome/tools/actions/runs/3418383900
Test run of the `release_js_api` workflow: https://github.com/rome/tools/actions/runs/3418397143
