### PR TITLE
feat(rome_js_analyze): `noConstEnum`

### DIFF
--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -79,6 +79,7 @@ define_dategories! {
     "lint/nursery/noBannedTypes":"https://docs.rome.tools/lint/rules/noBannedTypes",
     "lint/nursery/noConditionalAssignment": "https://docs.rome.tools/lint/rules/noConditionalAssignment",
     "lint/nursery/noConstAssign": "https://docs.rome.tools/lint/rules/noConstAssign",
+    "lint/nursery/noConstEnum": "https://docs.rome.tools/lint/rules/noConstEnum",
     "lint/nursery/noDistractingElements": "https://docs.rome.tools/lint/rules/noDistractingElements",
     "lint/nursery/noConstructorReturn": "https://docs.rome.tools/lint/rules/noConstructorReturn",
     "lint/nursery/noSetterReturn": "https://docs.rome.tools/lint/rules/noSetterReturn",

--- a/crates/rome_js_analyze/src/analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery.rs
@@ -4,6 +4,7 @@ use rome_analyze::declare_group;
 mod no_access_key;
 mod no_banned_types;
 mod no_conditional_assignment;
+mod no_const_enum;
 mod no_constructor_return;
 mod no_distracting_elements;
 mod no_dupe_keys;
@@ -21,4 +22,4 @@ mod use_default_switch_clause_last;
 mod use_flat_map;
 mod use_numeric_literals;
 mod use_valid_for_direction;
-declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_access_key :: NoAccessKey , self :: no_banned_types :: NoBannedTypes , self :: no_conditional_assignment :: NoConditionalAssignment , self :: no_constructor_return :: NoConstructorReturn , self :: no_distracting_elements :: NoDistractingElements , self :: no_dupe_keys :: NoDupeKeys , self :: no_empty_interface :: NoEmptyInterface , self :: no_explicit_any :: NoExplicitAny , self :: no_extra_non_null_assertion :: NoExtraNonNullAssertion , self :: no_header_scope :: NoHeaderScope , self :: no_invalid_constructor_super :: NoInvalidConstructorSuper , self :: no_precision_loss :: NoPrecisionLoss , self :: no_setter_return :: NoSetterReturn , self :: no_string_case_mismatch :: NoStringCaseMismatch , self :: no_unsafe_finally :: NoUnsafeFinally , self :: no_void_type_return :: NoVoidTypeReturn , self :: use_default_switch_clause_last :: UseDefaultSwitchClauseLast , self :: use_flat_map :: UseFlatMap , self :: use_numeric_literals :: UseNumericLiterals , self :: use_valid_for_direction :: UseValidForDirection ,] } }
+declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_access_key :: NoAccessKey , self :: no_banned_types :: NoBannedTypes , self :: no_conditional_assignment :: NoConditionalAssignment , self :: no_const_enum :: NoConstEnum , self :: no_constructor_return :: NoConstructorReturn , self :: no_distracting_elements :: NoDistractingElements , self :: no_dupe_keys :: NoDupeKeys , self :: no_empty_interface :: NoEmptyInterface , self :: no_explicit_any :: NoExplicitAny , self :: no_extra_non_null_assertion :: NoExtraNonNullAssertion , self :: no_header_scope :: NoHeaderScope , self :: no_invalid_constructor_super :: NoInvalidConstructorSuper , self :: no_precision_loss :: NoPrecisionLoss , self :: no_setter_return :: NoSetterReturn , self :: no_string_case_mismatch :: NoStringCaseMismatch , self :: no_unsafe_finally :: NoUnsafeFinally , self :: no_void_type_return :: NoVoidTypeReturn , self :: use_default_switch_clause_last :: UseDefaultSwitchClauseLast , self :: use_flat_map :: UseFlatMap , self :: use_numeric_literals :: UseNumericLiterals , self :: use_valid_for_direction :: UseValidForDirection ,] } }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_const_enum.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_const_enum.rs
@@ -1,0 +1,83 @@
+use rome_analyze::context::RuleContext;
+use rome_analyze::{declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
+use rome_console::markup;
+use rome_diagnostics::Applicability;
+use rome_js_syntax::{JsSyntaxToken, TsEnumDeclaration};
+use rome_rowan::{AstNode, BatchMutationExt};
+
+use crate::JsRuleAction;
+
+declare_rule! {
+    /// Disallow TypeScript `const enum`
+    ///
+    /// Const enums are enums that should be inlined at use sites.
+    /// Const enums are not supported by bundlers and are incompatible with the `isolatedModules` mode.
+    /// Their use can lead to import inexistent values (because const enums are erased).
+    ///
+    /// Thus, library authors and bundler users should not use const enums.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```ts,expect_diagnostic
+    /// const enum Status {
+    ///   Open,
+    ///   Close,
+    /// }
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```ts
+    /// enum Status {
+    ///   Open,
+    ///   Close,
+    /// }
+    /// ```
+    pub(crate) NoConstEnum {
+        version: "11.0.0",
+        name: "noConstEnum",
+        recommended: false,
+    }
+}
+
+impl Rule for NoConstEnum {
+    type Query = Ast<TsEnumDeclaration>;
+    type State = JsSyntaxToken;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let enum_decl = ctx.query();
+        enum_decl.const_token()
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
+        let enum_decl = ctx.query();
+        Some(RuleDiagnostic::new(
+            rule_category!(),
+            enum_decl.range(),
+            markup! {
+                "The "<Emphasis>"enum declaration"</Emphasis>" should not be "<Emphasis>"const"</Emphasis>
+            },
+        ).note(
+            "Const enums are not supported by bundlers and are incompatible with the 'isolatedModules' mode. Their use can lead to import inexistent values."
+        ).note(markup! {
+            "See "<Hyperlink href="https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls">"TypeSCript Docs"</Hyperlink>" for more details."
+        }))
+    }
+
+    fn action(ctx: &RuleContext<Self>, const_token: &Self::State) -> Option<JsRuleAction> {
+        let mut mutation = ctx.root().begin();
+        mutation.remove_token(const_token.to_owned());
+        Some(JsRuleAction {
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::Always,
+            message: markup! {
+                "Turn the "<Emphasis>"const enum"</Emphasis>" into a regular "<Emphasis>"enum"</Emphasis>"."
+            }.to_owned(),
+            mutation,
+        })
+    }
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noConstEnum.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noConstEnum.ts
@@ -1,0 +1,9 @@
+export /* const */ const /* enum */ enum Status {
+	Open,
+	Close,
+}
+
+export enum Direction {
+	Prev,
+	Next,
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noConstEnum.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noConstEnum.ts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 74
+expression: noConstEnum.ts
+---
+# Input
+```js
+export /* const */ const /* enum */ enum Status {
+	Open,
+	Close,
+}
+
+export enum Direction {
+	Prev,
+	Next,
+}
+```
+
+# Diagnostics
+```
+noConstEnum.ts:1:20 lint/nursery/noConstEnum  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum declaration should not be const
+  
+  > 1 │ export /* const */ const /* enum */ enum Status {
+      │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 2 │ 	Open,
+  > 3 │ 	Close,
+  > 4 │ }
+      │ ^
+    5 │ 
+    6 │ export enum Direction {
+  
+  i Const enums are not supported by bundlers and are incompatible with the 'isolatedModules' mode. Their use can lead to import inexistent values.
+  
+  i See TypeSCript Docs for more details.
+  
+  i Safe fix: Turn the const enum into a regular enum.
+  
+    1 │ export·/*·const·*/·const·/*·enum·*/·enum·Status·{
+      │                    -----------------             
+
+```
+
+

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -737,6 +737,8 @@ struct NurserySchema {
     no_conditional_assignment: Option<RuleConfiguration>,
     #[doc = "Prevents from having const variables being re-assigned."]
     no_const_assign: Option<RuleConfiguration>,
+    #[doc = "Disallow TypeScript const enum"]
+    no_const_enum: Option<RuleConfiguration>,
     #[doc = "Disallow returning a value from a constructor"]
     no_constructor_return: Option<RuleConfiguration>,
     #[doc = "Enforces that no distracting elements are used."]
@@ -782,11 +784,12 @@ struct NurserySchema {
 }
 impl Nursery {
     const CATEGORY_NAME: &'static str = "nursery";
-    pub(crate) const CATEGORY_RULES: [&'static str; 25] = [
+    pub(crate) const CATEGORY_RULES: [&'static str; 26] = [
         "noAccessKey",
         "noBannedTypes",
         "noConditionalAssignment",
         "noConstAssign",
+        "noConstEnum",
         "noConstructorReturn",
         "noDistractingElements",
         "noDupeKeys",

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -797,6 +797,17 @@
             }
           ]
         },
+        "noConstEnum": {
+          "description": "Disallow TypeScript const enum",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "noConstructorReturn": {
           "description": "Disallow returning a value from a constructor",
           "anyOf": [

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -364,6 +364,10 @@ export interface Nursery {
 	 */
 	noConstAssign?: RuleConfiguration;
 	/**
+	 * Disallow TypeScript const enum
+	 */
+	noConstEnum?: RuleConfiguration;
+	/**
 	 * Disallow returning a value from a constructor
 	 */
 	noConstructorReturn?: RuleConfiguration;
@@ -659,6 +663,7 @@ export type Category =
 	| "lint/nursery/noBannedTypes"
 	| "lint/nursery/noConditionalAssignment"
 	| "lint/nursery/noConstAssign"
+	| "lint/nursery/noConstEnum"
 	| "lint/nursery/noDistractingElements"
 	| "lint/nursery/noConstructorReturn"
 	| "lint/nursery/noSetterReturn"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -797,6 +797,17 @@
             }
           ]
         },
+        "noConstEnum": {
+          "description": "Disallow TypeScript const enum",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "noConstructorReturn": {
           "description": "Disallow returning a value from a constructor",
           "anyOf": [

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -467,6 +467,12 @@ Disallow assignment operators in conditional expressions.
 Prevents from having <code>const</code> variables being re-assigned.
 </section>
 <section class="rule">
+<h3 data-toc-exclude id="noConstEnum">
+	<a href="/lint/rules/noConstEnum">noConstEnum</a>
+</h3>
+Disallow TypeScript <code>const enum</code>
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noConstructorReturn">
 	<a href="/lint/rules/noConstructorReturn">noConstructorReturn</a>
 </h3>

--- a/website/src/pages/lint/rules/noConstEnum.md
+++ b/website/src/pages/lint/rules/noConstEnum.md
@@ -1,0 +1,57 @@
+---
+title: Lint Rule noConstEnum
+parent: lint/rules/index
+---
+
+# noConstEnum (since v11.0.0)
+
+Disallow TypeScript `const enum`
+
+Const enums are enums that should be inlined at use sites.
+Const enums are not supported by bundlers and are incompatible with the `isolatedModules` mode.
+Their use can lead to import inexistent values (because const enums are erased).
+
+Thus, library authors and bundler users should not use const enums.
+
+## Examples
+
+### Invalid
+
+```ts
+const enum Status {
+  Open,
+  Close,
+}
+```
+
+<pre class="language-text"><code class="language-text">nursery/noConstEnum.js:1:1 <a href="https://docs.rome.tools/lint/rules/noConstEnum">lint/nursery/noConstEnum</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The </span><span style="color: Orange;"><strong>enum declaration</strong></span><span style="color: Orange;"> should not be </span><span style="color: Orange;"><strong>const</strong></span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const enum Status {
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>  Open,
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>  Close,
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>}
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>5 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Const enums are not supported by bundlers and are incompatible with the 'isolatedModules' mode. Their use can lead to import inexistent values.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">See </span><span style="color: rgb(38, 148, 255);"><a href="https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls">TypeSCript Docs</a></span><span style="color: rgb(38, 148, 255);"> for more details.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Turn the </span><span style="color: rgb(38, 148, 255);"><strong>const enum</strong></span><span style="color: rgb(38, 148, 255);"> into a regular </span><span style="color: rgb(38, 148, 255);"><strong>enum</strong></span><span style="color: rgb(38, 148, 255);">.</span>
+  
+<strong>  </strong><strong>  1 │ </strong><span style="color: Tomato;">c</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;">s</span><span style="color: Tomato;">t</span><span style="opacity: 0.8;"><span style="color: Tomato;">·</span></span>enum<span style="opacity: 0.8;">·</span>Status<span style="opacity: 0.8;">·</span>{
+<strong>  </strong><strong>    │ </strong><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span><span style="color: Tomato;">-</span>             
+</code></pre>
+
+### Valid
+
+```ts
+enum Status {
+  Open,
+  Close,
+}
+```
+


### PR DESCRIPTION
## Summary

This is an exclusive rule for Rome!
This rule disallows TypeScript `const enums`.

Const enums pitfalls are described on [TS docs](https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls).

See [my comment](https://github.com/rome/tools/pull/3849#discussion_r1032400804) for more context.

## Test Plan

Unit test and doc-tests.