### PR TITLE
feat(rome_js_parser): Improve parser error for generator function in an ambient context

### DIFF
--- a/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
@@ -57,9 +57,11 @@ impl FormatFunction {
             FormatFunction::JsFunctionExportDefaultDeclaration(declaration) => {
                 declaration.function_token()
             }
-            FormatFunction::TsDeclareFunctionDeclaration(member) => member.function_token(),
-            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(member) => {
-                member.function_token()
+            FormatFunction::TsDeclareFunctionDeclaration(declaration) => {
+                declaration.function_token()
+            }
+            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(declaration) => {
+                declaration.function_token()
             }
         }
     }
@@ -81,8 +83,10 @@ impl FormatFunction {
             FormatFunction::JsFunctionDeclaration(declaration) => declaration.id().map(Some),
             FormatFunction::JsFunctionExpression(expression) => Ok(expression.id()),
             FormatFunction::JsFunctionExportDefaultDeclaration(declaration) => Ok(declaration.id()),
-            FormatFunction::TsDeclareFunctionDeclaration(member) => member.id().map(Some),
-            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(member) => Ok(member.id()),
+            FormatFunction::TsDeclareFunctionDeclaration(declaration) => declaration.id().map(Some),
+            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(declaration) => {
+                Ok(declaration.id())
+            }
         }
     }
 
@@ -93,9 +97,11 @@ impl FormatFunction {
             FormatFunction::JsFunctionExportDefaultDeclaration(declaration) => {
                 declaration.type_parameters()
             }
-            FormatFunction::TsDeclareFunctionDeclaration(member) => member.type_parameters(),
-            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(member) => {
-                member.type_parameters()
+            FormatFunction::TsDeclareFunctionDeclaration(declaration) => {
+                declaration.type_parameters()
+            }
+            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(declaration) => {
+                declaration.type_parameters()
             }
         }
     }
@@ -107,9 +113,9 @@ impl FormatFunction {
             FormatFunction::JsFunctionExportDefaultDeclaration(declaration) => {
                 declaration.parameters()
             }
-            FormatFunction::TsDeclareFunctionDeclaration(member) => member.parameters(),
-            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(member) => {
-                member.parameters()
+            FormatFunction::TsDeclareFunctionDeclaration(declaration) => declaration.parameters(),
+            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(declaration) => {
+                declaration.parameters()
             }
         }
     }
@@ -123,9 +129,11 @@ impl FormatFunction {
             FormatFunction::JsFunctionExportDefaultDeclaration(declaration) => {
                 declaration.return_type_annotation()
             }
-            FormatFunction::TsDeclareFunctionDeclaration(member) => member.return_type_annotation(),
-            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(member) => {
-                member.return_type_annotation()
+            FormatFunction::TsDeclareFunctionDeclaration(declaration) => {
+                declaration.return_type_annotation()
+            }
+            FormatFunction::TsDeclareFunctionExportDefaultDeclaration(declaration) => {
+                declaration.return_type_annotation()
             }
         }
     }

--- a/crates/rome_js_parser/test_data/inline/err/ts_declare_generator_function.rast
+++ b/crates/rome_js_parser/test_data/inline/err/ts_declare_generator_function.rast
@@ -1,0 +1,154 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsUnknownStatement {
+            items: [
+                DECLARE_KW@0..8 "declare" [] [Whitespace(" ")],
+                JsUnknownStatement {
+                    items: [
+                        FUNCTION_KW@8..16 "function" [] [],
+                        STAR@16..18 "*" [] [Whitespace(" ")],
+                        JsIdentifierBinding {
+                            name_token: IDENT@18..22 "test" [] [],
+                        },
+                        JsParameters {
+                            l_paren_token: L_PAREN@22..23 "(" [] [],
+                            items: JsParameterList [],
+                            r_paren_token: R_PAREN@23..24 ")" [] [],
+                        },
+                        TsReturnTypeAnnotation {
+                            colon_token: COLON@24..26 ":" [] [Whitespace(" ")],
+                            ty: TsVoidType {
+                                void_token: VOID_KW@26..30 "void" [] [],
+                            },
+                        },
+                        SEMICOLON@30..31 ";" [] [],
+                    ],
+                },
+            ],
+        },
+        TsDeclareStatement {
+            declare_token: DECLARE_KW@31..40 "declare" [Newline("\n")] [Whitespace(" ")],
+            declaration: TsExternalModuleDeclaration {
+                module_token: MODULE_KW@40..47 "module" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@47..51 "'x'" [] [Whitespace(" ")],
+                },
+                body: TsModuleBlock {
+                    l_curly_token: L_CURLY@51..52 "{" [] [],
+                    items: JsModuleItemList [
+                        JsUnknownStatement {
+                            items: [
+                                EXPORT_KW@52..62 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                JsUnknown {
+                                    items: [
+                                        DEFAULT_KW@62..70 "default" [] [Whitespace(" ")],
+                                        JsUnknown {
+                                            items: [
+                                                FUNCTION_KW@70..78 "function" [] [],
+                                                STAR@78..80 "*" [] [Whitespace(" ")],
+                                                JsIdentifierBinding {
+                                                    name_token: IDENT@80..84 "test" [] [],
+                                                },
+                                                JsParameters {
+                                                    l_paren_token: L_PAREN@84..85 "(" [] [],
+                                                    items: JsParameterList [],
+                                                    r_paren_token: R_PAREN@85..86 ")" [] [],
+                                                },
+                                                TsReturnTypeAnnotation {
+                                                    colon_token: COLON@86..88 ":" [] [Whitespace(" ")],
+                                                    ty: TsVoidType {
+                                                        void_token: VOID_KW@88..92 "void" [] [],
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@92..94 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@94..95 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..95
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..94
+    0: JS_UNKNOWN_STATEMENT@0..31
+      0: DECLARE_KW@0..8 "declare" [] [Whitespace(" ")]
+      1: JS_UNKNOWN_STATEMENT@8..31
+        0: FUNCTION_KW@8..16 "function" [] []
+        1: STAR@16..18 "*" [] [Whitespace(" ")]
+        2: JS_IDENTIFIER_BINDING@18..22
+          0: IDENT@18..22 "test" [] []
+        3: JS_PARAMETERS@22..24
+          0: L_PAREN@22..23 "(" [] []
+          1: JS_PARAMETER_LIST@23..23
+          2: R_PAREN@23..24 ")" [] []
+        4: TS_RETURN_TYPE_ANNOTATION@24..30
+          0: COLON@24..26 ":" [] [Whitespace(" ")]
+          1: TS_VOID_TYPE@26..30
+            0: VOID_KW@26..30 "void" [] []
+        5: SEMICOLON@30..31 ";" [] []
+    1: TS_DECLARE_STATEMENT@31..94
+      0: DECLARE_KW@31..40 "declare" [Newline("\n")] [Whitespace(" ")]
+      1: TS_EXTERNAL_MODULE_DECLARATION@40..94
+        0: MODULE_KW@40..47 "module" [] [Whitespace(" ")]
+        1: JS_MODULE_SOURCE@47..51
+          0: JS_STRING_LITERAL@47..51 "'x'" [] [Whitespace(" ")]
+        2: TS_MODULE_BLOCK@51..94
+          0: L_CURLY@51..52 "{" [] []
+          1: JS_MODULE_ITEM_LIST@52..92
+            0: JS_UNKNOWN_STATEMENT@52..92
+              0: EXPORT_KW@52..62 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+              1: JS_UNKNOWN@62..92
+                0: DEFAULT_KW@62..70 "default" [] [Whitespace(" ")]
+                1: JS_UNKNOWN@70..92
+                  0: FUNCTION_KW@70..78 "function" [] []
+                  1: STAR@78..80 "*" [] [Whitespace(" ")]
+                  2: JS_IDENTIFIER_BINDING@80..84
+                    0: IDENT@80..84 "test" [] []
+                  3: JS_PARAMETERS@84..86
+                    0: L_PAREN@84..85 "(" [] []
+                    1: JS_PARAMETER_LIST@85..85
+                    2: R_PAREN@85..86 ")" [] []
+                  4: TS_RETURN_TYPE_ANNOTATION@86..92
+                    0: COLON@86..88 ":" [] [Whitespace(" ")]
+                    1: TS_VOID_TYPE@88..92
+                      0: VOID_KW@88..92 "void" [] []
+          2: R_CURLY@92..94 "}" [Newline("\n")] []
+  3: EOF@94..95 "" [Newline("\n")] []
+--
+ts_declare_generator_function.ts:1:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Generators are not allowed in an ambient context.
+  
+  > 1 │ declare function* test(): void;
+      │                 ^
+    2 │ declare module 'x' {
+    3 │   export default function* test(): void
+  
+--
+ts_declare_generator_function.ts:3:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Generators are not allowed in an ambient context.
+  
+    1 │ declare function* test(): void;
+    2 │ declare module 'x' {
+  > 3 │   export default function* test(): void
+      │                          ^
+    4 │ }
+    5 │ 
+  
+--
+declare function* test(): void;
+declare module 'x' {
+  export default function* test(): void
+}

--- a/crates/rome_js_parser/test_data/inline/err/ts_declare_generator_function.ts
+++ b/crates/rome_js_parser/test_data/inline/err/ts_declare_generator_function.ts
@@ -1,0 +1,4 @@
+declare function* test(): void;
+declare module 'x' {
+  export default function* test(): void
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Add `Generators are not allowed in an ambient context.` error for generator functions in an ambient context.

[Typescript playground](https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEBbA9sArhBByAHl+A3gFDzwg4AOyMALvKAGZQZ0NoB2YNAlsuwFTwaIAM40AFMgo8+ALnhR2ATwCU8gG7JuwIgF8i5KrXrhoceG04yBQ0RLXxN2gNxA)

For function overloading Rome has an error:
https://github.com/rome/tools/blob/4084d3e18e5d38b006e0dc99b3ce5975f9e01bf2/crates/rome_js_parser/src/syntax/function.rs#L280-L285

## Test Plan

`cargo test`
