### PR TITLE
doc(website): Add context about Romes philosophy

### DIFF
--- a/website/src/pages/formatter/index.mdx
+++ b/website/src/pages/formatter/index.mdx
@@ -9,8 +9,8 @@ import PackageManagerRomeCommand from "/components/PackageManagerRomeCommand.ast
 
 # Formatter
 
-Rome's an opinionated formatter that has the goal to stop all ongoing debates over styles. That's why Rome only supports
-few options to avoid that debates over styles turn into debates over Rome options.
+Rome's an opinionated formatter that has the goal to stop all ongoing debates over styles. It follows a similar [philosophy to Prettier](https://prettier.io/docs/en/option-philosophy.html), only supporting
+few options to avoid that debates over styles turn into debates over Rome options. It deliberately [resists the urge to add new options](https://github.com/prettier/prettier/issues/40) to prevent [bike-shed discussions](https://en.wikipedia.org/wiki/Law_of_triviality) in teams so they can focus on what really matters instead.
 
 ## Options
 


### PR DESCRIPTION
## Summary

As discussed in https://github.com/rome/tools/discussions/3698#discussioncomment-4128011 if you are new to the world of formatting it might be hard to understand at first why Rome (and Prettier) are so opinionated. Prettier has a whole philosophy page which might be overkill at this point. But adding just a few of these links add's a lot of necessary context as they will either immediately resonate or alienate people which are looking for a less opinionated tool.
