### PR TITLE
fix(rome_js_analyze): improve exception control flow handling

### DIFF
--- a/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/JsTryFinallyStatement.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/JsTryFinallyStatement.js.snap
@@ -184,7 +184,7 @@ JsTryFinallyStatement.js:59:5 lint/correctness/noUnreachable ━━━━━━�
     60 │ }
     61 │ 
   
-  i ... because this statement will return from the function beforehand
+  i ... because either this statement ...
   
     44 │     try {
     45 │         tryBlock1();
@@ -192,6 +192,15 @@ JsTryFinallyStatement.js:59:5 lint/correctness/noUnreachable ━━━━━━�
        │         ^^^^^^^
     47 │     } catch {
     48 │         return;
+  
+  i ... or this statement will return from the function beforehand
+  
+    46 │         return;
+    47 │     } catch {
+  > 48 │         return;
+       │         ^^^^^^^
+    49 │     } finally {
+    50 │         if (value) {
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/issue-3654.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/issue-3654.js
@@ -1,0 +1,25 @@
+function testFAIL() {
+  try {
+    return fn();
+  } catch {
+    log();
+  } finally {
+    log();
+  }
+  return null;
+}
+
+function testOK() {
+  try {
+    return fn();
+  } catch {
+    log();
+  }
+  return null;
+}
+
+function fn() {
+  throw new Error('nope!');
+}
+
+function log() {}

--- a/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/issue-3654.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/issue-3654.js.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 73
+expression: issue-3654.js
+---
+# Input
+```js
+function testFAIL() {
+  try {
+    return fn();
+  } catch {
+    log();
+  } finally {
+    log();
+  }
+  return null;
+}
+
+function testOK() {
+  try {
+    return fn();
+  } catch {
+    log();
+  }
+  return null;
+}
+
+function fn() {
+  throw new Error('nope!');
+}
+
+function log() {}
+
+```
+
+


### PR DESCRIPTION
## Summary

Fixes #3654

This changes the analysis of exception control flow to stop at the first catch handler while visiting an exception branch instead of unwinding all the way to the function root.

## Test Plan

I've added a new test case for check for regressions for the associated issue. I've also updated the `JsTryFinallyStatement` snapshot since the fix also improves the diagnostics emitted by `noUnreachable` in some cases.
