### PR TITLE
fix(rome_cli): fix small CLI and test issues

### DIFF
--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -207,7 +207,7 @@ pub(crate) fn traverse(execution: Execution, mut session: CliSession) -> Result<
     }
 
     // Processing emitted error diagnostics, exit with a non-zero code
-    if (count - skipped) == 0 {
+    if count.saturating_sub(skipped) == 0 {
         Err(Termination::NoFilesWereProcessed)
     } else if errors > 0 {
         Err(Termination::CheckError)

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -1142,3 +1142,31 @@ fn print_verbose() {
         result,
     ));
 }
+
+#[test]
+fn unsupported_file() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("check.txt");
+    fs.insert(file_path.into(), LINT_ERROR.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        DynRef::Borrowed(&mut console),
+        Arguments::from_vec(vec![OsString::from("check"), file_path.as_os_str().into()]),
+    );
+
+    match result {
+        Err(Termination::NoFilesWereProcessed) => {}
+        _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "unsupported_file",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_dereferenced_symlink_unix.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_dereferenced_symlink_unix.snap
@@ -20,4 +20,8 @@ no files were processed in the specified paths.
 
 ```
 
+```block
+Checked 0 file(s) in <TIME>
+```
+
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_dereferenced_symlink_unix.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_dereferenced_symlink_unix.snap
@@ -11,11 +11,11 @@ no files were processed in the specified paths.
 # Emitted Messages
 
 ```block
-/tmp/rome_test_broken_symlink/broken_symlink internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<TEMP_DIR>/rome_test_broken_symlink/broken_symlink internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Dereferenced symlink
   
-  i Rome encountered a file system entry that is a broken symbolic link: /tmp/rome_test_broken_symlink/broken_symlink
+  i Rome encountered a file system entry that is a broken symbolic link: <TEMP_DIR>/rome_test_broken_symlink/broken_symlink
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_infinite_symlink_exapansion_unix.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_infinite_symlink_exapansion_unix.snap
@@ -11,21 +11,21 @@ no files were processed in the specified paths.
 # Emitted Messages
 
 ```block
-/tmp/rome_test_infinite_symlink_exapansion/prefix internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<TEMP_DIR>/rome_test_infinite_symlink_exapansion/prefix internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Infinite symlink expansion
   
-  × Rome encountered a file system entry that leads to an infinite symbolic link expansion, causing an infinite cycle: /tmp/rome_test_infinite_symlink_exapansion/prefix
+  × Rome encountered a file system entry that leads to an infinite symbolic link expansion, causing an infinite cycle: <TEMP_DIR>/rome_test_infinite_symlink_exapansion/prefix
   
 
 ```
 
 ```block
-/tmp/rome_test_infinite_symlink_exapansion/prefix internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<TEMP_DIR>/rome_test_infinite_symlink_exapansion/prefix internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Infinite symlink expansion
   
-  × Rome encountered a file system entry that leads to an infinite symbolic link expansion, causing an infinite cycle: /tmp/rome_test_infinite_symlink_exapansion/prefix
+  × Rome encountered a file system entry that leads to an infinite symbolic link expansion, causing an infinite cycle: <TEMP_DIR>/rome_test_infinite_symlink_exapansion/prefix
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_infinite_symlink_exapansion_unix.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/fs_error_infinite_symlink_exapansion_unix.snap
@@ -30,4 +30,8 @@ no files were processed in the specified paths.
 
 ```
 
+```block
+Checked 0 file(s) in <TIME>
+```
+
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/unsupported_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/unsupported_file.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `check.txt`
+
+```txt
+for(;true;);
+
+```
+
+# Termination Message
+
+```block
+no files were processed in the specified paths.
+```
+
+# Emitted Messages
+
+```block
+Checked 0 file(s) in <TIME>
+```
+
+


### PR DESCRIPTION
## Summary

I grouped two very small fixes to the CLI into this since I didn't want to open a PR for each of these:
- The first change is to use checked arithmetic when calculating the number of processed files. The CLI checks that at least one file was processed by subtracting the number of skipped files from the total number of files that were read, however in case a file fails to be read from the disk it will increment the skipped counter but not the total counter, making the subtraction panic in debug builds and to an integer underflow on release builds.
- The second change is an update to the Unix-specific snapshots of the CLI that were missed when I merged #3835, since I ran the snapshot update on Windows but not on Unix.

## Test Plan

I've added a new test case for the first change, and the second one is specifically about fixing tests anyway.
