### PR TITLE
doc(contributing): fix the wrong link for analyzers and lint rules selection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ from the main repository (not a fork), use these comments to run specific workfl
 ### Analyzers and lint rules
 
 To know the technical details of how our analyzer works, how to create a rule and how to write tests, please check our [internal
-documentation page](https://rustdocs.rome.tools/rome_js_analyze/index.html)
+documentation page](https://rustdocs.rome.tools/rome_analyze/index.html)
 
 ### JavaScript Parser
 


### PR DESCRIPTION
## Summary

While I am learning how to contribute to the rome project, I found that the internal link for `Analyzers and lint rules` selection was pointing to rome_js_analyzer instead of rome_analyze. This PR is for fixing that.
 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
