### PR TITLE
feat(rome_analyze): emit syntax error diagnostics for suppression comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,8 @@ dependencies = [
 name = "rome_js_syntax"
 version = "0.0.0"
 dependencies = [
- "rome_diagnostics_categories",
+ "rome_console",
+ "rome_diagnostics",
  "rome_js_factory",
  "rome_rowan",
  "schemars",

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -44,7 +44,9 @@ pub use crate::syntax::SyntaxVisitor;
 pub use crate::visitor::{NodeVisitor, Visitor, VisitorContext, VisitorFinishContext};
 
 use rome_console::markup;
-use rome_diagnostics::{category, Applicability, DiagnosticTags, FileId};
+use rome_diagnostics::{
+    category, Applicability, Diagnostic, DiagnosticExt, DiagnosticTags, FileId,
+};
 use rome_rowan::{
     AstNode, BatchMutation, Direction, Language, SyntaxElement, SyntaxToken, TextRange, TextSize,
     TokenAtOffset, TriviaPieceKind, WalkEvent,
@@ -56,7 +58,7 @@ use rome_rowan::{
 /// auxiliary data structures as well as emit "query match" events to be
 /// processed by lint rules and in turn emit "analyzer signals" in the form of
 /// diagnostics, code actions or both
-pub struct Analyzer<'analyzer, L: Language, Matcher, Break> {
+pub struct Analyzer<'analyzer, L: Language, Matcher, Break, Diag> {
     /// List of visitors being run by this instance of the analyzer for each phase
     phases: BTreeMap<Phases, Vec<Box<dyn Visitor<Language = L> + 'analyzer>>>,
     /// Holds the metadata for all the rules statically known to the analyzer
@@ -64,7 +66,7 @@ pub struct Analyzer<'analyzer, L: Language, Matcher, Break> {
     /// Executor for the query matches emitted by the visitors
     query_matcher: Matcher,
     /// Language-specific suppression comment parsing function
-    parse_suppression_comment: SuppressionParser,
+    parse_suppression_comment: SuppressionParser<Diag>,
     /// Language-specific suppression comment emitter
     apply_suppression_comment: SuppressionCommentEmitter<L>,
     /// Handles analyzer signals emitted by individual rules
@@ -79,17 +81,18 @@ pub struct AnalyzerContext<'a, L: Language> {
     pub options: &'a AnalyzerOptions,
 }
 
-impl<'analyzer, L, Matcher, Break> Analyzer<'analyzer, L, Matcher, Break>
+impl<'analyzer, L, Matcher, Break, Diag> Analyzer<'analyzer, L, Matcher, Break, Diag>
 where
     L: Language,
     Matcher: QueryMatcher<L>,
+    Diag: Diagnostic + Clone + Send + Sync + 'static,
 {
     /// Construct a new instance of the analyzer with the given rule registry
     /// and suppression comment parser
     pub fn new(
         metadata: &'analyzer MetadataRegistry,
         query_matcher: Matcher,
-        parse_suppression_comment: SuppressionParser,
+        parse_suppression_comment: SuppressionParser<Diag>,
         apply_suppression_comment: SuppressionCommentEmitter<L>,
         emit_signal: SignalHandler<'analyzer, L, Break>,
     ) -> Self {
@@ -193,7 +196,7 @@ where
 }
 
 /// Holds all the state required to run a single analysis phase to completion
-struct PhaseRunner<'analyzer, 'phase, L: Language, Matcher, Break> {
+struct PhaseRunner<'analyzer, 'phase, L: Language, Matcher, Break, Diag> {
     /// Identifier of the phase this runner is executing
     phase: Phases,
     /// List of visitors being run by this instance of the analyzer for each phase
@@ -205,7 +208,7 @@ struct PhaseRunner<'analyzer, 'phase, L: Language, Matcher, Break> {
     /// Queue for pending analyzer signals
     signal_queue: BinaryHeap<SignalEntry<'phase, L>>,
     /// Language-specific suppression comment parsing function
-    parse_suppression_comment: SuppressionParser,
+    parse_suppression_comment: SuppressionParser<Diag>,
     /// Language-specific suppression comment emitter
     apply_suppression_comment: SuppressionCommentEmitter<L>,
     /// Line index at the current position of the traversal
@@ -246,10 +249,11 @@ struct LineSuppression {
     did_suppress_signal: bool,
 }
 
-impl<'a, 'phase, L, Matcher, Break> PhaseRunner<'a, 'phase, L, Matcher, Break>
+impl<'a, 'phase, L, Matcher, Break, Diag> PhaseRunner<'a, 'phase, L, Matcher, Break, Diag>
 where
     L: Language,
     Matcher: QueryMatcher<L>,
+    Diag: Diagnostic + Clone + Send + Sync + 'static,
 {
     /// Runs phase 0 over nodes and tokens to process line breaks and
     /// suppression comments
@@ -457,7 +461,22 @@ where
         let mut suppressions = Vec::new();
         let mut has_legacy = false;
 
-        for kind in (self.parse_suppression_comment)(text) {
+        for result in (self.parse_suppression_comment)(text) {
+            let kind = match result {
+                Ok(kind) => kind,
+                Err(diag) => {
+                    // Emit the suppression parser diagnostic
+                    let signal = DiagnosticSignal::new(move || {
+                        let location = diag.location();
+                        let span = location.span.map_or(range, |span| span + range.start());
+                        diag.clone().with_file_path(file_id).with_file_span(span)
+                    });
+
+                    (self.emit_signal)(&signal)?;
+                    continue;
+                }
+            };
+
             let rule = match kind {
                 SuppressionKind::Everything => None,
                 SuppressionKind::Rule(rule) => Some(rule),
@@ -615,7 +634,7 @@ fn range_match(filter: Option<TextRange>, range: TextRange) -> bool {
 /// - `// rome-ignore lint/correctness/useWhile lint/nursery/noUnreachable` -> `vec![Rule("correctness/useWhile"), Rule("nursery/noUnreachable")]`
 /// - `// rome-ignore lint(correctness/useWhile)` -> `vec![MaybeLegacy("correctness/useWhile")]`
 /// - `// rome-ignore lint(correctness/useWhile) lint(nursery/noUnreachable)` -> `vec![MaybeLegacy("correctness/useWhile"), MaybeLegacy("nursery/noUnreachable")]`
-type SuppressionParser = fn(&str) -> Vec<SuppressionKind>;
+type SuppressionParser<D> = fn(&str) -> Vec<Result<SuppressionKind, D>>;
 
 /// This enum is used to categorize what is disabled by a suppression comment and with what syntax
 pub enum SuppressionKind<'a> {

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -153,6 +153,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
+
     use rome_diagnostics::{category, location::FileId, DiagnosticExt};
     use rome_diagnostics::{Diagnostic, Severity};
     use rome_rowan::{
@@ -315,11 +317,14 @@ mod tests {
             ControlFlow::Continue(())
         };
 
-        fn parse_suppression_comment(comment: &'_ str) -> Vec<SuppressionKind<'_>> {
+        fn parse_suppression_comment(
+            comment: &'_ str,
+        ) -> Vec<Result<SuppressionKind<'_>, Infallible>> {
             comment
                 .trim_start_matches("//")
                 .split(' ')
                 .map(SuppressionKind::Rule)
+                .map(Ok)
                 .collect()
         }
 

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -9,8 +9,7 @@ use crate::{
 };
 use rome_console::MarkupBuf;
 use rome_diagnostics::{
-    advice::CodeSuggestionAdvice, location::FileId, Applicability, CodeSuggestion, Diagnostic,
-    Error, FileSpan,
+    advice::CodeSuggestionAdvice, location::FileId, Applicability, CodeSuggestion, Error, FileSpan,
 };
 use rome_rowan::{BatchMutation, Language};
 use std::borrow::Cow;
@@ -38,7 +37,7 @@ pub(crate) struct DiagnosticSignal<D, A, L, T> {
 impl<L: Language, D, T> DiagnosticSignal<D, fn() -> Option<AnalyzerAction<L>>, L, T>
 where
     D: Fn() -> T,
-    T: Diagnostic + Send + Sync + 'static,
+    Error: From<T>,
 {
     pub(crate) fn new(factory: D) -> Self {
         Self {
@@ -65,7 +64,7 @@ impl<L: Language, D, A, T> DiagnosticSignal<D, A, L, T> {
 impl<L: Language, D, A, T> AnalyzerSignal<L> for DiagnosticSignal<D, A, L, T>
 where
     D: Fn() -> T,
-    T: Diagnostic + Send + Sync + 'static,
+    Error: From<T>,
     A: Fn() -> Option<AnalyzerAction<L>>,
 {
     fn diagnostic(&self) -> Option<AnalyzerDiagnostic> {

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -49,6 +49,8 @@ impl<L: Language> Visitor for SyntaxVisitor<L> {
 #[cfg(test)]
 mod tests {
 
+    use std::convert::Infallible;
+
     use rome_diagnostics::location::FileId;
     use rome_rowan::{
         raw_language::{RawLanguage, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
@@ -109,7 +111,7 @@ mod tests {
         let mut analyzer = Analyzer::new(
             &metadata,
             &mut matcher,
-            |_| unreachable!(),
+            |_| -> Vec<Result<_, Infallible>> { unreachable!() },
             |_| unreachable!(),
             &mut emit_signal,
         );

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -465,6 +465,7 @@ fn process_messages(options: ProcessMessagesOptions) {
                     }
                 } else {
                     for diag in diagnostics {
+                        eprintln!("Diagnostics {:?}", diag.severity());
                         let severity = diag.severity();
                         if severity == Severity::Error {
                             *errors += 1;

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -1154,3 +1154,31 @@ fn unsupported_file() {
         result,
     ));
 }
+
+#[test]
+fn suppression_syntax_error() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("check.js");
+    fs.insert(file_path.into(), *b"// rome-ignore(:\n");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("check"), file_path.as_os_str().into()]),
+    );
+
+    match result {
+        Err(Termination::CheckError) => {}
+        _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "suppression_syntax_error",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/rome_cli/tests/snapshots/main_commands_check/suppression_syntax_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/suppression_syntax_error.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `check.js`
+
+```js
+// rome-ignore(:
+
+```
+
+# Termination Message
+
+```block
+some errors were emitted while running checks
+```
+
+# Emitted Messages
+
+```block
+check.js:1:15 suppressions/parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × unexpected token, expected one of ':' or whitespace
+  
+  > 1 │ // rome-ignore(:
+      │               ^
+    2 │ 
+  
+
+```
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_diagnostics/src/context.rs
+++ b/crates/rome_diagnostics/src/context.rs
@@ -3,7 +3,7 @@ use rome_console::fmt;
 use crate::context::internal::{SeverityDiagnostic, TagsDiagnostic};
 use crate::{
     diagnostic::internal::AsDiagnostic,
-    location::{AsResource, AsSourceCode},
+    location::{AsResource, AsSourceCode, AsSpan},
     Category, DiagnosticTags, Error, Resource, Severity, SourceCode,
 };
 
@@ -32,6 +32,11 @@ pub trait DiagnosticExt: internal::Sealed + Sized {
     fn with_file_path(self, path: impl AsResource) -> Error
     where
         Error: From<internal::FilePathDiagnostic<Self>>;
+
+    /// Returns a new diagnostic using the provided `span` instead of the one in `self`.
+    fn with_file_span(self, span: impl AsSpan) -> Error
+    where
+        Error: From<internal::FileSpanDiagnostic<Self>>;
 
     /// Returns a new diagnostic using the provided `source_code` if `self`
     /// doesn't already have one.
@@ -81,6 +86,16 @@ impl<E: AsDiagnostic> DiagnosticExt for E {
     {
         Error::from(internal::FilePathDiagnostic {
             path: path.as_resource().map(Resource::to_owned),
+            source: self,
+        })
+    }
+
+    fn with_file_span(self, span: impl AsSpan) -> Error
+    where
+        Error: From<internal::FileSpanDiagnostic<E>>,
+    {
+        Error::from(internal::FileSpanDiagnostic {
+            span: span.as_span(),
             source: self,
         })
     }
@@ -147,6 +162,17 @@ pub trait Context<T, E>: internal::Sealed {
     fn with_tags(self, tags: DiagnosticTags) -> Result<T, Error>
     where
         Error: From<internal::TagsDiagnostic<E>>;
+
+    /// If `self` is an error, returns a new diagnostic using the provided
+    /// `span` instead of the one returned by `self`.
+    ///
+    /// This is useful in multi-language documents, where a given diagnostic
+    /// may be originally emitted with a span relative to a specific substring
+    /// of a larger document, and later needs to have its position remapped to
+    /// be relative to the entire file instead.
+    fn with_file_span(self, span: impl AsSpan) -> Result<T, Error>
+    where
+        Error: From<internal::FileSpanDiagnostic<E>>;
 }
 
 impl<T, E: AsDiagnostic> internal::Sealed for Result<T, E> {}
@@ -203,6 +229,16 @@ impl<T, E: AsDiagnostic> Context<T, E> for Result<T, E> {
             Err(source) => Err(source.with_tags(tags)),
         }
     }
+
+    fn with_file_span(self, span: impl AsSpan) -> Result<T, Error>
+    where
+        Error: From<internal::FileSpanDiagnostic<E>>,
+    {
+        match self {
+            Ok(value) => Ok(value),
+            Err(source) => Err(source.with_file_span(span)),
+        }
+    }
 }
 
 mod internal {
@@ -214,6 +250,7 @@ mod internal {
     use std::{fmt::Debug, io};
 
     use rome_console::{fmt, markup};
+    use rome_rowan::TextRange;
     use rome_text_edit::TextEdit;
 
     use crate::{
@@ -435,6 +472,61 @@ mod internal {
                     None => self.path.as_ref().map(Resource::as_deref),
                 },
                 span: loc.span,
+                source_code: loc.source_code,
+            }
+        }
+
+        fn tags(&self) -> DiagnosticTags {
+            self.source.as_diagnostic().tags()
+        }
+    }
+
+    /// Diagnostic type returned by [super::DiagnosticExt::with_file_span],
+    /// uses `span` as its location span instead of the one returned by `source`.
+    pub struct FileSpanDiagnostic<E> {
+        pub(super) span: Option<TextRange>,
+        pub(super) source: E,
+    }
+
+    impl<E: Debug> Debug for FileSpanDiagnostic<E> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Diagnostic")
+                .field("span", &self.span)
+                .field("source", &self.source)
+                .finish()
+        }
+    }
+
+    impl<E: AsDiagnostic> Diagnostic for FileSpanDiagnostic<E> {
+        fn category(&self) -> Option<&'static Category> {
+            self.source.as_diagnostic().category()
+        }
+
+        fn severity(&self) -> Severity {
+            self.source.as_diagnostic().severity()
+        }
+
+        fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.source.as_diagnostic().description(fmt)
+        }
+
+        fn message(&self, fmt: &mut fmt::Formatter<'_>) -> io::Result<()> {
+            self.source.as_diagnostic().message(fmt)
+        }
+
+        fn advices(&self, visitor: &mut dyn Visit) -> io::Result<()> {
+            self.source.as_diagnostic().advices(visitor)
+        }
+
+        fn verbose_advices(&self, visitor: &mut dyn Visit) -> io::Result<()> {
+            self.source.as_diagnostic().verbose_advices(visitor)
+        }
+
+        fn location(&self) -> Location<'_> {
+            let loc = self.source.as_diagnostic().location();
+            Location {
+                resource: loc.resource,
+                span: self.span.or(loc.span),
                 source_code: loc.source_code,
             }
         }

--- a/crates/rome_diagnostics/src/diagnostic.rs
+++ b/crates/rome_diagnostics/src/diagnostic.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, io};
+use std::{convert::Infallible, fmt::Debug, io};
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
@@ -148,6 +148,11 @@ bitflags! {
         const DEPRECATED_CODE = 1 << DiagnosticTag::DeprecatedCode as u8;
     }
 }
+
+// Implement the `Diagnostic` on the `Infallible` error type from the standard
+// library as a utility for implementing signatures that require a diagnostic
+// type when the operation can never fail
+impl Diagnostic for Infallible {}
 
 pub(crate) mod internal {
     //! The `AsDiagnostic` trait needs to be declared as public as its referred

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -124,6 +124,7 @@ define_dategories! {
     "lint/nursery",
 
     // Suppression comments
+    "suppressions/parse",
     "suppressions/unknownGroup",
     "suppressions/unknownRule",
     "suppressions/unused",

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -6,6 +6,7 @@ use rome_analyze::{
 };
 use rome_diagnostics::{category, FileId};
 use rome_js_factory::make::{jsx_expression_child, token};
+use rome_js_syntax::suppression::SuppressionDiagnostic;
 use rome_js_syntax::{
     suppression::parse_suppression_comment, JsLanguage, JsSyntaxToken, JsxAnyChild, T,
 };
@@ -63,22 +64,37 @@ where
     F: FnMut(&dyn AnalyzerSignal<JsLanguage>) -> ControlFlow<B> + 'a,
     B: 'a,
 {
-    fn parse_linter_suppression_comment(text: &str) -> Vec<SuppressionKind> {
-        parse_suppression_comment(text)
-            .flat_map(|comment| comment.categories)
-            .filter_map(|(key, value)| {
+    fn parse_linter_suppression_comment(
+        text: &str,
+    ) -> Vec<Result<SuppressionKind, SuppressionDiagnostic>> {
+        let mut result = Vec::new();
+
+        for comment in parse_suppression_comment(text) {
+            let categories = match comment {
+                Ok(comment) => comment.categories,
+                Err(err) => {
+                    result.push(Err(err));
+                    continue;
+                }
+            };
+
+            for (key, value) in categories {
                 if key == category!("lint") {
                     if let Some(value) = value {
-                        Some(SuppressionKind::MaybeLegacy(value))
+                        result.push(Ok(SuppressionKind::MaybeLegacy(value)));
                     } else {
-                        Some(SuppressionKind::Everything)
+                        result.push(Ok(SuppressionKind::Everything));
                     }
                 } else {
                     let category = key.name();
-                    category.strip_prefix("lint/").map(SuppressionKind::Rule)
+                    if let Some(rule) = category.strip_prefix("lint/") {
+                        result.push(Ok(SuppressionKind::Rule(rule)));
+                    }
                 }
-            })
-            .collect()
+            }
+        }
+
+        result
     }
 
     let mut registry = RuleRegistry::builder(&filter);
@@ -237,11 +253,19 @@ mod tests {
             function checkSuppressions4(a, b) {
                 a == b;
             }
+
+            function checkSuppressions5() {
+                // rome-ignore format explanation
+                // rome-ignore format(:
+                // rome-ignore (value): explanation
+                // rome-ignore unknown: explanation
+            }
         ";
 
         let parsed = parse(SOURCE, FileId::zero(), SourceType::js_module());
 
-        let mut error_ranges: Vec<TextRange> = Vec::new();
+        let mut lint_ranges: Vec<TextRange> = Vec::new();
+        let mut parse_ranges: Vec<TextRange> = Vec::new();
         let mut warn_ranges: Vec<TextRange> = Vec::new();
 
         let options = AnalyzerOptions::default();
@@ -260,7 +284,11 @@ mod tests {
 
                     let code = error.category().unwrap();
                     if code == category!("lint/correctness/noDoubleEquals") {
-                        error_ranges.push(span.unwrap());
+                        lint_ranges.push(span.unwrap());
+                    }
+
+                    if code == category!("suppressions/parse") {
+                        parse_ranges.push(span.unwrap());
                     }
 
                     if code == category!("suppressions/deprecatedSyntax") {
@@ -274,7 +302,7 @@ mod tests {
         );
 
         assert_eq!(
-            error_ranges.as_slice(),
+            lint_ranges.as_slice(),
             &[
                 TextRange::new(TextSize::from(67), TextSize::from(69)),
                 TextRange::new(TextSize::from(651), TextSize::from(653)),
@@ -282,6 +310,16 @@ mod tests {
                 TextRange::new(TextSize::from(932), TextSize::from(934)),
                 TextRange::new(TextSize::from(1523), TextSize::from(1525)),
                 TextRange::new(TextSize::from(1718), TextSize::from(1720)),
+            ]
+        );
+
+        assert_eq!(
+            parse_ranges.as_slice(),
+            &[
+                TextRange::new(TextSize::from(1821), TextSize::from(1832)),
+                TextRange::new(TextSize::from(1871), TextSize::from(1872)),
+                TextRange::new(TextSize::from(1904), TextSize::from(1905)),
+                TextRange::new(TextSize::from(1956), TextSize::from(1963)),
             ]
         );
 

--- a/crates/rome_js_formatter/src/comments.rs
+++ b/crates/rome_js_formatter/src/comments.rs
@@ -136,6 +136,7 @@ impl CommentStyle for JsCommentStyle {
 
     fn is_suppression(text: &str) -> bool {
         parse_suppression_comment(text)
+            .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
             .any(|(key, _)| key == category!("format"))
     }

--- a/crates/rome_js_syntax/Cargo.toml
+++ b/crates/rome_js_syntax/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/rome/tools"
 
 [dependencies]
 rome_rowan = { path = "../rome_rowan" }
-rome_diagnostics_categories = { path = "../rome_diagnostics_categories" }
+rome_diagnostics = { path = "../rome_diagnostics" }
+rome_console = { path = "../rome_console" }
 serde = { version = "1.0.136", features = ["derive"], optional = true }
 schemars = { version = "0.8.10", optional = true }
 

--- a/crates/rome_js_syntax/src/suppression.rs
+++ b/crates/rome_js_syntax/src/suppression.rs
@@ -1,4 +1,5 @@
-use rome_diagnostics_categories::Category;
+use rome_diagnostics::{Category, Diagnostic};
+use rome_rowan::{TextRange, TextSize};
 
 /// Single instance of a suppression comment, with the following syntax:
 ///
@@ -24,8 +25,10 @@ pub struct Suppression<'a> {
     pub reason: &'a str,
 }
 
-pub fn parse_suppression_comment(comment: &str) -> impl Iterator<Item = Suppression> {
-    let (head, mut comment) = comment.split_at(2);
+pub fn parse_suppression_comment(
+    base: &str,
+) -> impl Iterator<Item = Result<Suppression, SuppressionDiagnostic>> {
+    let (head, mut comment) = base.split_at(2);
     let is_block_comment = match head {
         "//" => false,
         "/*" => {
@@ -47,67 +50,199 @@ pub fn parse_suppression_comment(comment: &str) -> impl Iterator<Item = Suppress
             line = line.trim_start_matches('*').trim_start()
         }
 
-        // Check for the rome-ignore token or skip the line entirely
-        line = line.strip_prefix("rome-ignore")?.trim_start();
+        const PATTERNS: [[char; 2]; 11] = [
+            ['r', 'R'],
+            ['o', 'O'],
+            ['m', 'M'],
+            ['e', 'E'],
+            ['-', '_'],
+            ['i', 'I'],
+            ['g', 'G'],
+            ['n', 'N'],
+            ['o', 'O'],
+            ['r', 'R'],
+            ['e', 'E'],
+        ];
 
-        let mut categories = Vec::new();
-
-        loop {
-            // Find either a colon opening parenthesis or space
-            let separator = line.find(|c: char| c == ':' || c == '(' || c.is_whitespace())?;
-
-            let (category, rest) = line.split_at(separator);
-            let category = category.trim_end();
-            let category: Option<&'static Category> = if !category.is_empty() {
-                Some(category.parse().ok()?)
-            } else {
-                None
-            };
-
-            // Skip over and match the separator
-            let (separator, rest) = rest.split_at(1);
-
-            match separator {
-                // Colon token: stop parsing categories
-                ":" => {
-                    if let Some(category) = category {
-                        categories.push((category, None));
-                    }
-
-                    line = rest.trim_start();
-                    break;
-                }
-                // Paren token: parse a category + value
-                "(" => {
-                    let category = category?;
-                    let paren = rest.find(')')?;
-
-                    let (value, rest) = rest.split_at(paren);
-                    let value = value.trim();
-
-                    categories.push((category, Some(value)));
-
-                    line = rest.strip_prefix(')').unwrap().trim_start();
-                }
-                // Whitespace: push a category without value
-                _ => {
-                    if let Some(category) = category {
-                        categories.push((category, None));
-                    }
-
-                    line = rest.trim_start();
-                }
-            }
+        // Checks for `/rome[-_]ignore/i` without a regex, or skip the line
+        // entirely if it doesn't match
+        for pattern in PATTERNS {
+            line = line.strip_prefix(pattern)?;
         }
 
-        let reason = line.trim_end();
-        Some(Suppression { categories, reason })
+        let line = line.trim_start();
+        Some(
+            parse_suppression_line(line).map_err(|err| SuppressionDiagnostic {
+                message: err.message,
+                // Adjust the position of the diagnostic in the whole comment
+                span: err.span + offset_from(base, line),
+            }),
+        )
     })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Diagnostic)]
+#[diagnostic(category = "suppressions/parse")]
+pub struct SuppressionDiagnostic {
+    #[message]
+    #[description]
+    message: SuppressionDiagnosticKind,
+    #[location(span)]
+    span: TextRange,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SuppressionDiagnosticKind {
+    MissingColon,
+    ParseCategory(String),
+    MissingCategory,
+    MissingParen,
+}
+
+impl std::fmt::Display for SuppressionDiagnosticKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SuppressionDiagnosticKind::MissingColon => write!(
+                f,
+                "unexpected token, expected one of ':', '(' or whitespace"
+            ),
+            SuppressionDiagnosticKind::ParseCategory(category) => {
+                write!(f, "failed to parse category {category:?}")
+            }
+            SuppressionDiagnosticKind::MissingCategory => {
+                write!(f, "unexpected token, expected one of ':' or whitespace")
+            }
+            SuppressionDiagnosticKind::MissingParen => write!(f, "unexpected token, expected ')'"),
+        }
+    }
+}
+
+impl rome_console::fmt::Display for SuppressionDiagnosticKind {
+    fn fmt(&self, fmt: &mut rome_console::fmt::Formatter) -> std::io::Result<()> {
+        match self {
+            SuppressionDiagnosticKind::MissingColon => write!(
+                fmt,
+                "unexpected token, expected one of ':', '(' or whitespace"
+            ),
+            SuppressionDiagnosticKind::ParseCategory(category) => {
+                write!(fmt, "failed to parse category {category:?}")
+            }
+            SuppressionDiagnosticKind::MissingCategory => {
+                write!(fmt, "unexpected token, expected one of ':' or whitespace")
+            }
+            SuppressionDiagnosticKind::MissingParen => {
+                write!(fmt, "unexpected token, expected ')'")
+            }
+        }
+    }
+}
+
+/// Parse the `{ <category> { (<value>) }? }+: <reason>` section of a suppression line
+fn parse_suppression_line(base: &str) -> Result<Suppression, SuppressionDiagnostic> {
+    let mut line = base;
+    let mut categories = Vec::new();
+
+    loop {
+        // Find either a colon opening parenthesis or space
+        let separator = line
+            .find(|c: char| c == ':' || c == '(' || c.is_whitespace())
+            .ok_or_else(|| SuppressionDiagnostic {
+                message: SuppressionDiagnosticKind::MissingColon,
+                span: TextRange::at(offset_from(base, line), TextSize::of(line)),
+            })?;
+
+        let (category, rest) = line.split_at(separator);
+        let category = category.trim_end();
+        let category: Option<&'static Category> = if !category.is_empty() {
+            let category = category.parse().map_err(|()| SuppressionDiagnostic {
+                message: SuppressionDiagnosticKind::ParseCategory(category.into()),
+                span: TextRange::at(offset_from(base, category), TextSize::of(category)),
+            })?;
+            Some(category)
+        } else {
+            None
+        };
+
+        // Skip over and match the separator
+        let (separator, rest) = rest.split_at(1);
+
+        match separator {
+            // Colon token: stop parsing categories
+            ":" => {
+                if let Some(category) = category {
+                    categories.push((category, None));
+                }
+
+                line = rest.trim_start();
+                break;
+            }
+            // Paren token: parse a category + value
+            "(" => {
+                let category = category.ok_or_else(|| SuppressionDiagnostic {
+                    message: SuppressionDiagnosticKind::MissingCategory,
+                    span: TextRange::at(
+                        offset_from(base, line),
+                        offset_from(line, separator) + TextSize::of(separator),
+                    ),
+                })?;
+                let paren = rest.find(')').ok_or_else(|| SuppressionDiagnostic {
+                    message: SuppressionDiagnosticKind::MissingParen,
+                    span: TextRange::at(offset_from(base, rest), TextSize::of(rest)),
+                })?;
+
+                let (value, rest) = rest.split_at(paren);
+                let value = value.trim();
+
+                categories.push((category, Some(value)));
+
+                line = rest.strip_prefix(')').unwrap().trim_start();
+            }
+            // Whitespace: push a category without value
+            _ => {
+                if let Some(category) = category {
+                    categories.push((category, None));
+                }
+
+                line = rest.trim_start();
+            }
+        }
+    }
+
+    let reason = line.trim_end();
+    Ok(Suppression { categories, reason })
+}
+
+/// Returns the byte offset of `substr` within `base`
+///
+/// # Safety
+///
+/// `substr` must be a substring of `base`, or calling this method will result
+/// in undefined behavior.
+fn offset_from(base: &str, substr: &str) -> TextSize {
+    let base_len = base.len();
+    assert!(substr.len() <= base_len);
+
+    let base = base.as_ptr();
+    let substr = substr.as_ptr();
+    let offset = unsafe { substr.offset_from(base) };
+
+    // SAFETY: converting from `isize` to `usize` can only fail if `offset` is
+    // negative, meaning `base` is either a substring of `substr` or the two
+    // string slices are unrelated
+    let offset = usize::try_from(offset).expect("usize underflow");
+    assert!(offset <= base_len);
+
+    // SAFETY: the conversion from `usize` to `TextSize` can fail if `offset`
+    // is larger than 2^32
+    TextSize::try_from(offset).expect("TextSize overflow")
 }
 
 #[cfg(test)]
 mod tests {
-    use rome_diagnostics_categories::category;
+    use rome_diagnostics::category;
+    use rome_rowan::{TextRange, TextSize};
+
+    use crate::suppression::{offset_from, SuppressionDiagnostic, SuppressionDiagnosticKind};
 
     use super::{parse_suppression_comment, Suppression};
 
@@ -115,18 +250,18 @@ mod tests {
     fn parse_simple_suppression() {
         assert_eq!(
             parse_suppression_comment("// rome-ignore parse: explanation1").collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![(category!("parse"), None)],
                 reason: "explanation1"
-            }],
+            })],
         );
 
         assert_eq!(
             parse_suppression_comment("/** rome-ignore parse: explanation2 */").collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![(category!("parse"), None)],
                 reason: "explanation2"
-            }],
+            })],
         );
 
         assert_eq!(
@@ -136,10 +271,10 @@ mod tests {
                   */"
             )
             .collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![(category!("parse"), None)],
                 reason: "explanation3"
-            }],
+            })],
         );
 
         assert_eq!(
@@ -150,36 +285,36 @@ mod tests {
                   */"
             )
             .collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![(category!("parse"), None)],
                 reason: "explanation4"
-            }],
+            })],
         );
     }
     #[test]
     fn parse_unclosed_block_comment_suppressions() {
         assert_eq!(
             parse_suppression_comment("/* rome-ignore format: explanation").collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![(category!("format"), None)],
                 reason: "explanation"
-            }],
+            })],
         );
 
         assert_eq!(
             parse_suppression_comment("/* rome-ignore format: explanation *").collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![(category!("format"), None)],
                 reason: "explanation"
-            }],
+            })],
         );
 
         assert_eq!(
             parse_suppression_comment("/* rome-ignore format: explanation /").collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![(category!("format"), None)],
                 reason: "explanation"
-            }],
+            })],
         );
     }
 
@@ -188,25 +323,25 @@ mod tests {
         assert_eq!(
             parse_suppression_comment("// rome-ignore parse(foo) parse(dog): explanation")
                 .collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![
                     (category!("parse"), Some("foo")),
                     (category!("parse"), Some("dog"))
                 ],
                 reason: "explanation"
-            }],
+            })],
         );
 
         assert_eq!(
             parse_suppression_comment("/** rome-ignore parse(bar) parse(cat): explanation */")
                 .collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![
                     (category!("parse"), Some("bar")),
                     (category!("parse"), Some("cat"))
                 ],
                 reason: "explanation"
-            }],
+            })],
         );
 
         assert_eq!(
@@ -216,13 +351,13 @@ mod tests {
                   */"
             )
             .collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![
                     (category!("parse"), Some("yes")),
                     (category!("parse"), Some("frog"))
                 ],
                 reason: "explanation"
-            }],
+            })],
         );
 
         assert_eq!(
@@ -233,13 +368,13 @@ mod tests {
                   */"
             )
             .collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![
                     (category!("parse"), Some("wow")),
                     (category!("parse"), Some("fish"))
                 ],
                 reason: "explanation"
-            }],
+            })],
         );
     }
 
@@ -248,10 +383,67 @@ mod tests {
         assert_eq!(
             parse_suppression_comment("// rome-ignore format lint: explanation")
                 .collect::<Vec<_>>(),
-            vec![Suppression {
+            vec![Ok(Suppression {
                 categories: vec![(category!("format"), None), (category!("lint"), None)],
                 reason: "explanation"
-            }],
+            })],
+        );
+    }
+
+    #[test]
+    fn check_offset_from() {
+        const BASE: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua";
+
+        assert_eq!(offset_from(BASE, BASE), TextSize::from(0));
+
+        let (_, substr) = BASE.split_at(55);
+        assert_eq!(offset_from(BASE, substr), TextSize::from(55));
+
+        let (_, substr) = BASE.split_at(BASE.len());
+        assert_eq!(offset_from(BASE, substr), TextSize::of(BASE));
+    }
+
+    #[test]
+    fn diagnostic_missing_colon() {
+        assert_eq!(
+            parse_suppression_comment("// rome-ignore format explanation").collect::<Vec<_>>(),
+            vec![Err(SuppressionDiagnostic {
+                message: SuppressionDiagnosticKind::MissingColon,
+                span: TextRange::new(TextSize::from(22), TextSize::from(33))
+            })],
+        );
+    }
+
+    #[test]
+    fn diagnostic_missing_paren() {
+        assert_eq!(
+            parse_suppression_comment("// rome-ignore format(:").collect::<Vec<_>>(),
+            vec![Err(SuppressionDiagnostic {
+                message: SuppressionDiagnosticKind::MissingParen,
+                span: TextRange::new(TextSize::from(22), TextSize::from(23))
+            })],
+        );
+    }
+
+    #[test]
+    fn diagnostic_missing_category() {
+        assert_eq!(
+            parse_suppression_comment("// rome-ignore (value): explanation").collect::<Vec<_>>(),
+            vec![Err(SuppressionDiagnostic {
+                message: SuppressionDiagnosticKind::MissingCategory,
+                span: TextRange::new(TextSize::from(15), TextSize::from(16))
+            })],
+        );
+    }
+
+    #[test]
+    fn diagnostic_unknown_category() {
+        assert_eq!(
+            parse_suppression_comment("// rome-ignore unknown: explanation").collect::<Vec<_>>(),
+            vec![Err(SuppressionDiagnostic {
+                message: SuppressionDiagnosticKind::ParseCategory(String::from("unknown")),
+                span: TextRange::new(TextSize::from(15), TextSize::from(22))
+            })],
         );
     }
 }

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -240,8 +240,13 @@ fn lint(params: LintParams) -> LintResults {
             let severity = diagnostic
                 .category()
                 .filter(|category| category.name().starts_with("lint/"))
-                .and_then(|category| params.rules.as_ref()?.get_severity_from_code(category))
-                .unwrap_or(Severity::Warning);
+                .map(|category| {
+                    params
+                        .rules
+                        .and_then(|rules| rules.get_severity_from_code(category))
+                        .unwrap_or(Severity::Warning)
+                })
+                .unwrap_or_else(|| diagnostic.severity());
 
             if severity <= Severity::Error {
                 errors += 1;

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -694,6 +694,7 @@ export type Category =
 	| "lint/a11y"
 	| "lint/security"
 	| "lint/nursery"
+	| "suppressions/parse"
 	| "suppressions/unknownGroup"
 	| "suppressions/unknownRule"
 	| "suppressions/unused"

--- a/website/src/frontend-scripts/index.ts
+++ b/website/src/frontend-scripts/index.ts
@@ -63,7 +63,7 @@ function onColorSchemeChange() {
 }
 
 const colorSchemeSwitcher = document.querySelector(".color-scheme-switch");
-// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
+// rome-ignore lint/style/useOptionalChain: netlify's node version does not support optional call expressions
 if (colorSchemeSwitcher != null) {
 	colorSchemeSwitcher.addEventListener("click", toggleColorSchemeSwitch, false);
 }

--- a/website/src/frontend-scripts/mobile.ts
+++ b/website/src/frontend-scripts/mobile.ts
@@ -39,7 +39,7 @@ export function toggleMobileSidebar() {
 		}
 	}
 }
-// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
+// rome-ignore lint/style/useOptionalChain: netlify's node version does not support optional call expressions
 if (mobileSidebarHandle != null) {
 	mobileSidebarHandle.addEventListener(
 		"click",

--- a/website/src/frontend-scripts/toc.ts
+++ b/website/src/frontend-scripts/toc.ts
@@ -245,7 +245,7 @@ class Manager {
 			return false;
 		}
 
-		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
+		// rome-ignore lint/style/useOptionalChain: netlify's node version does not support optional call expressions
 		if (callback !== undefined) {
 			callback();
 		}
@@ -269,13 +269,13 @@ class Manager {
 		window.location.hash = hash;
 		this.scrollToHeading(hash);
 
-		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
+		// rome-ignore lint/style/useOptionalChain: netlify's node version does not support optional call expressions
 		if (navigator.clipboard !== undefined) {
 			navigator.clipboard.writeText(window.location.href);
 		}
 
 		// Only another copied text can appear here so delete it if it exists
-		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
+		// rome-ignore lint/style/useOptionalChain: netlify's node version does not support optional call expressions
 		if (target.nextElementSibling != null) {
 			target.nextElementSibling.remove();
 		}


### PR DESCRIPTION
## Summary

Fixes #3841

With the existing suppression comment parsing logic, any comment that failed to parse as a suppression was simply ignored by the analyzer and formatter. I've modified the signature of the suppression parser so that any comment line that starts with `rome-ignore` (I've also changed this to be case insensitive and allow underscores so `ROME_IGNORE` would work too) is now detected as a suppression comment, and everything that comes after must parse correctly or a diagnostic will get emitted.
I expect this change to improve the developer experience of using suppression comments since incorrectly written suppression will now emit an explicit syntax error instead of being silently ignored.

## Test Plan

I've added additional tests for the newly introduced errors to both the suppression parser in `rome_js_syntax` and the overall analyzer infrastructure in `rome_js_analyze`
