### PR TITLE
fix(rome_lsp): update all diagnostics after a configuration change

### DIFF
--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -267,6 +267,7 @@ impl LanguageServer for LSPServer {
                             if possible_rome_json.display().to_string() == CONFIG_NAME {
                                 self.session.update_configuration().await;
                                 self.session.fetch_client_configuration().await;
+                                self.session.update_all_diagnostics().await;
                                 // for now we are only interested to the configuration file,
                                 // so it's OK to exist the loop
                                 break;


### PR DESCRIPTION
## Summary

Fixes #3522

This change forces a diagnostic update on all open documents after a configuration update event

## Test Plan

I tested this locally by ensuring that disabling a lint rule in the configuration cause all the corresponding diagnostics to disappear on save
