### PR TITLE
feat(ci): add a new PR command to benchmark the CLI with hyperfine

### DIFF
--- a/.github/workflows/bench_cli.yml
+++ b/.github/workflows/bench_cli.yml
@@ -4,6 +4,7 @@
 name: CLI Benchmark
 
 on:
+  workflow_dispatch:
   issue_comment:
     types: [ created ]
 
@@ -13,7 +14,7 @@ env:
 jobs:
   bench:
     name: Bench
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '!bench_cli')
+    if: github.event_name == 'workflow_dispatch' || github.event.issue.pull_request && contains(github.event.comment.body, '!bench_cli')
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +24,12 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const response = await github.request(context.payload.issue.pull_request.url);
-            return response.data.head.sha;
+            if(context.eventName === "workflow_dispatch") {
+              return { result: context.sha, issue_number: 3764 };
+            } else {
+              const response = await github.request(context.payload.issue.pull_request.url);
+              return { result: response.data.head.sha, issue_number: context.payload.issue.number };
+            }
 
       - name: Checkout PR Branch
         uses: actions/checkout@v3
@@ -94,7 +99,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1.4.5
         continue-on-error: true
         with:
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ steps.sha.outputs.issue_number }}
           body: |
             ${{ steps.benchmarks.outputs.format }}
             ${{ steps.benchmarks.outputs.check }}

--- a/.github/workflows/bench_cli.yml
+++ b/.github/workflows/bench_cli.yml
@@ -1,0 +1,100 @@
+# CLI benchmark, compares main and PR branch with Hyperfine.
+# Comment with text containing `!bench_cli`, a new result will be commented at the bottom of this PR.
+
+name: CLI Benchmark
+
+on:
+  issue_comment:
+    types: [ created ]
+
+env:
+  RUST_LOG: info
+
+jobs:
+  bench:
+    name: Bench
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '!bench_cli')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR SHA
+        id: sha
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const response = await github.request(context.payload.issue.pull_request.url);
+            return response.data.head.sha;
+
+      - name: Checkout PR Branch
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+          ref: ${{ steps.sha.outputs.result }}
+
+      - name: Install toolchain
+        run: rustup show
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Install hyperfine
+        run: cargo install hyperfine
+
+      - name: Compile on PR Branch
+        run: |
+          cargo build --release --bin rome
+          mkdir -p benchmark/target
+          cp target/release/rome benchmark/target/rome_pr
+
+      - name: Checkout Main Branch
+        uses: actions/checkout@v3
+        with:
+          clean: false
+          ref: main
+
+      - name: Compile on Main Branch
+        run: |
+          cargo build --release --bin rome
+          cp target/release/rome benchmark/target/rome_main
+
+      - name: Checkout webpack
+        uses: actions/checkout@v3
+        with:
+          repository: https://github.com/webpack/webpack.git
+          path: benchmark/target/webpack
+      - name: Checkout prettier
+        uses: actions/checkout@v3
+        with:
+          repository: https://github.com/prettier/prettier.git
+          path: benchmark/target/prettier
+      - name: Checkout eslint
+        uses: actions/checkout@v3
+        with:
+          repository: https://github.com/eslint/eslint.git
+          path: benchmark/target/eslint
+
+      - name: Run Benchmarks
+        id: benchmarks
+        working-directory: benchmark/target
+        env:
+          FORMAT_BENCH_COMMAND: "format webpack/lib webpack/examples webpack/declarations webpack/benchmark prettier/src prettier/scripts --write"
+          CHECK_BENCH_COMMAND: "--max-diagnostics=0 eslint/lib eslint/messages eslint/tests/lib eslint/tests/performance eslint/tools webpack/lib"
+        run: |
+          hyperfine -w 2 --export-markdown benchmark_format.md \
+            -n "Rome (main)" "./rome_main $FORMAT_BENCH_COMMAND" \
+            -n "Rome (PR)" "./rome_pr $FORMAT_BENCH_COMMAND"
+          hyperfine -w 2 --export-markdown benchmark_check.md \
+            -n "Rome (main)" "./rome_main check $CHECK_BENCH_COMMAND" \
+            -n "Rome (PR)" "./rome_pr check $CHECK_BENCH_COMMAND"
+          echo "format=$(cat benchmark_format.md)" >> $GITHUB_OUTPUT
+          echo "check=$(cat benchmark_check.md)" >> $GITHUB_OUTPUT
+
+      - name: Write a new comment
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        continue-on-error: true
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ${{ steps.benchmarks.outputs.format }}
+            ${{ steps.benchmarks.outputs.check }}


### PR DESCRIPTION
## Summary

This adds a new `!bench_cli` command similar to the existing `!bench_*` comments we can use to trigger benchmark runs of the analyzer, formatter and parser on pull requests. The CLI is special though as it's using `hyperfine` to run the actual CLI binary on the same repos used for the benchmark suite in `benchmark/` (Webpack, Prettier and ESLint), as opposed to using `criterion` to benchmark individual parts of the toolchain.

## Test Plan

Unfortunately I don't think I can run this workflow without merging it first, hopefully it shouldn't take too many tries to get it to work correctly ...
