### PR TITLE
feat(rome_diagnostics): add `with_severity` API

### DIFF
--- a/crates/rome_analyze/src/diagnostics.rs
+++ b/crates/rome_analyze/src/diagnostics.rs
@@ -128,13 +128,6 @@ impl AnalyzerDiagnostic {
         }
     }
 
-    /// Sets the severity of the current diagnostic
-    pub fn set_severity(&mut self, new_severity: Severity) {
-        if let DiagnosticKind::Rule { severity, .. } = &mut self.kind {
-            *severity = Some(new_severity);
-        }
-    }
-
     pub fn get_span(&self) -> Option<TextRange> {
         match &self.kind {
             DiagnosticKind::Rule {

--- a/crates/rome_analyze/src/diagnostics.rs
+++ b/crates/rome_analyze/src/diagnostics.rs
@@ -38,8 +38,6 @@ impl From<RuleDiagnostic> for AnalyzerDiagnostic {
 enum DiagnosticKind {
     /// It holds various info related to diagnostics emitted by the rules
     Rule {
-        /// The severity of the rule
-        severity: Option<Severity>,
         /// The diagnostic emitted by a rule
         rule_diagnostic: RuleDiagnostic,
     },
@@ -76,7 +74,7 @@ impl Diagnostic for AnalyzerDiagnostic {
 
     fn severity(&self) -> Severity {
         match &self.kind {
-            DiagnosticKind::Rule { severity, .. } => severity.unwrap_or(Severity::Error),
+            DiagnosticKind::Rule { .. } => Severity::Error,
             DiagnosticKind::Raw(error) => error.severity(),
         }
     }
@@ -142,14 +140,10 @@ impl AnalyzerDiagnostic {
     pub fn add_code_suggestion(mut self, suggestion: CodeSuggestionAdvice<MarkupBuf>) -> Self {
         self.kind = match self.kind {
             DiagnosticKind::Rule {
-                severity,
                 mut rule_diagnostic,
             } => {
                 rule_diagnostic.tags = DiagnosticTags::FIXABLE;
-                DiagnosticKind::Rule {
-                    severity,
-                    rule_diagnostic,
-                }
+                DiagnosticKind::Rule { rule_diagnostic }
             }
             DiagnosticKind::Raw(error) => {
                 DiagnosticKind::Raw(error.with_tags(DiagnosticTags::FIXABLE))

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -153,7 +153,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use rome_diagnostics::{category, location::FileId};
+    use rome_diagnostics::{category, location::FileId, DiagnosticExt};
     use rome_diagnostics::{Diagnostic, Severity};
     use rome_rowan::{
         raw_language::{RawLanguage, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
@@ -306,10 +306,10 @@ mod tests {
 
         let mut diagnostics = Vec::new();
         let mut emit_signal = |signal: &dyn AnalyzerSignal<RawLanguage>| -> ControlFlow<Never> {
-            let mut diag = signal.diagnostic().expect("diagnostic");
-            diag.set_severity(Severity::Warning);
-            let code = diag.category().expect("code");
+            let diag = signal.diagnostic().expect("diagnostic");
             let range = diag.get_span().expect("range");
+            let error = diag.with_severity(Severity::Warning);
+            let code = error.category().expect("code");
 
             diagnostics.push((code, range));
             ControlFlow::Continue(())

--- a/crates/rome_diagnostics/src/context.rs
+++ b/crates/rome_diagnostics/src/context.rs
@@ -658,7 +658,7 @@ mod internal {
             self.source.as_diagnostic().verbose_advices(visitor)
         }
 
-        fn location(&self) -> Option<Location<'_>> {
+        fn location(&self) -> Location<'_> {
             self.source.as_diagnostic().location()
         }
 

--- a/crates/rome_diagnostics/src/context.rs
+++ b/crates/rome_diagnostics/src/context.rs
@@ -3,7 +3,7 @@ use rome_console::fmt;
 use crate::{
     diagnostic::internal::AsDiagnostic,
     location::{AsResource, AsSourceCode},
-    Category, DiagnosticTags, Error, Resource, SourceCode,
+    Category, DiagnosticTags, Error, Resource, Severity, SourceCode,
 };
 
 /// This trait is implemented for all types implementing [Diagnostic](super::Diagnostic)
@@ -42,6 +42,11 @@ pub trait DiagnosticExt: internal::Sealed + Sized {
     fn with_tags(self, tags: DiagnosticTags) -> Error
     where
         Error: From<internal::TagsDiagnostic<Self>>;
+
+    /// Returns a new diagnostic with additional `severity`
+    fn with_severity(self, severity: Severity) -> Error
+    where
+        Error: From<internal::SeverityDiagnostic<Self>>;
 }
 
 impl<E: AsDiagnostic> internal::Sealed for E {}
@@ -94,6 +99,16 @@ impl<E: AsDiagnostic> DiagnosticExt for E {
         Error: From<internal::TagsDiagnostic<Self>>,
     {
         Error::from(internal::TagsDiagnostic { tags, source: self })
+    }
+
+    fn with_severity(self, severity: Severity) -> Error
+    where
+        Error: From<internal::SeverityDiagnostic<Self>>,
+    {
+        Error::from(internal::SeverityDiagnostic {
+            severity,
+            source: self,
+        })
     }
 }
 
@@ -520,7 +535,7 @@ mod internal {
     }
 
     /// Diagnostic type returned by [super::DiagnosticExt::with_tags],
-    /// ùerges `tags` with the tags of its source
+    /// replaces `tags` with the tags of its source
     pub struct TagsDiagnostic<E> {
         pub(super) tags: DiagnosticTags,
         pub(super) source: E,
@@ -566,6 +581,56 @@ mod internal {
 
         fn tags(&self) -> DiagnosticTags {
             self.source.as_diagnostic().tags() | self.tags
+        }
+    }
+
+    /// Diagnostic type returned by [super::DiagnosticExt::with_severity],
+    /// replaces `severity` with the severity of its source
+    pub struct SeverityDiagnostic<E> {
+        pub(super) severity: Severity,
+        pub(super) source: E,
+    }
+
+    impl<E: Debug> Debug for SeverityDiagnostic<E> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Diagnostic")
+                .field("severity", &self.severity)
+                .field("source", &self.source)
+                .finish()
+        }
+    }
+
+    impl<E: AsDiagnostic> Diagnostic for SeverityDiagnostic<E> {
+        fn category(&self) -> Option<&'static Category> {
+            self.source.as_diagnostic().category()
+        }
+
+        fn severity(&self) -> Severity {
+            self.severity
+        }
+
+        fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.source.as_diagnostic().description(fmt)
+        }
+
+        fn message(&self, fmt: &mut fmt::Formatter<'_>) -> io::Result<()> {
+            self.source.as_diagnostic().message(fmt)
+        }
+
+        fn advices(&self, visitor: &mut dyn Visit) -> io::Result<()> {
+            self.source.as_diagnostic().advices(visitor)
+        }
+
+        fn verbose_advices(&self, visitor: &mut dyn Visit) -> io::Result<()> {
+            self.source.as_diagnostic().verbose_advices(visitor)
+        }
+
+        fn location(&self) -> Option<Location<'_>> {
+            self.source.as_diagnostic().location()
+        }
+
+        fn tags(&self) -> DiagnosticTags {
+            self.source.as_diagnostic().tags()
         }
     }
 }

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -173,10 +173,12 @@ mod tests {
             &options,
             |signal| {
                 dbg!("here");
-                if let Some(mut diag) = signal.diagnostic() {
-                    diag.set_severity(Severity::Warning);
+                if let Some(diag) = signal.diagnostic() {
                     error_ranges.push(diag.location().span.unwrap());
-                    let error = diag.with_file_path("ahahah").with_file_source_code(SOURCE);
+                    let error = diag
+                        .with_severity(Severity::Warning)
+                        .with_file_path("ahahah")
+                        .with_file_source_code(SOURCE);
                     let text = markup_to_string(markup! {
                         {PrintDiagnostic::verbose(&error)}
                     });
@@ -249,11 +251,10 @@ mod tests {
             AnalysisFilter::default(),
             &options,
             |signal| {
-                if let Some(mut diag) = signal.diagnostic() {
-                    diag.set_severity(Severity::Warning);
-
+                if let Some(diag) = signal.diagnostic() {
                     let span = diag.get_span();
                     let error = diag
+                        .with_severity(Severity::Warning)
                         .with_file_path(FileId::zero())
                         .with_file_source_code(SOURCE);
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -17,7 +17,7 @@ use rome_analyze::{
     AnalysisFilter, AnalyzerOptions, ControlFlow, GroupCategory, Never, QueryMatch,
     RegistryVisitor, RuleCategories, RuleCategory, RuleFilter, RuleGroup,
 };
-use rome_diagnostics::{category, Applicability, Diagnostic, Severity};
+use rome_diagnostics::{category, Applicability, Diagnostic, DiagnosticExt, Severity};
 use rome_formatter::{FormatError, Printed};
 use rome_fs::RomePath;
 use rome_js_analyze::utils::rename::{RenameError, RenameSymbolExtensions};
@@ -248,15 +248,14 @@ fn lint(params: LintParams) -> LintResults {
             }
 
             if diagnostic_count <= params.max_diagnostics {
-                diagnostic.set_severity(severity);
-
                 for action in signal.actions() {
                     if !action.is_suppression() {
                         diagnostic = diagnostic.add_code_suggestion(action.into());
                     }
                 }
+                let error = diagnostic.with_severity(severity);
 
-                diagnostics.push(rome_diagnostics::serde::Diagnostic::new(diagnostic));
+                diagnostics.push(rome_diagnostics::serde::Diagnostic::new(error));
             }
         }
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -241,7 +241,7 @@ fn lint(params: LintParams) -> LintResults {
                 .category()
                 .filter(|category| category.name().starts_with("lint/"))
                 .and_then(|category| params.rules.as_ref()?.get_severity_from_code(category))
-                .unwrap_or(Severity::Error);
+                .unwrap_or(Severity::Warning);
 
             if severity <= Severity::Error {
                 errors += 1;
@@ -253,6 +253,7 @@ fn lint(params: LintParams) -> LintResults {
                         diagnostic = diagnostic.add_code_suggestion(action.into());
                     }
                 }
+
                 let error = diagnostic.with_severity(severity);
 
                 diagnostics.push(rome_diagnostics::serde::Diagnostic::new(error));

--- a/website/src/playground/tabs/DiagnosticsListTab.tsx
+++ b/website/src/playground/tabs/DiagnosticsListTab.tsx
@@ -99,7 +99,7 @@ export default function DiagnosticsListTab({ editorRef, diagnostics }: Props) {
 		<ul className="diagnostics-list">
 			{diagnostics.map((diag, i) => {
 				return (
-					// rome-ignore lint(correctness/noArrayIndexKey): Diagnostic has no stable id.
+					// rome-ignore lint/correctness/noArrayIndexKey: Diagnostic has no stable id.
 					<DiagnosticListItem key={i} editorRef={editorRef} diagnostic={diag} />
 				);
 			})}

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -539,7 +539,6 @@ fn assert_lint(
                 let severity = settings.get_severity_from_rule_code(category).expect(
                     "If you see this error, it means you need to run cargo codegen-configuration",
                 );
-                diag.set_severity(severity);
 
                 for action in signal.actions() {
                     if !action.is_suppression() {
@@ -548,6 +547,7 @@ fn assert_lint(
                 }
 
                 let error = diag
+                    .with_severity(severity)
                     .with_file_path((file.clone(), FileId::zero()))
                     .with_file_source_code(code);
                 let res = write_diagnostic(code, error);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a new API to `DiagnosticExt` called `with_severity`, which allows changing the severity of a diagnostic in a "native" way. 

This change allows removing an API I had to create in the `AnalyzerDiagnostic`, which is not needed anymore.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

This is a "under the hoods" change, which means that the existing tests should pass. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
