### PR TITLE
refactor(rome_cli): improve the stability of the `max_diagnostics` tests

### DIFF
--- a/crates/rome_cli/tests/commands/ci.rs
+++ b/crates/rome_cli/tests/commands/ci.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use pico_args::Arguments;
 use rome_cli::Termination;
-use rome_console::BufferConsole;
+use rome_console::{BufferConsole, MarkupBuf};
 use rome_fs::{FileSystemExt, MemoryFileSystem};
 use rome_service::DynRef;
 use std::ffi::OsString;
@@ -538,7 +538,39 @@ fn max_diagnostics_default() {
         _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
     }
 
-    assert_eq!(console.out_buffer.len(), 51);
+    let mut diagnostic_count = 0;
+    let mut filtered_messages = Vec::new();
+
+    for msg in console.out_buffer {
+        let MarkupBuf(nodes) = &msg.content;
+        let is_diagnostic = nodes.iter().any(|node| {
+            node.content
+                .contains("File content differs from formatting output")
+        });
+
+        if is_diagnostic {
+            diagnostic_count += 1;
+        } else {
+            filtered_messages.push(msg);
+        }
+    }
+
+    console.out_buffer = filtered_messages;
+
+    for i in 0..60 {
+        let file_path = format!("src/file_{i}.js");
+        fs.remove(Path::new(&file_path));
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "max_diagnostics_default",
+        fs,
+        console,
+        result,
+    ));
+
+    assert_eq!(diagnostic_count, 50);
 }
 
 #[test]
@@ -567,5 +599,37 @@ fn max_diagnostics() {
         _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
     }
 
-    assert_eq!(console.out_buffer.len(), 11);
+    let mut diagnostic_count = 0;
+    let mut filtered_messages = Vec::new();
+
+    for msg in console.out_buffer {
+        let MarkupBuf(nodes) = &msg.content;
+        let is_diagnostic = nodes.iter().any(|node| {
+            node.content
+                .contains("File content differs from formatting output")
+        });
+
+        if is_diagnostic {
+            diagnostic_count += 1;
+        } else {
+            filtered_messages.push(msg);
+        }
+    }
+
+    console.out_buffer = filtered_messages;
+
+    for i in 0..60 {
+        let file_path = format!("src/file_{i}.js");
+        fs.remove(Path::new(&file_path));
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "max_diagnostics",
+        fs,
+        console,
+        result,
+    ));
+
+    assert_eq!(diagnostic_count, 10);
 }

--- a/crates/rome_cli/tests/snapshots/main_commands_check/max_diagnostics.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/max_diagnostics.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Termination Message
+
+```block
+some errors were emitted while running checks
+```
+
+# Emitted Messages
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_check/max_diagnostics_default.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/max_diagnostics_default.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Termination Message
+
+```block
+some errors were emitted while running checks
+```
+
+# Emitted Messages
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/max_diagnostics.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/max_diagnostics.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Termination Message
+
+```block
+some errors were emitted while running checks
+```
+
+# Emitted Messages
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/max_diagnostics_default.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/max_diagnostics_default.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Termination Message
+
+```block
+some errors were emitted while running checks
+```
+
+# Emitted Messages
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/max_diagnostics.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/max_diagnostics.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 223
+expression: content
+---
+# Emitted Messages
+
+```block
+The number of diagnostics exceeds the number allowed by Rome.
+Diagnostics not shown: 50.
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/max_diagnostics_default.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/max_diagnostics_default.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 223
+expression: content
+---
+# Emitted Messages
+
+```block
+The number of diagnostics exceeds the number allowed by Rome.
+Diagnostics not shown: 10.
+```
+
+


### PR DESCRIPTION
## Summary

The tests for the `--max-diagnostics` CLI arguments are failing semi-randomly (it seems to happen mostly with macOS on CI but I managed to reproduce the failure at least once on Windows), this PR tries to improve these tests by counting the console messages emitted for diagnostics but still checking the rest of the console output against a snapshot to try and narrow down the issue

## Test Plan

Run the new tests on CI
