### PR TITLE
fix(npm/js-api): Lazy load backend implementations

### DIFF
--- a/npm/js-api/package.json
+++ b/npm/js-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rometools/js-api",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JavaScript APIs for the Rome package",
   "scripts": {
     "tsc": "tsc --noEmit",

--- a/npm/js-api/src/daemon.ts
+++ b/npm/js-api/src/daemon.ts
@@ -17,7 +17,7 @@ export class Deamon {
 	 */
 	public static async connectToDaemon(pathToBinary?: string): Promise<Deamon> {
 		const { createWorkspace, createWorkspaceWithBinary } = await import(
-			"@rometools/backend-jsonrpc",
+			"@rometools/backend-jsonrpc"
 		);
 
 		if (pathToBinary) {

--- a/npm/js-api/src/daemon.ts
+++ b/npm/js-api/src/daemon.ts
@@ -1,8 +1,4 @@
-import {
-	createWorkspace,
-	createWorkspaceWithBinary,
-	Workspace,
-} from "@rometools/backend-jsonrpc";
+import type { Workspace } from "@rometools/backend-jsonrpc";
 
 /**
  * Class responsible to communicate with the Rome daemon.
@@ -20,6 +16,10 @@ export class Deamon {
 	 * It creates a new instance of a workspace connected to the Daemon
 	 */
 	public static async connectToDaemon(pathToBinary?: string): Promise<Deamon> {
+		const { createWorkspace, createWorkspaceWithBinary } = await import(
+			"@rometools/backend-jsonrpc",
+		);
+
 		if (pathToBinary) {
 			let workspace = await createWorkspaceWithBinary(pathToBinary);
 			if (workspace) {

--- a/npm/js-api/src/nodeWasm.ts
+++ b/npm/js-api/src/nodeWasm.ts
@@ -1,4 +1,4 @@
-import { main, Workspace } from "@rometools/wasm-nodejs";
+import type { Workspace } from "@rometools/wasm-nodejs";
 
 /**
  * Class responsible to connect with the WebAssembly backend of Rome.
@@ -13,13 +13,12 @@ export class NodeWasm {
 	 * It creates a new instance of a workspace connected to the WebAssembly backend
 	 */
 	public static async loadWebAssembly(): Promise<NodeWasm> {
-		return new NodeWasm(await NodeWasm.loadWorkspace());
-	}
+		const { main, Workspace } = await import("@rometools/wasm-nodejs");
 
-	private static async loadWorkspace(): Promise<Workspace> {
 		// load the web assembly module
 		main();
-		return Promise.resolve(new Workspace());
+
+		return new NodeWasm(new Workspace());
 	}
 }
 


### PR DESCRIPTION
The wasm and backendjsonrpc dependencies are both marked as optional but the implementation loads packages statically, making the `js-api` fail immediately if one of the two isn't installed.

This PR moves the imports into lazy async calls.


