### PR TITLE
fix(rome_js_formatter): new expression attribute

### DIFF
--- a/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/expression_attribute_value.rs
@@ -89,7 +89,6 @@ pub(crate) fn should_inline_jsx_expression(
         | JsObjectExpression(_)
         | JsArrowFunctionExpression(_)
         | JsCallExpression(_)
-        | JsNewExpression(_)
         | JsImportCallExpression(_)
         | ImportMeta(_)
         | JsFunctionExpression(_)

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -787,11 +787,11 @@ function() {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-const a = [
-	longlonglonglongItem1longlonglonglongItem1,
-	longlonglonglongItem1longlonglonglongItem2,
-	longlonglonglongItem1longlonglonglongItem3,
-];
+    <OtherComponent
+      value={
+        new Set(veryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzz)
+      }
+    />
 
 "#;
         let syntax = SourceType::tsx();

--- a/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx
+++ b/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx
@@ -68,3 +68,9 @@ const a = <Popconfirm
 		<span>Delete</span>
 	</Popconfirm>
 ;
+
+<OtherComponent
+	value={
+		new Set(veryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzz)
+	}
+/>

--- a/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx.snap
@@ -77,6 +77,12 @@ const a = <Popconfirm
 	</Popconfirm>
 ;
 
+<OtherComponent
+	value={
+		new Set(veryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzz)
+	}
+/>
+
 ```
 
 
@@ -176,6 +182,14 @@ const a = (
 	</Popconfirm>
 );
 
+<OtherComponent
+	value={
+		new Set(
+			veryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzz,
+		)
+	}
+/>;
+
 
 ## Unimplemented nodes/tokens
 
@@ -187,6 +201,7 @@ const a = (
 
    10: 			"ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
    30: 			"ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
+   85: 			veryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzz,
 ```
 
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix https://github.com/rome/tools/issues/3531#issuecomment-1311698292

https://github.com/prettier/prettier/blob/ae3dd17114bfb9831b85816f927eea90dcb0968b/src/language-js/print/jsx.js#L506-L521

[Playground](https://docs.rome.tools/playground/?code=%3COtherComponent%0A%09value%3D%7B%0A%09%09new+Set%28veryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzz%29%0A%09%7D%0A%2F%3E#PABPAHQAaABlAHIAQwBvAG0AcABvAG4AZQBuAHQACgAJAHYAYQBsAHUAZQA9AHsACgAJAAkAbgBlAHcAIABTAGUAdAAoAHYAZQByAHkATABvAG4AZwBDAG8AbgBkAGkAdABpAG8AbgBaAHoAegB6AHoAegB6AHoAegB6AHoAegB6AHoAegB6AHoAdgBlAHIAeQBMAG8AbgBnAEMAbwBuAGQAaQB0AGkAbwBuAFoAegB6AHoAegB6AHoAegB6AHoAegB6AHoAegB6AHoAegB2AGUAcgB5AEwAbwBuAGcAQwBvAG4AZABpAHQAaQBvAG4AWgB6AHoAegB6AHoAegB6AHoAegB6AHoAegB6AHoAegB6ACkACgAJAH0ACgAvAD4A)

## Test Plan

`cargo test -p rome_js_formatter`
