### PR TITLE
refactor(rome_analyze): align the syntax of lint suppression with the corresponding diagnostic category

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,6 +1693,7 @@ dependencies = [
  "quickcheck_macros",
  "rome_console",
  "rome_diagnostics",
+ "rome_diagnostics_categories",
  "rome_formatter",
  "rome_fs",
  "rome_js_factory",
@@ -1750,6 +1751,7 @@ dependencies = [
 name = "rome_js_syntax"
 version = "0.0.0"
 dependencies = [
+ "rome_diagnostics_categories",
  "rome_js_factory",
  "rome_rowan",
  "schemars",

--- a/crates/rome_analyze/src/diagnostics.rs
+++ b/crates/rome_analyze/src/diagnostics.rs
@@ -1,0 +1,232 @@
+use std::fmt::{Debug, Display, Formatter};
+
+use rome_console::{markup, MarkupBuf};
+use rome_diagnostics::{
+    advice::CodeSuggestionAdvice, category, Advices, Category, Diagnostic, DiagnosticExt,
+    DiagnosticTags, Error, FileId, Location, Severity, Visit,
+};
+use rome_rowan::TextRange;
+
+use crate::rule::RuleDiagnostic;
+
+/// Small wrapper for diagnostics during the analysis phase.
+///
+/// During these phases, analyzers can create various type diagnostics and some of them
+/// don't have all the info to actually create a real [Diagnostic].
+///
+/// This wrapper serves as glue, which eventually is able to spit out full fledged diagnostics.
+///
+#[derive(Debug)]
+pub struct AnalyzerDiagnostic {
+    kind: DiagnosticKind,
+    /// Series of code suggestions offered by rule code actions
+    code_suggestion_list: Vec<CodeSuggestionAdvice<MarkupBuf>>,
+}
+
+#[derive(Debug)]
+enum DiagnosticKind {
+    /// It holds various info related to diagnostics emitted by the rules
+    Rule {
+        /// Reference to the file
+        file_id: FileId,
+        /// The severity of the rule
+        severity: Option<Severity>,
+        /// The diagnostic emitted by a rule
+        rule_diagnostic: RuleDiagnostic,
+    },
+    /// We have raw information to create a basic [Diagnostic]
+    Raw(Error),
+}
+
+impl Diagnostic for AnalyzerDiagnostic {
+    fn category(&self) -> Option<&'static Category> {
+        match &self.kind {
+            DiagnosticKind::Rule {
+                rule_diagnostic, ..
+            } => Some(rule_diagnostic.category),
+            DiagnosticKind::Raw(error) => error.category(),
+        }
+    }
+    fn description(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.kind {
+            DiagnosticKind::Rule {
+                rule_diagnostic, ..
+            } => Debug::fmt(&rule_diagnostic.message, fmt),
+            DiagnosticKind::Raw(error) => error.description(fmt),
+        }
+    }
+
+    fn message(&self, fmt: &mut rome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        match &self.kind {
+            DiagnosticKind::Rule {
+                rule_diagnostic, ..
+            } => rome_console::fmt::Display::fmt(&rule_diagnostic.message, fmt),
+            DiagnosticKind::Raw(error) => error.message(fmt),
+        }
+    }
+
+    fn severity(&self) -> Severity {
+        match &self.kind {
+            DiagnosticKind::Rule { severity, .. } => severity.unwrap_or(Severity::Error),
+            DiagnosticKind::Raw(error) => error.severity(),
+        }
+    }
+
+    fn tags(&self) -> DiagnosticTags {
+        match &self.kind {
+            DiagnosticKind::Rule {
+                rule_diagnostic, ..
+            } => rule_diagnostic.tags,
+            DiagnosticKind::Raw(error) => error.tags(),
+        }
+    }
+
+    fn location(&self) -> Option<Location<'_>> {
+        match &self.kind {
+            DiagnosticKind::Rule {
+                rule_diagnostic,
+                file_id,
+                ..
+            } => {
+                let builder = Location::builder()
+                    .span(&rule_diagnostic.span)
+                    .resource(file_id);
+                builder.build()
+            }
+            DiagnosticKind::Raw(error) => error.location(),
+        }
+    }
+
+    fn advices(&self, visitor: &mut dyn Visit) -> std::io::Result<()> {
+        match &self.kind {
+            DiagnosticKind::Rule {
+                rule_diagnostic,
+                file_id,
+                ..
+            } => {
+                let rule_advices = rule_diagnostic.advices();
+                // we first print the details emitted by the rules
+                for detail in &rule_advices.details {
+                    visitor.record_log(
+                        detail.log_category,
+                        &markup! { {detail.message} }.to_owned(),
+                    )?;
+                    if let Some(location) = Location::builder()
+                        .span(&detail.range)
+                        .resource(file_id)
+                        .build()
+                    {
+                        visitor.record_frame(location)?;
+                    }
+                }
+                // we then print notes
+                for (log_category, note) in &rule_advices.notes {
+                    visitor.record_log(*log_category, &markup! { {note} }.to_owned())?;
+                }
+            }
+            DiagnosticKind::Raw(error) => error.advices(visitor)?,
+        }
+
+        // finally, we print possible code suggestions on how to fix the issue
+        for suggestion in &self.code_suggestion_list {
+            suggestion.record(visitor)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl AnalyzerDiagnostic {
+    /// Creates a diagnostic from a [RuleDiagnostic]
+    pub fn from_rule_diagnostic(file_id: FileId, rule_diagnostic: RuleDiagnostic) -> Self {
+        Self {
+            kind: DiagnosticKind::Rule {
+                file_id,
+                rule_diagnostic,
+                severity: None,
+            },
+            code_suggestion_list: vec![],
+        }
+    }
+
+    /// Creates a diagnostic from a generic [Error]
+    pub fn from_error(error: Error) -> Self {
+        Self {
+            kind: DiagnosticKind::Raw(error),
+            code_suggestion_list: vec![],
+        }
+    }
+
+    /// Sets the severity of the current diagnostic
+    pub fn set_severity(&mut self, new_severity: Severity) {
+        if let DiagnosticKind::Rule { severity, .. } = &mut self.kind {
+            *severity = Some(new_severity);
+        }
+    }
+
+    pub fn get_span(&self) -> Option<TextRange> {
+        match &self.kind {
+            DiagnosticKind::Rule {
+                rule_diagnostic, ..
+            } => rule_diagnostic.span,
+            DiagnosticKind::Raw(error) => error.location().and_then(|location| location.span),
+        }
+    }
+
+    /// It adds a code suggestion, use this API to tell the user that a rule can benefit from
+    /// a automatic code fix.
+    pub fn add_code_suggestion(mut self, suggestion: CodeSuggestionAdvice<MarkupBuf>) -> Self {
+        self.kind = match self.kind {
+            DiagnosticKind::Rule {
+                file_id,
+                severity,
+                mut rule_diagnostic,
+            } => {
+                rule_diagnostic.tags = DiagnosticTags::FIXABLE;
+                DiagnosticKind::Rule {
+                    file_id,
+                    severity,
+                    rule_diagnostic,
+                }
+            }
+            DiagnosticKind::Raw(error) => {
+                DiagnosticKind::Raw(error.with_tags(DiagnosticTags::FIXABLE))
+            }
+        };
+
+        self.code_suggestion_list.push(suggestion);
+        self
+    }
+}
+
+#[derive(Debug, Diagnostic)]
+pub(crate) struct SuppressionDiagnostic {
+    #[category]
+    category: &'static Category,
+    #[severity]
+    severity: Severity,
+    #[location(span)]
+    range: TextRange,
+    #[location(resource)]
+    file_id: FileId,
+    #[message]
+    #[description]
+    message: String,
+}
+
+impl SuppressionDiagnostic {
+    pub(crate) fn new(
+        file_id: FileId,
+        category: &'static Category,
+        range: TextRange,
+        message: impl Display,
+    ) -> Self {
+        Self {
+            file_id,
+            category,
+            severity: Severity::Warning,
+            range,
+            message: message.to_string(),
+        }
+    }
+}

--- a/crates/rome_analyze/src/diagnostics.rs
+++ b/crates/rome_analyze/src/diagnostics.rs
@@ -200,11 +200,10 @@ impl AnalyzerDiagnostic {
 }
 
 #[derive(Debug, Diagnostic)]
+#[diagnostic(severity = Warning)]
 pub(crate) struct SuppressionDiagnostic {
     #[category]
     category: &'static Category,
-    #[severity]
-    severity: Severity,
     #[location(span)]
     range: TextRange,
     #[location(resource)]
@@ -212,6 +211,8 @@ pub(crate) struct SuppressionDiagnostic {
     #[message]
     #[description]
     message: String,
+    #[tags]
+    tags: DiagnosticTags,
 }
 
 impl SuppressionDiagnostic {
@@ -224,9 +225,14 @@ impl SuppressionDiagnostic {
         Self {
             file_id,
             category,
-            severity: Severity::Warning,
             range,
             message: message.to_string(),
+            tags: DiagnosticTags::empty(),
         }
+    }
+
+    pub(crate) fn with_tags(mut self, tags: DiagnosticTags) -> Self {
+        self.tags |= tags;
+        self
     }
 }

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -44,7 +44,7 @@ pub use crate::syntax::SyntaxVisitor;
 pub use crate::visitor::{NodeVisitor, Visitor, VisitorContext, VisitorFinishContext};
 
 use rome_console::markup;
-use rome_diagnostics::{category, Applicability, FileId};
+use rome_diagnostics::{category, Applicability, DiagnosticTags, FileId};
 use rome_rowan::{
     AstNode, BatchMutation, Direction, Language, SyntaxElement, SyntaxToken, TextRange, TextSize,
     TriviaPieceKind, WalkEvent,
@@ -508,6 +508,7 @@ where
                     range,
                     "Suppression is using a deprecated syntax",
                 )
+                .with_tags(DiagnosticTags::DEPRECATED_CODE)
             });
 
             let signal = signal.with_action(|| {

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -3,11 +3,11 @@
 
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BinaryHeap};
-use std::fmt::{Debug, Formatter};
 use std::ops;
 
 mod categories;
 pub mod context;
+mod diagnostics;
 mod matcher;
 mod options;
 mod query;
@@ -24,6 +24,8 @@ pub use rome_diagnostics::category_concat;
 pub use crate::categories::{
     ActionCategory, RefactorKind, RuleCategories, RuleCategory, SourceActionKind,
 };
+pub use crate::diagnostics::AnalyzerDiagnostic;
+use crate::diagnostics::SuppressionDiagnostic;
 pub use crate::matcher::{InspectMatcher, MatchQueryParams, QueryMatcher, RuleKey, SignalEntry};
 pub use crate::options::{AnalyzerConfiguration, AnalyzerOptions, AnalyzerRules};
 pub use crate::query::{Ast, QueryKey, QueryMatch, Queryable};
@@ -40,15 +42,12 @@ use crate::signals::DiagnosticSignal;
 pub use crate::signals::{AnalyzerAction, AnalyzerSignal};
 pub use crate::syntax::SyntaxVisitor;
 pub use crate::visitor::{NodeVisitor, Visitor, VisitorContext, VisitorFinishContext};
-use rome_console::{markup, MarkupBuf};
-use rome_diagnostics::advice::CodeSuggestionAdvice;
-use rome_diagnostics::{
-    category, Advices, Category, Diagnostic, DiagnosticTags, Error, FileId, Location, Severity,
-    Visit,
-};
+
+use rome_console::markup;
+use rome_diagnostics::{category, Applicability, FileId};
 use rome_rowan::{
-    AstNode, Direction, Language, SyntaxElement, SyntaxToken, TextRange, TextSize, TriviaPieceKind,
-    WalkEvent,
+    AstNode, BatchMutation, Direction, Language, SyntaxElement, SyntaxToken, TextRange, TextSize,
+    TriviaPieceKind, WalkEvent,
 };
 
 /// The analyzer is the main entry point into the `rome_analyze` infrastructure.
@@ -170,14 +169,12 @@ where
             }
 
             let signal = DiagnosticSignal::new(|| {
-                let diag = SuppressionDiagnostic::new(
+                SuppressionDiagnostic::new(
                     ctx.file_id,
                     category!("suppressions/unused"),
                     suppression.comment_span,
                     "Suppression comment is not being used",
-                );
-
-                AnalyzerDiagnostic::from_error(diag.into())
+                )
             });
 
             if let ControlFlow::Break(br) = (emit_signal)(&signal) {
@@ -319,7 +316,7 @@ where
     /// whose position is less then the end of the token within the file
     fn handle_token(&mut self, file_id: FileId, token: SyntaxToken<L>) -> ControlFlow<Break> {
         // Process the content of the token for comments and newline
-        for piece in token.leading_trivia().pieces() {
+        for (index, piece) in token.leading_trivia().pieces().enumerate() {
             if matches!(
                 piece.kind(),
                 TriviaPieceKind::Newline
@@ -330,13 +327,20 @@ where
             }
 
             if let Some(comment) = piece.as_comments() {
-                self.handle_comment(file_id, comment.text(), piece.text_range())?;
+                self.handle_comment(
+                    file_id,
+                    &token,
+                    true,
+                    index,
+                    comment.text(),
+                    piece.text_range(),
+                )?;
             }
         }
 
         self.bump_line_index(token.text_trimmed(), token.text_trimmed_range());
 
-        for piece in token.trailing_trivia().pieces() {
+        for (index, piece) in token.trailing_trivia().pieces().enumerate() {
             if matches!(
                 piece.kind(),
                 TriviaPieceKind::Newline
@@ -347,7 +351,14 @@ where
             }
 
             if let Some(comment) = piece.as_comments() {
-                self.handle_comment(file_id, comment.text(), piece.text_range())?;
+                self.handle_comment(
+                    file_id,
+                    &token,
+                    false,
+                    index,
+                    comment.text(),
+                    piece.text_range(),
+                )?;
             }
         }
 
@@ -409,7 +420,7 @@ where
             // hit, otherwise emit the signal
             if let Some(suppression) = suppression {
                 suppression.did_suppress_signal = true;
-            } else {
+            } else if range_match(self.range, entry.text_range) {
                 (self.emit_signal)(&*entry.signal)?;
             }
 
@@ -426,13 +437,23 @@ where
     fn handle_comment(
         &mut self,
         file_id: FileId,
+        token: &SyntaxToken<L>,
+        is_leading: bool,
+        index: usize,
         text: &str,
         range: TextRange,
     ) -> ControlFlow<Break> {
         let mut suppress_all = false;
         let mut suppressions = Vec::new();
+        let mut has_legacy = false;
 
-        for rule in (self.parse_suppression_comment)(text) {
+        for kind in (self.parse_suppression_comment)(text) {
+            let rule = match kind {
+                SuppressionKind::Everything => None,
+                SuppressionKind::Rule(rule) => Some(rule),
+                SuppressionKind::MaybeLegacy(rule) => Some(rule),
+            };
+
             if let Some(rule) = rule {
                 let group_rule = rule.find('/').map(|index| {
                     let (start, end) = rule.split_at(index);
@@ -448,30 +469,23 @@ where
 
                 if let Some(key) = key {
                     suppressions.push(key);
-                } else {
+                    has_legacy |= matches!(kind, SuppressionKind::MaybeLegacy(_));
+                } else if range_match(self.range, range) {
                     // Emit a warning for the unknown rule
-                    let signal = DiagnosticSignal::new(move || {
-                        let diag = match group_rule {
-                            Some((group, rule)) => SuppressionDiagnostic::new(
-                                file_id,
-                                category!("suppressions/unknownRule"),
-                                range,
-                                markup! {
-                                    "Unknown lint rule "{group}"/"{rule}" in suppression comment"
-                                },
-                            ),
+                    let signal = DiagnosticSignal::new(move || match group_rule {
+                        Some((group, rule)) => SuppressionDiagnostic::new(
+                            file_id,
+                            category!("suppressions/unknownRule"),
+                            range,
+                            format_args!("Unknown lint rule {group}/{rule} in suppression comment"),
+                        ),
 
-                            None => SuppressionDiagnostic::new(
-                                file_id,
-                                category!("suppressions/unknownGroup"),
-                                range,
-                                markup! {
-                                    "Unknown lint rule group "{rule}" in suppression comment"
-                                },
-                            ),
-                        };
-
-                        AnalyzerDiagnostic::from_error(diag.into())
+                        None => SuppressionDiagnostic::new(
+                            file_id,
+                            category!("suppressions/unknownGroup"),
+                            range,
+                            format_args!("Unknown lint rule group {rule} in suppression comment"),
+                        ),
                     });
 
                     (self.emit_signal)(&signal)?;
@@ -483,6 +497,24 @@ where
                 // parse anything else
                 break;
             }
+        }
+
+        // Emit a warning for legacy suppression syntax
+        if has_legacy && range_match(self.range, range) {
+            let signal = DiagnosticSignal::new(move || {
+                SuppressionDiagnostic::new(
+                    file_id,
+                    category!("suppressions/deprecatedSyntax"),
+                    range,
+                    "Suppression is using a deprecated syntax",
+                )
+            });
+
+            let signal = signal.with_action(|| {
+                update_suppression(file_id, self.root, token, is_leading, index, text)
+            });
+
+            (self.emit_signal)(&signal)?;
         }
 
         if !suppress_all && suppressions.is_empty() {
@@ -554,6 +586,10 @@ where
     }
 }
 
+fn range_match(filter: Option<TextRange>, range: TextRange) -> bool {
+    filter.map_or(true, |filter| filter.intersect(range).is_some())
+}
+
 /// Signature for a suppression comment parser function
 ///
 /// This function receives the text content of a comment and returns a list of
@@ -563,10 +599,79 @@ where
 /// # Examples
 ///
 /// - `// rome-ignore format` -> `vec![]`
-/// - `// rome-ignore lint` -> `vec![None]`
-/// - `// rome-ignore lint(correctness/useWhile)` -> `vec![Some("correctness/useWhile")]`
-/// - `// rome-ignore lint(correctness/useWhile) lint(nursery/noUnreachable)` -> `vec![Some("correctness/useWhile"), Some("nursery/noUnreachable")]`
-type SuppressionParser = fn(&str) -> Vec<Option<&str>>;
+/// - `// rome-ignore lint` -> `vec![Everything]`
+/// - `// rome-ignore lint/correctness/useWhile` -> `vec![Rule("correctness/useWhile")]`
+/// - `// rome-ignore lint/correctness/useWhile lint/nursery/noUnreachable` -> `vec![Rule("correctness/useWhile"), Rule("nursery/noUnreachable")]`
+/// - `// rome-ignore lint(correctness/useWhile)` -> `vec![MaybeLegacy("correctness/useWhile")]`
+/// - `// rome-ignore lint(correctness/useWhile) lint(nursery/noUnreachable)` -> `vec![MaybeLegacy("correctness/useWhile"), MaybeLegacy("nursery/noUnreachable")]`
+type SuppressionParser = fn(&str) -> Vec<SuppressionKind>;
+
+/// This enum is used to categorize what is disabled by a suppression comment and with what syntax
+pub enum SuppressionKind<'a> {
+    /// A suppression disabling all lints eg. `// rome-ignore lint`
+    Everything,
+    /// A suppression disabling a specific rule eg. `// rome-ignore lint/correctness/useWhile`
+    Rule(&'a str),
+    /// A suppression using the legacy syntax to disable a specific rule eg. `// rome-ignore lint(correctness/useWhile)`
+    MaybeLegacy(&'a str),
+}
+
+fn update_suppression<L: Language>(
+    file_id: FileId,
+    root: &L::Root,
+    token: &SyntaxToken<L>,
+    is_leading: bool,
+    index: usize,
+    text: &str,
+) -> Option<AnalyzerAction<L>> {
+    let old_token = token.clone();
+    let new_token = token.clone().detach();
+
+    let old_trivia = if is_leading {
+        old_token.leading_trivia()
+    } else {
+        old_token.trailing_trivia()
+    };
+
+    let old_trivia: Vec<_> = old_trivia.pieces().collect();
+
+    let mut text = text.to_string();
+
+    while let Some(range_start) = text.find("lint(") {
+        let range_end = range_start + text[range_start..].find(')')?;
+        text.replace_range(range_end..range_end + 1, "");
+        text.replace_range(range_start + 4..range_start + 5, "/");
+    }
+
+    let new_trivia = old_trivia.iter().enumerate().map(|(piece_index, piece)| {
+        if piece_index == index {
+            (piece.kind(), text.as_str())
+        } else {
+            (piece.kind(), piece.text())
+        }
+    });
+
+    let new_token = if is_leading {
+        new_token.with_leading_trivia(new_trivia)
+    } else {
+        new_token.with_trailing_trivia(new_trivia)
+    };
+
+    let mut mutation = BatchMutation::new(root.syntax().clone());
+    mutation.replace_token_discard_trivia(old_token, new_token);
+
+    Some(AnalyzerAction {
+        rule_name: None,
+        file_id,
+        category: ActionCategory::QuickFix,
+        applicability: Applicability::Always,
+        message: markup! {
+            "Rewrite suppression to use the newer syntax"
+        }
+        .to_owned(),
+        mutation,
+    })
+}
 
 type SignalHandler<'a, L, Break> = &'a mut dyn FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<Break>;
 
@@ -652,206 +757,6 @@ impl<'analysis> AnalysisFilter<'analysis> {
         Self {
             enabled_rules,
             ..AnalysisFilter::default()
-        }
-    }
-}
-
-/// Small wrapper for diagnostics during the analysis phase.
-///
-/// During these phases, analyzers can create various type diagnostics and some of them
-/// don't have all the info to actually create a real [Diagnostic].
-///
-/// This wrapper serves as glue, which eventually is able to spit out full fledged diagnostics.
-///
-#[derive(Debug)]
-pub enum AnalyzerDiagnostic {
-    /// It holds various info related to diagnostics emitted by the rules
-    Rule {
-        /// Reference to the file
-        file_id: FileId,
-        /// The severity of the rule
-        severity: Option<Severity>,
-        /// The diagnostic emitted by a rule
-        rule_diagnostic: RuleDiagnostic,
-        /// Series of code suggestions offered by rule code actions
-        code_suggestion_list: Vec<CodeSuggestionAdvice<MarkupBuf>>,
-    },
-    /// We have raw information to create a basic [Diagnostic]
-    Raw(Error),
-}
-
-impl Diagnostic for AnalyzerDiagnostic {
-    fn category(&self) -> Option<&'static Category> {
-        match self {
-            AnalyzerDiagnostic::Rule {
-                rule_diagnostic, ..
-            } => Some(rule_diagnostic.category),
-            AnalyzerDiagnostic::Raw(error) => error.category(),
-        }
-    }
-    fn description(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AnalyzerDiagnostic::Rule {
-                rule_diagnostic, ..
-            } => Debug::fmt(&rule_diagnostic.message, fmt),
-            AnalyzerDiagnostic::Raw(error) => error.description(fmt),
-        }
-    }
-
-    fn message(&self, fmt: &mut rome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
-        match self {
-            AnalyzerDiagnostic::Rule {
-                rule_diagnostic, ..
-            } => rome_console::fmt::Display::fmt(&rule_diagnostic.message, fmt),
-            AnalyzerDiagnostic::Raw(error) => error.message(fmt),
-        }
-    }
-
-    fn severity(&self) -> Severity {
-        match self {
-            AnalyzerDiagnostic::Rule { severity, .. } => severity.unwrap_or(Severity::Error),
-            AnalyzerDiagnostic::Raw(error) => error.severity(),
-        }
-    }
-
-    fn tags(&self) -> DiagnosticTags {
-        match self {
-            AnalyzerDiagnostic::Rule {
-                rule_diagnostic, ..
-            } => rule_diagnostic.tags,
-            AnalyzerDiagnostic::Raw(error) => error.tags(),
-        }
-    }
-
-    fn location(&self) -> Option<Location<'_>> {
-        match self {
-            AnalyzerDiagnostic::Rule {
-                rule_diagnostic,
-                file_id,
-                ..
-            } => {
-                let builder = Location::builder()
-                    .span(&rule_diagnostic.span)
-                    .resource(file_id);
-                builder.build()
-            }
-            AnalyzerDiagnostic::Raw(error) => error.location(),
-        }
-    }
-
-    fn advices(&self, visitor: &mut dyn Visit) -> std::io::Result<()> {
-        match self {
-            AnalyzerDiagnostic::Rule {
-                rule_diagnostic,
-                code_suggestion_list,
-                file_id,
-                ..
-            } => {
-                let rule_advices = rule_diagnostic.advices();
-                // we first print the details emitted by the rules
-                for detail in &rule_advices.details {
-                    visitor.record_log(
-                        detail.log_category,
-                        &markup! { {detail.message} }.to_owned(),
-                    )?;
-                    if let Some(location) = Location::builder()
-                        .span(&detail.range)
-                        .resource(file_id)
-                        .build()
-                    {
-                        visitor.record_frame(location)?;
-                    }
-                }
-                // we then print notes
-                for (log_category, note) in &rule_advices.notes {
-                    visitor.record_log(*log_category, &markup! { {note} }.to_owned())?;
-                }
-
-                // finally, we print possible code suggestions on how to fix the issue
-                for suggestion in code_suggestion_list {
-                    suggestion.record(visitor)?;
-                }
-                Ok(())
-            }
-            AnalyzerDiagnostic::Raw(error) => error.advices(visitor),
-        }
-    }
-}
-
-impl AnalyzerDiagnostic {
-    /// Creates a diagnostic from a [RuleDiagnostic]
-    pub fn from_rule_diagnostic(file_id: FileId, rule_diagnostic: RuleDiagnostic) -> Self {
-        Self::Rule {
-            file_id,
-            rule_diagnostic,
-            severity: None,
-            code_suggestion_list: vec![],
-        }
-    }
-
-    /// Creates a diagnostic from a generic [Error]
-    pub fn from_error(error: Error) -> Self {
-        Self::Raw(error)
-    }
-
-    /// Sets the severity of the current diagnostic
-    pub fn set_severity(&mut self, new_severity: Severity) {
-        if let AnalyzerDiagnostic::Rule { severity, .. } = self {
-            *severity = Some(new_severity);
-        }
-    }
-
-    pub fn get_span(&self) -> Option<TextRange> {
-        match self {
-            AnalyzerDiagnostic::Rule {
-                rule_diagnostic, ..
-            } => rule_diagnostic.span,
-            AnalyzerDiagnostic::Raw(error) => error.location().and_then(|location| location.span),
-        }
-    }
-
-    /// It adds a code suggestion, use this API to tell the user that a rule can benefit from
-    /// a automatic code fix.
-    pub fn add_code_suggestion(&mut self, suggestion: CodeSuggestionAdvice<MarkupBuf>) {
-        if let AnalyzerDiagnostic::Rule {
-            code_suggestion_list: suggestions,
-            rule_diagnostic,
-            ..
-        } = self
-        {
-            rule_diagnostic.tags = DiagnosticTags::FIXABLE;
-            suggestions.push(suggestion)
-        }
-    }
-}
-
-#[derive(Debug, Diagnostic)]
-pub(crate) struct SuppressionDiagnostic {
-    #[category]
-    category: &'static Category,
-    #[severity]
-    severity: Severity,
-    #[location(span)]
-    range: TextRange,
-    #[location(resource)]
-    file_id: FileId,
-    #[message]
-    message: MarkupBuf,
-}
-
-impl SuppressionDiagnostic {
-    pub(crate) fn new(
-        file_id: FileId,
-        category: &'static Category,
-        range: TextRange,
-        message: impl rome_console::fmt::Display,
-    ) -> Self {
-        Self {
-            file_id,
-            category,
-            severity: Severity::Warning,
-            range,
-            message: markup!({ message }).to_owned(),
         }
     }
 }

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -21,8 +21,10 @@ pub trait AnalyzerSignal<L: Language> {
     fn action(&self) -> Option<AnalyzerAction<L>>;
 }
 
-/// Simple implementation of [AnalyzerSignal] generating a [AnalyzerDiagnostic] from a
-/// provided factory function
+/// Simple implementation of [AnalyzerSignal] generating a [AnalyzerDiagnostic]
+/// from a provided factory function. Optionally, this signal can be configured
+/// to also emit a code action, by calling `.with_action` with a secondary
+/// factory function for said action.
 pub(crate) struct DiagnosticSignal<D, A, L, T> {
     diagnostic: D,
     action: A,

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::{
     categories::ActionCategory,
     context::RuleContext,
@@ -6,8 +8,10 @@ use crate::{
     AnalyzerDiagnostic, AnalyzerOptions, Queryable, RuleGroup, ServiceBag,
 };
 use rome_console::MarkupBuf;
-use rome_diagnostics::advice::CodeSuggestionAdvice;
-use rome_diagnostics::{location::FileId, Applicability, CodeSuggestion, FileSpan};
+use rome_diagnostics::{
+    advice::CodeSuggestionAdvice, location::FileId, Applicability, CodeSuggestion, Diagnostic,
+    Error, FileSpan,
+};
 use rome_rowan::{BatchMutation, Language};
 
 /// Event raised by the analyzer when a [Rule](crate::Rule)
@@ -19,29 +23,53 @@ pub trait AnalyzerSignal<L: Language> {
 
 /// Simple implementation of [AnalyzerSignal] generating a [AnalyzerDiagnostic] from a
 /// provided factory function
-pub(crate) struct DiagnosticSignal<F> {
-    factory: F,
+pub(crate) struct DiagnosticSignal<D, A, L, T> {
+    diagnostic: D,
+    action: A,
+    _diag: PhantomData<(L, T)>,
 }
 
-impl<F> DiagnosticSignal<F>
+impl<L: Language, D, T> DiagnosticSignal<D, fn() -> Option<AnalyzerAction<L>>, L, T>
 where
-    F: Fn() -> AnalyzerDiagnostic,
+    D: Fn() -> T,
+    T: Diagnostic + Send + Sync + 'static,
 {
-    pub(crate) fn new(factory: F) -> Self {
-        Self { factory }
+    pub(crate) fn new(factory: D) -> Self {
+        Self {
+            diagnostic: factory,
+            action: || None,
+            _diag: PhantomData,
+        }
     }
 }
 
-impl<L: Language, F> AnalyzerSignal<L> for DiagnosticSignal<F>
+impl<L: Language, D, A, T> DiagnosticSignal<D, A, L, T> {
+    pub(crate) fn with_action<B>(self, factory: B) -> DiagnosticSignal<D, B, L, T>
+    where
+        B: Fn() -> Option<AnalyzerAction<L>>,
+    {
+        DiagnosticSignal {
+            diagnostic: self.diagnostic,
+            action: factory,
+            _diag: PhantomData,
+        }
+    }
+}
+
+impl<L: Language, D, A, T> AnalyzerSignal<L> for DiagnosticSignal<D, A, L, T>
 where
-    F: Fn() -> AnalyzerDiagnostic,
+    D: Fn() -> T,
+    T: Diagnostic + Send + Sync + 'static,
+    A: Fn() -> Option<AnalyzerAction<L>>,
 {
     fn diagnostic(&self) -> Option<AnalyzerDiagnostic> {
-        Some((self.factory)())
+        let diag = (self.diagnostic)();
+        let error = Error::from(diag);
+        Some(AnalyzerDiagnostic::from_error(error))
     }
 
     fn action(&self) -> Option<AnalyzerAction<L>> {
-        None
+        (self.action)()
     }
 }
 
@@ -52,8 +80,7 @@ where
 /// a diagnostic emitted by the same signal
 #[derive(Debug)]
 pub struct AnalyzerAction<L: Language> {
-    pub group_name: &'static str,
-    pub rule_name: &'static str,
+    pub rule_name: Option<(&'static str, &'static str)>,
     pub file_id: FileId,
     pub category: ActionCategory,
     pub applicability: Applicability,
@@ -145,8 +172,7 @@ where
             RuleContext::new(&self.query_result, self.root, self.services, &self.options).ok()?;
 
         R::action(&ctx, &self.state).map(|action| AnalyzerAction {
-            group_name: <R::Group as RuleGroup>::NAME,
-            rule_name: R::METADATA.name,
+            rule_name: Some((<R::Group as RuleGroup>::NAME, R::METADATA.name)),
             file_id: self.file_id,
             category: action.category,
             applicability: action.applicability,

--- a/crates/rome_cli/src/commands/daemon.rs
+++ b/crates/rome_cli/src/commands/daemon.rs
@@ -209,10 +209,17 @@ pub(super) fn rome_log_dir() -> PathBuf {
 /// - All spans and events at level debug in crates whose name starts with `rome`
 struct LoggingFilter;
 
+/// Tracing filter used for spans emitted by `rome*` crates
+const SELF_FILTER: LevelFilter = if cfg!(debug_assertions) {
+    LevelFilter::TRACE
+} else {
+    LevelFilter::DEBUG
+};
+
 impl LoggingFilter {
     fn is_enabled(&self, meta: &Metadata<'_>) -> bool {
         let filter = if meta.target().starts_with("rome") {
-            LevelFilter::DEBUG
+            SELF_FILTER
         } else {
             LevelFilter::INFO
         };
@@ -235,6 +242,6 @@ impl<S> Filter<S> for LoggingFilter {
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {
-        Some(LevelFilter::DEBUG)
+        Some(SELF_FILTER)
     }
 }

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -992,3 +992,35 @@ fn no_supported_file_found() {
         result,
     ));
 }
+
+#[test]
+fn deprecated_suppression_comment() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("file.js");
+    fs.insert(
+        file_path.into(),
+        *b"// rome-ignore lint(correctness/noDoubleEquals): test
+a == b;",
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            std::ffi::OsString::from("check"),
+            file_path.as_os_str().into(),
+        ]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "deprecated_suppression_comment",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/rome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+// rome-ignore lint(correctness/noDoubleEquals): test
+a == b;
+```
+
+# Emitted Messages
+
+```block
+file.js:1:1 suppressions/deprecatedSyntax  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Suppression is using a deprecated syntax
+  
+  > 1 │ // rome-ignore lint(correctness/noDoubleEquals): test
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ a == b;
+  
+  i Safe fix: Rewrite suppression to use the newer syntax
+  
+    1   │ - //·rome-ignore·lint(correctness/noDoubleEquals):·test
+      1 │ + //·rome-ignore·lint/correctness/noDoubleEquals:·test
+    2 2 │   a == b;
+  
+
+```
+
+

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -99,14 +99,26 @@ define_dategories! {
     "internalError/io",
     "internalError/fs",
     "internalError/panic",
-    "lint",
+
     // parse categories
     "parse",
     "parse/noSuperWithoutExtends",
 
+    // Lint groups
+    "lint",
+    "lint/correctness",
+    "lint/style",
+    "lint/complexity",
+    "lint/a11y",
+    "lint/security",
+    "lint/nursery",
+
+    // Suppression comments
     "suppressions/unknownGroup",
     "suppressions/unknownRule",
     "suppressions/unused",
+    "suppressions/deprecatedSyntax",
+
     // Used in tests and examples
     "args/fileNotFound",
     "flags/invalid",

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -93,7 +93,7 @@ fn write_analysis_to_snapshot(
             diag.set_severity(Severity::Warning);
             if let Some(action) = event.action() {
                 check_code_action(input_file, input_code, source_type, &action);
-                diag.add_code_suggestion(action.into());
+                diag = diag.add_code_suggestion(action.into());
             }
 
             diagnostics.push(diagnostic_to_string(file_name, input_code, diag));

--- a/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/SuppressionComments.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/SuppressionComments.js
@@ -1,4 +1,4 @@
-// rome-ignore lint(correctness/noUnreachable): this comment does nothing
+// rome-ignore lint/correctness/noUnreachable: this comment does nothing
 function SuppressionComments1() {
     beforeReturn();
     return;
@@ -8,6 +8,6 @@ function SuppressionComments1() {
 function SuppressionComments2() {
     beforeReturn();
     return;
-    // rome-ignore lint(correctness/noUnreachable): supress warning
+    // rome-ignore lint/correctness/noUnreachable: supress warning
     afterReturn();
 }

--- a/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/SuppressionComments.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnreachable/SuppressionComments.js.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 99
 expression: SuppressionComments.js
 ---
 # Input
 ```js
-// rome-ignore lint(correctness/noUnreachable): this comment does nothing
+// rome-ignore lint/correctness/noUnreachable: this comment does nothing
 function SuppressionComments1() {
     beforeReturn();
     return;
@@ -15,7 +14,7 @@ function SuppressionComments1() {
 function SuppressionComments2() {
     beforeReturn();
     return;
-    // rome-ignore lint(correctness/noUnreachable): supress warning
+    // rome-ignore lint/correctness/noUnreachable: supress warning
     afterReturn();
 }
 
@@ -51,8 +50,8 @@ SuppressionComments.js:1:1 suppressions/unused ━━━━━━━━━━━
 
   ! Suppression comment is not being used
   
-  > 1 │ // rome-ignore lint(correctness/noUnreachable): this comment does nothing
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 1 │ // rome-ignore lint/correctness/noUnreachable: this comment does nothing
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ function SuppressionComments1() {
     3 │     beforeReturn();
   

--- a/crates/rome_js_formatter/Cargo.toml
+++ b/crates/rome_js_formatter/Cargo.toml
@@ -15,6 +15,7 @@ rome_js_factory = { path = "../rome_js_factory" }
 rome_formatter = { path = "../rome_formatter" }
 rome_rowan = { path = "../rome_rowan" }
 rome_text_size = { path = "../rome_text_size"}
+rome_diagnostics_categories = { path = "../rome_diagnostics_categories"}
 tracing = { workspace = true }
 unicode-width = "0.1.9"
 serde = { version = "1.0.136", features = ["derive"], optional = true }

--- a/crates/rome_js_formatter/src/comments.rs
+++ b/crates/rome_js_formatter/src/comments.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use crate::utils::JsAnyConditional;
+use rome_diagnostics_categories::category;
 use rome_formatter::{
     comments::{
         CommentKind, CommentPlacement, CommentStyle, CommentTextPosition, Comments,
@@ -7,7 +8,7 @@ use rome_formatter::{
     },
     write,
 };
-use rome_js_syntax::suppression::{parse_suppression_comment, SuppressionCategory};
+use rome_js_syntax::suppression::parse_suppression_comment;
 use rome_js_syntax::{
     JsAnyClass, JsAnyName, JsAnyRoot, JsAnyStatement, JsArrayHole, JsArrowFunctionExpression,
     JsBlockStatement, JsCallArguments, JsCatchClause, JsEmptyStatement, JsFinallyClause,
@@ -136,7 +137,7 @@ impl CommentStyle for JsCommentStyle {
     fn is_suppression(text: &str) -> bool {
         parse_suppression_comment(text)
             .flat_map(|suppression| suppression.categories)
-            .any(|(category, _)| category == SuppressionCategory::Format)
+            .any(|(key, _)| key == category!("format"))
     }
 
     fn get_comment_kind(comment: &SyntaxTriviaPieceComments<JsLanguage>) -> CommentKind {

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js
@@ -3,7 +3,7 @@
 function supported1(){
 	return (
 		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
-		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
 		a && b
 	);
 }
@@ -11,7 +11,7 @@ function supported1(){
 function supported2(){
 	return !(
 		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
-		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
 		a && b
 	);
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
@@ -11,7 +11,7 @@ expression: return_verbatim_argument.js
 function supported1(){
 	return (
 		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
-		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
 		a && b
 	);
 }
@@ -19,7 +19,7 @@ function supported1(){
 function supported2(){
 	return !(
 		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
-		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
 		a && b
 	);
 }
@@ -56,7 +56,7 @@ Semicolons: Always
 function supported1() {
 	return (
 		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
-		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
 		a && b
 	);
 }
@@ -64,7 +64,7 @@ function supported1() {
 function supported2() {
 	return !(
 		// rome-ignore format: Work around https://github.com/rome/tools/issues/3734
-		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
 		a && b
 	);
 }
@@ -80,8 +80,8 @@ function supported3() {
 
 ## Lines exceeding width of 80 characters
 
-    6: 		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
-   14: 		// rome-ignore lint(style/useOptionalChain): Optional chaining creates more complicated ES2019 code
+    6: 		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
+   14: 		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
 ```
 
 

--- a/crates/rome_js_syntax/Cargo.toml
+++ b/crates/rome_js_syntax/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rome/tools"
 
 [dependencies]
 rome_rowan = { path = "../rome_rowan" }
+rome_diagnostics_categories = { path = "../rome_diagnostics_categories" }
 serde = { version = "1.0.136", features = ["derive"], optional = true }
 schemars = { version = "0.8.10", optional = true }
 

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -135,7 +135,7 @@ impl Session {
     /// Computes diagnostics for the file matching the provided url and publishes
     /// them to the client. Called from [`handlers::text_document`] when a file's
     /// contents changes.
-    #[tracing::instrument(level = "trace", skip(self), err)]
+    #[tracing::instrument(level = "trace", skip_all, fields(url = display(&url), diagnostic_count), err)]
     pub(crate) async fn update_diagnostics(&self, url: lsp_types::Url) -> anyhow::Result<()> {
         let rome_path = self.file_path(&url);
         let doc = self.document(&url)?;
@@ -144,22 +144,39 @@ impl Session {
             path: rome_path.clone(),
         })?;
 
-        let diagnostics = if unsupported_lint.reason.is_none() {
+        let diagnostics = if let Some(reason) = unsupported_lint.reason {
+            tracing::trace!("linting not supported: {reason:?}");
+            // Sending empty vector clears published diagnostics
+            vec![]
+        } else {
             let result = self.workspace.pull_diagnostics(PullDiagnosticsParams {
                 path: rome_path,
                 categories: RuleCategories::SYNTAX | RuleCategories::LINT,
                 max_diagnostics: u64::MAX,
             })?;
 
-            result
+            tracing::trace!("rome diagnostics: {:#?}", result.diagnostics);
+
+            let result = result
                 .diagnostics
                 .into_iter()
-                .filter_map(|d| utils::diagnostic_to_lsp(d, &url, &doc.line_index))
-                .collect()
-        } else {
-            // Sending empty vector clears published diagnostics
-            vec![]
+                .filter_map(
+                    |d| match utils::diagnostic_to_lsp(d, &url, &doc.line_index) {
+                        Ok(diag) => Some(diag),
+                        Err(err) => {
+                            tracing::error!("failed to convert diagnostic to LSP: {err:?}");
+                            None
+                        }
+                    },
+                )
+                .collect();
+
+            tracing::trace!("lsp diagnostics: {:#?}", result);
+
+            result
         };
+
+        tracing::Span::current().record("diagnostic_count", diagnostics.len());
 
         self.client
             .publish_diagnostics(url, diagnostics, Some(doc.version))

--- a/crates/rome_lsp/src/utils.rs
+++ b/crates/rome_lsp/src/utils.rs
@@ -4,7 +4,7 @@ use std::fmt::{Debug, Display};
 use std::io;
 
 use crate::line_index::{LineCol, LineIndex};
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 use rome_analyze::ActionCategory;
 use rome_console::fmt::Termcolor;
 use rome_console::fmt::{self, Formatter};
@@ -120,38 +120,43 @@ pub(crate) fn code_fix_to_lsp(
     action: CodeAction,
 ) -> Result<lsp::CodeAction> {
     // Mark diagnostics emitted by the same rule as resolved by this action
-    let diagnostics: Vec<_> = if matches!(action.category, ActionCategory::QuickFix) {
-        diagnostics
-            .iter()
-            .filter_map(|d| {
-                let code = d.code.as_ref()?;
-                let code = match code {
-                    lsp::NumberOrString::String(code) => code.as_str(),
-                    lsp::NumberOrString::Number(_) => return None,
-                };
+    let diagnostics: Vec<_> = action
+        .rule_name
+        .as_ref()
+        .filter(|_| matches!(action.category, ActionCategory::QuickFix))
+        .map(|(group_name, rule_name)| {
+            diagnostics
+                .iter()
+                .filter_map(|d| {
+                    let code = d.code.as_ref()?;
+                    let code = match code {
+                        lsp::NumberOrString::String(code) => code.as_str(),
+                        lsp::NumberOrString::Number(_) => return None,
+                    };
 
-                let code = code.strip_prefix("lint/")?;
-                let code = code.strip_prefix(action.group_name.as_ref())?;
-                let code = code.strip_prefix('/')?;
+                    let code = code.strip_prefix("lint/")?;
+                    let code = code.strip_prefix(group_name.as_ref())?;
+                    let code = code.strip_prefix('/')?;
 
-                if code == action.rule_name {
-                    Some(d.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
-    } else {
-        Vec::new()
-    };
+                    if code == rule_name {
+                        Some(d.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
 
     let kind = action.category.to_str();
     let mut kind = kind.into_owned();
 
-    kind.push('.');
-    kind.push_str(action.group_name.as_ref());
-    kind.push('.');
-    kind.push_str(action.rule_name.as_ref());
+    if let Some((group, rule)) = action.rule_name {
+        kind.push('.');
+        kind.push_str(group.as_ref());
+        kind.push('.');
+        kind.push_str(rule.as_ref());
+    }
 
     let suggestion = action.suggestion;
 
@@ -194,9 +199,13 @@ pub(crate) fn diagnostic_to_lsp<D: Diagnostic>(
     diagnostic: D,
     url: &lsp::Url,
     line_index: &LineIndex,
-) -> Option<lsp::Diagnostic> {
-    let location = diagnostic.location()?;
-    let span = range(line_index, location.span?).ok()?;
+) -> Result<lsp::Diagnostic> {
+    let location = diagnostic
+        .location()
+        .context("diagnostic has no location")?;
+
+    let span = location.span.context("diagnostic location has no span")?;
+    let span = range(line_index, span).context("failed to convert diagnostic span to LSP range")?;
 
     let severity = match diagnostic.severity() {
         Severity::Fatal | Severity::Error => lsp::DiagnosticSeverity::ERROR,
@@ -210,6 +219,7 @@ pub(crate) fn diagnostic_to_lsp<D: Diagnostic>(
         .map(|category| lsp::NumberOrString::String(category.name().to_string()));
 
     let message = PrintDescription(&diagnostic).to_string();
+    ensure!(!message.is_empty(), "diagnostic description is empty");
 
     let mut related_information = None;
     let mut visitor = RelatedInformationVisitor {
@@ -239,7 +249,7 @@ pub(crate) fn diagnostic_to_lsp<D: Diagnostic>(
         }
     };
 
-    Some(lsp::Diagnostic::new(
+    Ok(lsp::Diagnostic::new(
         span,
         Some(severity),
         code,

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -253,7 +253,7 @@ fn lint(params: LintParams) -> LintResults {
                 diagnostic.set_severity(severity);
 
                 if let Some(action) = signal.action() {
-                    diagnostic.add_code_suggestion(action.into());
+                    diagnostic = diagnostic.add_code_suggestion(action.into());
                 }
 
                 diagnostics.push(rome_diagnostics::serde::Diagnostic::new(diagnostic));
@@ -340,8 +340,9 @@ fn code_actions(
         if let Some(action) = signal.action() {
             actions.push(CodeAction {
                 category: action.category.clone(),
-                group_name: Cow::Borrowed(action.group_name),
-                rule_name: Cow::Borrowed(action.rule_name),
+                rule_name: action
+                    .rule_name
+                    .map(|(group, rule)| (Cow::Borrowed(group), Cow::Borrowed(rule))),
                 suggestion: CodeSuggestion::from(action),
             });
         }
@@ -417,14 +418,17 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, RomeError> {
                         None => {
                             return Err(RomeError::RuleError(
                                 RuleError::ReplacedRootWithNonRootError {
-                                    rule_name: Cow::Borrowed(action.rule_name),
+                                    rule_name: action.rule_name.map(|(group, rule)| {
+                                        (Cow::Borrowed(group), Cow::Borrowed(rule))
+                                    }),
                                 },
                             ))
                         }
                     };
                     actions.push(FixAction {
-                        group_name: Cow::Borrowed(action.group_name),
-                        rule_name: Cow::Borrowed(action.rule_name),
+                        rule_name: action
+                            .rule_name
+                            .map(|(group, rule)| (Cow::Borrowed(group), Cow::Borrowed(rule))),
                         range,
                     });
                 }

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -205,8 +205,7 @@ pub struct PullActionsResult {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CodeAction {
     pub category: ActionCategory,
-    pub group_name: Cow<'static, str>,
-    pub rule_name: Cow<'static, str>,
+    pub rule_name: Option<(Cow<'static, str>, Cow<'static, str>)>,
     pub suggestion: CodeSuggestion,
 }
 
@@ -262,9 +261,8 @@ pub struct FixFileResult {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct FixAction {
-    pub group_name: Cow<'static, str>,
-    /// Name of the rule that emitted this code action
-    pub rule_name: Cow<'static, str>,
+    /// Name of the rule group and rule that emitted this code action
+    pub rule_name: Option<(Cow<'static, str>, Cow<'static, str>)>,
     /// Source range at which this action was applied
     pub range: TextRange,
 }

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -635,12 +635,19 @@ export type Category =
 	| "internalError/io"
 	| "internalError/fs"
 	| "internalError/panic"
-	| "lint"
 	| "parse"
 	| "parse/noSuperWithoutExtends"
+	| "lint"
+	| "lint/correctness"
+	| "lint/style"
+	| "lint/complexity"
+	| "lint/a11y"
+	| "lint/security"
+	| "lint/nursery"
 	| "suppressions/unknownGroup"
 	| "suppressions/unknownRule"
 	| "suppressions/unused"
+	| "suppressions/deprecatedSyntax"
 	| "args/fileNotFound"
 	| "flags/invalid"
 	| "semanticTests";
@@ -750,8 +757,7 @@ export interface PullActionsResult {
 }
 export interface CodeAction {
 	category: ActionCategory;
-	group_name: string;
-	rule_name: string;
+	rule_name?: [string, string];
 	suggestion: CodeSuggestion;
 }
 /**
@@ -858,15 +864,14 @@ export interface FixFileResult {
 	skipped_suggested_fixes: number;
 }
 export interface FixAction {
-	group_name: string;
 	/**
 	 * Source range at which this action was applied
 	 */
 	range: TextRange;
 	/**
-	 * Name of the rule that emitted this code action
+	 * Name of the rule group and rule that emitted this code action
 	 */
-	rule_name: string;
+	rule_name?: [string, string];
 }
 export interface RenameParams {
 	new_name: string;

--- a/website/src/pages/linter/index.mdx
+++ b/website/src/pages/linter/index.mdx
@@ -57,7 +57,7 @@ Suppression comments have the following format:
 
 ```js
 // rome-ignore lint: <explanation>
-// rome-ignore lint(correctness/noDebugger): <explanation>
+// rome-ignore lint/correctness/noDebugger: <explanation>
 ```
 
 Where
@@ -72,7 +72,7 @@ Here's an example:
 ```ts
 // rome-ignore lint: reason
 debugger;
-// rome-ignore lint(correctness/noDebugger): reason
+// rome-ignore lint/correctness/noDebugger: reason
 debugger;
 ```
 

--- a/website/src/playground/tabs/ControlFlowTab.tsx
+++ b/website/src/playground/tabs/ControlFlowTab.tsx
@@ -29,7 +29,7 @@ export default function ControlFlowTab({ graph }: Props) {
 	}, [graph]);
 
 	return (
-		// rome-ignore lint(security/noDangerouslySetInnerHtml): SVG should be safe
+		// rome-ignore lint/security/noDangerouslySetInnerHtml: SVG should be safe
 		<div className="mermaid" dangerouslySetInnerHTML={{ __html: graphSVG }} />
 	);
 }

--- a/website/src/playground/tabs/DiagnosticsConsoleTab.tsx
+++ b/website/src/playground/tabs/DiagnosticsConsoleTab.tsx
@@ -11,7 +11,7 @@ export default function DiagnosticsConsoleTab({ console }: Props) {
 		<>
 			<pre className="language-shellsession diagnostics-console">
 				<code
-					// rome-ignore lint(security/noDangerouslySetInnerHtml): the HTML is sanitized by our diagnostic printer
+					// rome-ignore lint/security/noDangerouslySetInnerHtml: the HTML is sanitized by our diagnostic printer
 					dangerouslySetInnerHTML={{ __html: console }}
 				/>
 			</pre>

--- a/website/src/playground/tabs/SettingsTab.tsx
+++ b/website/src/playground/tabs/SettingsTab.tsx
@@ -384,7 +384,7 @@ function FilenameInput({
 	return (
 		<input
 			type="text"
-			// rome-ignore lint(a11y/noAutofocus): Not sure how else to do this
+			// rome-ignore lint/a11y/noAutofocus: Not sure how else to do this
 			autoFocus={true}
 			onKeyDown={onKeyDown}
 			onChange={onChange}

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -542,7 +542,7 @@ fn assert_lint(
                 diag.set_severity(severity);
 
                 if let Some(action) = signal.action() {
-                    diag.add_code_suggestion(action.into());
+                    diag = diag.add_code_suggestion(action.into());
                 }
 
                 let error = diag


### PR DESCRIPTION
## Summary

Fixes #3446

This PR changes the syntax of lint suppression comments from `rome-ignore lint(group/rule)` to `rome-ignore lint/group/rule` to align with how lint categories are presented in diagnostics. I've tried to keep backwards compatibility by continuing to parse the previous syntax, and emitting a diagnostic with a safe fix when such a comment is encountered by the linter.

## Test Plan

I've extended the suppression comment tests in `rome_js_analyze` to check that both the new and old syntax remain supported, and that a diagnostic is correctly emitted for the deprecated syntax. Additionally I've also used a local build of the language server to apply the automatic fix to all the files with suppression comments that we have.
