### PR TITLE
fix(rome_js_formatter): Unnecessary parentheses for return/unary with verbatim argument

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -33,7 +33,9 @@ impl FormatNodeRule<JsUnaryExpression> for FormatJsUnaryExpression {
             write!(f, [space()])?;
         }
 
-        if f.context().comments().has_comments(argument.syntax()) {
+        if f.comments().has_comments(argument.syntax())
+            && !f.comments().is_suppressed(argument.syntax())
+        {
             write!(
                 f,
                 [group(&format_args![

--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use rome_formatter::{format_args, write, CstFormatContext};
+use rome_formatter::{format_args, write};
 
 use crate::parentheses::{unary_like_expression_needs_parentheses, NeedsParentheses};
 

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -110,12 +110,14 @@ pub(super) struct FormatReturnOrThrowArgument<'a>(&'a JsAnyExpression);
 impl Format<JsFormatContext> for FormatReturnOrThrowArgument<'_> {
     fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
         let argument = self.0;
+        let is_suppressed = f.comments().is_suppressed(argument.syntax());
 
         if has_argument_leading_comments(argument, f.context().comments())
             && !matches!(argument, JsAnyExpression::JsxTagExpression(_))
+            && !is_suppressed
         {
             write!(f, [text("("), &block_indent(&argument.format()), text(")")])
-        } else if is_binary_or_sequence_argument(argument) {
+        } else if is_binary_or_sequence_argument(argument) && !is_suppressed {
             write!(
                 f,
                 [group(&format_args![

--- a/crates/rome_js_formatter/src/utils/conditional.rs
+++ b/crates/rome_js_formatter/src/utils/conditional.rs
@@ -778,7 +778,7 @@ fn format_jsx_chain_alternate(alternate: &JsAnyExpression) -> FormatJsxChainExpr
 }
 
 /// Wraps all expressions in parentheses if they break EXCEPT
-/// * Nested conditionals in the alterante
+/// * Nested conditionals in the alternate
 /// * `null`
 /// * `undefined`
 struct FormatJsxChainExpression<'a> {

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js
@@ -1,0 +1,8 @@
+// https://github.com/rome/tools/issues/3735
+
+!(
+	// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
+	a && b
+);
+
+

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
@@ -30,7 +30,6 @@ Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
-Semicolons: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: unary_expression_verbatim_argument.js
+---
+
+# Input
+
+```js
+// https://github.com/rome/tools/issues/3735
+
+!(
+	// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
+	a && b
+);
+
+
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+// https://github.com/rome/tools/issues/3735
+
+!(
+	// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
+	a && b
+);
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js
@@ -1,0 +1,25 @@
+// https://github.com/rome/tools/issues/3735
+
+function supported1(){
+	return (
+		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
+		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		a && b
+	);
+}
+
+function supported2(){
+	return !(
+		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
+		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		a && b
+	);
+}
+
+function supported3(){
+	return (
+		// rome-ignore format:
+		aVeryLongLogicalExpression &&
+		thatBreaksOverMultipleLines
+	);
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
@@ -1,0 +1,87 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: return_verbatim_argument.js
+---
+
+# Input
+
+```js
+// https://github.com/rome/tools/issues/3735
+
+function supported1(){
+	return (
+		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
+		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		a && b
+	);
+}
+
+function supported2(){
+	return !(
+		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
+		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		a && b
+	);
+}
+
+function supported3(){
+	return (
+		// rome-ignore format:
+		aVeryLongLogicalExpression &&
+		thatBreaksOverMultipleLines
+	);
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+// https://github.com/rome/tools/issues/3735
+
+function supported1() {
+	return (
+		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
+		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		a && b
+	);
+}
+
+function supported2() {
+	return !(
+		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
+		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		a && b
+	);
+}
+
+function supported3() {
+	return (
+		// rome-ignore format:
+		aVeryLongLogicalExpression &&
+		thatBreaksOverMultipleLines
+	);
+}
+
+
+## Lines exceeding width of 80 characters
+
+    6: 		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+   14: 		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
@@ -47,7 +47,6 @@ Line width: 80
 Quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
-Semicolons: Always
 -----
 
 ```js


### PR DESCRIPTION
… 

## Summary
This PR fixes #3735 by only adding parentheses around the argument if the argument isn't suppressed. This is necessary because the verbatim formatting of the argument includes the parentheses too. Formatting the parentheses in the return/unary formatting and as part of the verbatim results in duplicating the parentheses on every save.

## Test Plan
I added a handful of new tests covering the problematic cases.
