### PR TITLE
feat(rome_js_analyze): faster version of noArguments

### DIFF
--- a/crates/rome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/rome_js_semantic/src/semantic_model/reference.rs
@@ -116,6 +116,11 @@ impl UnresolvedReference {
         let reference = &self.data.unresolved_references[self.id];
         &self.data.node_by_range[&reference.range]
     }
+
+    pub fn range(&self) -> &TextRange {
+        let reference = &self.data.unresolved_references[self.id];
+        &reference.range
+    }
 }
 
 /// Marker trait that groups all "AstNode" that have declarations


### PR DESCRIPTION
## Summary

Small performance improvement for `noArguments`.

```
> hyperfine "~/github/tools/target/release/rome check ~/github/vscode" "~/github/toolsmain/target/release/rome check ~/github/vscode" -i
Benchmark 1: ~/github/tools/target/release/rome check ~/github/vscode
  Time (mean ± σ):     661.1 ms ±   7.2 ms    [User: 8643.3 ms, System: 201.7 ms]
  Range (min … max):   649.0 ms … 673.3 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: ~/github/toolsmain/target/release/rome check ~/github/vscode
  Time (mean ± σ):     722.4 ms ±   9.8 ms    [User: 9576.6 ms, System: 210.6 ms]
  Range (min … max):   710.3 ms … 745.3 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  '~/github/tools/target/release/rome check ~/github/vscode' ran
    1.09 ± 0.02 times faster than '~/github/toolsmain/target/release/rome check ~/github/vscode'
```

## Test Plan

```
> cargo test -- no_arguments
```
