### PR TITLE
fix(npm/js-api): Import type from @rometools/backend-jsonrpc

### DIFF
--- a/npm/js-api/src/index.ts
+++ b/npm/js-api/src/index.ts
@@ -1,6 +1,6 @@
 import { NodeWasm } from "./nodeWasm";
 import { Deamon } from "./daemon";
-import { Diagnostic, Configuration } from "@rometools/backend-jsonrpc";
+import type { Diagnostic, Configuration } from "@rometools/backend-jsonrpc";
 import { createError } from "./utils";
 
 // Re-export of some useful types for users


### PR DESCRIPTION
Imports `Diagnostic` and `Configuration` as type instead of an object

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
