### PR TITLE
website(docs): More website tweaks

### DIFF
--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -143,10 +143,10 @@ function inlineIntegration(): AstroIntegration {
 }
 
 function remarkDefaultLayoutPlugin() {
-  return function (tree, file) {
-		const {frontmatter} = file.data.astro;
-    frontmatter.layout = frontmatter.layout ?? "/Layout.astro";
-  };
+	return function (tree, file) {
+		const { frontmatter } = file.data.astro;
+		frontmatter.layout = frontmatter.layout ?? "/Layout.astro";
+	};
 }
 
 // https://astro.build/config

--- a/website/src/Layout.astro
+++ b/website/src/Layout.astro
@@ -6,7 +6,10 @@ import {buildGetPages, buildTOC} from "./navigation-utils";
 const {props} = Astro;
 const {frontmatter = {}} = props;
 
-const getPages = buildGetPages(await Astro.glob("./**/*.mdx"));
+const getPages = buildGetPages([
+  ...(await Astro.glob("./**/*.mdx")),
+  ...(await Astro.glob("./**/*.md")),
+]);
 let sidebarEnabled = false;
 let toc = "";
 
@@ -18,6 +21,19 @@ for (const page of allPages) {
     break;
   }
 }
+
+let parentPage;
+if (frontmatter.parent) {
+  for (const page of allPages) {
+    if (page.file.includes(frontmatter.parent)) {
+      parentPage = page;
+      break;
+    }
+  }
+  if (parentPage === undefined) {
+    throw new Error(`Could not find parent page ${frontmatter.parent}`);
+  }
+}
 ---
 
 <BaseLayout sidebarEnabled={sidebarEnabled} {...Astro.props}>
@@ -25,6 +41,10 @@ for (const page of allPages) {
     <NavigationSidebar />
 
     <main class={`main content ${frontmatter.mainClass ?? ""}`}>
+      {parentPage && <p class="parent-back"><a href={parentPage.url}>
+        <span aria-hidden="true" class="symbol">⏎</span>
+        <span class="text">{parentPage.frontmatter.title}</span>
+      </a></p>}
       <slot />
     </main>
 

--- a/website/src/navigation-utils.ts
+++ b/website/src/navigation-utils.ts
@@ -1,14 +1,20 @@
 import type Astro from "astro";
 
-export function buildGetPages(pages: Astro.MDXInstance<any>[]) {
-	return (category?: string): Astro.MDXInstance<any>[] => {
+type GlobInstance = Astro.MarkdownInstance<any> | Astro.MDXInstance<any>;
+
+function getTitle(page: GlobInstance): string {
+	return page.frontmatter.title ?? "";
+}
+
+export function buildGetPages(pages: GlobInstance[]) {
+	return (category?: string): GlobInstance[] => {
 		return pages
 			.filter(
 				(page) =>
 					category === undefined || page.frontmatter.category === category,
 			)
 			.sort((a, b) => {
-				return a.frontmatter.title.localeCompare(b.frontmatter.title);
+				return getTitle(a).localeCompare(getTitle(b));
 			});
 	};
 }

--- a/website/src/pages/configuration.mdx
+++ b/website/src/pages/configuration.mdx
@@ -6,6 +6,7 @@ description: How to customize and configure Rome with rome.json.
 ---
 
 import LintGroups from "/components/reference/Groups.astro";
+import CodeBlockHeader from "/components/CodeBlockHeader.astro";
 
 {/** Make sure to update the redirect in `static/_redirects` when changing the configuration title --> **/}
 
@@ -18,6 +19,8 @@ The Rome configuration file is named `rome.json` and should be placed in the roo
 directory is usually the directory containing your project's `package.json`.
 
 Here's an example:
+
+<CodeBlockHeader filename="rome.json" />
 
 ```json
 {
@@ -34,28 +37,28 @@ Here's an example:
 
 This configuration file enables the formatter and sets the preferred indent style and width. The linter is disabled.
 
-## `rome.json`
+## `files`
 
-#### Files
-
-##### `files.maxSize`
+### `files.maxSize`
 
 The maximum allowed size for source code files in bytes. Files above
 this limit will be ignored for performance reason.
 
 > Default: 1024*1024 (1MB)
 
-### Linter
+## `linter`
 
-#### `linter.enabled`
+### `linter.enabled`
 
 Enables Rome's linter
 
 > Default: `true`
 
-#### `linter.ignore`
+### `linter.ignore`
 
 An array of Unix shell style patterns.
+
+<CodeBlockHeader filename="rome.json" />
 
 ```json
 {
@@ -65,23 +68,25 @@ An array of Unix shell style patterns.
 }
 ```
 
-#### `linter.rules.recommended`
+### `linter.rules.recommended`
 
 Enables the [recommended rules](/lint/rules) for all categories.
 
 > Default: `true`
 
-#### `linter.rules.[category]`
+### `linter.rules.[category]`
 
 Options that influence the rules of a single category. Rome supports the following categories:
 
 <LintGroups />
 
-#### `linter.rules.[category].recommended`
+### `linter.rules.[category].recommended`
 
 Enables the recommended rules for a single category.
 
 Example:
+
+<CodeBlockHeader filename="rome.json" />
 
 ```json
 {
@@ -96,17 +101,19 @@ Example:
 }
 ```
 
-### Formatter
+## `formatter`
 
-#### `formatter.enabled`
+### `formatter.enabled`
 
 Enables Rome's formatter
 
 > Default: `true`
 
-#### `formatter.ignore`
+### `formatter.ignore`
 
 An array of Unix shell style patterns.
+
+<CodeBlockHeader filename="rome.json" />
 
 ```json
 {
@@ -116,7 +123,7 @@ An array of Unix shell style patterns.
 }
 ```
 
-#### `formatter.indentStyle`
+### `formatter.indentStyle`
 
 The style of the indentation. It can be `"tab"` or `"space"`.
 
@@ -124,31 +131,31 @@ The style of the indentation. It can be `"tab"` or `"space"`.
 
 Rome's default is `"tab"`.
 
-#### `formatter.indentSize`
+### `formatter.indentSize`
 
 How big the indentation should be.
 
-#### `formatter.lineWidth`
+### `formatter.lineWidth`
 
 How many characters can be written on a single line.
 
 > Default: `80`
 
-### JavaScript
+## `javascript`
 
-#### `javascript.formatter.quoteStyle`
+### `javascript.formatter.quoteStyle`
 
 The type of quote used when representing string literals. It can be `single` or `double`.
 
 > Default: `double`
 
-#### `javascript.formatter.quoteProperties`
+### `javascript.formatter.quoteProperties`
 
 When properties inside objects should be quoted. It can be `asNeeded` or `preserve`.
 
 > Default: `asNeeded`
 
-#### `javascript.formatter.trailingComma`
+### `javascript.formatter.trailingComma`
 
 Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Possible values:
 - `all`, the trailing comma is always added

--- a/website/src/pages/formatter/index.mdx
+++ b/website/src/pages/formatter/index.mdx
@@ -39,7 +39,7 @@ USAGE:
 OPTIONS:
     --write                                  Edit the files in place (beware!) instead of printing the diff to the console
     --skip-errors                            Skip over files containing syntax errors instead of emitting an error diagnostic.
-    --indent-style <tab|space>              Change the indention character (default: tab)
+    --indent-style <tab|space>               Change the indention character (default: tab)
     --indent-size <number>                   If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
     --line-width <number>                    Change how many characters the formatter is allowed to print in a single line (default: 80)
     --quote-style <single|double>            Changes the quotation character for strings (default: ")
@@ -50,25 +50,13 @@ OPTIONS:
 
 ## Ignoring Code
 
-There are times when a developer wants to keep a specific formatting.
-
-You can achieve this by adding a suppression comment right before the syntax node (expressions, statements, etc.).
-
-Suppression comments have the following format:
+There are times when the way we format code might not be ideal. For these cases you can use a format suppression comment:
 
 ```js
 // rome-ignore format: <explanation>
 ```
 
-Where
-
-- `rome-ignore` is the start of a suppression comment;
-- `format:` suppresses the formatting;
-- `<explanation>` is an explanation why the formatting is disabled;
-
-Here's an example of how a code will look like before and after the formatter does its job:
-
-Before running the formatter
+Example:
 
 ```js
 const expr =
@@ -91,69 +79,4 @@ const expr =
     -1,
     0,
   ];
-
-const expr = [
-  (2 * n) / (r - l),
-  0,
-  (r + l) / (r - l),
-  0,
-  0,
-  (2 * n) / (t - b),
-  (t + b) / (t - b),
-  0,
-  0,
-  0,
-  -(f + n) / (f - n),
-  -(2 * f * n) / (f - n),
-  0,
-  0,
-  -1,
-  0,
-];
 ```
-
-After running the formatter
-
-```js
-const expr =
-  // rome-ignore format: the array should not be formatted
-  [
-    (2 * n) / (r - l),
-    0,
-    (r + l) / (r - l),
-    0,
-    0,
-    (2 * n) / (t - b),
-    (t + b) / (t - b),
-    0,
-    0,
-    0,
-    -(f + n) / (f - n),
-    -(2 * f * n) / (f - n),
-    0,
-    0,
-    -1,
-    0,
-  ];
-
-const expr = [
-  (2 * n) / (r - l),
-  0,
-  (r + l) / (r - l),
-  0,
-  0,
-  (2 * n) / (t - b),
-  (t + b) / (t - b),
-  0,
-  0,
-  0,
-  -(f + n) / (f - n),
-  -(2 * f * n) / (f - n),
-  0,
-  0,
-  -1,
-  0,
-];
-```
-
-As you can see the first array, which has a suppression comment, is left untouched!

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Lint Rules
+parent: linter/index
 emoji: 📏
 description: List of available lint rules.
 category: reference

--- a/website/src/pages/lint/rules/noArguments.md
+++ b/website/src/pages/lint/rules/noArguments.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noArguments
+parent: lint/rules/index
 ---
 
 # noArguments (since v0.7.0)

--- a/website/src/pages/lint/rules/noArrayIndexKey.md
+++ b/website/src/pages/lint/rules/noArrayIndexKey.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noArrayIndexKey
+parent: lint/rules/index
 ---
 
 # noArrayIndexKey (since v0.10.0)

--- a/website/src/pages/lint/rules/noAsyncPromiseExecutor.md
+++ b/website/src/pages/lint/rules/noAsyncPromiseExecutor.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noAsyncPromiseExecutor
+parent: lint/rules/index
 ---
 
 # noAsyncPromiseExecutor (since v0.7.0)

--- a/website/src/pages/lint/rules/noAutofocus.md
+++ b/website/src/pages/lint/rules/noAutofocus.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noAutofocus
+parent: lint/rules/index
 ---
 
 # noAutofocus (since v10.0.0)

--- a/website/src/pages/lint/rules/noBannedTypes.md
+++ b/website/src/pages/lint/rules/noBannedTypes.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noBannedTypes
+parent: lint/rules/index
 ---
 
 # noBannedTypes (since v10.0.0)

--- a/website/src/pages/lint/rules/noCatchAssign.md
+++ b/website/src/pages/lint/rules/noCatchAssign.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noCatchAssign
+parent: lint/rules/index
 ---
 
 # noCatchAssign (since v0.7.0)

--- a/website/src/pages/lint/rules/noChildrenProp.md
+++ b/website/src/pages/lint/rules/noChildrenProp.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noChildrenProp
+parent: lint/rules/index
 ---
 
 # noChildrenProp (since v0.10.0)

--- a/website/src/pages/lint/rules/noCommentText.md
+++ b/website/src/pages/lint/rules/noCommentText.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noCommentText
+parent: lint/rules/index
 ---
 
 # noCommentText (since v0.7.0)

--- a/website/src/pages/lint/rules/noCompareNegZero.md
+++ b/website/src/pages/lint/rules/noCompareNegZero.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noCompareNegZero
+parent: lint/rules/index
 ---
 
 # noCompareNegZero (since v0.7.0)

--- a/website/src/pages/lint/rules/noConstAssign.md
+++ b/website/src/pages/lint/rules/noConstAssign.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noConstAssign
+parent: lint/rules/index
 ---
 
 # noConstAssign (since v10.0.0)

--- a/website/src/pages/lint/rules/noDangerouslySetInnerHtml.md
+++ b/website/src/pages/lint/rules/noDangerouslySetInnerHtml.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noDangerouslySetInnerHtml
+parent: lint/rules/index
 ---
 
 # noDangerouslySetInnerHtml (since v0.10.0)

--- a/website/src/pages/lint/rules/noDangerouslySetInnerHtmlWithChildren.md
+++ b/website/src/pages/lint/rules/noDangerouslySetInnerHtmlWithChildren.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noDangerouslySetInnerHtmlWithChildren
+parent: lint/rules/index
 ---
 
 # noDangerouslySetInnerHtmlWithChildren (since v0.10.0)

--- a/website/src/pages/lint/rules/noDebugger.md
+++ b/website/src/pages/lint/rules/noDebugger.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noDebugger
+parent: lint/rules/index
 ---
 
 # noDebugger (since v0.7.0)

--- a/website/src/pages/lint/rules/noDelete.md
+++ b/website/src/pages/lint/rules/noDelete.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noDelete
+parent: lint/rules/index
 ---
 
 # noDelete (since v0.7.0)

--- a/website/src/pages/lint/rules/noDoubleEquals.md
+++ b/website/src/pages/lint/rules/noDoubleEquals.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noDoubleEquals
+parent: lint/rules/index
 ---
 
 # noDoubleEquals (since v0.7.0)

--- a/website/src/pages/lint/rules/noDupeArgs.md
+++ b/website/src/pages/lint/rules/noDupeArgs.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noDupeArgs
+parent: lint/rules/index
 ---
 
 # noDupeArgs (since v0.9.0)

--- a/website/src/pages/lint/rules/noEmptyPattern.md
+++ b/website/src/pages/lint/rules/noEmptyPattern.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noEmptyPattern
+parent: lint/rules/index
 ---
 
 # noEmptyPattern (since v0.7.0)

--- a/website/src/pages/lint/rules/noExplicitAny.md
+++ b/website/src/pages/lint/rules/noExplicitAny.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noExplicitAny
+parent: lint/rules/index
 ---
 
 # noExplicitAny (since v10.0.0)

--- a/website/src/pages/lint/rules/noExtraBooleanCast.md
+++ b/website/src/pages/lint/rules/noExtraBooleanCast.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noExtraBooleanCast
+parent: lint/rules/index
 ---
 
 # noExtraBooleanCast (since v0.9.0)

--- a/website/src/pages/lint/rules/noFunctionAssign.md
+++ b/website/src/pages/lint/rules/noFunctionAssign.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noFunctionAssign
+parent: lint/rules/index
 ---
 
 # noFunctionAssign (since v0.7.0)

--- a/website/src/pages/lint/rules/noImplicitBoolean.md
+++ b/website/src/pages/lint/rules/noImplicitBoolean.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noImplicitBoolean
+parent: lint/rules/index
 ---
 
 # noImplicitBoolean (since v0.7.0)

--- a/website/src/pages/lint/rules/noImportAssign.md
+++ b/website/src/pages/lint/rules/noImportAssign.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noImportAssign
+parent: lint/rules/index
 ---
 
 # noImportAssign (since v0.9.0)

--- a/website/src/pages/lint/rules/noInvalidConstructorSuper.md
+++ b/website/src/pages/lint/rules/noInvalidConstructorSuper.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noInvalidConstructorSuper
+parent: lint/rules/index
 ---
 
 # noInvalidConstructorSuper (since v10.0.0)

--- a/website/src/pages/lint/rules/noLabelVar.md
+++ b/website/src/pages/lint/rules/noLabelVar.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noLabelVar
+parent: lint/rules/index
 ---
 
 # noLabelVar (since v0.7.0)

--- a/website/src/pages/lint/rules/noMultipleSpacesInRegularExpressionLiterals.md
+++ b/website/src/pages/lint/rules/noMultipleSpacesInRegularExpressionLiterals.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noMultipleSpacesInRegularExpressionLiterals
+parent: lint/rules/index
 ---
 
 # noMultipleSpacesInRegularExpressionLiterals (since v0.7.0)

--- a/website/src/pages/lint/rules/noNegationElse.md
+++ b/website/src/pages/lint/rules/noNegationElse.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noNegationElse
+parent: lint/rules/index
 ---
 
 # noNegationElse (since v0.7.0)

--- a/website/src/pages/lint/rules/noNewSymbol.md
+++ b/website/src/pages/lint/rules/noNewSymbol.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noNewSymbol
+parent: lint/rules/index
 ---
 
 # noNewSymbol (since v0.10.0)

--- a/website/src/pages/lint/rules/noPositiveTabindex.md
+++ b/website/src/pages/lint/rules/noPositiveTabindex.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noPositiveTabindex
+parent: lint/rules/index
 ---
 
 # noPositiveTabindex (since v10.0.0)

--- a/website/src/pages/lint/rules/noRenderReturnValue.md
+++ b/website/src/pages/lint/rules/noRenderReturnValue.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noRenderReturnValue
+parent: lint/rules/index
 ---
 
 # noRenderReturnValue (since v0.10.0)

--- a/website/src/pages/lint/rules/noRestrictedGlobals.md
+++ b/website/src/pages/lint/rules/noRestrictedGlobals.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noRestrictedGlobals
+parent: lint/rules/index
 ---
 
 # noRestrictedGlobals (since v0.10.0)

--- a/website/src/pages/lint/rules/noShadowRestrictedNames.md
+++ b/website/src/pages/lint/rules/noShadowRestrictedNames.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noShadowRestrictedNames
+parent: lint/rules/index
 ---
 
 # noShadowRestrictedNames (since v0.9.0)

--- a/website/src/pages/lint/rules/noShoutyConstants.md
+++ b/website/src/pages/lint/rules/noShoutyConstants.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noShoutyConstants
+parent: lint/rules/index
 ---
 
 # noShoutyConstants (since v0.7.0)

--- a/website/src/pages/lint/rules/noSparseArray.md
+++ b/website/src/pages/lint/rules/noSparseArray.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noSparseArray
+parent: lint/rules/index
 ---
 
 # noSparseArray (since v0.7.0)

--- a/website/src/pages/lint/rules/noUndeclaredVariables.md
+++ b/website/src/pages/lint/rules/noUndeclaredVariables.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noUndeclaredVariables
+parent: lint/rules/index
 ---
 
 # noUndeclaredVariables (since v0.10.0)

--- a/website/src/pages/lint/rules/noUnnecessaryContinue.md
+++ b/website/src/pages/lint/rules/noUnnecessaryContinue.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noUnnecessaryContinue
+parent: lint/rules/index
 ---
 
 # noUnnecessaryContinue (since v0.7.0)

--- a/website/src/pages/lint/rules/noUnreachable.md
+++ b/website/src/pages/lint/rules/noUnreachable.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noUnreachable
+parent: lint/rules/index
 ---
 
 # noUnreachable (since v0.7.0)

--- a/website/src/pages/lint/rules/noUnsafeNegation.md
+++ b/website/src/pages/lint/rules/noUnsafeNegation.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noUnsafeNegation
+parent: lint/rules/index
 ---
 
 # noUnsafeNegation (since v0.7.0)

--- a/website/src/pages/lint/rules/noUnusedTemplateLiteral.md
+++ b/website/src/pages/lint/rules/noUnusedTemplateLiteral.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noUnusedTemplateLiteral
+parent: lint/rules/index
 ---
 
 # noUnusedTemplateLiteral (since v0.7.0)

--- a/website/src/pages/lint/rules/noUnusedVariables.md
+++ b/website/src/pages/lint/rules/noUnusedVariables.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noUnusedVariables
+parent: lint/rules/index
 ---
 
 # noUnusedVariables (since v0.9.0)

--- a/website/src/pages/lint/rules/noUselessFragments.md
+++ b/website/src/pages/lint/rules/noUselessFragments.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noUselessFragments
+parent: lint/rules/index
 ---
 
 # noUselessFragments (since v0.10.0)

--- a/website/src/pages/lint/rules/noVoidElementsWithChildren.md
+++ b/website/src/pages/lint/rules/noVoidElementsWithChildren.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule noVoidElementsWithChildren
+parent: lint/rules/index
 ---
 
 # noVoidElementsWithChildren (since v0.10.0)

--- a/website/src/pages/lint/rules/useAltText.md
+++ b/website/src/pages/lint/rules/useAltText.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useAltText
+parent: lint/rules/index
 ---
 
 # useAltText (since v10.0.0)

--- a/website/src/pages/lint/rules/useAnchorContent.md
+++ b/website/src/pages/lint/rules/useAnchorContent.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useAnchorContent
+parent: lint/rules/index
 ---
 
 # useAnchorContent (since v10.0.0)

--- a/website/src/pages/lint/rules/useBlankTarget.md
+++ b/website/src/pages/lint/rules/useBlankTarget.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useBlankTarget
+parent: lint/rules/index
 ---
 
 # useBlankTarget (since v10.0.0)

--- a/website/src/pages/lint/rules/useBlockStatements.md
+++ b/website/src/pages/lint/rules/useBlockStatements.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useBlockStatements
+parent: lint/rules/index
 ---
 
 # useBlockStatements (since v0.7.0)

--- a/website/src/pages/lint/rules/useButtonType.md
+++ b/website/src/pages/lint/rules/useButtonType.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useButtonType
+parent: lint/rules/index
 ---
 
 # useButtonType (since v0.10.0)

--- a/website/src/pages/lint/rules/useCamelCase.md
+++ b/website/src/pages/lint/rules/useCamelCase.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useCamelCase
+parent: lint/rules/index
 ---
 
 # useCamelCase (since v0.8.0)

--- a/website/src/pages/lint/rules/useExhaustiveDependencies.md
+++ b/website/src/pages/lint/rules/useExhaustiveDependencies.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useExhaustiveDependencies
+parent: lint/rules/index
 ---
 
 # useExhaustiveDependencies (since v10.0.0)

--- a/website/src/pages/lint/rules/useFlatMap.md
+++ b/website/src/pages/lint/rules/useFlatMap.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useFlatMap
+parent: lint/rules/index
 ---
 
 # useFlatMap (since v10.0.0)

--- a/website/src/pages/lint/rules/useFragmentSyntax.md
+++ b/website/src/pages/lint/rules/useFragmentSyntax.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useFragmentSyntax
+parent: lint/rules/index
 ---
 
 # useFragmentSyntax (since v0.10.0)

--- a/website/src/pages/lint/rules/useKeyWithClickEvents.md
+++ b/website/src/pages/lint/rules/useKeyWithClickEvents.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useKeyWithClickEvents
+parent: lint/rules/index
 ---
 
 # useKeyWithClickEvents (since v10.0.0)

--- a/website/src/pages/lint/rules/useKeyWithMouseEvents.md
+++ b/website/src/pages/lint/rules/useKeyWithMouseEvents.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useKeyWithMouseEvents
+parent: lint/rules/index
 ---
 
 # useKeyWithMouseEvents (since v10.0.0)

--- a/website/src/pages/lint/rules/useOptionalChain.md
+++ b/website/src/pages/lint/rules/useOptionalChain.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useOptionalChain
+parent: lint/rules/index
 ---
 
 # useOptionalChain (since v0.10.0)

--- a/website/src/pages/lint/rules/useSelfClosingElements.md
+++ b/website/src/pages/lint/rules/useSelfClosingElements.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useSelfClosingElements
+parent: lint/rules/index
 ---
 
 # useSelfClosingElements (since v0.7.0)

--- a/website/src/pages/lint/rules/useShorthandArrayType.md
+++ b/website/src/pages/lint/rules/useShorthandArrayType.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useShorthandArrayType
+parent: lint/rules/index
 ---
 
 # useShorthandArrayType (since v0.7.0)

--- a/website/src/pages/lint/rules/useSimplifiedLogicExpression.md
+++ b/website/src/pages/lint/rules/useSimplifiedLogicExpression.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useSimplifiedLogicExpression
+parent: lint/rules/index
 ---
 
 # useSimplifiedLogicExpression (since v0.7.0)

--- a/website/src/pages/lint/rules/useSingleCaseStatement.md
+++ b/website/src/pages/lint/rules/useSingleCaseStatement.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useSingleCaseStatement
+parent: lint/rules/index
 ---
 
 # useSingleCaseStatement (since v0.7.0)

--- a/website/src/pages/lint/rules/useSingleVarDeclarator.md
+++ b/website/src/pages/lint/rules/useSingleVarDeclarator.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useSingleVarDeclarator
+parent: lint/rules/index
 ---
 
 # useSingleVarDeclarator (since v0.7.0)

--- a/website/src/pages/lint/rules/useTemplate.md
+++ b/website/src/pages/lint/rules/useTemplate.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useTemplate
+parent: lint/rules/index
 ---
 
 # useTemplate (since v0.7.0)

--- a/website/src/pages/lint/rules/useValidAnchor.md
+++ b/website/src/pages/lint/rules/useValidAnchor.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useValidAnchor
+parent: lint/rules/index
 ---
 
 # useValidAnchor (since v10.0.0)

--- a/website/src/pages/lint/rules/useValidForDirection.md
+++ b/website/src/pages/lint/rules/useValidForDirection.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useValidForDirection
+parent: lint/rules/index
 ---
 
 # useValidForDirection (since v10.0.0)

--- a/website/src/pages/lint/rules/useValidTypeof.md
+++ b/website/src/pages/lint/rules/useValidTypeof.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useValidTypeof
+parent: lint/rules/index
 ---
 
 # useValidTypeof (since v0.7.0)

--- a/website/src/pages/lint/rules/useWhile.md
+++ b/website/src/pages/lint/rules/useWhile.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rule useWhile
+parent: lint/rules/index
 ---
 
 # useWhile (since v0.7.0)

--- a/website/src/styles/_content.scss
+++ b/website/src/styles/_content.scss
@@ -41,6 +41,29 @@
 		}
 	}
 
+	p.parent-back {
+		margin: 0;
+		margin-top: 10px;
+		font-size: 18px;
+		font-weight: bold;
+
+		.symbol {
+			font-weight: bold;
+		}
+
+		a {
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+
+		+ h1 {
+			margin-top: 10px;
+		}
+	}
+
 	strong {
 		font-weight: bold;
 	}

--- a/website/src/styles/_global.scss
+++ b/website/src/styles/_global.scss
@@ -145,3 +145,11 @@ html {
 		scroll-padding-top: 64px;
 	}
 }
+
+input {
+	color-scheme: light;
+
+	@include dark-mode {
+		color-scheme: dark;
+	}
+}

--- a/website/src/styles/_pre.scss
+++ b/website/src/styles/_pre.scss
@@ -43,7 +43,7 @@ ul.package-manager-selector li {
 
   &.active {
     font-weight: bold;
-    border-bottom: 1px solid black;
+    border-bottom: 2px solid black;
 
     @include dark-mode {
       border-color: white;

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -47,6 +47,7 @@ fn main() -> Result<()> {
     let mut reference_buffer = Vec::new();
     writeln!(index, "---")?;
     writeln!(index, "title: Lint Rules")?;
+    writeln!(index, "parent: linter/index")?;
     writeln!(index, "emoji: 📏")?;
     writeln!(index, "description: List of available lint rules.")?;
     writeln!(index, "category: reference")?;
@@ -178,6 +179,7 @@ fn generate_rule(
     // Write the header for this lint rule
     writeln!(content, "---")?;
     writeln!(content, "title: Lint Rule {rule}")?;
+    writeln!(content, "parent: lint/rules/index")?;
     writeln!(content, "---")?;
     writeln!(content)?;
 


### PR DESCRIPTION
This PR makes some slight documentation changes and the following design tweaks:

# Set `color-scheme` for inputs and dark mode

This allows the browser to choose better styles when in dark mode. Ex:

**Before**

![image](https://user-images.githubusercontent.com/853712/201538370-8350d798-f42d-4c28-817a-976e1be29cac.png)

**After**

![image2](https://user-images.githubusercontent.com/853712/201538374-666d9d6e-2421-4837-bcae-155d038ba63e.png)

Thanks Mayhem in Discord for the suggestion!

# `parent` frontmatter property

This allow pages to specify that they're the child of another. All this does is add a back link at the top of the page. This is especially nice on lint rules:

<img width="1282" alt="Screenshot 2022-11-13 at 12 32 30 PM" src="https://user-images.githubusercontent.com/853712/201538341-90a011ac-8262-47e4-8784-a453357e34de.png">
