### PR TITLE
fix(rome_diagnostics): allow diagnostic locations to be created without a resource

### DIFF
--- a/crates/rome_analyze/src/diagnostics.rs
+++ b/crates/rome_analyze/src/diagnostics.rs
@@ -81,7 +81,7 @@ impl Diagnostic for AnalyzerDiagnostic {
         }
     }
 
-    fn location(&self) -> Option<Location<'_>> {
+    fn location(&self) -> Location<'_> {
         match &self.kind {
             DiagnosticKind::Rule {
                 rule_diagnostic,
@@ -111,13 +111,12 @@ impl Diagnostic for AnalyzerDiagnostic {
                         detail.log_category,
                         &markup! { {detail.message} }.to_owned(),
                     )?;
-                    if let Some(location) = Location::builder()
-                        .span(&detail.range)
-                        .resource(file_id)
-                        .build()
-                    {
-                        visitor.record_frame(location)?;
-                    }
+                    visitor.record_frame(
+                        Location::builder()
+                            .span(&detail.range)
+                            .resource(file_id)
+                            .build(),
+                    )?;
                 }
                 // we then print notes
                 for (log_category, note) in &rule_advices.notes {
@@ -169,7 +168,7 @@ impl AnalyzerDiagnostic {
             DiagnosticKind::Rule {
                 rule_diagnostic, ..
             } => rule_diagnostic.span,
-            DiagnosticKind::Raw(error) => error.location().and_then(|location| location.span),
+            DiagnosticKind::Raw(error) => error.location().span,
         }
     }
 

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -397,9 +397,7 @@ impl Advices for RuleAdvice {
                 detail.log_category,
                 &markup! { {detail.message} }.to_owned(),
             )?;
-            if let Some(location) = Location::builder().span(&detail.range).build() {
-                visitor.record_frame(location)?;
-            }
+            visitor.record_frame(Location::builder().span(&detail.range).build())?;
         }
         // we then print notes
         for (log_category, note) in &self.notes {

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -368,34 +368,33 @@ fn process_messages(options: ProcessMessagesOptions) {
             }
 
             Message::Error(mut err) => {
-                if let Some(location) = err.location() {
-                    if let Resource::File(FilePath::FileId(file_id)) = location.resource {
-                        // Retrieves the file name from the file ID cache, if it's a miss
-                        // flush entries from the interner channel until it's found
-                        let file_name = match paths.get(&file_id) {
-                            Some(path) => Some(path),
-                            None => loop {
-                                match recv_files.recv() {
-                                    Ok((id, path)) => {
-                                        paths.insert(id, path.display().to_string());
-                                        if id == file_id {
-                                            break Some(&paths[&file_id]);
-                                        }
+                let location = err.location();
+                if let Some(Resource::File(FilePath::FileId(file_id))) = &location.resource {
+                    // Retrieves the file name from the file ID cache, if it's a miss
+                    // flush entries from the interner channel until it's found
+                    let file_name = match paths.get(file_id) {
+                        Some(path) => Some(path),
+                        None => loop {
+                            match recv_files.recv() {
+                                Ok((id, path)) => {
+                                    paths.insert(id, path.display().to_string());
+                                    if id == *file_id {
+                                        break Some(&paths[file_id]);
                                     }
-                                    // In case the channel disconnected without sending
-                                    // the path we need, print the error without a file
-                                    // name (normally this should never happen)
-                                    Err(_) => break None,
                                 }
-                            },
-                        };
+                                // In case the channel disconnected without sending
+                                // the path we need, print the error without a file
+                                // name (normally this should never happen)
+                                Err(_) => break None,
+                            }
+                        },
+                    };
 
-                        if let Some(path) = file_name {
-                            err = err.with_file_path(FilePath::PathAndId {
-                                path: path.as_str(),
-                                file_id,
-                            });
-                        }
+                    if let Some(path) = file_name {
+                        err = err.with_file_path(FilePath::PathAndId {
+                            path: path.as_str(),
+                            file_id: *file_id,
+                        });
                     }
                 }
 
@@ -417,18 +416,13 @@ fn process_messages(options: ProcessMessagesOptions) {
                         });
                     }
                 } else {
-                    let file_name = err
-                        .location()
-                        .and_then(|location| {
-                            let path = match &location.resource {
-                                Resource::File(file) => file,
-                                _ => return None,
-                            };
+                    let location = err.location();
+                    let path = match &location.resource {
+                        Some(Resource::File(file)) => file.path(),
+                        _ => None,
+                    };
 
-                            path.path()
-                        })
-                        .unwrap_or("<unknown>");
-
+                    let file_name = path.unwrap_or("<unknown>");
                     let title = PrintDescription(&err).to_string();
                     let code = err.category().and_then(|code| code.name().parse().ok());
 

--- a/crates/rome_diagnostics/examples/fs.rs
+++ b/crates/rome_diagnostics/examples/fs.rs
@@ -38,7 +38,7 @@ impl Advices for NotFoundAdvices {
 
         visitor.record_log(LogCategory::Info, &"Ignore patterns were defined here")?;
         visitor.record_frame(Location {
-            resource: Resource::File(FilePath::Path(&self.configuration_path)),
+            resource: Some(Resource::File(FilePath::Path(&self.configuration_path))),
             span: Some(self.configuration_span),
             source_code: Some(SourceCode {
                 text: &self.configuration_source_code,

--- a/crates/rome_diagnostics/examples/lint.rs
+++ b/crates/rome_diagnostics/examples/lint.rs
@@ -44,7 +44,7 @@ impl Advices for LintAdvices {
 
         visitor.record_log(LogCategory::Info, &"This constant is declared here")?;
         visitor.record_frame(Location {
-            resource: Resource::File(FilePath::Path(&self.path)),
+            resource: Some(Resource::File(FilePath::Path(&self.path))),
             span: Some(self.declaration_span),
             source_code: Some(SourceCode {
                 text: &self.source_code,

--- a/crates/rome_diagnostics/src/advice.rs
+++ b/crates/rome_diagnostics/src/advice.rs
@@ -120,9 +120,7 @@ where
             .source_code(&self.source_code)
             .build();
 
-        if let Some(location) = location {
-            visitor.record_frame(location)?;
-        }
+        visitor.record_frame(location)?;
 
         Ok(())
     }

--- a/crates/rome_diagnostics/src/context.rs
+++ b/crates/rome_diagnostics/src/context.rs
@@ -221,7 +221,7 @@ mod internal {
             self.source.as_diagnostic().verbose_advices(visitor)
         }
 
-        fn location(&self) -> Option<Location<'_>> {
+        fn location(&self) -> Location<'_> {
             self.source.as_diagnostic().location()
         }
 
@@ -321,7 +321,7 @@ mod internal {
             self.source.as_diagnostic().verbose_advices(visitor)
         }
 
-        fn location(&self) -> Option<Location<'_>> {
+        fn location(&self) -> Location<'_> {
             self.source.as_diagnostic().location()
         }
 
@@ -371,32 +371,24 @@ mod internal {
             self.source.as_diagnostic().verbose_advices(visitor)
         }
 
-        fn location(&self) -> Option<Location<'_>> {
-            self.source
-                .as_diagnostic()
-                .location()
-                .map(|loc| Location {
-                    resource: match loc.resource {
-                        Resource::Argv => Resource::Argv,
-                        Resource::Memory => Resource::Memory,
-                        Resource::File(file) => {
-                            if let Some(Resource::File(path)) = &self.path {
-                                Resource::File(file.or(path.as_deref()))
-                            } else {
-                                Resource::File(file)
-                            }
+        fn location(&self) -> Location<'_> {
+            let loc = self.source.as_diagnostic().location();
+            Location {
+                resource: match loc.resource {
+                    Some(Resource::Argv) => Some(Resource::Argv),
+                    Some(Resource::Memory) => Some(Resource::Memory),
+                    Some(Resource::File(file)) => {
+                        if let Some(Resource::File(path)) = &self.path {
+                            Some(Resource::File(file.or(path.as_deref())))
+                        } else {
+                            Some(Resource::File(file))
                         }
-                    },
-                    span: loc.span,
-                    source_code: loc.source_code,
-                })
-                .or_else(|| {
-                    Some(Location {
-                        resource: self.path.as_ref()?.as_deref(),
-                        span: None,
-                        source_code: None,
-                    })
-                })
+                    }
+                    None => self.path.as_ref().map(Resource::as_deref),
+                },
+                span: loc.span,
+                source_code: loc.source_code,
+            }
         }
 
         fn tags(&self) -> DiagnosticTags {
@@ -464,14 +456,14 @@ mod internal {
             }
         }
 
-        fn location(&self) -> Option<Location<'_>> {
-            let location = self.source.as_diagnostic().location()?;
-            Some(Location {
+        fn location(&self) -> Location<'_> {
+            let location = self.source.as_diagnostic().location();
+            Location {
                 source_code: location
                     .source_code
                     .or_else(|| Some(self.source_code.as_ref()?.as_deref())),
                 ..location
-            })
+            }
         }
 
         fn tags(&self) -> DiagnosticTags {
@@ -568,7 +560,7 @@ mod internal {
             self.source.as_diagnostic().verbose_advices(visitor)
         }
 
-        fn location(&self) -> Option<Location<'_>> {
+        fn location(&self) -> Location<'_> {
             self.source.as_diagnostic().location()
         }
 

--- a/crates/rome_diagnostics/src/diagnostic.rs
+++ b/crates/rome_diagnostics/src/diagnostic.rs
@@ -82,8 +82,8 @@ pub trait Diagnostic: Debug {
     /// specific text range within the content of that location. Finally, it
     /// may also provide the source string for that location (this is required
     /// in order to display a code frame advice for the diagnostic).
-    fn location(&self) -> Option<Location<'_>> {
-        None
+    fn location(&self) -> Location<'_> {
+        Location::builder().build()
     }
 
     /// Tags convey additional boolean metadata about the nature of a diagnostic:

--- a/crates/rome_diagnostics/src/error.rs
+++ b/crates/rome_diagnostics/src/error.rs
@@ -69,7 +69,7 @@ impl Error {
     }
 
     /// Calls [Diagnostic::location] on the [Diagnostic] wrapped by this [Error].
-    pub fn location(&self) -> Option<Location<'_>> {
+    pub fn location(&self) -> Location<'_> {
         self.as_diagnostic().location()
     }
 

--- a/crates/rome_diagnostics/src/location.rs
+++ b/crates/rome_diagnostics/src/location.rs
@@ -8,7 +8,7 @@ use std::{borrow::Borrow, ops::Deref};
 #[derive(Debug, Clone, Copy)]
 pub struct Location<'a> {
     /// The resource this diagnostic is associated with.
-    pub resource: Resource<&'a str>,
+    pub resource: Option<Resource<&'a str>>,
     /// An optional range of text within the resource associated with the
     /// diagnostic.
     pub span: Option<TextRange>,
@@ -326,12 +326,12 @@ impl<'a> LocationBuilder<'a> {
         self
     }
 
-    pub fn build(self) -> Option<Location<'a>> {
-        Some(Location {
-            resource: self.resource?,
+    pub fn build(self) -> Location<'a> {
+        Location {
+            resource: self.resource,
             span: self.span,
             source_code: self.source_code,
-        })
+        }
     }
 }
 

--- a/crates/rome_diagnostics_macros/src/generate.rs
+++ b/crates/rome_diagnostics_macros/src/generate.rs
@@ -212,7 +212,7 @@ fn generate_location(input: &DeriveInput) -> TokenStream {
     let method = input.location.iter().map(|(_, method)| method);
 
     quote! {
-        fn location(&self) -> Option<rome_diagnostics::Location<'_>> {
+        fn location(&self) -> rome_diagnostics::Location<'_> {
             rome_diagnostics::Location::builder()
                 #( .#method(&self.#field) )*
                 .build()

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -175,7 +175,7 @@ mod tests {
                 dbg!("here");
                 if let Some(mut diag) = signal.diagnostic() {
                     diag.set_severity(Severity::Warning);
-                    error_ranges.push(diag.location().unwrap().span.unwrap());
+                    error_ranges.push(diag.location().span.unwrap());
                     let error = diag.with_file_path("ahahah").with_file_source_code(SOURCE);
                     let text = markup_to_string(markup! {
                         {PrintDiagnostic(&error)}

--- a/crates/rome_js_parser/src/lib.rs
+++ b/crates/rome_js_parser/src/lib.rs
@@ -464,10 +464,9 @@ impl Advices for ParserAdvice {
                 file_id,
             } = detail;
             visitor.record_log(LogCategory::Info, &markup! { {message} }.to_owned())?;
+
             let location = Location::builder().span(span).resource(file_id).build();
-            if let Some(location) = location {
-                visitor.record_frame(location)?;
-            }
+            visitor.record_frame(location)?;
         }
         if let Some(hint) = &self.hint {
             visitor.record_log(LogCategory::Info, &markup! { {hint} }.to_owned())?;

--- a/crates/rome_js_semantic/src/tests/assertions.rs
+++ b/crates/rome_js_semantic/src/tests/assertions.rs
@@ -185,9 +185,7 @@ impl Advices for TestAdvice {
         for (span, message) in &self.advices {
             let location = Location::builder().span(&span).build();
             visitor.record_log(LogCategory::Info, &message)?;
-            if let Some(location) = location {
-                visitor.record_frame(location)?;
-            }
+            visitor.record_frame(location)?;
         }
         Ok(())
     }

--- a/crates/rome_json_parser/src/lib.rs
+++ b/crates/rome_json_parser/src/lib.rs
@@ -73,9 +73,7 @@ impl Advices for ParserAdvice {
             } = detail;
             visitor.record_log(LogCategory::Info, &markup! { {message} }.to_owned())?;
             let location = Location::builder().span(span).resource(file_id).build();
-            if let Some(location) = location {
-                visitor.record_frame(location)?;
-            }
+            visitor.record_frame(location)?;
         }
         if let Some(hint) = &self.hint {
             visitor.record_log(LogCategory::Info, &markup! { {hint} }.to_owned())?;

--- a/crates/rome_lsp/src/utils.rs
+++ b/crates/rome_lsp/src/utils.rs
@@ -200,9 +200,7 @@ pub(crate) fn diagnostic_to_lsp<D: Diagnostic>(
     url: &lsp::Url,
     line_index: &LineIndex,
 ) -> Result<lsp::Diagnostic> {
-    let location = diagnostic
-        .location()
-        .context("diagnostic has no location")?;
+    let location = diagnostic.location();
 
     let span = location.span.context("diagnostic location has no span")?;
     let span = range(line_index, span).context("failed to convert diagnostic span to LSP range")?;


### PR DESCRIPTION
## Summary

Fixes #3829

This change makes the `resource` field of a diagnostics `Location` optional instead of the location itself. This allows a diagnostic to be initially created with a span but no resource, and have the resource only injected later.

## Test Plan

This change is mostly at the type level and should be checked by the Rust compiler. Since it only allows diagnostics to be combined in new ways and no code is making use of the new feature yet, it shouldn't have any visible change on existing diagnostics.
