### PR TITLE
fix(lindoc): fix generated docs path

### DIFF
--- a/xtask/contributors/src/main.rs
+++ b/xtask/contributors/src/main.rs
@@ -9,7 +9,7 @@ use xtask::*;
 ///
 /// Only users that have read rights can run this script
 fn main() -> Result<()> {
-    let root = project_root().join("website/docs/src/components");
+    let root = project_root().join("website/src/components");
     let mut args = Arguments::from_env();
     let token: String = args.value_from_str("--token").unwrap();
     let contributors = get_contributors(&token);

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -25,8 +25,8 @@ use std::{
 use xtask::{glue::fs2, *};
 
 fn main() -> Result<()> {
-    let root = project_root().join("website/docs/src/pages/lint/rules");
-    let reference_groups = project_root().join("website/docs/src/components/reference/Groups.md");
+    let root = project_root().join("website/src/pages/lint/rules");
+    let reference_groups = project_root().join("website/src/components/reference/Groups.md");
 
     // Clear the rules directory ignoring "not found" errors
     if let Err(err) = fs2::remove_dir_all(&root) {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

lintdoc is generating md files under `website/docs` but that path has been changed.

## Test Plan

NA
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
