### PR TITLE
fix(docs): use the standard picture element to display the logo

### DIFF
--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -158,7 +158,4 @@ jobs:
           tag_name: js-api/v${{ needs.build.outputs.version }}
           draft: false
           prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
-          files: |
-            dist/*
-          fail_on_unmatched_files: true
           generate_release_notes: true

--- a/npm/rome/README.md
+++ b/npm/rome/README.md
@@ -1,8 +1,9 @@
 <p align="center">
-	<img alt="Rome's logo depicting an ancient Roman arch with the word Rome to its side" src="https://raw.githubusercontent.com/rome/brand/main/PNG/logo_transparent.png#gh-light-mode-only" width="700">
-	<img alt="Rome's logo depicting an ancient Roman arch with the word Rome to its side" src="https://raw.githubusercontent.com/rome/brand/main/PNG/logo_white_yellow_transparent.png#gh-dark-mode-only" width="700">
+	<picture>
+		<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rome/brand/main/PNG/logo_white_yellow_transparent.png" width="700">
+		<img alt="Rome's logo depicting an ancient Roman arch with the word Rome to its side" src="https://raw.githubusercontent.com/rome/brand/main/PNG/logo_transparent.png" width="700">
+	</picture>
 </p>
-
 
 <div align="center">
 


### PR DESCRIPTION
## Summary

This fixes how the Rome logo is displayed in the README when the markdown file is rendered outside of GitHub. The logo exists in two versions for dark and light mode, and the correct version to display in the readme was selected using the `gh-light-mode-only` and `gh-dark-mode-only` fragments. This logic is GitHub-specific though, and doesn't work when the readme file is rendered outside of GitHub (for instance on the `rome` npm package: https://www.npmjs.com/package/rome/v/0.10.1-nightly.a9db0f0). I've replaced the images with the standard `picture` element to automatically select the correct version of the image using the `prefers-color-scheme: dark` CSS media query.

I've also rolled up a simple fix to the `release_js_api` workflow into this, it fixes the creation of GitHub releases for the API by removing the attachments since the JS API doesn't have any build artifact.

## Test Plan

Push a new nightly version to npm and check the logo is only rendered once
