### PR TITLE
feat(rome_service): add `$schema` to configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,8 @@ crates/rome_js_analyze/src/registry.rs linguist-generated=true text=auto eol=lf
 crates/rome_service/src/configuration/linter/rules.rs linguist-generated=true text=auto eol=lf
 npm/backend-jsonrpc/src/workspace.ts linguist-generated=true text=auto eol=lf
 website/src/docs/lint/rules/**/*.md linguist-generated=true text=auto eol=lf
+npm/rome/configuration_schema.json linguist-generated=true text=auto eol=lf
+editors/vscode/configuration_schema.json linguist-generated=true text=auto eol=lf
 
 
 crates/rome_js_formatter/tests/**/*.ts.prettier-snap linguist-language=TypeScript
@@ -19,4 +21,5 @@ crates/rome_js_formatter/tests/**/*.ts.snap linguist-language=Markdown
 crates/rome_js_formatter/tests/**/*.js.snap linguist-language=Markdown
 crates/rome_cli/tests/**/*.snap linguist-language=Markdown
 crates/rome_js_analyze/tests/specs/**/*.snap linguist-language=Markdown
+
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,7 @@ dependencies = [
  "git2",
  "pico-args",
  "proc-macro2",
+ "pulldown-cmark",
  "quote",
  "rome_analyze",
  "rome_js_analyze",

--- a/crates/rome_cli/tests/commands/init.rs
+++ b/crates/rome_cli/tests/commands/init.rs
@@ -51,7 +51,7 @@ fn creates_config_file_when_rome_installed_via_package_manager() {
         .join("node_modules")
         .join("rome")
         .join("configuration_schema.json");
-    fs.insert(file_path.into(), *b"{}");
+    fs.insert(file_path, *b"{}");
 
     let result = run_cli(
         DynRef::Borrowed(&mut fs),

--- a/crates/rome_cli/tests/commands/init.rs
+++ b/crates/rome_cli/tests/commands/init.rs
@@ -1,0 +1,83 @@
+use crate::configs::{CONFIG_INIT_DEFAULT, CONFIG_INIT_DEFAULT_WHEN_INSTALLED};
+use crate::run_cli;
+use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
+use pico_args::Arguments;
+use rome_console::BufferConsole;
+use rome_fs::{FileSystemExt, MemoryFileSystem};
+use rome_service::DynRef;
+use std::ffi::OsString;
+use std::path::Path;
+
+#[test]
+fn creates_config_file() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("init")]),
+    );
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let file_path = Path::new("rome.json");
+
+    let mut file = fs
+        .open(file_path)
+        .expect("configuration file was not written on disk");
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .expect("failed to read file from memory FS");
+    assert_eq!(content, CONFIG_INIT_DEFAULT);
+
+    drop(file);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "creates_config_file",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn creates_config_file_when_rome_installed_via_package_manager() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("./")
+        .join("node_modules")
+        .join("rome")
+        .join("configuration_schema.json");
+    fs.insert(file_path.into(), *b"{}");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("init")]),
+    );
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let file_path = Path::new("rome.json");
+
+    let mut file = fs
+        .open(file_path)
+        .expect("configuration file was not written on disk");
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .expect("failed to read file from memory FS");
+    assert_eq!(content, CONFIG_INIT_DEFAULT_WHEN_INSTALLED);
+
+    drop(file);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "creates_config_file_when_rome_installed_via_package_manager",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/rome_cli/tests/commands/mod.rs
+++ b/crates/rome_cli/tests/commands/mod.rs
@@ -1,5 +1,6 @@
 mod check;
 mod ci;
 mod format;
+mod init;
 mod rage;
 mod version;

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -9,6 +9,7 @@ pub const CONFIG_FORMAT: &str = r#"{
 "#;
 
 pub const CONFIG_INIT_DEFAULT: &str = r#"{
+  "$schema": "./node_modules/rome/configuration_schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -9,6 +9,15 @@ pub const CONFIG_FORMAT: &str = r#"{
 "#;
 
 pub const CONFIG_INIT_DEFAULT: &str = r#"{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}"#;
+
+pub const CONFIG_INIT_DEFAULT_WHEN_INSTALLED: &str = r#"{
   "$schema": "./node_modules/rome/configuration_schema.json",
   "linter": {
     "enabled": true,

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -217,52 +217,6 @@ mod main {
     }
 }
 
-mod init {
-    use super::*;
-    use crate::configs::CONFIG_INIT_DEFAULT;
-    use crate::snap_test::SnapshotPayload;
-    use pico_args::Arguments;
-    use rome_console::BufferConsole;
-    use rome_fs::{FileSystemExt, MemoryFileSystem};
-    use rome_service::DynRef;
-    use std::ffi::OsString;
-    use std::path::Path;
-
-    #[test]
-    fn creates_config_file() {
-        let mut fs = MemoryFileSystem::default();
-        let mut console = BufferConsole::default();
-
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
-            DynRef::Borrowed(&mut console),
-            Arguments::from_vec(vec![OsString::from("init")]),
-        );
-        assert!(result.is_ok(), "run_cli returned {result:?}");
-
-        let file_path = Path::new("rome.json");
-
-        let mut file = fs
-            .open(file_path)
-            .expect("configuration file was not written on disk");
-
-        let mut content = String::new();
-        file.read_to_string(&mut content)
-            .expect("failed to read file from memory FS");
-        assert_eq!(content, CONFIG_INIT_DEFAULT);
-
-        drop(file);
-
-        assert_cli_snapshot(SnapshotPayload::new(
-            module_path!(),
-            "creates_config_file",
-            fs,
-            console,
-            result,
-        ));
-    }
-}
-
 mod configuration {
     use super::*;
     use crate::configs::{

--- a/crates/rome_cli/tests/snapshots/main_commands_init/creates_config_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_init/creates_config_file.snap
@@ -6,7 +6,6 @@ expression: content
 
 ```json
 {
-  "$schema": "./node_modules/rome/configuration_schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/crates/rome_cli/tests/snapshots/main_commands_init/creates_config_file_when_rome_installed_via_package_manager.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_init/creates_config_file_when_rome_installed_via_package_manager.snap
@@ -1,0 +1,51 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "$schema": "./node_modules/rome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}
+```
+
+## `./node_modules/rome/configuration_schema.json`
+
+```json
+{}
+```
+
+# Emitted Messages
+
+```block
+
+Welcome to Rome! Let's get you started...
+
+Files created ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  - rome.json: Your project configuration. Documentation: https://rome.tools/configuration
+
+Next Steps ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  1. Setup an editor extension
+     Get live errors as you type and format when you save. Learn more: https://rome.tools/editors
+
+  2. Try a command
+     rome ci checks for lint errors and verifies formatting. Run rome --help for a full list of commands and options.
+
+  3. Read the documentation
+     Our website serves as a comprehensive source of guides and documentation: https://docs.rome.tools
+
+  4. Get involved in the community
+     Ask questions, get support, or contribute by participating on GitHub (https://github.com/rome/tools),
+     or join our community Discord (https://discord.gg/rome)
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_init/creates_config_file.snap
@@ -6,6 +6,7 @@ expression: content
 
 ```json
 {
+  "$schema": "./node_modules/rome/configuration_schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/crates/rome_fs/src/fs/memory.rs
+++ b/crates/rome_fs/src/fs/memory.rs
@@ -75,6 +75,8 @@ impl FileSystem for MemoryFileSystem {
             self.open(path)
         } else if options.create_new || options.write {
             self.create(path)
+        } else if options.read {
+            self.read(path)
         } else {
             unimplemented!("the set of open options provided don't match any case")
         }

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -297,14 +297,23 @@ pub struct A11y {
 #[allow(dead_code)]
 #[doc = r" A list of rules that belong to this group"]
 struct A11ySchema {
+    #[doc = "Avoid the autoFocus attribute"]
     no_autofocus: Option<RuleConfiguration>,
+    #[doc = "Prevent the usage of positive integers on tabIndex property"]
     no_positive_tabindex: Option<RuleConfiguration>,
+    #[doc = "It asserts that alternative text to images or areas, help to rely on to screen readers to understand the purpose and the context of the image."]
     use_alt_text: Option<RuleConfiguration>,
+    #[doc = "Enforce that anchor elements have content and that the content is accessible to screen readers."]
     use_anchor_content: Option<RuleConfiguration>,
+    #[doc = "Disallow target=\"_blank\" attribute without rel=\"noreferrer\""]
     use_blank_target: Option<RuleConfiguration>,
+    #[doc = "Enforces the usage of the attribute type for the element button"]
     use_button_type: Option<RuleConfiguration>,
+    #[doc = "Enforce to have the onClick mouse event with the onKeyUp, the onKeyDown, or the onKeyPress keyboard event."]
     use_key_with_click_events: Option<RuleConfiguration>,
+    #[doc = "Enforce that onMouseOver/onMouseOut are accompanied by onFocus/onBlur for keyboard-only users. It is important to take into account users with physical disabilities who cannot use a mouse, who use assistive technology or screenreader."]
     use_key_with_mouse_events: Option<RuleConfiguration>,
+    #[doc = "Enforce that all anchors are valid, and they are navigable elements."]
     use_valid_anchor: Option<RuleConfiguration>,
 }
 impl A11y {
@@ -411,7 +420,9 @@ pub struct Complexity {
 #[allow(dead_code)]
 #[doc = r" A list of rules that belong to this group"]
 struct ComplexitySchema {
+    #[doc = "Disallow unnecessary boolean casts"]
     no_extra_boolean_cast: Option<RuleConfiguration>,
+    #[doc = "Discard redundant terms from logical expressions."]
     use_simplified_logic_expression: Option<RuleConfiguration>,
 }
 impl Complexity {
@@ -493,36 +504,67 @@ pub struct Correctness {
 #[allow(dead_code)]
 #[doc = r" A list of rules that belong to this group"]
 struct CorrectnessSchema {
+    #[doc = "Disallow the use of arguments"]
     no_arguments: Option<RuleConfiguration>,
+    #[doc = "Discourage the usage of Array index in keys."]
     no_array_index_key: Option<RuleConfiguration>,
+    #[doc = "Disallows using an async function as a Promise executor."]
     no_async_promise_executor: Option<RuleConfiguration>,
+    #[doc = "Disallow reassigning exceptions in catch clauses"]
     no_catch_assign: Option<RuleConfiguration>,
+    #[doc = "Prevent passing of children as props."]
     no_children_prop: Option<RuleConfiguration>,
+    #[doc = "Prevent comments from being inserted as text nodes"]
     no_comment_text: Option<RuleConfiguration>,
+    #[doc = "Disallow comparing against -0"]
     no_compare_neg_zero: Option<RuleConfiguration>,
+    #[doc = "Disallow the use of debugger"]
     no_debugger: Option<RuleConfiguration>,
+    #[doc = "Disallow the use of the delete operator"]
     no_delete: Option<RuleConfiguration>,
+    #[doc = "Require the use of === and !=="]
     no_double_equals: Option<RuleConfiguration>,
+    #[doc = "Disallow duplicate function arguments name."]
     no_dupe_args: Option<RuleConfiguration>,
+    #[doc = "Disallows empty destructuring patterns."]
     no_empty_pattern: Option<RuleConfiguration>,
+    #[doc = "Disallow reassigning function declarations."]
     no_function_assign: Option<RuleConfiguration>,
+    #[doc = "Disallow assigning to imported bindings"]
     no_import_assign: Option<RuleConfiguration>,
+    #[doc = "Disallow labels that share a name with a variable"]
     no_label_var: Option<RuleConfiguration>,
+    #[doc = "Disallow unclear usage of multiple space characters in regular expression literals"]
     no_multiple_spaces_in_regular_expression_literals: Option<RuleConfiguration>,
+    #[doc = "Disallow new operators with the Symbol object"]
     no_new_symbol: Option<RuleConfiguration>,
+    #[doc = "Prevent the usage of the return value of React.render."]
     no_render_return_value: Option<RuleConfiguration>,
+    #[doc = "This rule allows you to specify global variable names that you don’t want to use in your application."]
     no_restricted_globals: Option<RuleConfiguration>,
+    #[doc = "Disallow identifiers from shadowing restricted names."]
     no_shadow_restricted_names: Option<RuleConfiguration>,
+    #[doc = "Disallow sparse arrays"]
     no_sparse_array: Option<RuleConfiguration>,
+    #[doc = "Prevents the usage of variables that haven't been declared inside the document"]
     no_undeclared_variables: Option<RuleConfiguration>,
+    #[doc = "Avoid using unnecessary continue."]
     no_unnecessary_continue: Option<RuleConfiguration>,
+    #[doc = "Disallow unreachable code"]
     no_unreachable: Option<RuleConfiguration>,
+    #[doc = "Disallow using unsafe negation."]
     no_unsafe_negation: Option<RuleConfiguration>,
+    #[doc = "Disallow unused variables."]
     no_unused_variables: Option<RuleConfiguration>,
+    #[doc = "Disallow unnecessary fragments"]
     no_useless_fragments: Option<RuleConfiguration>,
+    #[doc = "This rules prevents void elements (AKA self-closing elements) from having children."]
     no_void_elements_with_children: Option<RuleConfiguration>,
+    #[doc = "Enforces case clauses have a single statement, emits a quick fix wrapping the statements in a block"]
     use_single_case_statement: Option<RuleConfiguration>,
+    #[doc = "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions"]
     use_valid_typeof: Option<RuleConfiguration>,
+    #[doc = "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed"]
     use_while: Option<RuleConfiguration>,
 }
 impl Correctness {
@@ -687,19 +729,33 @@ pub struct Nursery {
 #[allow(dead_code)]
 #[doc = r" A list of rules that belong to this group"]
 struct NurserySchema {
+    #[doc = "Disallow certain types."]
     no_banned_types: Option<RuleConfiguration>,
+    #[doc = "Disallow assignment operators in conditional expressions."]
     no_conditional_assignment: Option<RuleConfiguration>,
+    #[doc = "Prevents from having const variables being re-assigned."]
     no_const_assign: Option<RuleConfiguration>,
+    #[doc = "Prevents object literals having more than one property declaration for the same name. If an object property with the same name is defined multiple times (except when combining a getter with a setter), only the last definition makes it into the object and previous definitions are ignored, which is likely a mistake."]
     no_dupe_keys: Option<RuleConfiguration>,
+    #[doc = "Disallow the any type usage"]
     no_explicit_any: Option<RuleConfiguration>,
+    #[doc = "Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors."]
     no_invalid_constructor_super: Option<RuleConfiguration>,
+    #[doc = "Disallow literal numbers that lose precision"]
     no_precision_loss: Option<RuleConfiguration>,
+    #[doc = "Disallow control flow statements in finally blocks."]
     no_unsafe_finally: Option<RuleConfiguration>,
+    #[doc = "Enforce camel case naming convention."]
     use_camel_case: Option<RuleConfiguration>,
+    #[doc = "Require const declarations for variables that are never reassigned after declared."]
     use_const: Option<RuleConfiguration>,
+    #[doc = "Enforce all dependencies are correctly specified."]
     use_exhaustive_dependencies: Option<RuleConfiguration>,
+    #[doc = "Promotes the use of .flatMap() when map().flat() are used together."]
     use_flat_map: Option<RuleConfiguration>,
+    #[doc = "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals"]
     use_numeric_literals: Option<RuleConfiguration>,
+    #[doc = "Enforce \"for\" loop update clause moving the counter in the right direction."]
     use_valid_for_direction: Option<RuleConfiguration>,
 }
 impl Nursery {
@@ -791,7 +847,9 @@ pub struct Security {
 #[allow(dead_code)]
 #[doc = r" A list of rules that belong to this group"]
 struct SecuritySchema {
+    #[doc = "Prevent the usage of dangerous JSX props"]
     no_dangerously_set_inner_html: Option<RuleConfiguration>,
+    #[doc = "Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop."]
     no_dangerously_set_inner_html_with_children: Option<RuleConfiguration>,
 }
 impl Security {
@@ -877,16 +935,27 @@ pub struct Style {
 #[allow(dead_code)]
 #[doc = r" A list of rules that belong to this group"]
 struct StyleSchema {
+    #[doc = "Disallow implicit true values on JSX boolean attributes"]
     no_implicit_boolean: Option<RuleConfiguration>,
+    #[doc = "Disallow negation in the condition of an if statement if it has an else clause"]
     no_negation_else: Option<RuleConfiguration>,
+    #[doc = "Disallow the use of constants which its value is the upper-case version of its name."]
     no_shouty_constants: Option<RuleConfiguration>,
+    #[doc = "Disallow template literals if interpolation and special-character handling are not needed"]
     no_unused_template_literal: Option<RuleConfiguration>,
+    #[doc = "Requires following curly brace conventions. JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to never omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity."]
     use_block_statements: Option<RuleConfiguration>,
+    #[doc = "This rule enforces the use of <>...</> over <Fragment>...</Fragment>."]
     use_fragment_syntax: Option<RuleConfiguration>,
+    #[doc = "Enforce using concise optional chain instead of chained logical expressions."]
     use_optional_chain: Option<RuleConfiguration>,
+    #[doc = "Prevent extra closing tags for components without children"]
     use_self_closing_elements: Option<RuleConfiguration>,
+    #[doc = "When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>."]
     use_shorthand_array_type: Option<RuleConfiguration>,
+    #[doc = "Disallow multiple variable declarations in the same variable statement"]
     use_single_var_declarator: Option<RuleConfiguration>,
+    #[doc = "Template literals are preferred over string concatenation."]
     use_template: Option<RuleConfiguration>,
 }
 impl Style {

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -237,7 +237,7 @@ pub fn create_config(
         .join("rome")
         .join("configuration_schema.json");
     let options = OpenOptions::default().read(true);
-    if let Ok(_) = fs.open_with_options(&schema_path, options) {
+    if fs.open_with_options(&schema_path, options).is_ok() {
         configuration.schema = schema_path.to_str().map(String::from);
     }
 

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -13,7 +13,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::io::ErrorKind;
 use std::marker::PhantomData;
 use std::num::NonZeroU64;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{error, info};
 
 mod formatter;
@@ -232,12 +232,9 @@ pub fn create_config(
     })?;
 
     // we now check if rome is installed inside `node_modules` and if so, we
-    let schema_path = PathBuf::from("./")
-        .join("node_modules")
-        .join("rome")
-        .join("configuration_schema.json");
+    let schema_path = Path::new("./node_modules/rome/configuration_schema.json");
     let options = OpenOptions::default().read(true);
-    if fs.open_with_options(&schema_path, options).is_ok() {
+    if fs.open_with_options(schema_path, options).is_ok() {
         configuration.schema = schema_path.to_str().map(String::from);
     }
 

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -31,6 +31,10 @@ use rome_js_analyze::metadata;
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Configuration {
+    /// A field for the [JSON schema](https://json-schema.org/) specification
+    #[serde(rename(serialize = "$schema", deserialize = "$schema"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
     /// The configuration of the filesystem
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<FilesConfiguration>,
@@ -58,6 +62,9 @@ impl Default for Configuration {
             }),
             formatter: None,
             javascript: None,
+            schema: Some(String::from(
+                "./node_modules/rome/configuration_schema.json",
+            )),
         }
     }
 }

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -857,6 +857,7 @@
           ]
         },
         "useConst": {
+          "description": "Require const declarations for variables that are never reassigned after declared.",
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -765,6 +765,7 @@
           ]
         },
         "noConditionalAssignment": {
+          "description": "Disallow assignment operators in conditional expressions.",
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"
@@ -819,6 +820,7 @@
           ]
         },
         "noPrecisionLoss": {
+          "description": "Disallow literal numbers that lose precision",
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"
@@ -829,6 +831,7 @@
           ]
         },
         "noUnsafeFinally": {
+          "description": "Disallow control flow statements in finally blocks.",
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -4,6 +4,13 @@
   "description": "The configuration that is contained inside the file `rome.json`",
   "type": "object",
   "properties": {
+    "$schema": {
+      "description": "A field for the [JSON schema](https://json-schema.org/) specification",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "files": {
       "description": "The configuration of the filesystem",
       "anyOf": [
@@ -46,13 +53,6 @@
         {
           "type": "null"
         }
-      ]
-    },
-    "schema": {
-      "description": "A field for the [JSON schema](https://json-schema.org/) specification",
-      "type": [
-        "string",
-        "null"
       ]
     }
   },

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -28,6 +28,10 @@ export interface UpdateSettingsParams {
  */
 export interface Configuration {
 	/**
+	 * A field for the [JSON schema](https://json-schema.org/) specification
+	 */
+	$schema?: string;
+	/**
 	 * The configuration of the filesystem
 	 */
 	files?: FilesConfiguration;
@@ -148,99 +152,273 @@ export type TrailingComma = "all" | "es5" | "none";
  * A list of rules that belong to this group
  */
 export interface A11y {
+	/**
+	 * Avoid the autoFocus attribute
+	 */
 	noAutofocus?: RuleConfiguration;
+	/**
+	 * Prevent the usage of positive integers on tabIndex property
+	 */
 	noPositiveTabindex?: RuleConfiguration;
 	/**
 	 * It enables the recommended rules for this group
 	 */
 	recommended?: boolean;
+	/**
+	 * It asserts that alternative text to images or areas, help to rely on to screen readers to understand the purpose and the context of the image.
+	 */
 	useAltText?: RuleConfiguration;
+	/**
+	 * Enforce that anchor elements have content and that the content is accessible to screen readers.
+	 */
 	useAnchorContent?: RuleConfiguration;
+	/**
+	 * Disallow target="_blank" attribute without rel="noreferrer"
+	 */
 	useBlankTarget?: RuleConfiguration;
+	/**
+	 * Enforces the usage of the attribute type for the element button
+	 */
 	useButtonType?: RuleConfiguration;
+	/**
+	 * Enforce to have the onClick mouse event with the onKeyUp, the onKeyDown, or the onKeyPress keyboard event.
+	 */
 	useKeyWithClickEvents?: RuleConfiguration;
+	/**
+	 * Enforce that onMouseOver/onMouseOut are accompanied by onFocus/onBlur for keyboard-only users. It is important to take into account users with physical disabilities who cannot use a mouse, who use assistive technology or screenreader.
+	 */
 	useKeyWithMouseEvents?: RuleConfiguration;
+	/**
+	 * Enforce that all anchors are valid, and they are navigable elements.
+	 */
 	useValidAnchor?: RuleConfiguration;
 }
 /**
  * A list of rules that belong to this group
  */
 export interface Complexity {
+	/**
+	 * Disallow unnecessary boolean casts
+	 */
 	noExtraBooleanCast?: RuleConfiguration;
 	/**
 	 * It enables the recommended rules for this group
 	 */
 	recommended?: boolean;
+	/**
+	 * Discard redundant terms from logical expressions.
+	 */
 	useSimplifiedLogicExpression?: RuleConfiguration;
 }
 /**
  * A list of rules that belong to this group
  */
 export interface Correctness {
+	/**
+	 * Disallow the use of arguments
+	 */
 	noArguments?: RuleConfiguration;
+	/**
+	 * Discourage the usage of Array index in keys.
+	 */
 	noArrayIndexKey?: RuleConfiguration;
+	/**
+	 * Disallows using an async function as a Promise executor.
+	 */
 	noAsyncPromiseExecutor?: RuleConfiguration;
+	/**
+	 * Disallow reassigning exceptions in catch clauses
+	 */
 	noCatchAssign?: RuleConfiguration;
+	/**
+	 * Prevent passing of children as props.
+	 */
 	noChildrenProp?: RuleConfiguration;
+	/**
+	 * Prevent comments from being inserted as text nodes
+	 */
 	noCommentText?: RuleConfiguration;
+	/**
+	 * Disallow comparing against -0
+	 */
 	noCompareNegZero?: RuleConfiguration;
+	/**
+	 * Disallow the use of debugger
+	 */
 	noDebugger?: RuleConfiguration;
+	/**
+	 * Disallow the use of the delete operator
+	 */
 	noDelete?: RuleConfiguration;
+	/**
+	 * Require the use of === and !==
+	 */
 	noDoubleEquals?: RuleConfiguration;
+	/**
+	 * Disallow duplicate function arguments name.
+	 */
 	noDupeArgs?: RuleConfiguration;
+	/**
+	 * Disallows empty destructuring patterns.
+	 */
 	noEmptyPattern?: RuleConfiguration;
+	/**
+	 * Disallow reassigning function declarations.
+	 */
 	noFunctionAssign?: RuleConfiguration;
+	/**
+	 * Disallow assigning to imported bindings
+	 */
 	noImportAssign?: RuleConfiguration;
+	/**
+	 * Disallow labels that share a name with a variable
+	 */
 	noLabelVar?: RuleConfiguration;
+	/**
+	 * Disallow unclear usage of multiple space characters in regular expression literals
+	 */
 	noMultipleSpacesInRegularExpressionLiterals?: RuleConfiguration;
+	/**
+	 * Disallow new operators with the Symbol object
+	 */
 	noNewSymbol?: RuleConfiguration;
+	/**
+	 * Prevent the usage of the return value of React.render.
+	 */
 	noRenderReturnValue?: RuleConfiguration;
+	/**
+	 * This rule allows you to specify global variable names that you don’t want to use in your application.
+	 */
 	noRestrictedGlobals?: RuleConfiguration;
+	/**
+	 * Disallow identifiers from shadowing restricted names.
+	 */
 	noShadowRestrictedNames?: RuleConfiguration;
+	/**
+	 * Disallow sparse arrays
+	 */
 	noSparseArray?: RuleConfiguration;
+	/**
+	 * Prevents the usage of variables that haven't been declared inside the document
+	 */
 	noUndeclaredVariables?: RuleConfiguration;
+	/**
+	 * Avoid using unnecessary continue.
+	 */
 	noUnnecessaryContinue?: RuleConfiguration;
+	/**
+	 * Disallow unreachable code
+	 */
 	noUnreachable?: RuleConfiguration;
+	/**
+	 * Disallow using unsafe negation.
+	 */
 	noUnsafeNegation?: RuleConfiguration;
+	/**
+	 * Disallow unused variables.
+	 */
 	noUnusedVariables?: RuleConfiguration;
+	/**
+	 * Disallow unnecessary fragments
+	 */
 	noUselessFragments?: RuleConfiguration;
+	/**
+	 * This rules prevents void elements (AKA self-closing elements) from having children.
+	 */
 	noVoidElementsWithChildren?: RuleConfiguration;
 	/**
 	 * It enables the recommended rules for this group
 	 */
 	recommended?: boolean;
+	/**
+	 * Enforces case clauses have a single statement, emits a quick fix wrapping the statements in a block
+	 */
 	useSingleCaseStatement?: RuleConfiguration;
+	/**
+	 * This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions
+	 */
 	useValidTypeof?: RuleConfiguration;
+	/**
+	 * Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed
+	 */
 	useWhile?: RuleConfiguration;
 }
 /**
  * A list of rules that belong to this group
  */
 export interface Nursery {
+	/**
+	 * Disallow certain types.
+	 */
 	noBannedTypes?: RuleConfiguration;
+	/**
+	 * Disallow assignment operators in conditional expressions.
+	 */
 	noConditionalAssignment?: RuleConfiguration;
+	/**
+	 * Prevents from having const variables being re-assigned.
+	 */
 	noConstAssign?: RuleConfiguration;
+	/**
+	 * Prevents object literals having more than one property declaration for the same name. If an object property with the same name is defined multiple times (except when combining a getter with a setter), only the last definition makes it into the object and previous definitions are ignored, which is likely a mistake.
+	 */
 	noDupeKeys?: RuleConfiguration;
+	/**
+	 * Disallow the any type usage
+	 */
 	noExplicitAny?: RuleConfiguration;
+	/**
+	 * Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors.
+	 */
 	noInvalidConstructorSuper?: RuleConfiguration;
+	/**
+	 * Disallow literal numbers that lose precision
+	 */
 	noPrecisionLoss?: RuleConfiguration;
+	/**
+	 * Disallow control flow statements in finally blocks.
+	 */
 	noUnsafeFinally?: RuleConfiguration;
 	/**
 	 * It enables the recommended rules for this group
 	 */
 	recommended?: boolean;
+	/**
+	 * Enforce camel case naming convention.
+	 */
 	useCamelCase?: RuleConfiguration;
+	/**
+	 * Require const declarations for variables that are never reassigned after declared.
+	 */
 	useConst?: RuleConfiguration;
+	/**
+	 * Enforce all dependencies are correctly specified.
+	 */
 	useExhaustiveDependencies?: RuleConfiguration;
+	/**
+	 * Promotes the use of .flatMap() when map().flat() are used together.
+	 */
 	useFlatMap?: RuleConfiguration;
+	/**
+	 * Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals
+	 */
 	useNumericLiterals?: RuleConfiguration;
+	/**
+	 * Enforce "for" loop update clause moving the counter in the right direction.
+	 */
 	useValidForDirection?: RuleConfiguration;
 }
 /**
  * A list of rules that belong to this group
  */
 export interface Security {
+	/**
+	 * Prevent the usage of dangerous JSX props
+	 */
 	noDangerouslySetInnerHtml?: RuleConfiguration;
+	/**
+	 * Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop.
+	 */
 	noDangerouslySetInnerHtmlWithChildren?: RuleConfiguration;
 	/**
 	 * It enables the recommended rules for this group
@@ -251,20 +429,53 @@ export interface Security {
  * A list of rules that belong to this group
  */
 export interface Style {
+	/**
+	 * Disallow implicit true values on JSX boolean attributes
+	 */
 	noImplicitBoolean?: RuleConfiguration;
+	/**
+	 * Disallow negation in the condition of an if statement if it has an else clause
+	 */
 	noNegationElse?: RuleConfiguration;
+	/**
+	 * Disallow the use of constants which its value is the upper-case version of its name.
+	 */
 	noShoutyConstants?: RuleConfiguration;
+	/**
+	 * Disallow template literals if interpolation and special-character handling are not needed
+	 */
 	noUnusedTemplateLiteral?: RuleConfiguration;
 	/**
 	 * It enables the recommended rules for this group
 	 */
 	recommended?: boolean;
+	/**
+	 * Requires following curly brace conventions. JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to never omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity.
+	 */
 	useBlockStatements?: RuleConfiguration;
+	/**
+	 * This rule enforces the use of <>...</> over <Fragment>...</Fragment>.
+	 */
 	useFragmentSyntax?: RuleConfiguration;
+	/**
+	 * Enforce using concise optional chain instead of chained logical expressions.
+	 */
 	useOptionalChain?: RuleConfiguration;
+	/**
+	 * Prevent extra closing tags for components without children
+	 */
 	useSelfClosingElements?: RuleConfiguration;
+	/**
+	 * When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>.
+	 */
 	useShorthandArrayType?: RuleConfiguration;
+	/**
+	 * Disallow multiple variable declarations in the same variable statement
+	 */
 	useSingleVarDeclarator?: RuleConfiguration;
+	/**
+	 * Template literals are preferred over string concatenation.
+	 */
 	useTemplate?: RuleConfiguration;
 }
 export type RuleConfiguration = RulePlainConfiguration | RuleWithOptions;

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -563,17 +563,6 @@
       "description": "The configuration of the filesystem",
       "type": "object",
       "properties": {
-        "ignore": {
-          "description": "A list of Unix shell style patterns. Rome tools will ignore files/folders that will match these patterns.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
         "maxSize": {
           "description": "The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB",
           "default": null,
@@ -686,15 +675,6 @@
             }
           ]
         },
-        "semicolons": {
-          "description": "Whether the formatter prints semicolons for all statements or only in for statements where it is necessary because of ASI.",
-          "default": "always",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Semicolons"
-            }
-          ]
-        },
         "trailingComma": {
           "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to \"all\".",
           "default": "all",
@@ -764,16 +744,6 @@
             }
           ]
         },
-        "noConditionalAssignment": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleConfiguration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "noConstAssign": {
           "description": "Prevents from having const variables being re-assigned.",
           "anyOf": [
@@ -818,26 +788,6 @@
             }
           ]
         },
-        "noPrecisionLoss": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleConfiguration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "noUnsafeFinally": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleConfiguration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "recommended": {
           "description": "It enables the recommended rules for this group",
           "type": [
@@ -847,16 +797,6 @@
         },
         "useCamelCase": {
           "description": "Enforce camel case naming convention.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleConfiguration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "useConst": {
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"
@@ -1072,13 +1012,6 @@
           ]
         }
       }
-    },
-    "Semicolons": {
-      "type": "string",
-      "enum": [
-        "always",
-        "asNeeded"
-      ]
     },
     "Style": {
       "description": "A list of rules that belong to this group",

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -563,6 +563,17 @@
       "description": "The configuration of the filesystem",
       "type": "object",
       "properties": {
+        "ignore": {
+          "description": "A list of Unix shell style patterns. Rome tools will ignore files/folders that will match these patterns.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
         "maxSize": {
           "description": "The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB",
           "default": null,
@@ -797,6 +808,17 @@
         },
         "useCamelCase": {
           "description": "Enforce camel case naming convention.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "useConst": {
+          "description": "Require const declarations for variables that are never reassigned after declared.",
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -4,6 +4,13 @@
   "description": "The configuration that is contained inside the file `rome.json`",
   "type": "object",
   "properties": {
+    "$schema": {
+      "description": "A field for the [JSON schema](https://json-schema.org/) specification",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "files": {
       "description": "The configuration of the filesystem",
       "anyOf": [
@@ -46,13 +53,6 @@
         {
           "type": "null"
         }
-      ]
-    },
-    "schema": {
-      "description": "A field for the [JSON schema](https://json-schema.org/) specification",
-      "type": [
-        "string",
-        "null"
       ]
     }
   },

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -686,6 +686,15 @@
             }
           ]
         },
+        "semicolons": {
+          "description": "Whether the formatter prints semicolons for all statements or only in for statements where it is necessary because of ASI.",
+          "default": "always",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Semicolons"
+            }
+          ]
+        },
         "trailingComma": {
           "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to \"all\".",
           "default": "all",
@@ -755,6 +764,17 @@
             }
           ]
         },
+        "noConditionalAssignment": {
+          "description": "Disallow assignment operators in conditional expressions.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "noConstAssign": {
           "description": "Prevents from having const variables being re-assigned.",
           "anyOf": [
@@ -790,6 +810,28 @@
         },
         "noInvalidConstructorSuper": {
           "description": "Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noPrecisionLoss": {
+          "description": "Disallow literal numbers that lose precision",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "noUnsafeFinally": {
+          "description": "Disallow control flow statements in finally blocks.",
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"
@@ -1034,6 +1076,13 @@
           ]
         }
       }
+    },
+    "Semicolons": {
+      "type": "string",
+      "enum": [
+        "always",
+        "asNeeded"
+      ]
     },
     "Style": {
       "description": "A list of rules that belong to this group",

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -18,6 +18,7 @@
     "files": [
         "bin/rome",
         "scripts/postinstall.js",
+        "configuration_schema.json",
         "README.md"
     ],
     "keywords": [

--- a/npm/rome/schema.json
+++ b/npm/rome/schema.json
@@ -563,17 +563,6 @@
       "description": "The configuration of the filesystem",
       "type": "object",
       "properties": {
-        "ignore": {
-          "description": "A list of Unix shell style patterns. Rome tools will ignore files/folders that will match these patterns.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
         "maxSize": {
           "description": "The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB",
           "default": null,
@@ -686,15 +675,6 @@
             }
           ]
         },
-        "semicolons": {
-          "description": "Whether the formatter prints semicolons for all statements or only in for statements where it is necessary because of ASI.",
-          "default": "always",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Semicolons"
-            }
-          ]
-        },
         "trailingComma": {
           "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to \"all\".",
           "default": "all",
@@ -764,16 +744,6 @@
             }
           ]
         },
-        "noConditionalAssignment": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleConfiguration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "noConstAssign": {
           "description": "Prevents from having const variables being re-assigned.",
           "anyOf": [
@@ -818,26 +788,6 @@
             }
           ]
         },
-        "noPrecisionLoss": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleConfiguration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "noUnsafeFinally": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleConfiguration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "recommended": {
           "description": "It enables the recommended rules for this group",
           "type": [
@@ -847,16 +797,6 @@
         },
         "useCamelCase": {
           "description": "Enforce camel case naming convention.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleConfiguration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "useConst": {
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"
@@ -1072,13 +1012,6 @@
           ]
         }
       }
-    },
-    "Semicolons": {
-      "type": "string",
-      "enum": [
-        "always",
-        "asNeeded"
-      ]
     },
     "Style": {
       "description": "A list of rules that belong to this group",

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -16,6 +16,7 @@ ureq = "2.4.0"
 git2 = { version = "0.15.0", default-features = false }
 filetime = "0.2.15"
 case = "1.0.0"
+pulldown-cmark = { version = "0.9", default-features = false }
 
 rome_rowan = { path = "../../crates/rome_rowan", optional = true }
 rome_analyze = { path = "../../crates/rome_analyze", optional = true }

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -76,11 +76,29 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                             docs.push(' ');
                         }
 
+                        Event::Start(Tag::Paragraph) => {}
                         Event::End(Tag::Paragraph) => {
                             break;
                         }
 
-                        _ => {}
+                        Event::Start(tag) => match tag {
+                            Tag::Strong | Tag::Paragraph => {
+                                continue;
+                            }
+
+                            _ => panic!("Unimplemented tag {:?}", { tag }),
+                        },
+
+                        Event::End(tag) => match tag {
+                            Tag::Strong | Tag::Paragraph => {
+                                continue;
+                            }
+                            _ => panic!("Unimplemented tag {:?}", { tag }),
+                        },
+
+                        _ => {
+                            panic!("Unimplemented event {:?}", { event })
+                        }
                     }
                 }
                 docs

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -1,7 +1,10 @@
 use case::CaseExt;
 use proc_macro2::{Ident, Literal, Span};
+use pulldown_cmark::{Event, Parser, Tag};
 use quote::quote;
-use rome_analyze::{GroupCategory, Queryable, RegistryVisitor, Rule, RuleCategory, RuleGroup};
+use rome_analyze::{
+    GroupCategory, Queryable, RegistryVisitor, Rule, RuleCategory, RuleGroup, RuleMetadata,
+};
 use rome_js_analyze::visit_registry;
 use rome_js_syntax::JsLanguage;
 use std::collections::BTreeMap;
@@ -13,7 +16,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
 
     #[derive(Default)]
     struct LintRulesVisitor {
-        groups: BTreeMap<&'static str, BTreeMap<&'static str, bool>>,
+        groups: BTreeMap<&'static str, BTreeMap<&'static str, RuleMetadata>>,
     }
 
     impl RegistryVisitor<JsLanguage> for LintRulesVisitor {
@@ -32,7 +35,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
             self.groups
                 .entry(<R::Group as RuleGroup>::NAME)
                 .or_insert_with(BTreeMap::new)
-                .insert(R::METADATA.name, R::METADATA.recommended);
+                .insert(R::METADATA.name, R::METADATA);
         }
     }
 
@@ -57,7 +60,32 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
 
         let mut number_of_recommended_rules: u8 = 0;
         let number_of_rules = Literal::u8_unsuffixed(rules.len() as u8);
-        for (index, (rule, recommended)) in rules.iter().enumerate() {
+        for (index, (rule, metadata)) in rules.iter().enumerate() {
+            let summary = {
+                let mut docs = String::new();
+                let parser = Parser::new(metadata.docs);
+                for event in parser {
+                    match event {
+                        Event::Text(text) => {
+                            docs.push_str(text.as_ref());
+                        }
+                        Event::Code(text) => {
+                            docs.push_str(text.as_ref());
+                        }
+                        Event::SoftBreak => {
+                            docs.push(' ');
+                        }
+
+                        Event::End(Tag::Paragraph) => {
+                            break;
+                        }
+
+                        _ => {}
+                    }
+                }
+                docs
+            };
+
             let rule_position = Literal::u8_unsuffixed(index as u8);
             let rule_identifier = Ident::new(&to_lower_snake_case(rule), Span::call_site());
             let declaration = quote! {
@@ -65,7 +93,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                 pub #rule_identifier: RuleConfiguration
             };
             declarations.push(declaration);
-            if *recommended {
+            if metadata.recommended {
                 lines_recommended_rule_as_filter.push(quote! {
                     RuleFilter::Rule(#group, Self::CATEGORY_RULES[#rule_position])
                 });
@@ -79,6 +107,7 @@ pub(crate) fn generate_rules_configuration(mode: Mode) -> Result<()> {
                  #rule
             });
             schema_lines_rules.push(quote! {
+                #[doc = #summary]
                 #rule_identifier: Option<RuleConfiguration>
             });
         }

--- a/xtask/codegen/src/generate_schema.rs
+++ b/xtask/codegen/src/generate_schema.rs
@@ -5,11 +5,13 @@ use xtask::{project_root, Mode, Result};
 use xtask_codegen::update;
 
 pub(crate) fn generate_configuration_schema(mode: Mode) -> Result<()> {
-    let schema_path = project_root().join("editors/vscode/configuration_schema.json");
+    let schema_path_vscode = project_root().join("editors/vscode/configuration_schema.json");
+    let schema_path_npm = project_root().join("npm/rome/configuration_schema.json");
 
     let schema = schema_for!(Configuration);
     let json_schema = to_string_pretty(&schema)?;
-    update(&schema_path, &json_schema, &mode)?;
+    update(&schema_path_vscode, &json_schema, &mode)?;
+    update(&schema_path_npm, &json_schema, &mode)?;
 
     Ok(())
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #3690 

- added a new `$schema` property to the configuration
- updated the `codegen-configuration` and `codegen-schema` aliases to store the first paragraph of the documentation of the rules
- updated the `rome` package to publish a new file called `configuration_schema.json`
- updated the `Default` implementation of `Configuration`, with the `$schema` value that points to `./node_modules/rome/configuration_schema.json`.
This change is very biased. I thought that it could be a nice DX improvement to have it as part of the `rome init` command. The path is hard coded, I checked on the internet and it seems that all local paths use unix paths, it don't seem to be OS dependent. 


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I updated the existing CLI tests. The CI should pass for code generated files.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
