### PR TITLE
website(docs): set `color-scheme` on the root element

### DIFF
--- a/website/src/styles/_global.scss
+++ b/website/src/styles/_global.scss
@@ -145,8 +145,8 @@ a, .link {
 	@include mobile-only {
 		scroll-padding-top: 64px;
 	}
+}
 
-	@include dark-mode {
-		color-scheme: dark only;
-	}
+@include dark-mode {
+	color-scheme: dark only;
 }

--- a/website/src/styles/_global.scss
+++ b/website/src/styles/_global.scss
@@ -138,18 +138,15 @@ a, .link {
 	}
 }
 
-html {
+:root {
 	scroll-padding-top: 80px;
+	color-scheme: light only;
 
 	@include mobile-only {
 		scroll-padding-top: 64px;
 	}
-}
-
-input {
-	color-scheme: light;
 
 	@include dark-mode {
-		color-scheme: dark;
+		color-scheme: dark only;
 	}
 }

--- a/website/src/styles/_mixins.scss
+++ b/website/src/styles/_mixins.scss
@@ -57,12 +57,12 @@
 }
 
 @mixin dark-mode {
-	@at-root html[data-theme='dark'] #{if(&, "&", "")} {
+	@at-root :root[data-theme='dark'] #{if(&, "&", "")} {
 		@content;
 	}
 
 	@media (prefers-color-scheme: dark) {
-		@at-root html[data-theme='auto'] #{if(&, "&", "")} {
+		@at-root :root[data-theme='auto'] #{if(&, "&", "")} {
 			@content;
 		}
 	}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`color-scheme` was previously set on `input`s only, while we can set it on the root/html element to affect other elements on the page, including scrollbars.

I've also added the `only` keyword to prevent user agents from applying color overrides.

I've also changed from the `html` selector to `:root`, shouldn't matter much, though I do wonder if browsers optimize it as there can only be one `:root` per document, while you are allowed to create random `html` elements and append them just about anywhere.

For reference:
https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
https://developer.mozilla.org/en-US/docs/Web/CSS/:root

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

### Before

![image](https://user-images.githubusercontent.com/567105/201647130-29fa1f7d-58d3-491a-a0c5-4cb3008de4d9.png)
![image](https://user-images.githubusercontent.com/567105/201647641-49892f64-f94c-4a14-a986-351a7673a21a.png)


### After

![image](https://user-images.githubusercontent.com/567105/201647488-c3300f9d-78a4-4740-b304-02fc4ffdd709.png)
![image](https://user-images.githubusercontent.com/567105/201647683-a7cade55-8dc3-493d-93e2-de12017a2f69.png)


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
Tested in the live website with Chrome's DevTools.
Double-checked with the deploy preview.