### PR TITLE
docs: change indent-style from tabs to tab

### DIFF
--- a/website/docs/src/formatter/index.md
+++ b/website/docs/src/formatter/index.md
@@ -11,7 +11,7 @@ few options to avoid that debates over styles turn into debates over Rome option
 
 The language agnostic options supported by Rome are:
 
-- indent style (default: `tabs`): Use spaces or tabs for indention
+- indent style (default: `tab`): Use spaces or tabs for indention
 - tab width (default: `2`): The number of spaces per indention level
 - line width (default: `80`): The column width at which Rome wraps code
 
@@ -36,7 +36,7 @@ USAGE:
 OPTIONS:
     --write                                  Edit the files in place (beware!) instead of printing the diff to the console
     --skip-errors                            Skip over files containing syntax errors instead of emitting an error diagnostic.
-    --indent-style <tabs|space>              Change the indention character (default: tabs)
+    --indent-style <tab|space>              Change the indention character (default: tab)
     --indent-size <number>                   If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
     --line-width <number>                    Change how many characters the formatter is allowed to print in a single line (default: 80)
     --quote-style <single|double>            Changes the quotation character for strings (default: ")


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

using `tabs` gives the following error so updating the docs:

```
Error: failed to parse argument '--indent-style': failed to parse 'tabs': Value not supported for IndentStyle
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

ran  

```
rome format --indent-style tab . 
```

and it worked