### PR TITLE
fix(rome_cli): Allow to run on read-only file systems

### DIFF
--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -770,7 +770,14 @@ fn process_file(ctx: &TraversalOptions, path: &Path, file_id: FileId) -> FileRes
             };
         }
 
-        let open_options = OpenOptions::default().read(true).write(true);
+        let write_access = matches!(
+            ctx.execution.traversal_mode(),
+            TraversalMode::Check {
+                fix_file_mode: Some(_),
+            } | TraversalMode::Format { write: true, .. }
+        );
+
+        let open_options = OpenOptions::default().read(true).write(write_access);
         let mut file = ctx
             .fs
             .open_with_options(path, open_options)

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -86,6 +86,23 @@ fn ok() {
 }
 
 #[test]
+fn ok_read_only() {
+    let mut fs = MemoryFileSystem::new_read_only();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("check.js");
+    fs.insert(file_path.into(), FORMATTED.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("check"), file_path.as_os_str().into()]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+}
+
+#[test]
 fn parse_error() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
@@ -787,6 +804,38 @@ fn fs_error_infinite_symlink_exapansion() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "fs_error_infinite_symlink_expansion",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn fs_error_read_only() {
+    let mut fs = MemoryFileSystem::new_read_only();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("test.js");
+    fs.insert(file_path.into(), *b"content");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("check"),
+            OsString::from("--apply"),
+            file_path.as_os_str().into(),
+        ]),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    // Do not store the content of the file in the snapshot
+    fs.remove(file_path);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "fs_error_read_only",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -1159,6 +1159,38 @@ fn does_not_format_ignored_directories() {
 }
 
 #[test]
+fn fs_error_read_only() {
+    let mut fs = MemoryFileSystem::new_read_only();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("test.js");
+    fs.insert(file_path.into(), *b"content");
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![
+            OsString::from("format"),
+            OsString::from("--write"),
+            file_path.as_os_str().into(),
+        ]),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    // Do not store the content of the file in the snapshot
+    fs.remove(file_path);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "fs_error_read_only",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn file_too_large() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_read_only.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_read_only.snap
@@ -1,0 +1,30 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 334
+expression: content
+---
+# Termination Message
+
+```block
+no files were processed in the specified paths.
+```
+
+# Emitted Messages
+
+```block
+test.js internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × cannot acquire write access to file in read-only filesystem
+  
+
+```
+
+```block
+Fixed 0 file(s) in <TIME>
+```
+
+```block
+Skipped 1 file(s)
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/fs_error_read_only.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/fs_error_read_only.snap
@@ -1,0 +1,30 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+assertion_line: 334
+expression: content
+---
+# Termination Message
+
+```block
+no files were processed in the specified paths.
+```
+
+# Emitted Messages
+
+```block
+test.js internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × cannot acquire write access to file in read-only filesystem
+  
+
+```
+
+```block
+Formatted 0 file(s) in <TIME>
+```
+
+```block
+Skipped 1 file(s)
+```
+
+

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -177,7 +177,7 @@ pub fn load_config(
         "Attempting to load the configuration file at path {:?}",
         configuration_path
     );
-    let options = OpenOptions::default().read(true).write(true);
+    let options = OpenOptions::default().read(true);
     let file = file_system.open_with_options(&configuration_path, options);
     match file {
         Ok(mut file) => {


### PR DESCRIPTION
Fixes an issue where Rome could not process files on read-only file systems during traversal, where write access to the file system was not required.

This is required to execute Rome in isolated environments (sandboxes).

Example -  Error message when running the check command on a read-only file system

```sh
$ rome check .
```

```
/test.js internalError/io ━━━━━━━━━━

  × Read-only file system (os error 30)
  

Checked 0 file(s) in 939µs
Skipped 1 file(s)
Rome encountered an unexpected error

This is a bug in Rome, not an error in your code, and we would appreciate it if you could report it to https://github.com/rome/tools/issues/ along with the following information to help us fixing the issue:

Source Location: crates/rome_cli/src/traversal.rs:210:8
Thread Name: main
Message: attempt to subtract with overflow
```

References

- Unix: os error 30 (EROFS) ([Documentation](https://man7.org/linux/man-pages/man3/errno.3.html))