### PR TITLE
fix(rome_js_analyze): inline variable considering initializer

### DIFF
--- a/crates/rome_js_analyze/src/assists/correctness/inline_variable.rs
+++ b/crates/rome_js_analyze/src/assists/correctness/inline_variable.rs
@@ -60,8 +60,8 @@ impl Rule for InlineVariable {
         let expr = initializer.expression().ok()?;
         match expr {
             JsAnyExpression::JsArrowFunctionExpression(_)
-            | JsAnyExpression::JsFunctionExpression(_) 
-            | JsAnyExpression::JsClassExpression(_) 
+            | JsAnyExpression::JsFunctionExpression(_)
+            | JsAnyExpression::JsClassExpression(_)
             | JsAnyExpression::JsAssignmentExpression(_) => return None,
             _ => {}
         }
@@ -79,7 +79,6 @@ impl Rule for InlineVariable {
 
         // Inline variable
 
-        
         let expression = initializer.expression().ok()?;
         Some(State {
             references,

--- a/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/doNotInline.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/doNotInline.js
@@ -1,0 +1,22 @@
+
+// Do not inline arrow function expressions
+
+const arrowFunctionExpression = (x) => x;
+arrowFunctionExpression(1);
+
+// Do not inline function expressions
+
+const functionExpression = function(x) {};
+functionExpression(1);
+
+// Do not inline class expressions
+
+const classExpression = class A {};
+new classExpression();
+
+// Do not inline assignment expressions
+
+const assignmentExpressionA = 1;
+assignmentExpressionA = 2;
+const assignmentExpressionB = assignmentExpressionA = 2;
+console.log(assignmentExpressionB);

--- a/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/doNotInline.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/doNotInline.js.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: doNotInline.js
+---
+# Input
+```js
+
+// Do not inline arrow function expressions
+
+const arrowFunctionExpression = (x) => x;
+arrowFunctionExpression(1);
+
+// Do not inline function expressions
+
+const functionExpression = function(x) {};
+functionExpression(1);
+
+// Do not inline class expressions
+
+const classExpression = class A {};
+new classExpression();
+
+// Do not inline assignment expressions
+
+const assignmentExpressionA = 1;
+assignmentExpressionA = 2;
+const assignmentExpressionB = assignmentExpressionA = 2;
+console.log(assignmentExpressionB);
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/recursiveInvalid.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/recursiveInvalid.js
@@ -1,0 +1,7 @@
+// see https://github.com/rome/tools/issues/3697
+
+const romeKiller = () => {
+    const fn = (callback) => {
+      callback(fn);
+    };
+  };

--- a/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/recursiveInvalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/recursiveInvalid.js.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: recursiveInvalid.js
+---
+# Input
+```js
+// see https://github.com/rome/tools/issues/3697
+
+const romeKiller = () => {
+    const fn = (callback) => {
+      callback(fn);
+    };
+  };
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/valid.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/valid.js
@@ -18,3 +18,8 @@ statement(multipleDeclaratorsNotInlinable);
 
 let variable = expression();
 statement(variable);
+
+// Inline sequence expression
+
+const sequenceExpression = (1,2);
+console.log(sequenceExpression);

--- a/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/valid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/inlineVariable/valid.js.snap
@@ -1,0 +1,122 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```js
+let inlinable = "value1";
+let notInlinable = "value2";
+
+if (inlinable) {
+    notInlinable = inlinable;
+}
+
+statement(notInlinable);
+
+let multipleDeclaratorsInlinable = "value3",
+    multipleDeclaratorsNotInlinable = "value4";
+
+if (multipleDeclaratorsInlinable) {
+    multipleDeclaratorsNotInlinable.memberWrite = multipleDeclaratorsInlinable;
+}
+
+statement(multipleDeclaratorsNotInlinable);
+
+let variable = expression();
+statement(variable);
+
+// Inline sequence expression
+
+const sequenceExpression = (1,2);
+console.log(sequenceExpression);
+
+```
+
+# Actions
+```diff
+@@ -1,8 +1,8 @@
+-let inlinable = "value1";
++
+ let notInlinable = "value2";
+ 
+-if (inlinable) {
+-    notInlinable = inlinable;
++if ("value1") {
++    notInlinable = "value1";
+ }
+ 
+ statement(notInlinable);
+
+```
+
+```diff
+@@ -7,11 +7,11 @@
+ 
+ statement(notInlinable);
+ 
+-let multipleDeclaratorsInlinable = "value3",
++let 
+     multipleDeclaratorsNotInlinable = "value4";
+ 
+-if (multipleDeclaratorsInlinable) {
+-    multipleDeclaratorsNotInlinable.memberWrite = multipleDeclaratorsInlinable;
++if ("value3") {
++    multipleDeclaratorsNotInlinable.memberWrite = "value3";
+ }
+ 
+ statement(multipleDeclaratorsNotInlinable);
+
+```
+
+```diff
+@@ -7,14 +7,13 @@
+ 
+ statement(notInlinable);
+ 
+-let multipleDeclaratorsInlinable = "value3",
+-    multipleDeclaratorsNotInlinable = "value4";
++let multipleDeclaratorsInlinable = "value3";
+ 
+ if (multipleDeclaratorsInlinable) {
+-    multipleDeclaratorsNotInlinable.memberWrite = multipleDeclaratorsInlinable;
++    "value4".memberWrite = multipleDeclaratorsInlinable;
+ }
+ 
+-statement(multipleDeclaratorsNotInlinable);
++statement("value4");
+ 
+ let variable = expression();
+ statement(variable);
+
+```
+
+```diff
+@@ -15,9 +15,7 @@
+ }
+ 
+ statement(multipleDeclaratorsNotInlinable);
+-
+-let variable = expression();
+-statement(variable);
++statement(expression());
+ 
+ // Inline sequence expression
+ 
+
+```
+
+```diff
+@@ -18,8 +18,4 @@
+ 
+ let variable = expression();
+ statement(variable);
+-
+-// Inline sequence expression
+-
+-const sequenceExpression = (1,2);
+-console.log(sequenceExpression);
++console.log((1,2));
+
+```
+
+

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -30,6 +30,8 @@ f(1);"#,
             case 4: console.log(4, a/*READ A2*/, c/*READ C*/, d/*?*/);
         }
         console.log(5, a/*READ A1*/);",
+    ok_reference_recursive,
+        "const fn/*#A*/ = (callback) => { callback(fn/*READ A*/) };",
 }
 
 // Read Hoisting

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -347,7 +347,7 @@ where
                             // last write wins
                             if let Some(last) = modifications.last() {
                                 if last.0 == next_change.new_node_slot {
-                                    modifications.pop();      
+                                    modifications.pop();
                                 }
                             }
                             modifications.push((next_change.new_node_slot, next_change.new_node));

--- a/crates/rome_rowan/src/ast/batch.rs
+++ b/crates/rome_rowan/src/ast/batch.rs
@@ -342,6 +342,14 @@ where
                         if *next_change_parent == current_parent {
                             // SAFETY: We can .pop().unwrap() because we .peek() above
                             let next_change = changes.pop().expect("changes.pop");
+
+                            // If we have two modification to the same slot,
+                            // last write wins
+                            if let Some(last) = modifications.last() {
+                                if last.0 == next_change.new_node_slot {
+                                    modifications.pop();      
+                                }
+                            }
                             modifications.push((next_change.new_node_slot, next_change.new_node));
                             continue;
                         }
@@ -356,8 +364,11 @@ where
                 let is_list = current_parent.kind().is_list();
                 let mut removed_slots = 0;
 
+                dbg!(&modifications);
                 for (index, replace_with) in modifications {
-                    let index = index.checked_sub( removed_slots).unwrap_or_else(|| panic!("cannot replace element in slot {index} with {removed_slots} removed slots"));
+                    debug_assert!(index >= removed_slots);
+                    let index = index.checked_sub(removed_slots)
+                        .unwrap_or_else(|| panic!("cannot replace element in slot {index} with {removed_slots} removed slots"));
 
                     current_parent = if is_list && replace_with.is_none() {
                         removed_slots += 1;


### PR DESCRIPTION
## Summary

Fixes https://github.com/rome/tools/issues/3697.
Better together with https://github.com/rome/tools/pull/3740.

This PR increments the code action "inline variable" considering the type of the initializer. 
There is a chance that we may want to revisit this in the future, because some expressions do not make sense to be inlined. Example:

```js
const a = (1, (x) => {}, true);
```

Don't know why someone would write this, but this sure do not make sense to be inlined.

## Test Plan

```
> cargo test -p rome_js_analyze -- inline_variable
```
