### PR TITLE
ci: fix conformance workflow

### DIFF
--- a/.github/workflows/parser_conformance.yml
+++ b/.github/workflows/parser_conformance.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
     paths:
-      - 'crates/rome_js_syntax/**/*'
-      - 'crates/rome_js_factory/**/*'
-      - 'crates/rome_js_parser/**/*'
-      - 'crates/rome_rowan/**/*'
-      - 'xtask/**/*'
+      - 'crates/rome_js_syntax/**'
+      - 'crates/rome_js_factory/**'
+      - 'crates/rome_js_parser/**'
+      - 'crates/rome_rowan/**'
+      - 'xtask/**'
 
 env:
   RUST_LOG: info


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/3682

It's weird that conformance always runs even though we have the paths in the workflow. Personally I don't know if this fixes the issue, but I noticed that the paths of this workflow are different from the workflows that work.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Merge it and see if a new PR doesn't trigger the workflow? 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
