### PR TITLE
feat(rome_lsp): stop the daemon after the last client disconnects

### DIFF
--- a/crates/rome_cli/src/commands/daemon.rs
+++ b/crates/rome_cli/src/commands/daemon.rs
@@ -63,10 +63,10 @@ pub(crate) fn stop(mut session: CliSession) -> Result<(), Termination> {
 pub(crate) fn run_server(mut session: CliSession) -> Result<(), Termination> {
     setup_tracing_subscriber();
 
-    let is_oneshot = session.args.contains("--oneshot");
+    let stop_on_disconnect = session.args.contains("--stop-on-disconnect");
 
     let rt = Runtime::new()?;
-    let factory = ServerFactory::new(is_oneshot);
+    let factory = ServerFactory::new(stop_on_disconnect);
     let cancellation = factory.cancellation();
     let span = debug_span!("Running Server", pid = std::process::id());
 

--- a/crates/rome_cli/src/commands/daemon.rs
+++ b/crates/rome_cli/src/commands/daemon.rs
@@ -21,7 +21,7 @@ use crate::{
 
 pub(crate) fn start(mut session: CliSession) -> Result<(), Termination> {
     let rt = Runtime::new()?;
-    let did_spawn = rt.block_on(ensure_daemon())?;
+    let did_spawn = rt.block_on(ensure_daemon(true))?;
 
     if did_spawn {
         session.app.console.log(markup! {
@@ -60,11 +60,13 @@ pub(crate) fn stop(mut session: CliSession) -> Result<(), Termination> {
     Ok(())
 }
 
-pub(crate) fn run_server() -> Result<(), Termination> {
+pub(crate) fn run_server(mut session: CliSession) -> Result<(), Termination> {
     setup_tracing_subscriber();
 
+    let no_timeout = session.args.contains("--no-timeout");
+
     let rt = Runtime::new()?;
-    let factory = ServerFactory::default();
+    let factory = ServerFactory::new(!no_timeout);
     let cancellation = factory.cancellation();
     let span = debug_span!("Running Server", pid = std::process::id());
 
@@ -101,7 +103,7 @@ pub(crate) fn lsp_proxy() -> Result<(), Termination> {
 /// Receives a process via `stdin` and then copy the content to the LSP socket.
 /// Copy to the process on `stdout` when the LSP responds to a message
 async fn start_lsp_proxy(rt: &Runtime) -> Result<(), Termination> {
-    ensure_daemon().await?;
+    ensure_daemon(false).await?;
 
     match open_socket().await? {
         Some((mut owned_read_half, mut owned_write_half)) => {

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -93,7 +93,7 @@ impl<'app> CliSession<'app> {
             Some("lsp-proxy") => commands::daemon::lsp_proxy(),
 
             // Internal commands
-            Some("__run_server") => commands::daemon::run_server(),
+            Some("__run_server") => commands::daemon::run_server(self),
             Some("__print_socket") => commands::daemon::print_socket(),
 
             // Print the help for known commands called without any arguments, and exit with an error

--- a/crates/rome_cli/src/service/unix.rs
+++ b/crates/rome_cli/src/service/unix.rs
@@ -51,14 +51,14 @@ async fn try_connect() -> io::Result<UnixStream> {
 }
 
 /// Spawn the daemon server process in the background
-fn spawn_daemon(is_oneshot: bool) -> io::Result<Child> {
+fn spawn_daemon(stop_on_disconnect: bool) -> io::Result<Child> {
     let binary = env::current_exe()?;
 
     let mut cmd = Command::new(binary);
     cmd.arg("__run_server");
 
-    if is_oneshot {
-        cmd.arg("--oneshot");
+    if stop_on_disconnect {
+        cmd.arg("--stop-on-disconnect");
     }
 
     // Create a new session for the process and make it the leader, this will
@@ -106,7 +106,7 @@ pub(crate) async fn open_socket() -> io::Result<Option<(OwnedReadHalf, OwnedWrit
 ///
 /// Returns false if the daemon process was already running or true if it had
 /// to be started
-pub(crate) async fn ensure_daemon(is_oneshot: bool) -> io::Result<bool> {
+pub(crate) async fn ensure_daemon(stop_on_disconnect: bool) -> io::Result<bool> {
     let mut current_child: Option<Child> = None;
     let mut last_error = None;
 
@@ -144,7 +144,7 @@ pub(crate) async fn ensure_daemon(is_oneshot: bool) -> io::Result<bool> {
                 } else {
                     // Spawn the daemon process and wait a few milliseconds for
                     // it to become ready then retry the connection
-                    current_child = Some(spawn_daemon(is_oneshot)?);
+                    current_child = Some(spawn_daemon(stop_on_disconnect)?);
                     time::sleep(Duration::from_millis(50)).await;
                 }
             }

--- a/crates/rome_cli/src/service/unix.rs
+++ b/crates/rome_cli/src/service/unix.rs
@@ -51,14 +51,14 @@ async fn try_connect() -> io::Result<UnixStream> {
 }
 
 /// Spawn the daemon server process in the background
-fn spawn_daemon(no_timeout: bool) -> io::Result<Child> {
+fn spawn_daemon(is_oneshot: bool) -> io::Result<Child> {
     let binary = env::current_exe()?;
 
     let mut cmd = Command::new(binary);
     cmd.arg("__run_server");
 
-    if no_timeout {
-        cmd.arg("--no-timeout");
+    if is_oneshot {
+        cmd.arg("--oneshot");
     }
 
     // Create a new session for the process and make it the leader, this will
@@ -106,7 +106,7 @@ pub(crate) async fn open_socket() -> io::Result<Option<(OwnedReadHalf, OwnedWrit
 ///
 /// Returns false if the daemon process was already running or true if it had
 /// to be started
-pub(crate) async fn ensure_daemon(no_timeout: bool) -> io::Result<bool> {
+pub(crate) async fn ensure_daemon(is_oneshot: bool) -> io::Result<bool> {
     let mut current_child: Option<Child> = None;
     let mut last_error = None;
 
@@ -144,7 +144,7 @@ pub(crate) async fn ensure_daemon(no_timeout: bool) -> io::Result<bool> {
                 } else {
                     // Spawn the daemon process and wait a few milliseconds for
                     // it to become ready then retry the connection
-                    current_child = Some(spawn_daemon(no_timeout)?);
+                    current_child = Some(spawn_daemon(is_oneshot)?);
                     time::sleep(Duration::from_millis(50)).await;
                 }
             }
@@ -166,7 +166,7 @@ pub(crate) async fn ensure_daemon(no_timeout: bool) -> io::Result<bool> {
 /// Ensure the server daemon is running and ready to receive connections and
 /// print the global socket name in the standard output
 pub(crate) async fn print_socket() -> io::Result<()> {
-    ensure_daemon(false).await?;
+    ensure_daemon(true).await?;
     println!("{}", get_socket_name().display());
     Ok(())
 }

--- a/crates/rome_cli/src/service/windows.rs
+++ b/crates/rome_cli/src/service/windows.rs
@@ -67,14 +67,14 @@ async fn try_connect() -> io::Result<NamedPipeClient> {
 const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
 
 /// Spawn the daemon server process in the background
-fn spawn_daemon(is_oneshot: bool) -> io::Result<()> {
+fn spawn_daemon(stop_on_disconnect: bool) -> io::Result<()> {
     let binary = env::current_exe()?;
 
     let mut cmd = Command::new(binary);
     cmd.arg("__run_server");
 
-    if is_oneshot {
-        cmd.arg("--oneshot");
+    if stop_on_disconnect {
+        cmd.arg("--stop-on-disconnect");
     }
 
     cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
@@ -168,14 +168,14 @@ impl AsyncWrite for ClientWriteHalf {
 ///
 /// Returns false if the daemon process was already running or true if it had
 /// to be started
-pub(crate) async fn ensure_daemon(is_oneshot: bool) -> io::Result<bool> {
+pub(crate) async fn ensure_daemon(stop_on_disconnect: bool) -> io::Result<bool> {
     let mut did_spawn = false;
 
     loop {
         match open_socket().await {
             Ok(Some(_)) => break,
             Ok(None) => {
-                spawn_daemon(is_oneshot)?;
+                spawn_daemon(stop_on_disconnect)?;
                 did_spawn = true;
                 time::sleep(Duration::from_millis(50)).await;
             }

--- a/crates/rome_cli/src/service/windows.rs
+++ b/crates/rome_cli/src/service/windows.rs
@@ -67,11 +67,15 @@ async fn try_connect() -> io::Result<NamedPipeClient> {
 const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
 
 /// Spawn the daemon server process in the background
-fn spawn_daemon() -> io::Result<()> {
+fn spawn_daemon(no_timeout: bool) -> io::Result<()> {
     let binary = env::current_exe()?;
 
     let mut cmd = Command::new(binary);
     cmd.arg("__run_server");
+
+    if no_timeout {
+        cmd.arg("--no-timeout");
+    }
 
     cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
 
@@ -164,14 +168,14 @@ impl AsyncWrite for ClientWriteHalf {
 ///
 /// Returns false if the daemon process was already running or true if it had
 /// to be started
-pub(crate) async fn ensure_daemon() -> io::Result<bool> {
+pub(crate) async fn ensure_daemon(no_timeout: bool) -> io::Result<bool> {
     let mut did_spawn = false;
 
     loop {
         match open_socket().await {
             Ok(Some(_)) => break,
             Ok(None) => {
-                spawn_daemon()?;
+                spawn_daemon(no_timeout)?;
                 did_spawn = true;
                 time::sleep(Duration::from_millis(50)).await;
             }
@@ -185,7 +189,7 @@ pub(crate) async fn ensure_daemon() -> io::Result<bool> {
 /// Ensure the server daemon is running and ready to receive connections and
 /// print the global pipe name in the standard output
 pub(crate) async fn print_socket() -> io::Result<()> {
-    ensure_daemon().await?;
+    ensure_daemon(false).await?;
     println!("{}", get_pipe_name());
     Ok(())
 }

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -63,7 +63,7 @@ pub(crate) struct Session {
     documents: RwLock<HashMap<lsp_types::Url, Document>>,
     url_interner: RwLock<UrlInterner>,
 
-    cancellation: Arc<Notify>,
+    pub(crate) cancellation: Arc<Notify>,
 }
 
 pub(crate) type SessionHandle = Arc<Session>;

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -84,20 +84,6 @@ Rome doesn’t yet support loading the `rome.json` file from a directory other t
 
 Rome isn't yet able to pick up the `rome.json` configuration in [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces) if the configuration isn't in the first root folder ([issue 3538](https://github.com/rome/tools/issues/3538)). You can work around this limitation by making the folder with the configuration the first root folder of the workspace (drag it to the top).
 
-### The extension uses an outdated version of Rome
-
-Make sure to restart Rome’s LSP server after updating the extension. To stop Rome’s LSP, send the `stop` command (VS will start a new LSP instance for you):
-
-```bash
-npx rome stop
-
-# or
-pnpx exec rome stop
-
-# or
-yarn run rome stop
-```
-
 ### Disable Rome for workspaces without a `rome.json` configuration
 
 Rome's VS Code extension is active for every workspace regardless if the workspace contains a `rome.json` configuration ([issue 3506](https://github.com/rome/tools/issues/3506)). That may be surprising to you if you use other extensions like ESLint where the extension is disabled if the configuration is missing. This behavior is intentional because it's Rome's philosophy that the configuration should be optional.


### PR DESCRIPTION
## Summary

Fixes #3636

This change makes use of the existing session tracking code to schedule a background task once the last session is dropped from the server. After a short timeout (correctly set at 60 seconds), this task will broadcast the shutdown signal to the server if no new session was started in the meantime.

This behavior can be disabled by passing the `--no-timeout` flag to the `__run_server` internal command, this is done automatically by the `rome start` command to ensure manually started instances of the server never times out. Importantly, the timeout task is only scheduled when a client disconnects, meaning a newly started server instance will run indefinitely until at least one client connects event if it wasn't passed the `--no-timeout` flag (this should rarely happen if ever as the daemon spawning code tries to open a connection immediately afterward to ensure the newly created process is working correctly).

## Test Plan

I tested this locally by configuring the VSCode extension to use a locally built binary from this branch, and checking the `rome` process correctly stops about one minute after exiting the editor.
