### PR TITLE
Fix pnpm install command

### DIFF
--- a/website/src/pages/guides/getting-started.mdx
+++ b/website/src/pages/guides/getting-started.mdx
@@ -34,7 +34,7 @@ You can now use `npx rome` to run Rome.
 #### pnpm
 
 ```bash
-pnpm install --save-dev rome
+pnpm add --save-dev rome
 ```
 
 You can now use `pnpm rome` to run Rome.


### PR DESCRIPTION
According to https://pnpm.io/cli/install `pnpm install` is used to install a whole project and not to add a single dependency. `pnpm add` should be used instead.
I just tried to use `pnpm install` like shown here and it surprisingly worked but since this is not documented it might be better to use `pnpm add` in Rome's documentation.
