### PR TITLE
docs: Add `repository` field in `package.json` files of published npm packages

### DIFF
--- a/npm/backend-jsonrpc/package.json
+++ b/npm/backend-jsonrpc/package.json
@@ -9,6 +9,11 @@
     "build": "tsc"
   },
   "homepage": "https://rome.tools",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rome/tools.git",
+    "directory": "npm/backend-jsonrpc"
+  },
   "author": "Rome Tools Developers and Contributors",
   "bugs": "https://github.com/rome/tools/issues",
   "description": "Bindings to the JSON-RPC Workspace API of the Rome daemon",

--- a/npm/js-api/package.json
+++ b/npm/js-api/package.json
@@ -29,6 +29,11 @@
   ],
   "license": "MIT",
   "homepage": "https://rome.tools",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rome/tools.git",
+    "directory": "npm/js-api"
+  },
   "author": "Rome Tools Developers and Contributors",
   "bugs": "https://github.com/rome/tools/issues",
   "devDependencies": {

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -6,6 +6,11 @@
         "postinstall": "node scripts/postinstall.js"
     },
     "homepage": "https://rome.tools",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/rome/tools.git",
+      "directory": "npm/rome"
+    },
     "author": "Sebastian McKenzie",
     "license": "MIT",
     "bugs": "https://github.com/rome/tools/issues",


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This will add a standard link to the repo in the npm registry website.

For reference: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
After the next publish to npm, the packages on the npm website should link to the correct directory in GitHub.