### PR TITLE
fix(rome_js_analyze): improve the logic of jsx_reference_identifier_is_fragment

### DIFF
--- a/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/fromImportRenameValid.jsx
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/fromImportRenameValid.jsx
@@ -1,6 +1,9 @@
-import AwesomeReact, { Fragment as AwesomeFragment } from "noReact";
+import AwesomeNoReact, { Fragment as AwesomeFragment } from "noReact";
+import AwesomeReact, { StrictMode as AwesomeStrictMode } from "react";
 
 <>
     <AwesomeFragment></AwesomeFragment>
-    <AwesomeReact.Fragment>foo</AwesomeReact.Fragment>
+    <AwesomeNoReact.Fragment>foo</AwesomeNoReact.Fragment>
+    <AwesomeStrictMode></AwesomeStrictMode>
+    <AwesomeReact.StrictMode>foo</AwesomeReact.StrictMode>
 </>

--- a/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/fromImportRenameValid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/fromImportRenameValid.jsx.snap
@@ -1,14 +1,18 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 99
 expression: fromImportRenameValid.jsx
 ---
 # Input
 ```js
-import AwesomeReact, { Fragment as AwesomeFragment } from "noReact";
+import AwesomeNoReact, { Fragment as AwesomeFragment } from "noReact";
+import AwesomeReact, { StrictMode as AwesomeStrictMode } from "react";
 
 <>
     <AwesomeFragment></AwesomeFragment>
-    <AwesomeReact.Fragment>foo</AwesomeReact.Fragment>
+    <AwesomeNoReact.Fragment>foo</AwesomeNoReact.Fragment>
+    <AwesomeStrictMode></AwesomeStrictMode>
+    <AwesomeReact.StrictMode>foo</AwesomeReact.StrictMode>
 </>
 
 ```

--- a/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/notFragmentValid.jsx
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/notFragmentValid.jsx
@@ -1,0 +1,6 @@
+import React, { StrictMode } from "react";
+
+<>
+    <StrictMode></StrictMode>
+    <React.StrictMode></React.StrictMode>
+</>

--- a/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/notFragmentValid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/notFragmentValid.jsx.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 99
+expression: notFragmentValid.jsx
+---
+# Input
+```js
+import React, { StrictMode } from "react";
+
+<>
+    <StrictMode></StrictMode>
+    <React.StrictMode></React.StrictMode>
+</>
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/userDefinedValid.jsx
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/userDefinedValid.jsx
@@ -2,5 +2,5 @@ function Fragment() {}
 let React = { Fragment };
 <>
     <Fragment>test</Fragment>
-    <React>test</React>
+    <React.Fragment>test</React.Fragment>
 </>

--- a/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/userDefinedValid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUselessFragments/userDefinedValid.jsx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 99
 expression: userDefinedValid.jsx
 ---
 # Input
@@ -8,7 +9,7 @@ function Fragment() {}
 let React = { Fragment };
 <>
     <Fragment>test</Fragment>
-    <React>test</React>
+    <React.Fragment>test</React.Fragment>
 </>
 
 ```


### PR DESCRIPTION
## Summary

The `jsx_reference_identifier_is_fragment` has a subtle logic bug that cause it to return false positive for symbol imported from `"react"` other than `Fragment`, for instance `StrictMode`. I've modified the implementation to explicitly inspect the import nod and, check the source name of the imported symbol against "Fragment"

## Test Plan

I've added a few test case to ensure that `StrictMode` and `React.StrictMode` do not trigger the `noUselessFragments` rule in various context