### PR TITLE
fix(rome_cli): correctly account for diff diagnostics in the printed diagnostics count

### DIFF
--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -1,34 +1,11 @@
 use crate::commands::format::apply_format_settings_from_cli;
 use crate::configuration::load_configuration;
 use crate::{execute_mode, CliSession, Execution, Termination, TraversalMode};
-use rome_diagnostics::MAXIMUM_DISPLAYABLE_DIAGNOSTICS;
 use rome_service::workspace::{FixFileMode, UpdateSettingsParams};
 
 /// Handler for the "check" command of the Rome CLI
 pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
     let mut configuration = load_configuration(&mut session)?;
-
-    let max_diagnostics: Option<u16> = session
-        .args
-        .opt_value_from_str("--max-diagnostics")
-        .map_err(|source| Termination::ParseError {
-            argument: "--max-diagnostics",
-            source,
-        })?;
-
-    let max_diagnostics = if let Some(max_diagnostics) = max_diagnostics {
-        if max_diagnostics > MAXIMUM_DISPLAYABLE_DIAGNOSTICS {
-            return Err(Termination::OverflowNumberArgument(
-                "--max-diagnostics",
-                MAXIMUM_DISPLAYABLE_DIAGNOSTICS,
-            ));
-        }
-
-        max_diagnostics
-    } else {
-        // default value
-        20
-    };
 
     apply_format_settings_from_cli(&mut session, &mut configuration)?;
 
@@ -54,10 +31,7 @@ pub(crate) fn check(mut session: CliSession) -> Result<(), Termination> {
     };
 
     execute_mode(
-        Execution::new(TraversalMode::Check {
-            max_diagnostics,
-            fix_file_mode,
-        }),
+        Execution::new(TraversalMode::Check { fix_file_mode }),
         session,
     )
 }

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -61,7 +61,8 @@ const CI: Markup = markup! {
 
 "<Emphasis>"OPTIONS:"</Emphasis>"
     "<Dim>"--formatter-enabled"</Dim>"                      Allow to enable or disable the formatter check. (default: true)
-    "<Dim>"--linter-enabled"</Dim>"                         Allow to enable or disable the linter check. (default: true)"
+    "<Dim>"--linter-enabled"</Dim>"                         Allow to enable or disable the linter check. (default: true)
+    "<Dim>"--max-diagnostics"</Dim>"                        Cap the amount of diagnostics displayed (default: 50)"
     {FORMAT_OPTIONS}
 };
 
@@ -75,7 +76,8 @@ const FORMAT: Markup = markup! {
 
 "<Emphasis>"OPTIONS:"</Emphasis>"
     "<Dim>"--write"</Dim>"                                  Edit the files in place (beware!) instead of printing the diff to the console
-    "<Dim>"--skip-errors"</Dim>"                            Skip over files containing syntax errors instead of emitting an error diagnostic."
+    "<Dim>"--skip-errors"</Dim>"                            Skip over files containing syntax errors instead of emitting an error diagnostic.
+    "<Dim>"--max-diagnostics"</Dim>"                        Cap the amount of diagnostics displayed (default: 50)"
     {FORMAT_OPTIONS}
    ""<Dim>"--stdin-file-path <string>"</Dim>"               A file name with its extension to pass when reading from standard in, e.g. echo 'let a;' | rome format --stdin-file-path file.js
 "

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -777,3 +777,56 @@ fn files_max_size_parse_error() {
         result,
     ));
 }
+
+#[test]
+fn max_diagnostics_default() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    for i in 0..60 {
+        let file_path = PathBuf::from(format!("src/file_{i}.js"));
+        fs.insert(file_path, LINT_ERROR.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("check"), OsString::from("src")]),
+    );
+
+    match result {
+        Err(Termination::CheckError) => {}
+        _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
+    }
+
+    assert_eq!(console.out_buffer.len(), 21);
+}
+
+#[test]
+fn max_diagnostics() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    for i in 0..60 {
+        let file_path = PathBuf::from(format!("src/file_{i}.js"));
+        fs.insert(file_path, LINT_ERROR.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("check"),
+            OsString::from("--max-diagnostics"),
+            OsString::from("10"),
+            Path::new("src").as_os_str().into(),
+        ]),
+    );
+
+    match result {
+        Err(Termination::CheckError) => {}
+        _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
+    }
+
+    assert_eq!(console.out_buffer.len(), 11);
+}

--- a/crates/rome_cli/tests/commands/ci.rs
+++ b/crates/rome_cli/tests/commands/ci.rs
@@ -511,3 +511,56 @@ fn ci_runs_linter_not_formatter_issue_3495() {
         result,
     ));
 }
+
+#[test]
+fn max_diagnostics_default() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    for i in 0..60 {
+        let file_path = PathBuf::from(format!("src/file_{i}.js"));
+        fs.insert(file_path, UNFORMATTED.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("ci"), OsString::from("src")]),
+    );
+
+    match result {
+        Err(Termination::CheckError) => {}
+        _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
+    }
+
+    assert_eq!(console.out_buffer.len(), 51);
+}
+
+#[test]
+fn max_diagnostics() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    for i in 0..60 {
+        let file_path = PathBuf::from(format!("src/file_{i}.js"));
+        fs.insert(file_path, UNFORMATTED.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("ci"),
+            OsString::from("--max-diagnostics"),
+            OsString::from("10"),
+            OsString::from("src"),
+        ]),
+    );
+
+    match result {
+        Err(Termination::CheckError) => {}
+        _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
+    }
+
+    assert_eq!(console.out_buffer.len(), 11);
+}

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -1153,3 +1153,50 @@ fn files_max_size_parse_error() {
         result,
     ));
 }
+
+#[test]
+fn max_diagnostics_default() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    for i in 0..60 {
+        let file_path = PathBuf::from(format!("src/file_{i}.js"));
+        fs.insert(file_path, UNFORMATTED.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("format"), OsString::from("src")]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_eq!(console.out_buffer.len(), 52);
+}
+
+#[test]
+fn max_diagnostics() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    for i in 0..60 {
+        let file_path = PathBuf::from(format!("src/file_{i}.js"));
+        fs.insert(file_path, UNFORMATTED.as_bytes());
+    }
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("format"),
+            OsString::from("--max-diagnostics"),
+            OsString::from("10"),
+            OsString::from("src"),
+        ]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_eq!(console.out_buffer.len(), 12);
+}


### PR DESCRIPTION
## Summary

Fixes #3593

This PR adds checks against the `printed_diagnostics` counter in the console thread for diff diagnostics and general errors. This ensures the CLI never prints more diagnostics than the allowed maximum. I've also extended the `--max-diagnostics` argument from the `check` command to the `ci` and `format` commands, albeit with a different default value.

## Test Plan

I've added new tests for this in the CLI test suite but couldn't use the snapshot testing utility since the CLI runs multithreaded, and as a result the order of diagnostics printed in multiple files (for instance in many files formatted in parallel) is not deterministic and changes from one test run to another.
