### PR TITLE
docs(configuration): add to sidebar

### DIFF
--- a/website/src/pages/configuration.mdx
+++ b/website/src/pages/configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuration
 emoji: ⚙️
+category: reference
 description: How to customize and configure Rome with <code>rome.json</code>.
 layout: ../Layout.astro
 ---


### PR DESCRIPTION
https://docs.rome.tools/configuration/ cannot be accessed from the sidebar.

Solution: add `category: reference` to frontmatter.