### PR TITLE
feat(rome_js_analyze): `noConstructorReturn`

### DIFF
--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -79,6 +79,7 @@ define_dategories! {
     "lint/nursery/noBannedTypes":"https://docs.rome.tools/lint/rules/noBannedTypes",
     "lint/nursery/noConditionalAssignment": "https://docs.rome.tools/lint/rules/noConditionalAssignment",
     "lint/nursery/noConstAssign": "https://docs.rome.tools/lint/rules/noConstAssign",
+    "lint/nursery/noConstructorReturn": "https://docs.rome.tools/lint/rules/noConstructorReturn",
     "lint/nursery/noDupeKeys":"https://docs.rome.tools/lint/rules/noDupeKeys",
     "lint/nursery/noEmptyInterface": "https://docs.rome.tools/lint/rules/noEmptyInterface",
     "lint/nursery/noExplicitAny": "https://docs.rome.tools/lint/rules/noExplicitAny",

--- a/crates/rome_js_analyze/src/analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery.rs
@@ -4,6 +4,7 @@ use rome_analyze::declare_group;
 mod no_access_key;
 mod no_banned_types;
 mod no_conditional_assignment;
+mod no_constructor_return;
 mod no_dupe_keys;
 mod no_empty_interface;
 mod no_explicit_any;
@@ -15,4 +16,4 @@ mod no_unsafe_finally;
 mod use_flat_map;
 mod use_numeric_literals;
 mod use_valid_for_direction;
-declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_access_key :: NoAccessKey , self :: no_banned_types :: NoBannedTypes , self :: no_conditional_assignment :: NoConditionalAssignment , self :: no_dupe_keys :: NoDupeKeys , self :: no_empty_interface :: NoEmptyInterface , self :: no_explicit_any :: NoExplicitAny , self :: no_header_scope :: NoHeaderScope , self :: no_invalid_constructor_super :: NoInvalidConstructorSuper , self :: no_precision_loss :: NoPrecisionLoss , self :: no_string_case_mismatch :: NoStringCaseMismatch , self :: no_unsafe_finally :: NoUnsafeFinally , self :: use_flat_map :: UseFlatMap , self :: use_numeric_literals :: UseNumericLiterals , self :: use_valid_for_direction :: UseValidForDirection ,] } }
+declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_access_key :: NoAccessKey , self :: no_banned_types :: NoBannedTypes , self :: no_conditional_assignment :: NoConditionalAssignment , self :: no_constructor_return :: NoConstructorReturn , self :: no_dupe_keys :: NoDupeKeys , self :: no_empty_interface :: NoEmptyInterface , self :: no_explicit_any :: NoExplicitAny , self :: no_header_scope :: NoHeaderScope , self :: no_invalid_constructor_super :: NoInvalidConstructorSuper , self :: no_precision_loss :: NoPrecisionLoss , self :: no_string_case_mismatch :: NoStringCaseMismatch , self :: no_unsafe_finally :: NoUnsafeFinally , self :: use_flat_map :: UseFlatMap , self :: use_numeric_literals :: UseNumericLiterals , self :: use_valid_for_direction :: UseValidForDirection ,] } }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_constructor_return.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_constructor_return.rs
@@ -1,0 +1,83 @@
+use rome_analyze::context::RuleContext;
+use rome_analyze::{declare_rule, Ast, Rule, RuleDiagnostic};
+use rome_console::markup;
+use rome_js_syntax::{JsConstructorClassMember, JsReturnStatement};
+use rome_rowan::AstNode;
+
+use crate::control_flow::JsAnyControlFlowRoot;
+
+declare_rule! {
+    /// Disallow returning a value from a constructor
+    ///
+    /// While returning a value from a constructor does not produce an error, the returned value is being ignored. Therefore, returning a value from a constructor is either unnecessary or a possible error.
+    ///
+    /// Only returning without a value is allowed, as it’s a control flow statement.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// class A {
+    ///     constructor() {
+    ///         return 0;
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// class A {
+    ///     constructor() {}
+    /// }
+    /// ```
+    ///
+    /// ```js
+    /// class B {
+    ///     constructor(x) {
+    ///         return;
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```
+    pub(crate) NoConstructorReturn {
+        version: "11.0.0",
+        name: "noConstructorReturn",
+        recommended: false,
+    }
+}
+
+impl Rule for NoConstructorReturn {
+    type Query = Ast<JsReturnStatement>;
+    type State = JsConstructorClassMember;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let ret = ctx.query();
+        // Do not take arg-less returns into account
+        let _arg = ret.argument()?;
+        let constructor = ret
+            .syntax()
+            .ancestors()
+            .find(|x| JsAnyControlFlowRoot::can_cast(x.kind()))
+            .and_then(JsConstructorClassMember::cast);
+        constructor
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, constructor: &Self::State) -> Option<RuleDiagnostic> {
+        let ret = ctx.query();
+        Some(RuleDiagnostic::new(
+            rule_category!(),
+            ret.range(),
+            markup! {
+                "The "<Emphasis>"constructor"</Emphasis>" should not "<Emphasis>"return"</Emphasis>" a value."
+            },
+        ).detail(
+            constructor.range(),
+            "The constructor is here:"
+        ).note("Returning a value from a constructor is ignored."))
+    }
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noConstructorReturn/invalid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noConstructorReturn/invalid.js
@@ -1,0 +1,28 @@
+class A {
+	constructor() {
+		return 0;
+	}
+}
+
+class B {
+	constructor() {
+		return this;
+	}
+}
+
+class C {
+	constructor(x) {
+		this.x = x;
+		return x;
+	}
+}
+
+class D {
+	constructor(x) {
+		if (x > 0) {
+			this.x = x;
+			return x;
+		}
+		this.x = 0;
+	}
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noConstructorReturn/invalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noConstructorReturn/invalid.js.snap
@@ -1,0 +1,155 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 73
+expression: invalid.js
+---
+# Input
+```js
+class A {
+	constructor() {
+		return 0;
+	}
+}
+
+class B {
+	constructor() {
+		return this;
+	}
+}
+
+class C {
+	constructor(x) {
+		this.x = x;
+		return x;
+	}
+}
+
+class D {
+	constructor(x) {
+		if (x > 0) {
+			this.x = x;
+			return x;
+		}
+		this.x = 0;
+	}
+}
+```
+
+# Diagnostics
+```
+invalid.js:3:3 lint/nursery/noConstructorReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The constructor should not return a value.
+  
+    1 │ class A {
+    2 │ 	constructor() {
+  > 3 │ 		return 0;
+      │ 		^^^^^^^^^
+    4 │ 	}
+    5 │ }
+  
+  i The constructor is here:
+  
+    1 │ class A {
+  > 2 │ 	constructor() {
+      │ 	^^^^^^^^^^^^^^^
+  > 3 │ 		return 0;
+  > 4 │ 	}
+      │ 	^
+    5 │ }
+    6 │ 
+  
+  i Returning a value from a constructor is ignored.
+  
+
+```
+
+```
+invalid.js:9:3 lint/nursery/noConstructorReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The constructor should not return a value.
+  
+     7 │ class B {
+     8 │ 	constructor() {
+   > 9 │ 		return this;
+       │ 		^^^^^^^^^^^^
+    10 │ 	}
+    11 │ }
+  
+  i The constructor is here:
+  
+     7 │ class B {
+   > 8 │ 	constructor() {
+       │ 	^^^^^^^^^^^^^^^
+   > 9 │ 		return this;
+  > 10 │ 	}
+       │ 	^
+    11 │ }
+    12 │ 
+  
+  i Returning a value from a constructor is ignored.
+  
+
+```
+
+```
+invalid.js:16:3 lint/nursery/noConstructorReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The constructor should not return a value.
+  
+    14 │ 	constructor(x) {
+    15 │ 		this.x = x;
+  > 16 │ 		return x;
+       │ 		^^^^^^^^^
+    17 │ 	}
+    18 │ }
+  
+  i The constructor is here:
+  
+    13 │ class C {
+  > 14 │ 	constructor(x) {
+       │ 	^^^^^^^^^^^^^^^^
+  > 15 │ 		this.x = x;
+  > 16 │ 		return x;
+  > 17 │ 	}
+       │ 	^
+    18 │ }
+    19 │ 
+  
+  i Returning a value from a constructor is ignored.
+  
+
+```
+
+```
+invalid.js:24:4 lint/nursery/noConstructorReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The constructor should not return a value.
+  
+    22 │ 		if (x > 0) {
+    23 │ 			this.x = x;
+  > 24 │ 			return x;
+       │ 			^^^^^^^^^
+    25 │ 		}
+    26 │ 		this.x = 0;
+  
+  i The constructor is here:
+  
+    20 │ class D {
+  > 21 │ 	constructor(x) {
+       │ 	^^^^^^^^^^^^^^^^
+  > 22 │ 		if (x > 0) {
+  > 23 │ 			this.x = x;
+  > 24 │ 			return x;
+  > 25 │ 		}
+  > 26 │ 		this.x = 0;
+  > 27 │ 	}
+       │ 	^
+    28 │ }
+  
+  i Returning a value from a constructor is ignored.
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noConstructorReturn/valid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noConstructorReturn/valid.js
@@ -1,0 +1,33 @@
+class A {
+	constructor() {}
+}
+
+class B {
+	constructor() {
+		return;
+	}
+}
+
+class C {
+	constructor(x) {
+		this.x = x;
+	}
+}
+
+class D {
+	constructor(x) {
+		if (x > 0) {
+			this.x = x;
+			return;
+		}
+		this.x = 0;
+	}
+}
+
+class E {
+	constructor(x) {
+		void (() => {
+			return x;
+		})();
+	}
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noConstructorReturn/valid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noConstructorReturn/valid.js.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 73
+expression: valid.js
+---
+# Input
+```js
+class A {
+	constructor() {}
+}
+
+class B {
+	constructor() {
+		return;
+	}
+}
+
+class C {
+	constructor(x) {
+		this.x = x;
+	}
+}
+
+class D {
+	constructor(x) {
+		if (x > 0) {
+			this.x = x;
+			return;
+		}
+		this.x = 0;
+	}
+}
+
+class E {
+	constructor(x) {
+		void (() => {
+			return x;
+		})();
+	}
+}
+```
+
+

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -737,6 +737,8 @@ struct NurserySchema {
     no_conditional_assignment: Option<RuleConfiguration>,
     #[doc = "Prevents from having const variables being re-assigned."]
     no_const_assign: Option<RuleConfiguration>,
+    #[doc = "Disallow returning a value from a constructor"]
+    no_constructor_return: Option<RuleConfiguration>,
     #[doc = "Prevents object literals having more than one property declaration for the same name. If an object property with the same name is defined multiple times (except when combining a getter with a setter), only the last definition makes it into the object and previous definitions are ignored, which is likely a mistake."]
     no_dupe_keys: Option<RuleConfiguration>,
     #[doc = "Disallow the declaration of empty interfaces."]
@@ -770,11 +772,12 @@ struct NurserySchema {
 }
 impl Nursery {
     const CATEGORY_NAME: &'static str = "nursery";
-    pub(crate) const CATEGORY_RULES: [&'static str; 19] = [
+    pub(crate) const CATEGORY_RULES: [&'static str; 20] = [
         "noAccessKey",
         "noBannedTypes",
         "noConditionalAssignment",
         "noConstAssign",
+        "noConstructorReturn",
         "noDupeKeys",
         "noEmptyInterface",
         "noExplicitAny",

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -797,6 +797,17 @@
             }
           ]
         },
+        "noConstructorReturn": {
+          "description": "Disallow returning a value from a constructor",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "noDupeKeys": {
           "description": "Prevents object literals having more than one property declaration for the same name. If an object property with the same name is defined multiple times (except when combining a getter with a setter), only the last definition makes it into the object and previous definitions are ignored, which is likely a mistake.",
           "anyOf": [

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -364,6 +364,10 @@ export interface Nursery {
 	 */
 	noConstAssign?: RuleConfiguration;
 	/**
+	 * Disallow returning a value from a constructor
+	 */
+	noConstructorReturn?: RuleConfiguration;
+	/**
 	 * Prevents object literals having more than one property declaration for the same name. If an object property with the same name is defined multiple times (except when combining a getter with a setter), only the last definition makes it into the object and previous definitions are ignored, which is likely a mistake.
 	 */
 	noDupeKeys?: RuleConfiguration;
@@ -635,6 +639,7 @@ export type Category =
 	| "lint/nursery/noBannedTypes"
 	| "lint/nursery/noConditionalAssignment"
 	| "lint/nursery/noConstAssign"
+	| "lint/nursery/noConstructorReturn"
 	| "lint/nursery/noDupeKeys"
 	| "lint/nursery/noEmptyInterface"
 	| "lint/nursery/noExplicitAny"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -797,6 +797,17 @@
             }
           ]
         },
+        "noConstructorReturn": {
+          "description": "Disallow returning a value from a constructor",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "noDupeKeys": {
           "description": "Prevents object literals having more than one property declaration for the same name. If an object property with the same name is defined multiple times (except when combining a getter with a setter), only the last definition makes it into the object and previous definitions are ignored, which is likely a mistake.",
           "anyOf": [

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -467,6 +467,12 @@ Disallow assignment operators in conditional expressions.
 Prevents from having <code>const</code> variables being re-assigned.
 </section>
 <section class="rule">
+<h3 data-toc-exclude id="noConstructorReturn">
+	<a href="/lint/rules/noConstructorReturn">noConstructorReturn</a>
+</h3>
+Disallow returning a value from a constructor
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noDupeKeys">
 	<a href="/lint/rules/noDupeKeys">noDupeKeys</a>
 </h3>

--- a/website/src/pages/lint/rules/noConstructorReturn.md
+++ b/website/src/pages/lint/rules/noConstructorReturn.md
@@ -1,0 +1,70 @@
+---
+title: Lint Rule noConstructorReturn
+parent: lint/rules/index
+---
+
+# noConstructorReturn (since v11.0.0)
+
+Disallow returning a value from a constructor
+
+While returning a value from a constructor does not produce an error, the returned value is being ignored. Therefore, returning a value from a constructor is either unnecessary or a possible error.
+
+Only returning without a value is allowed, as it’s a control flow statement.
+
+## Examples
+
+### Invalid
+
+```jsx
+class A {
+    constructor() {
+        return 0;
+    }
+}
+```
+
+<pre class="language-text"><code class="language-text">nursery/noConstructorReturn.js:3:9 <a href="https://docs.rome.tools/lint/rules/noConstructorReturn">lint/nursery/noConstructorReturn</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The </span><span style="color: Orange;"><strong>constructor</strong></span><span style="color: Orange;"> should not </span><span style="color: Orange;"><strong>return</strong></span><span style="color: Orange;"> a value.</span>
+  
+    <strong>1 │ </strong>class A {
+    <strong>2 │ </strong>    constructor() {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>        return 0;
+   <strong>   │ </strong>        <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>    }
+    <strong>5 │ </strong>}
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The constructor is here:</span>
+  
+    <strong>1 │ </strong>class A {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>    constructor() {
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>        return 0;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    }
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
+    <strong>5 │ </strong>}
+    <strong>6 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Returning a value from a constructor is ignored.</span>
+  
+</code></pre>
+
+### Valid
+
+```jsx
+class A {
+    constructor() {}
+}
+```
+
+```jsx
+class B {
+    constructor(x) {
+        return;
+    }
+}
+```
+
+```
+```
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This implements ESLint's [no-constructor-return](https://eslint.org/docs/latest/rules/no-constructor-return).

## Test Plan

Unit test and doc-test included.
