### PR TITLE
fix(rome_cli): ensures the service only connects to compatible versions

### DIFF
--- a/crates/rome_cli/src/service/mod.rs
+++ b/crates/rome_cli/src/service/mod.rs
@@ -43,14 +43,16 @@ use tokio::{
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-pub(crate) use self::windows::{ensure_daemon, open_socket, print_socket, run_daemon};
+pub(crate) use self::windows::{
+    ensure_daemon, enumerate_pipes, open_socket, print_socket, run_daemon,
+};
 
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-pub(crate) use self::unix::open_socket;
-#[cfg(unix)]
-pub(crate) use self::unix::{ensure_daemon, print_socket, run_daemon};
+pub(crate) use self::unix::{
+    ensure_daemon, enumerate_pipes, open_socket, print_socket, run_daemon,
+};
 
 /// Tries to open a connection to a running daemon instance, returning a
 /// [WorkspaceTransport] instance if the socket is currently active

--- a/crates/rome_cli/src/service/unix.rs
+++ b/crates/rome_cli/src/service/unix.rs
@@ -21,7 +21,7 @@ use tracing::Instrument;
 /// Returns the filesystem path of the global socket used to communicate with
 /// the server daemon
 fn get_socket_name() -> PathBuf {
-    env::temp_dir().join("rome-socket")
+    env::temp_dir().join(format!("rome-socket-{}", rome_service::VERSION))
 }
 
 /// Try to connect to the global socket and wait for the connection to become ready

--- a/crates/rome_cli/src/service/unix.rs
+++ b/crates/rome_cli/src/service/unix.rs
@@ -25,7 +25,7 @@ fn get_socket_name() -> PathBuf {
 }
 
 pub(crate) fn enumerate_pipes() -> io::Result<impl Iterator<Item = String>> {
-    read_dir(env::temp_dir()).map(|iter| {
+    fs::read_dir(env::temp_dir()).map(|iter| {
         iter.filter_map(|entry| {
             let entry = entry.ok()?.path();
             let file_name = entry.file_name()?;

--- a/crates/rome_cli/src/service/windows.rs
+++ b/crates/rome_cli/src/service/windows.rs
@@ -19,8 +19,11 @@ use tokio::{
 };
 use tracing::Instrument;
 
-/// Name of the global named pipe used to communicate with the server daemon
-const PIPE_NAME: &str = r"\\.\pipe\rome-service";
+/// Returns the name of the global named pipe used to communicate with the
+/// server daemon
+fn get_pipe_name() -> String {
+    format!(r"\\.\pipe\rome-service-{}", rome_service::VERSION)
+}
 
 /// Error code from the Win32 API
 const ERROR_PIPE_BUSY: i32 = 231;
@@ -28,7 +31,7 @@ const ERROR_PIPE_BUSY: i32 = 231;
 /// Try to connect to the global pipe and wait for the connection to become ready
 async fn try_connect() -> io::Result<NamedPipeClient> {
     loop {
-        match ClientOptions::new().open(PIPE_NAME) {
+        match ClientOptions::new().open(get_pipe_name()) {
             Ok(client) => return Ok(client),
             // If the connection failed with ERROR_PIPE_BUSY, wait a few
             // milliseconds then retry the connection (we should be using
@@ -165,7 +168,7 @@ pub(crate) async fn ensure_daemon() -> io::Result<bool> {
 /// print the global pipe name in the standard output
 pub(crate) async fn print_socket() -> io::Result<()> {
     ensure_daemon().await?;
-    println!("{PIPE_NAME}");
+    println!("{}", get_pipe_name());
     Ok(())
 }
 
@@ -174,11 +177,11 @@ pub(crate) async fn print_socket() -> io::Result<()> {
 pub(crate) async fn run_daemon(factory: ServerFactory) -> io::Result<Infallible> {
     let mut prev_server = ServerOptions::new()
         .first_pipe_instance(true)
-        .create(PIPE_NAME)?;
+        .create(get_pipe_name())?;
 
     loop {
         prev_server.connect().await?;
-        let mut next_server = ServerOptions::new().create(PIPE_NAME)?;
+        let mut next_server = ServerOptions::new().create(get_pipe_name())?;
         swap(&mut prev_server, &mut next_server);
 
         let connection = factory.create();


### PR DESCRIPTION
## Summary

Fixes #3637

This PR changes the path of the named pipe / domain socket used to communicate between the language client and server to include the version string of `rome_service`. This ensures a given instance of the Rome CLI binary always spawns (and connects to) an instance of the Rome daemon it's compatible with.

Due to the nature of this check (using filesystem paths) the comparison between version IDs is a strict equality, however as the version string of `rome_service` is an internal value we could change it independently from the main Rome version number. We could also truncate the patch number from the version string, but for now I expect even patch release of Rome may include breaking changes to the protocol so I'm leaving the full version string.

## Test Plan

I tested this locally by running two versions of the Rome server in parallel (the prebuilt binary from the npm package and a locally built version of this branch) and ensuring each version of the CLI and editor extension were connection to the right version.
