### PR TITLE
fix: apply chmod at pkg creation time

### DIFF
--- a/npm/rome/scripts/generate-packages.mjs
+++ b/npm/rome/scripts/generate-packages.mjs
@@ -44,6 +44,7 @@ function generateNativePackage(platform, arch) {
 
 	console.log(`Copy binary ${binaryTarget}`);
 	fs.copyFileSync(binarySource, binaryTarget);
+	fs.chmodSync(binaryTarget, 0o755);
 }
 
 function updateWasmPackage(target) {

--- a/npm/rome/scripts/postinstall.js
+++ b/npm/rome/scripts/postinstall.js
@@ -25,17 +25,6 @@ if (binName) {
 			`The Rome CLI postinstall script failed to resolve the binary file "${binName}". Running Rome from the npm package will probably not work correctly.`,
 		);
 	}
-
-	if (binPath) {
-		try {
-			require("fs").chmodSync(binPath, 0o755);
-		} catch {
-			console.warn(
-				"The Rome CLI postinstall script failed to set execution permissions to the native binary. " +
-					"Running Rome from the npm package will probably not work correctly.",
-			);
-		}
-	}
 } else {
 	console.warn(
 		"The Rome CLI package doesn't ship with prebuilt binaries for your platform yet. " +


### PR DESCRIPTION
## Summary

- Apply chmod at package creation time instead of doing it when running the postinstall hook.
- I did not disabled postinstall hook entirely because it can give interesting information to users, I just removed the part where it applies chmod (because it's supposed to be done before, at package creation time).

Fixes #3799 .

## Test Plan

Testing this change is not trivial because it impacts CD pipelines. My suggestion:
1. make an alpha/beta/rc release, to avoid risking users' installations.
2. Modify your local `.npmrc` file, by adding this line: `ignore-scripts=true`
3. Install this alpha/beta/rc package version, and check that the installed binary has execution permissions, even when the `postinstall` hook has not been triggered because of our change on the `.npmrc` config file.

As a side note, it would be great if some of the steps that are being executed in the CD pipeline were extracted into scripts that we could run locally. This way it would be easier to test some of these details. I'm not doing that in this PR because I believe it deserves some prior discussion, and I don't want to mix too many things in a single PR.

---

Signed-off-by: Andres Correa Casablanca <castarco@coderspirit.xyz>