### PR TITLE
docs(website): fix broken link to blog

### DIFF
--- a/website/src/components/NavigationSidebar.astro
+++ b/website/src/components/NavigationSidebar.astro
@@ -25,7 +25,7 @@ for (const page of allPages) {
   <ul class="mobile-navigation">
     <li><a href="/">Docs</a></li>
     <li><a href="/playground">Playground</a></li>
-    <li><ActiveLink href="/blog/">Blog</ActiveLink></li>
+    <li><ActiveLink href="https://rome.tools/blog/">Blog</ActiveLink></li>
   </ul>
 
   <ExternalLinks />


### PR DESCRIPTION
Currently, clicking "Blog" when in `doc.rome.tools` from mobile, results in 404. So I hard-coded the link like in https://github.com/rome/tools/blob/acffd660ebbd9b0b10d39b77ae4cd1fd305a0d8e/website/src/BaseLayout.astro#L80