### PR TITLE
website(docs): Remove base property from netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
-base = "website/"
-publish = "build/"
-command = "./build-netlify.sh"
+base = ""
+publish = "website/build/"
+command = "./website/build-netlify.sh"

--- a/website/build-netlify.sh
+++ b/website/build-netlify.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
 
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh 
 pnpm build:wasm


### PR DESCRIPTION
This PR removes the `base` property from `netlify.toml`. Netlify checks if there are any changes to the base directory to decide if it needs to skip a build. Unfortunately, since we merged the playground into the docs, we should be doing a build for every playground change. After this PR the builds will no longer be skipped.