### PR TITLE
fix(rome_js_analyze): False positives for interactive elements in `useKeyWithClickEvents`

### DIFF
--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -116,7 +116,7 @@ pub fn ok_find_attributes_by_name() {
         .filter_map(rome_js_syntax::JsxAttributeList::cast)
         .next()
         .unwrap();
-    let [a, c, d] = list.find_attributes_by_name(["a", "c", "d"]);
+    let [a, c, d] = list.find_by_names(["a", "c", "d"]);
     assert_eq!(
         a.unwrap()
             .initializer()

--- a/website/docs/src/lint/rules/index.md
+++ b/website/docs/src/lint/rules/index.md
@@ -57,7 +57,7 @@ Enforces the usage of the attribute <code>type</code> for the element <code>butt
 	<a href="/lint/rules/useKeyWithClickEvents">useKeyWithClickEvents</a>
 	<span class="recommended">recommended</span>
 </h3>
-Enforce to have the <code>onClick</code> mouse event with the <code>onKeyUp</code>, the <code>onKeyDown</code>, or the <code>noKeyPress</code> keyboard event.
+Enforce to have the <code>onClick</code> mouse event with the <code>onKeyUp</code>, the <code>onKeyDown</code>, or the <code>onKeyPress</code> keyboard event.
 </section>
 <section class="rule">
 <h3 data-toc-exclude id="useKeyWithMouseEvents">

--- a/website/docs/src/lint/rules/useKeyWithClickEvents.md
+++ b/website/docs/src/lint/rules/useKeyWithClickEvents.md
@@ -6,7 +6,7 @@ title: Lint Rule useKeyWithClickEvents
 
 > This rule is recommended by Rome.
 
-Enforce to have the `onClick` mouse event with the `onKeyUp`, the `onKeyDown`, or the `noKeyPress` keyboard event.
+Enforce to have the `onClick` mouse event with the `onKeyUp`, the `onKeyDown`, or the `onKeyPress` keyboard event.
 
 ## Examples
 
@@ -69,5 +69,9 @@ Enforce to have the `onClick` mouse event with the `onKeyUp`, the `onKeyDown`, o
 
 ```jsx
 <div {...spread} onClick={() => {}} ></div>
+```
+
+```jsx
+<button onClick={() => console.log("test")}>Submit</button>
 ```
 


### PR DESCRIPTION
Interactive elements like `button`, `a`, `input` etc. don't need key events as they are supported by the browser.

This is a simplified implementation and the rule should also consider if the element is hidden for screen readers but that's out of the scope of this fix. See #3640

## Test Plan

I added a new test that verifies that `button` no longer gets flagged.



## Versioning

This reduces the number of lint warnings and is thus, safe to land