### PR TITLE
feat(rome_cli): add a `--force-colors` argument

### DIFF
--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -19,6 +19,7 @@ const MAIN: Markup = markup! {
 
 "<Emphasis>"OPTIONS:"</Emphasis>"
     "<Dim>"--no-colors"</Dim>"              Disable the formatting of markup (print everything as plain text)
+    "<Dim>"--force-colors"</Dim>"           Force the formatting of markup using ANSI, even if the console output is determined to be incompatible
     "<Dim>"--use-server"</Dim>"             Connect to a running instance of the Rome daemon server
     "<Dim>"--version"</Dim>"                Show the Rome version information and quit
     "<Dim>"--files-max-size"</Dim>"         The maximum allowed size for source code files in bytes (default: 1MB)

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -18,8 +18,7 @@ const MAIN: Markup = markup! {
     - "<Emphasis>"help"</Emphasis>"         Prints this help message
 
 "<Emphasis>"OPTIONS:"</Emphasis>"
-    "<Dim>"--no-colors"</Dim>"              Disable the formatting of markup (print everything as plain text)
-    "<Dim>"--force-colors"</Dim>"           Force the formatting of markup using ANSI, even if the console output is determined to be incompatible
+    "<Dim>"--colors=<off|force>"</Dim>"     Set the formatting mode for markup: \"off\" prints everything as plain text, \"force\" forces the formatting of markup using ANSI even if the console output is determined to be incompatible
     "<Dim>"--use-server"</Dim>"             Connect to a running instance of the Rome daemon server
     "<Dim>"--version"</Dim>"                Show the Rome version information and quit
     "<Dim>"--files-max-size"</Dim>"         The maximum allowed size for source code files in bytes (default: 1MB)

--- a/crates/rome_cli/src/main.rs
+++ b/crates/rome_cli/src/main.rs
@@ -35,5 +35,6 @@ fn main() -> Result<(), Termination> {
         workspace::server()
     };
 
-    CliSession::new(&*workspace, args).run()
+    let session = CliSession::new(&*workspace, args)?;
+    session.run()
 }

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -186,7 +186,7 @@ mod main {
     #[test]
     fn no_colors() {
         let workspace = workspace::server();
-        let args = Arguments::from_vec(vec![OsString::from("--no-colors")]);
+        let args = Arguments::from_vec(vec![OsString::from("--colors=off")]);
         let result = CliSession::new(&*workspace, args).and_then(|session| session.run());
 
         assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -195,26 +195,22 @@ mod main {
     #[test]
     fn force_colors() {
         let workspace = workspace::server();
-        let args = Arguments::from_vec(vec![OsString::from("--force-colors")]);
+        let args = Arguments::from_vec(vec![OsString::from("--colors=force")]);
         let result = CliSession::new(&*workspace, args).and_then(|session| session.run());
 
         assert!(result.is_ok(), "run_cli returned {result:?}");
     }
 
     #[test]
-    fn incompatible_colors() {
+    fn invalid_colors() {
         let workspace = workspace::server();
-        let args = Arguments::from_vec(vec![
-            OsString::from("--no-colors"),
-            OsString::from("--force-colors"),
-        ]);
+        let args = Arguments::from_vec(vec![OsString::from("--colors=other")]);
 
         let result = CliSession::new(&*workspace, args).and_then(|session| session.run());
 
         match result {
-            Err(Termination::IncompatibleArguments(lhs, rhs)) => {
-                assert_eq!(lhs, "--no-colors");
-                assert_eq!(rhs, "--force-colors");
+            Err(Termination::ParseError { argument, .. }) => {
+                assert_eq!(argument, "--colors");
             }
             _ => panic!("run_cli returned {result:?} for a malformed, expected an error"),
         }

--- a/crates/rome_js_semantic/src/tests/assertions.rs
+++ b/crates/rome_js_semantic/src/tests/assertions.rs
@@ -108,7 +108,7 @@ pub fn assert(code: &str, test_name: &str) {
     let r = rome_js_parser::parse(code, FileId::zero(), SourceType::tsx());
 
     if r.has_errors() {
-        let mut console = EnvConsole::new(false);
+        let mut console = EnvConsole::default();
         for diag in r.into_diagnostics() {
             let error = diag
                 .with_file_path(FileId::zero())
@@ -756,7 +756,7 @@ fn error_assertion_not_attached_to_a_declaration(
         .with_file_path((test_name.to_string(), FileId::zero()))
         .with_file_source_code(code);
 
-    let mut console = EnvConsole::new(false);
+    let mut console = EnvConsole::default();
     console.log(markup! {
         {PrintDiagnostic(&error)}
     });
@@ -777,7 +777,7 @@ fn error_declaration_pointing_to_unknown_scope(
         .with_file_path((test_name.to_string(), FileId::zero()))
         .with_file_source_code(code);
 
-    let mut console = EnvConsole::new(false);
+    let mut console = EnvConsole::default();
     console.log(markup! {
         {PrintDiagnostic(&error)}
     });
@@ -802,7 +802,7 @@ fn error_assertion_name_clash(
         .with_file_path((test_name.to_string(), FileId::zero()))
         .with_file_source_code(code);
 
-    let mut console = EnvConsole::new(false);
+    let mut console = EnvConsole::default();
     console.log(markup! {
         {PrintDiagnostic(&error)}
     });
@@ -825,7 +825,7 @@ fn error_scope_end_assertion_points_to_non_existing_scope_start_assertion(
         .with_file_path((file_name.to_string(), FileId::zero()))
         .with_file_source_code(code);
 
-    let mut console = EnvConsole::new(false);
+    let mut console = EnvConsole::default();
     console.log(markup! {
         {PrintDiagnostic(&error)}
     });
@@ -852,7 +852,7 @@ fn error_scope_end_assertion_points_to_the_wrong_scope_start(
         .with_file_path((file_name.to_string(), FileId::zero()))
         .with_file_source_code(code);
 
-    let mut console = EnvConsole::new(false);
+    let mut console = EnvConsole::default();
     console.log(markup! {
         {PrintDiagnostic(&error)}
     });

--- a/website/src/pages/cli.mdx
+++ b/website/src/pages/cli.mdx
@@ -53,9 +53,11 @@ Stop the Rome [daemon](/internals/architecture#deamon) server
 
 ## Common Options
 
-### `--no-colors`
+### `--colors=<off|force>`
 
-Disable the formatting of markup (print everything as plain text)
+Set the formatting mode for markup: `off` prints everything as plain text,
+`force` forces the formatting of markup using ANSI even if the console output
+is determined to be incompatible
 
 ### `--use-server`
 

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -474,7 +474,7 @@ fn assert_lint(
         if test.expect_diagnostic {
             // Print all diagnostics to help the user
             if all_diagnostics.len() > 1 {
-                let mut console = rome_console::EnvConsole::new(false);
+                let mut console = rome_console::EnvConsole::default();
                 for diag in all_diagnostics.iter() {
                     console.print(
                         rome_console::LogLevel::Error,
@@ -492,7 +492,7 @@ fn assert_lint(
             );
         } else {
             // Print all diagnostics to help the user
-            let mut console = rome_console::EnvConsole::new(false);
+            let mut console = rome_console::EnvConsole::default();
             for diag in all_diagnostics.iter() {
                 console.print(
                     rome_console::LogLevel::Error,


### PR DESCRIPTION
## Summary

Fixes #3623

This adds a new `--force-colors` argument to the CLI to force the `EnvConsole` to use ANSI colors event if the stream would have otherwise been determined to be incompatible (not a TTY)

## Test Plan

I've added a few tests that ensure the `--no-colors` and `--force-colors` arguments are correctly parsed, unfortunately it's not really possible to check they actually work since this relies on using the actual `EnvConsole` instead of the `MemoryConsole` and writes directly to the stdout / stderr streams using `termcolor`, meaning it's not possible to inspect the output that got written by the CLI run (this also means the tests also circumvent the `println!` inhibiting behavior of the Rust test framework and write directly to the test output anyway)
