### PR TITLE
feat(rome_json_formatter): Setup JSON Formatter crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rome_json_formatter"
+version = "0.1.0"
+dependencies = [
+ "insta",
+ "rome_diagnostics",
+ "rome_formatter",
+ "rome_json_parser",
+ "rome_json_syntax",
+ "rome_rowan",
+]
+
+[[package]]
 name = "rome_json_parser"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "rome_json_formatter"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "insta",
  "rome_diagnostics",

--- a/crates/rome_formatter/shared_traits.rs
+++ b/crates/rome_formatter/shared_traits.rs
@@ -1,0 +1,141 @@
+// Code that must be included in every language specific formatter crate. Redefining these types
+// in every formatter crate is necessary because of Rust's orphan rule that prohibits implementing
+// unowned traits (traits defined in this file) on unowned types (node types)
+
+/// Used to get an object that knows how to format this object.
+pub(crate) trait AsFormat<Context> {
+    type Format<'a>: rome_formatter::Format<Context>
+    where
+        Self: 'a;
+
+    /// Returns an object that is able to format this object.
+    fn format(&self) -> Self::Format<'_>;
+}
+
+/// Implement [AsFormat] for references to types that implement [AsFormat].
+impl<T, C> AsFormat<C> for &T
+where
+    T: AsFormat<C>,
+{
+    type Format<'a> = T::Format<'a> where Self: 'a;
+
+    fn format(&self) -> Self::Format<'_> {
+        AsFormat::format(&**self)
+    }
+}
+
+/// Implement [AsFormat] for [SyntaxResult] where `T` implements [AsFormat].
+///
+/// Useful to format mandatory AST fields without having to unwrap the value first.
+impl<T, C> AsFormat<C> for rome_rowan::SyntaxResult<T>
+where
+    T: AsFormat<C>,
+{
+    type Format<'a> = rome_rowan::SyntaxResult<T::Format<'a>> where Self: 'a;
+
+    fn format(&self) -> Self::Format<'_> {
+        match self {
+            Ok(value) => Ok(value.format()),
+            Err(err) => Err(*err),
+        }
+    }
+}
+
+/// Implement [AsFormat] for [Option] when `T` implements [AsFormat]
+///
+/// Allows to call format on optional AST fields without having to unwrap the field first.
+impl<T, C> AsFormat<C> for Option<T>
+where
+    T: AsFormat<C>,
+{
+    type Format<'a> = Option<T::Format<'a>> where Self: 'a;
+
+    fn format(&self) -> Self::Format<'_> {
+        self.as_ref().map(|value| value.format())
+    }
+}
+
+/// Used to convert this object into an object that can be formatted.
+///
+/// The difference to [AsFormat] is that this trait takes ownership of `self`.
+pub(crate) trait IntoFormat<Context> {
+    type Format: rome_formatter::Format<Context>;
+
+    fn into_format(self) -> Self::Format;
+}
+
+impl<T, Context> IntoFormat<Context> for rome_rowan::SyntaxResult<T>
+where
+    T: IntoFormat<Context>,
+{
+    type Format = rome_rowan::SyntaxResult<T::Format>;
+
+    fn into_format(self) -> Self::Format {
+        self.map(IntoFormat::into_format)
+    }
+}
+
+/// Implement [IntoFormat] for [Option] when `T` implements [IntoFormat]
+///
+/// Allows to call format on optional AST fields without having to unwrap the field first.
+impl<T, Context> IntoFormat<Context> for Option<T>
+where
+    T: IntoFormat<Context>,
+{
+    type Format = Option<T::Format>;
+
+    fn into_format(self) -> Self::Format {
+        self.map(IntoFormat::into_format)
+    }
+}
+
+/// Formatting specific [Iterator] extensions
+pub(crate) trait FormattedIterExt {
+    /// Converts every item to an object that knows how to format it.
+    fn formatted<Context>(self) -> FormattedIter<Self, Self::Item, Context>
+    where
+        Self: Iterator + Sized,
+        Self::Item: IntoFormat<Context>,
+    {
+        FormattedIter {
+            inner: self,
+            options: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<I> FormattedIterExt for I where I: std::iter::Iterator {}
+
+pub(crate) struct FormattedIter<Iter, Item, Context>
+where
+    Iter: Iterator<Item = Item>,
+{
+    inner: Iter,
+    options: std::marker::PhantomData<Context>,
+}
+
+impl<Iter, Item, Context> std::iter::Iterator for FormattedIter<Iter, Item, Context>
+where
+    Iter: Iterator<Item = Item>,
+    Item: IntoFormat<Context>,
+{
+    type Item = Item::Format;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.inner.next()?.into_format())
+    }
+}
+
+impl<Iter, Item, Context> std::iter::FusedIterator for FormattedIter<Iter, Item, Context>
+where
+    Iter: std::iter::FusedIterator<Item = Item>,
+    Item: IntoFormat<Context>,
+{
+}
+
+impl<Iter, Item, Context> std::iter::ExactSizeIterator for FormattedIter<Iter, Item, Context>
+where
+    Iter: Iterator<Item = Item> + std::iter::ExactSizeIterator,
+    Item: IntoFormat<Context>,
+{
+}

--- a/crates/rome_formatter/src/printer/printer_options/mod.rs
+++ b/crates/rome_formatter/src/printer/printer_options/mod.rs
@@ -1,4 +1,4 @@
-use crate::{IndentStyle, LineWidth};
+use crate::{FormatOptions, IndentStyle, LineWidth};
 
 /// Options that affect how the [crate::Printer] prints the format tokens
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -40,6 +40,17 @@ impl From<LineWidth> for PrintWidth {
 impl From<PrintWidth> for usize {
     fn from(width: PrintWidth) -> Self {
         width.0 as usize
+    }
+}
+
+impl<'a, O> From<&'a O> for PrinterOptions
+where
+    O: FormatOptions,
+{
+    fn from(options: &'a O) -> Self {
+        PrinterOptions::default()
+            .with_indent(options.indent_style())
+            .with_print_width(options.line_width().into())
     }
 }
 

--- a/crates/rome_js_formatter/src/builders.rs
+++ b/crates/rome_js_formatter/src/builders.rs
@@ -5,9 +5,9 @@ use rome_rowan::AstNode;
 
 /// Formats a node using its [`AsFormat`] implementation but falls back to printing the node as
 /// it is in the source document if the formatting returns an [`FormatError`].
-pub const fn format_or_verbatim<Node>(node: &Node) -> FormatNodeOrVerbatim<Node>
+pub(crate) const fn format_or_verbatim<Node>(node: &Node) -> FormatNodeOrVerbatim<Node>
 where
-    Node: AstNode<Language = JsLanguage> + AsFormat,
+    Node: AstNode<Language = JsLanguage> + AsFormat<JsFormatContext>,
 {
     FormatNodeOrVerbatim { node }
 }
@@ -20,7 +20,7 @@ pub struct FormatNodeOrVerbatim<'a, Node> {
 
 impl<'a, Node> Format<JsFormatContext> for FormatNodeOrVerbatim<'a, Node>
 where
-    Node: AstNode<Language = JsLanguage> + AsFormat,
+    Node: AstNode<Language = JsLanguage> + AsFormat<JsFormatContext>,
 {
     fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
         let snapshot = Formatter::state_snapshot(f);

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -233,9 +233,7 @@ impl FormatOptions for JsFormatOptions {
     }
 
     fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::default()
-            .with_indent(self.indent_style)
-            .with_print_width(self.line_width.into())
+        PrinterOptions::from(self)
     }
 }
 

--- a/crates/rome_js_formatter/src/cst.rs
+++ b/crates/rome_js_formatter/src/cst.rs
@@ -15,7 +15,7 @@ impl rome_formatter::FormatRule<JsSyntaxNode> for FormatJsSyntaxNode {
     }
 }
 
-impl AsFormat for JsSyntaxNode {
+impl AsFormat<JsFormatContext> for JsSyntaxNode {
     type Format<'a> = FormatRefWithRule<'a, JsSyntaxNode, FormatJsSyntaxNode>;
 
     fn format(&self) -> Self::Format<'_> {

--- a/crates/rome_js_formatter/src/generated.rs
+++ b/crates/rome_js_formatter/src/generated.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::{
     AsFormat, FormatNodeRule, FormatUnknownNodeRule, IntoFormat, JsFormatContext, JsFormatter,
@@ -11,7 +11,7 @@ impl FormatRule<rome_js_syntax::JsScript> for crate::js::auxiliary::script::Form
         FormatNodeRule::<rome_js_syntax::JsScript>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsScript {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsScript {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsScript,
@@ -24,7 +24,7 @@ impl AsFormat for rome_js_syntax::JsScript {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsScript {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsScript {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsScript, crate::js::auxiliary::script::FormatJsScript>;
     fn into_format(self) -> Self::Format {
@@ -41,7 +41,7 @@ impl FormatRule<rome_js_syntax::JsModule> for crate::js::auxiliary::module::Form
         FormatNodeRule::<rome_js_syntax::JsModule>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsModule {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsModule {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsModule,
@@ -54,7 +54,7 @@ impl AsFormat for rome_js_syntax::JsModule {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsModule {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsModule {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsModule, crate::js::auxiliary::module::FormatJsModule>;
     fn into_format(self) -> Self::Format {
@@ -77,7 +77,7 @@ impl FormatRule<rome_js_syntax::JsExpressionSnipped>
         FormatNodeRule::<rome_js_syntax::JsExpressionSnipped>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExpressionSnipped {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExpressionSnipped {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExpressionSnipped,
@@ -90,7 +90,7 @@ impl AsFormat for rome_js_syntax::JsExpressionSnipped {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExpressionSnipped {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExpressionSnipped {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExpressionSnipped,
         crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped,
@@ -111,7 +111,7 @@ impl FormatRule<rome_js_syntax::JsDirective>
         FormatNodeRule::<rome_js_syntax::JsDirective>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsDirective {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsDirective {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsDirective,
@@ -124,7 +124,7 @@ impl AsFormat for rome_js_syntax::JsDirective {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsDirective {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsDirective {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsDirective,
         crate::js::auxiliary::directive::FormatJsDirective,
@@ -149,7 +149,7 @@ impl FormatRule<rome_js_syntax::JsBlockStatement>
         FormatNodeRule::<rome_js_syntax::JsBlockStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsBlockStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsBlockStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsBlockStatement,
@@ -162,7 +162,7 @@ impl AsFormat for rome_js_syntax::JsBlockStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsBlockStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsBlockStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsBlockStatement,
         crate::js::statements::block_statement::FormatJsBlockStatement,
@@ -187,7 +187,7 @@ impl FormatRule<rome_js_syntax::JsBreakStatement>
         FormatNodeRule::<rome_js_syntax::JsBreakStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsBreakStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsBreakStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsBreakStatement,
@@ -200,7 +200,7 @@ impl AsFormat for rome_js_syntax::JsBreakStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsBreakStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsBreakStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsBreakStatement,
         crate::js::statements::break_statement::FormatJsBreakStatement,
@@ -225,7 +225,7 @@ impl FormatRule<rome_js_syntax::JsClassDeclaration>
         FormatNodeRule::<rome_js_syntax::JsClassDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsClassDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsClassDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsClassDeclaration,
@@ -238,7 +238,7 @@ impl AsFormat for rome_js_syntax::JsClassDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsClassDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsClassDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsClassDeclaration,
         crate::js::declarations::class_declaration::FormatJsClassDeclaration,
@@ -263,7 +263,7 @@ impl FormatRule<rome_js_syntax::JsContinueStatement>
         FormatNodeRule::<rome_js_syntax::JsContinueStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsContinueStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsContinueStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsContinueStatement,
@@ -276,7 +276,7 @@ impl AsFormat for rome_js_syntax::JsContinueStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsContinueStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsContinueStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsContinueStatement,
         crate::js::statements::continue_statement::FormatJsContinueStatement,
@@ -301,7 +301,7 @@ impl FormatRule<rome_js_syntax::JsDebuggerStatement>
         FormatNodeRule::<rome_js_syntax::JsDebuggerStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsDebuggerStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsDebuggerStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsDebuggerStatement,
@@ -314,7 +314,7 @@ impl AsFormat for rome_js_syntax::JsDebuggerStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsDebuggerStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsDebuggerStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsDebuggerStatement,
         crate::js::statements::debugger_statement::FormatJsDebuggerStatement,
@@ -339,7 +339,7 @@ impl FormatRule<rome_js_syntax::JsDoWhileStatement>
         FormatNodeRule::<rome_js_syntax::JsDoWhileStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsDoWhileStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsDoWhileStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsDoWhileStatement,
@@ -352,7 +352,7 @@ impl AsFormat for rome_js_syntax::JsDoWhileStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsDoWhileStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsDoWhileStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsDoWhileStatement,
         crate::js::statements::do_while_statement::FormatJsDoWhileStatement,
@@ -377,7 +377,7 @@ impl FormatRule<rome_js_syntax::JsEmptyStatement>
         FormatNodeRule::<rome_js_syntax::JsEmptyStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsEmptyStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsEmptyStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsEmptyStatement,
@@ -390,7 +390,7 @@ impl AsFormat for rome_js_syntax::JsEmptyStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsEmptyStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsEmptyStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsEmptyStatement,
         crate::js::statements::empty_statement::FormatJsEmptyStatement,
@@ -415,7 +415,7 @@ impl FormatRule<rome_js_syntax::JsExpressionStatement>
         FormatNodeRule::<rome_js_syntax::JsExpressionStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExpressionStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExpressionStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExpressionStatement,
@@ -428,7 +428,7 @@ impl AsFormat for rome_js_syntax::JsExpressionStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExpressionStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExpressionStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExpressionStatement,
         crate::js::statements::expression_statement::FormatJsExpressionStatement,
@@ -453,7 +453,7 @@ impl FormatRule<rome_js_syntax::JsForInStatement>
         FormatNodeRule::<rome_js_syntax::JsForInStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsForInStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsForInStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsForInStatement,
@@ -466,7 +466,7 @@ impl AsFormat for rome_js_syntax::JsForInStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsForInStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsForInStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsForInStatement,
         crate::js::statements::for_in_statement::FormatJsForInStatement,
@@ -491,7 +491,7 @@ impl FormatRule<rome_js_syntax::JsForOfStatement>
         FormatNodeRule::<rome_js_syntax::JsForOfStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsForOfStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsForOfStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsForOfStatement,
@@ -504,7 +504,7 @@ impl AsFormat for rome_js_syntax::JsForOfStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsForOfStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsForOfStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsForOfStatement,
         crate::js::statements::for_of_statement::FormatJsForOfStatement,
@@ -525,7 +525,7 @@ impl FormatRule<rome_js_syntax::JsForStatement>
         FormatNodeRule::<rome_js_syntax::JsForStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsForStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsForStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsForStatement,
@@ -538,7 +538,7 @@ impl AsFormat for rome_js_syntax::JsForStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsForStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsForStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsForStatement,
         crate::js::statements::for_statement::FormatJsForStatement,
@@ -559,7 +559,7 @@ impl FormatRule<rome_js_syntax::JsIfStatement>
         FormatNodeRule::<rome_js_syntax::JsIfStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsIfStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsIfStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsIfStatement,
@@ -572,7 +572,7 @@ impl AsFormat for rome_js_syntax::JsIfStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsIfStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsIfStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsIfStatement,
         crate::js::statements::if_statement::FormatJsIfStatement,
@@ -597,7 +597,7 @@ impl FormatRule<rome_js_syntax::JsLabeledStatement>
         FormatNodeRule::<rome_js_syntax::JsLabeledStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsLabeledStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsLabeledStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsLabeledStatement,
@@ -610,7 +610,7 @@ impl AsFormat for rome_js_syntax::JsLabeledStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsLabeledStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsLabeledStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsLabeledStatement,
         crate::js::statements::labeled_statement::FormatJsLabeledStatement,
@@ -635,7 +635,7 @@ impl FormatRule<rome_js_syntax::JsReturnStatement>
         FormatNodeRule::<rome_js_syntax::JsReturnStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsReturnStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsReturnStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsReturnStatement,
@@ -648,7 +648,7 @@ impl AsFormat for rome_js_syntax::JsReturnStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsReturnStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsReturnStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsReturnStatement,
         crate::js::statements::return_statement::FormatJsReturnStatement,
@@ -673,7 +673,7 @@ impl FormatRule<rome_js_syntax::JsSwitchStatement>
         FormatNodeRule::<rome_js_syntax::JsSwitchStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsSwitchStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsSwitchStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsSwitchStatement,
@@ -686,7 +686,7 @@ impl AsFormat for rome_js_syntax::JsSwitchStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSwitchStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsSwitchStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsSwitchStatement,
         crate::js::statements::switch_statement::FormatJsSwitchStatement,
@@ -711,7 +711,7 @@ impl FormatRule<rome_js_syntax::JsThrowStatement>
         FormatNodeRule::<rome_js_syntax::JsThrowStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsThrowStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsThrowStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsThrowStatement,
@@ -724,7 +724,7 @@ impl AsFormat for rome_js_syntax::JsThrowStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsThrowStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsThrowStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsThrowStatement,
         crate::js::statements::throw_statement::FormatJsThrowStatement,
@@ -749,7 +749,7 @@ impl FormatRule<rome_js_syntax::JsTryFinallyStatement>
         FormatNodeRule::<rome_js_syntax::JsTryFinallyStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsTryFinallyStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsTryFinallyStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsTryFinallyStatement,
@@ -762,7 +762,7 @@ impl AsFormat for rome_js_syntax::JsTryFinallyStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsTryFinallyStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsTryFinallyStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsTryFinallyStatement,
         crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement,
@@ -783,7 +783,7 @@ impl FormatRule<rome_js_syntax::JsTryStatement>
         FormatNodeRule::<rome_js_syntax::JsTryStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsTryStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsTryStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsTryStatement,
@@ -796,7 +796,7 @@ impl AsFormat for rome_js_syntax::JsTryStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsTryStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsTryStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsTryStatement,
         crate::js::statements::try_statement::FormatJsTryStatement,
@@ -821,7 +821,7 @@ impl FormatRule<rome_js_syntax::JsVariableStatement>
         FormatNodeRule::<rome_js_syntax::JsVariableStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsVariableStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsVariableStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsVariableStatement,
@@ -834,7 +834,7 @@ impl AsFormat for rome_js_syntax::JsVariableStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsVariableStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsVariableStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsVariableStatement,
         crate::js::statements::variable_statement::FormatJsVariableStatement,
@@ -859,7 +859,7 @@ impl FormatRule<rome_js_syntax::JsWhileStatement>
         FormatNodeRule::<rome_js_syntax::JsWhileStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsWhileStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsWhileStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsWhileStatement,
@@ -872,7 +872,7 @@ impl AsFormat for rome_js_syntax::JsWhileStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsWhileStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsWhileStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsWhileStatement,
         crate::js::statements::while_statement::FormatJsWhileStatement,
@@ -893,7 +893,7 @@ impl FormatRule<rome_js_syntax::JsWithStatement>
         FormatNodeRule::<rome_js_syntax::JsWithStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsWithStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsWithStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsWithStatement,
@@ -906,7 +906,7 @@ impl AsFormat for rome_js_syntax::JsWithStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsWithStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsWithStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsWithStatement,
         crate::js::statements::with_statement::FormatJsWithStatement,
@@ -931,7 +931,7 @@ impl FormatRule<rome_js_syntax::JsFunctionDeclaration>
         FormatNodeRule::<rome_js_syntax::JsFunctionDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsFunctionDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsFunctionDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsFunctionDeclaration,
@@ -944,7 +944,7 @@ impl AsFormat for rome_js_syntax::JsFunctionDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsFunctionDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsFunctionDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsFunctionDeclaration,
         crate::js::declarations::function_declaration::FormatJsFunctionDeclaration,
@@ -969,7 +969,7 @@ impl FormatRule<rome_js_syntax::TsEnumDeclaration>
         FormatNodeRule::<rome_js_syntax::TsEnumDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsEnumDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsEnumDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsEnumDeclaration,
@@ -982,7 +982,7 @@ impl AsFormat for rome_js_syntax::TsEnumDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsEnumDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsEnumDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsEnumDeclaration,
         crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration,
@@ -1007,7 +1007,7 @@ impl FormatRule<rome_js_syntax::TsTypeAliasDeclaration>
         FormatNodeRule::<rome_js_syntax::TsTypeAliasDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeAliasDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeAliasDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeAliasDeclaration,
@@ -1021,7 +1021,7 @@ impl AsFormat for rome_js_syntax::TsTypeAliasDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeAliasDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeAliasDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeAliasDeclaration,
         crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration,
@@ -1047,7 +1047,7 @@ impl FormatRule<rome_js_syntax::TsInterfaceDeclaration>
         FormatNodeRule::<rome_js_syntax::TsInterfaceDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsInterfaceDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsInterfaceDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsInterfaceDeclaration,
@@ -1060,7 +1060,7 @@ impl AsFormat for rome_js_syntax::TsInterfaceDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsInterfaceDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsInterfaceDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsInterfaceDeclaration,
         crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration,
@@ -1085,7 +1085,7 @@ impl FormatRule<rome_js_syntax::TsDeclareFunctionDeclaration>
         FormatNodeRule::<rome_js_syntax::TsDeclareFunctionDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsDeclareFunctionDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsDeclareFunctionDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsDeclareFunctionDeclaration,
@@ -1095,7 +1095,7 @@ impl AsFormat for rome_js_syntax::TsDeclareFunctionDeclaration {
         FormatRefWithRule :: new (self , crate :: ts :: declarations :: declare_function_declaration :: FormatTsDeclareFunctionDeclaration :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsDeclareFunctionDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsDeclareFunctionDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsDeclareFunctionDeclaration,
         crate::ts::declarations::declare_function_declaration::FormatTsDeclareFunctionDeclaration,
@@ -1117,7 +1117,7 @@ impl FormatRule<rome_js_syntax::TsDeclareStatement>
         FormatNodeRule::<rome_js_syntax::TsDeclareStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsDeclareStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsDeclareStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsDeclareStatement,
@@ -1130,7 +1130,7 @@ impl AsFormat for rome_js_syntax::TsDeclareStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsDeclareStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsDeclareStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsDeclareStatement,
         crate::ts::statements::declare_statement::FormatTsDeclareStatement,
@@ -1155,7 +1155,7 @@ impl FormatRule<rome_js_syntax::TsModuleDeclaration>
         FormatNodeRule::<rome_js_syntax::TsModuleDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsModuleDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsModuleDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsModuleDeclaration,
@@ -1168,7 +1168,7 @@ impl AsFormat for rome_js_syntax::TsModuleDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsModuleDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsModuleDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsModuleDeclaration,
         crate::ts::declarations::module_declaration::FormatTsModuleDeclaration,
@@ -1193,7 +1193,7 @@ impl FormatRule<rome_js_syntax::TsExternalModuleDeclaration>
         FormatNodeRule::<rome_js_syntax::TsExternalModuleDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsExternalModuleDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsExternalModuleDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsExternalModuleDeclaration,
@@ -1203,7 +1203,7 @@ impl AsFormat for rome_js_syntax::TsExternalModuleDeclaration {
         FormatRefWithRule :: new (self , crate :: ts :: declarations :: external_module_declaration :: FormatTsExternalModuleDeclaration :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsExternalModuleDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsExternalModuleDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsExternalModuleDeclaration,
         crate::ts::declarations::external_module_declaration::FormatTsExternalModuleDeclaration,
@@ -1225,7 +1225,7 @@ impl FormatRule<rome_js_syntax::TsGlobalDeclaration>
         FormatNodeRule::<rome_js_syntax::TsGlobalDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsGlobalDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsGlobalDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsGlobalDeclaration,
@@ -1238,7 +1238,7 @@ impl AsFormat for rome_js_syntax::TsGlobalDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsGlobalDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsGlobalDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsGlobalDeclaration,
         crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration,
@@ -1263,7 +1263,7 @@ impl FormatRule<rome_js_syntax::TsImportEqualsDeclaration>
         FormatNodeRule::<rome_js_syntax::TsImportEqualsDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsImportEqualsDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsImportEqualsDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsImportEqualsDeclaration,
@@ -1273,7 +1273,7 @@ impl AsFormat for rome_js_syntax::TsImportEqualsDeclaration {
         FormatRefWithRule :: new (self , crate :: ts :: declarations :: import_equals_declaration :: FormatTsImportEqualsDeclaration :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsImportEqualsDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsImportEqualsDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsImportEqualsDeclaration,
         crate::ts::declarations::import_equals_declaration::FormatTsImportEqualsDeclaration,
@@ -1291,7 +1291,7 @@ impl FormatRule<rome_js_syntax::JsElseClause>
         FormatNodeRule::<rome_js_syntax::JsElseClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsElseClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsElseClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsElseClause,
@@ -1304,7 +1304,7 @@ impl AsFormat for rome_js_syntax::JsElseClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsElseClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsElseClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsElseClause,
         crate::js::auxiliary::else_clause::FormatJsElseClause,
@@ -1329,7 +1329,7 @@ impl FormatRule<rome_js_syntax::JsVariableDeclaration>
         FormatNodeRule::<rome_js_syntax::JsVariableDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsVariableDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsVariableDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsVariableDeclaration,
@@ -1342,7 +1342,7 @@ impl AsFormat for rome_js_syntax::JsVariableDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsVariableDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsVariableDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsVariableDeclaration,
         crate::js::declarations::variable_declaration::FormatJsVariableDeclaration,
@@ -1367,7 +1367,7 @@ impl FormatRule<rome_js_syntax::JsForVariableDeclaration>
         FormatNodeRule::<rome_js_syntax::JsForVariableDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsForVariableDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsForVariableDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsForVariableDeclaration,
@@ -1377,7 +1377,7 @@ impl AsFormat for rome_js_syntax::JsForVariableDeclaration {
         FormatRefWithRule :: new (self , crate :: js :: declarations :: for_variable_declaration :: FormatJsForVariableDeclaration :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsForVariableDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsForVariableDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsForVariableDeclaration,
         crate::js::declarations::for_variable_declaration::FormatJsForVariableDeclaration,
@@ -1399,7 +1399,7 @@ impl FormatRule<rome_js_syntax::JsVariableDeclarator>
         FormatNodeRule::<rome_js_syntax::JsVariableDeclarator>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsVariableDeclarator {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsVariableDeclarator {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsVariableDeclarator,
@@ -1412,7 +1412,7 @@ impl AsFormat for rome_js_syntax::JsVariableDeclarator {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsVariableDeclarator {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsVariableDeclarator {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsVariableDeclarator,
         crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator,
@@ -1433,7 +1433,7 @@ impl FormatRule<rome_js_syntax::JsCaseClause>
         FormatNodeRule::<rome_js_syntax::JsCaseClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsCaseClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsCaseClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsCaseClause,
@@ -1446,7 +1446,7 @@ impl AsFormat for rome_js_syntax::JsCaseClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsCaseClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsCaseClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsCaseClause,
         crate::js::auxiliary::case_clause::FormatJsCaseClause,
@@ -1467,7 +1467,7 @@ impl FormatRule<rome_js_syntax::JsDefaultClause>
         FormatNodeRule::<rome_js_syntax::JsDefaultClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsDefaultClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsDefaultClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsDefaultClause,
@@ -1480,7 +1480,7 @@ impl AsFormat for rome_js_syntax::JsDefaultClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsDefaultClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsDefaultClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsDefaultClause,
         crate::js::auxiliary::default_clause::FormatJsDefaultClause,
@@ -1501,7 +1501,7 @@ impl FormatRule<rome_js_syntax::JsCatchClause>
         FormatNodeRule::<rome_js_syntax::JsCatchClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsCatchClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsCatchClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsCatchClause,
@@ -1514,7 +1514,7 @@ impl AsFormat for rome_js_syntax::JsCatchClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsCatchClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsCatchClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsCatchClause,
         crate::js::auxiliary::catch_clause::FormatJsCatchClause,
@@ -1535,7 +1535,7 @@ impl FormatRule<rome_js_syntax::JsFinallyClause>
         FormatNodeRule::<rome_js_syntax::JsFinallyClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsFinallyClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsFinallyClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsFinallyClause,
@@ -1548,7 +1548,7 @@ impl AsFormat for rome_js_syntax::JsFinallyClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsFinallyClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsFinallyClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsFinallyClause,
         crate::js::auxiliary::finally_clause::FormatJsFinallyClause,
@@ -1573,7 +1573,7 @@ impl FormatRule<rome_js_syntax::JsCatchDeclaration>
         FormatNodeRule::<rome_js_syntax::JsCatchDeclaration>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsCatchDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsCatchDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsCatchDeclaration,
@@ -1586,7 +1586,7 @@ impl AsFormat for rome_js_syntax::JsCatchDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsCatchDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsCatchDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsCatchDeclaration,
         crate::js::declarations::catch_declaration::FormatJsCatchDeclaration,
@@ -1611,7 +1611,7 @@ impl FormatRule<rome_js_syntax::TsTypeAnnotation>
         FormatNodeRule::<rome_js_syntax::TsTypeAnnotation>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeAnnotation {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeAnnotation {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeAnnotation,
@@ -1624,7 +1624,7 @@ impl AsFormat for rome_js_syntax::TsTypeAnnotation {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeAnnotation {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeAnnotation {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeAnnotation,
         crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation,
@@ -1643,7 +1643,7 @@ impl FormatRule<rome_js_syntax::ImportMeta> for crate::js::module::import_meta::
         FormatNodeRule::<rome_js_syntax::ImportMeta>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::ImportMeta {
+impl AsFormat<JsFormatContext> for rome_js_syntax::ImportMeta {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::ImportMeta,
@@ -1656,7 +1656,7 @@ impl AsFormat for rome_js_syntax::ImportMeta {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::ImportMeta {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::ImportMeta {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::ImportMeta,
         crate::js::module::import_meta::FormatImportMeta,
@@ -1681,7 +1681,7 @@ impl FormatRule<rome_js_syntax::JsArrayExpression>
         FormatNodeRule::<rome_js_syntax::JsArrayExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsArrayExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrayExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsArrayExpression,
@@ -1694,7 +1694,7 @@ impl AsFormat for rome_js_syntax::JsArrayExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrayExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsArrayExpression,
         crate::js::expressions::array_expression::FormatJsArrayExpression,
@@ -1719,7 +1719,7 @@ impl FormatRule<rome_js_syntax::JsArrowFunctionExpression>
         FormatNodeRule::<rome_js_syntax::JsArrowFunctionExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsArrowFunctionExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrowFunctionExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsArrowFunctionExpression,
@@ -1729,7 +1729,7 @@ impl AsFormat for rome_js_syntax::JsArrowFunctionExpression {
         FormatRefWithRule :: new (self , crate :: js :: expressions :: arrow_function_expression :: FormatJsArrowFunctionExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrowFunctionExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrowFunctionExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsArrowFunctionExpression,
         crate::js::expressions::arrow_function_expression::FormatJsArrowFunctionExpression,
@@ -1751,7 +1751,7 @@ impl FormatRule<rome_js_syntax::JsAssignmentExpression>
         FormatNodeRule::<rome_js_syntax::JsAssignmentExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsAssignmentExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAssignmentExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAssignmentExpression,
@@ -1764,7 +1764,7 @@ impl AsFormat for rome_js_syntax::JsAssignmentExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAssignmentExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAssignmentExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAssignmentExpression,
         crate::js::expressions::assignment_expression::FormatJsAssignmentExpression,
@@ -1789,7 +1789,7 @@ impl FormatRule<rome_js_syntax::JsAwaitExpression>
         FormatNodeRule::<rome_js_syntax::JsAwaitExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsAwaitExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAwaitExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAwaitExpression,
@@ -1802,7 +1802,7 @@ impl AsFormat for rome_js_syntax::JsAwaitExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAwaitExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAwaitExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAwaitExpression,
         crate::js::expressions::await_expression::FormatJsAwaitExpression,
@@ -1827,7 +1827,7 @@ impl FormatRule<rome_js_syntax::JsBinaryExpression>
         FormatNodeRule::<rome_js_syntax::JsBinaryExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsBinaryExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsBinaryExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsBinaryExpression,
@@ -1840,7 +1840,7 @@ impl AsFormat for rome_js_syntax::JsBinaryExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsBinaryExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsBinaryExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsBinaryExpression,
         crate::js::expressions::binary_expression::FormatJsBinaryExpression,
@@ -1865,7 +1865,7 @@ impl FormatRule<rome_js_syntax::JsCallExpression>
         FormatNodeRule::<rome_js_syntax::JsCallExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsCallExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsCallExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsCallExpression,
@@ -1878,7 +1878,7 @@ impl AsFormat for rome_js_syntax::JsCallExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsCallExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsCallExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsCallExpression,
         crate::js::expressions::call_expression::FormatJsCallExpression,
@@ -1903,7 +1903,7 @@ impl FormatRule<rome_js_syntax::JsClassExpression>
         FormatNodeRule::<rome_js_syntax::JsClassExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsClassExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsClassExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsClassExpression,
@@ -1916,7 +1916,7 @@ impl AsFormat for rome_js_syntax::JsClassExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsClassExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsClassExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsClassExpression,
         crate::js::expressions::class_expression::FormatJsClassExpression,
@@ -1941,7 +1941,7 @@ impl FormatRule<rome_js_syntax::JsComputedMemberExpression>
         FormatNodeRule::<rome_js_syntax::JsComputedMemberExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsComputedMemberExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsComputedMemberExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsComputedMemberExpression,
@@ -1951,7 +1951,7 @@ impl AsFormat for rome_js_syntax::JsComputedMemberExpression {
         FormatRefWithRule :: new (self , crate :: js :: expressions :: computed_member_expression :: FormatJsComputedMemberExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsComputedMemberExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsComputedMemberExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsComputedMemberExpression,
         crate::js::expressions::computed_member_expression::FormatJsComputedMemberExpression,
@@ -1973,7 +1973,7 @@ impl FormatRule<rome_js_syntax::JsConditionalExpression>
         FormatNodeRule::<rome_js_syntax::JsConditionalExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsConditionalExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsConditionalExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsConditionalExpression,
@@ -1987,7 +1987,7 @@ impl AsFormat for rome_js_syntax::JsConditionalExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConditionalExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsConditionalExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsConditionalExpression,
         crate::js::expressions::conditional_expression::FormatJsConditionalExpression,
@@ -2013,7 +2013,7 @@ impl FormatRule<rome_js_syntax::JsFunctionExpression>
         FormatNodeRule::<rome_js_syntax::JsFunctionExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsFunctionExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsFunctionExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsFunctionExpression,
@@ -2026,7 +2026,7 @@ impl AsFormat for rome_js_syntax::JsFunctionExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsFunctionExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsFunctionExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsFunctionExpression,
         crate::js::expressions::function_expression::FormatJsFunctionExpression,
@@ -2051,7 +2051,7 @@ impl FormatRule<rome_js_syntax::JsIdentifierExpression>
         FormatNodeRule::<rome_js_syntax::JsIdentifierExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsIdentifierExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsIdentifierExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsIdentifierExpression,
@@ -2064,7 +2064,7 @@ impl AsFormat for rome_js_syntax::JsIdentifierExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsIdentifierExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsIdentifierExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsIdentifierExpression,
         crate::js::expressions::identifier_expression::FormatJsIdentifierExpression,
@@ -2089,7 +2089,7 @@ impl FormatRule<rome_js_syntax::JsImportCallExpression>
         FormatNodeRule::<rome_js_syntax::JsImportCallExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsImportCallExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsImportCallExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsImportCallExpression,
@@ -2102,7 +2102,7 @@ impl AsFormat for rome_js_syntax::JsImportCallExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportCallExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsImportCallExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsImportCallExpression,
         crate::js::expressions::import_call_expression::FormatJsImportCallExpression,
@@ -2123,7 +2123,7 @@ impl FormatRule<rome_js_syntax::JsInExpression>
         FormatNodeRule::<rome_js_syntax::JsInExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsInExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsInExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsInExpression,
@@ -2136,7 +2136,7 @@ impl AsFormat for rome_js_syntax::JsInExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsInExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsInExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsInExpression,
         crate::js::expressions::in_expression::FormatJsInExpression,
@@ -2161,7 +2161,7 @@ impl FormatRule<rome_js_syntax::JsInstanceofExpression>
         FormatNodeRule::<rome_js_syntax::JsInstanceofExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsInstanceofExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsInstanceofExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsInstanceofExpression,
@@ -2174,7 +2174,7 @@ impl AsFormat for rome_js_syntax::JsInstanceofExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsInstanceofExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsInstanceofExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsInstanceofExpression,
         crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression,
@@ -2199,7 +2199,7 @@ impl FormatRule<rome_js_syntax::JsLogicalExpression>
         FormatNodeRule::<rome_js_syntax::JsLogicalExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsLogicalExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsLogicalExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsLogicalExpression,
@@ -2212,7 +2212,7 @@ impl AsFormat for rome_js_syntax::JsLogicalExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsLogicalExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsLogicalExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsLogicalExpression,
         crate::js::expressions::logical_expression::FormatJsLogicalExpression,
@@ -2233,7 +2233,7 @@ impl FormatRule<rome_js_syntax::JsNewExpression>
         FormatNodeRule::<rome_js_syntax::JsNewExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsNewExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsNewExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsNewExpression,
@@ -2246,7 +2246,7 @@ impl AsFormat for rome_js_syntax::JsNewExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsNewExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsNewExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsNewExpression,
         crate::js::expressions::new_expression::FormatJsNewExpression,
@@ -2271,7 +2271,7 @@ impl FormatRule<rome_js_syntax::JsObjectExpression>
         FormatNodeRule::<rome_js_syntax::JsObjectExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsObjectExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsObjectExpression,
@@ -2284,7 +2284,7 @@ impl AsFormat for rome_js_syntax::JsObjectExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsObjectExpression,
         crate::js::expressions::object_expression::FormatJsObjectExpression,
@@ -2309,7 +2309,7 @@ impl FormatRule<rome_js_syntax::JsParenthesizedExpression>
         FormatNodeRule::<rome_js_syntax::JsParenthesizedExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsParenthesizedExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsParenthesizedExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsParenthesizedExpression,
@@ -2319,7 +2319,7 @@ impl AsFormat for rome_js_syntax::JsParenthesizedExpression {
         FormatRefWithRule :: new (self , crate :: js :: expressions :: parenthesized_expression :: FormatJsParenthesizedExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsParenthesizedExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsParenthesizedExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsParenthesizedExpression,
         crate::js::expressions::parenthesized_expression::FormatJsParenthesizedExpression,
@@ -2341,7 +2341,7 @@ impl FormatRule<rome_js_syntax::JsPostUpdateExpression>
         FormatNodeRule::<rome_js_syntax::JsPostUpdateExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsPostUpdateExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsPostUpdateExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsPostUpdateExpression,
@@ -2354,7 +2354,7 @@ impl AsFormat for rome_js_syntax::JsPostUpdateExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsPostUpdateExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsPostUpdateExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsPostUpdateExpression,
         crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression,
@@ -2379,7 +2379,7 @@ impl FormatRule<rome_js_syntax::JsPreUpdateExpression>
         FormatNodeRule::<rome_js_syntax::JsPreUpdateExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsPreUpdateExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsPreUpdateExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsPreUpdateExpression,
@@ -2392,7 +2392,7 @@ impl AsFormat for rome_js_syntax::JsPreUpdateExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsPreUpdateExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsPreUpdateExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsPreUpdateExpression,
         crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression,
@@ -2417,7 +2417,7 @@ impl FormatRule<rome_js_syntax::JsSequenceExpression>
         FormatNodeRule::<rome_js_syntax::JsSequenceExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsSequenceExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsSequenceExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsSequenceExpression,
@@ -2430,7 +2430,7 @@ impl AsFormat for rome_js_syntax::JsSequenceExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSequenceExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsSequenceExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsSequenceExpression,
         crate::js::expressions::sequence_expression::FormatJsSequenceExpression,
@@ -2455,7 +2455,7 @@ impl FormatRule<rome_js_syntax::JsStaticMemberExpression>
         FormatNodeRule::<rome_js_syntax::JsStaticMemberExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsStaticMemberExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsStaticMemberExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsStaticMemberExpression,
@@ -2465,7 +2465,7 @@ impl AsFormat for rome_js_syntax::JsStaticMemberExpression {
         FormatRefWithRule :: new (self , crate :: js :: expressions :: static_member_expression :: FormatJsStaticMemberExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsStaticMemberExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsStaticMemberExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsStaticMemberExpression,
         crate::js::expressions::static_member_expression::FormatJsStaticMemberExpression,
@@ -2487,7 +2487,7 @@ impl FormatRule<rome_js_syntax::JsSuperExpression>
         FormatNodeRule::<rome_js_syntax::JsSuperExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsSuperExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsSuperExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsSuperExpression,
@@ -2500,7 +2500,7 @@ impl AsFormat for rome_js_syntax::JsSuperExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSuperExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsSuperExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsSuperExpression,
         crate::js::expressions::super_expression::FormatJsSuperExpression,
@@ -2525,7 +2525,7 @@ impl FormatRule<rome_js_syntax::JsThisExpression>
         FormatNodeRule::<rome_js_syntax::JsThisExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsThisExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsThisExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsThisExpression,
@@ -2538,7 +2538,7 @@ impl AsFormat for rome_js_syntax::JsThisExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsThisExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsThisExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsThisExpression,
         crate::js::expressions::this_expression::FormatJsThisExpression,
@@ -2563,7 +2563,7 @@ impl FormatRule<rome_js_syntax::JsUnaryExpression>
         FormatNodeRule::<rome_js_syntax::JsUnaryExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnaryExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnaryExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnaryExpression,
@@ -2576,7 +2576,7 @@ impl AsFormat for rome_js_syntax::JsUnaryExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnaryExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnaryExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnaryExpression,
         crate::js::expressions::unary_expression::FormatJsUnaryExpression,
@@ -2601,7 +2601,7 @@ impl FormatRule<rome_js_syntax::JsYieldExpression>
         FormatNodeRule::<rome_js_syntax::JsYieldExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsYieldExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsYieldExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsYieldExpression,
@@ -2614,7 +2614,7 @@ impl AsFormat for rome_js_syntax::JsYieldExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsYieldExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsYieldExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsYieldExpression,
         crate::js::expressions::yield_expression::FormatJsYieldExpression,
@@ -2633,7 +2633,7 @@ impl FormatRule<rome_js_syntax::NewTarget> for crate::js::auxiliary::new_target:
         FormatNodeRule::<rome_js_syntax::NewTarget>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::NewTarget {
+impl AsFormat<JsFormatContext> for rome_js_syntax::NewTarget {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::NewTarget,
@@ -2646,7 +2646,7 @@ impl AsFormat for rome_js_syntax::NewTarget {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::NewTarget {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::NewTarget {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::NewTarget,
         crate::js::auxiliary::new_target::FormatNewTarget,
@@ -2665,7 +2665,7 @@ impl FormatRule<rome_js_syntax::JsTemplate> for crate::js::expressions::template
         FormatNodeRule::<rome_js_syntax::JsTemplate>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsTemplate {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsTemplate {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsTemplate,
@@ -2678,7 +2678,7 @@ impl AsFormat for rome_js_syntax::JsTemplate {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsTemplate {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsTemplate {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsTemplate,
         crate::js::expressions::template::FormatJsTemplate,
@@ -2703,7 +2703,7 @@ impl FormatRule<rome_js_syntax::TsTypeAssertionExpression>
         FormatNodeRule::<rome_js_syntax::TsTypeAssertionExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeAssertionExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeAssertionExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeAssertionExpression,
@@ -2713,7 +2713,7 @@ impl AsFormat for rome_js_syntax::TsTypeAssertionExpression {
         FormatRefWithRule :: new (self , crate :: ts :: expressions :: type_assertion_expression :: FormatTsTypeAssertionExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeAssertionExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeAssertionExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeAssertionExpression,
         crate::ts::expressions::type_assertion_expression::FormatTsTypeAssertionExpression,
@@ -2731,7 +2731,7 @@ impl FormatRule<rome_js_syntax::TsAsExpression>
         FormatNodeRule::<rome_js_syntax::TsAsExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsAsExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAsExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAsExpression,
@@ -2744,7 +2744,7 @@ impl AsFormat for rome_js_syntax::TsAsExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAsExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAsExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAsExpression,
         crate::ts::expressions::as_expression::FormatTsAsExpression,
@@ -2769,7 +2769,7 @@ impl FormatRule<rome_js_syntax::TsNonNullAssertionExpression>
         FormatNodeRule::<rome_js_syntax::TsNonNullAssertionExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsNonNullAssertionExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsNonNullAssertionExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsNonNullAssertionExpression,
@@ -2779,7 +2779,7 @@ impl AsFormat for rome_js_syntax::TsNonNullAssertionExpression {
         FormatRefWithRule :: new (self , crate :: ts :: expressions :: non_null_assertion_expression :: FormatTsNonNullAssertionExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsNonNullAssertionExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsNonNullAssertionExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsNonNullAssertionExpression,
         crate::ts::expressions::non_null_assertion_expression::FormatTsNonNullAssertionExpression,
@@ -2801,7 +2801,7 @@ impl FormatRule<rome_js_syntax::TsInstantiationExpression>
         FormatNodeRule::<rome_js_syntax::TsInstantiationExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsInstantiationExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsInstantiationExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsInstantiationExpression,
@@ -2811,7 +2811,7 @@ impl AsFormat for rome_js_syntax::TsInstantiationExpression {
         FormatRefWithRule :: new (self , crate :: ts :: expressions :: instantiation_expression :: FormatTsInstantiationExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsInstantiationExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsInstantiationExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsInstantiationExpression,
         crate::ts::expressions::instantiation_expression::FormatTsInstantiationExpression,
@@ -2833,7 +2833,7 @@ impl FormatRule<rome_js_syntax::JsxTagExpression>
         FormatNodeRule::<rome_js_syntax::JsxTagExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxTagExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxTagExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxTagExpression,
@@ -2846,7 +2846,7 @@ impl AsFormat for rome_js_syntax::JsxTagExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxTagExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxTagExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxTagExpression,
         crate::jsx::expressions::tag_expression::FormatJsxTagExpression,
@@ -2867,7 +2867,7 @@ impl FormatRule<rome_js_syntax::TsTypeArguments>
         FormatNodeRule::<rome_js_syntax::TsTypeArguments>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeArguments {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeArguments {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeArguments,
@@ -2880,7 +2880,7 @@ impl AsFormat for rome_js_syntax::TsTypeArguments {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeArguments {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeArguments {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeArguments,
         crate::ts::expressions::type_arguments::FormatTsTypeArguments,
@@ -2905,7 +2905,7 @@ impl FormatRule<rome_js_syntax::JsTemplateChunkElement>
         FormatNodeRule::<rome_js_syntax::JsTemplateChunkElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsTemplateChunkElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsTemplateChunkElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsTemplateChunkElement,
@@ -2918,7 +2918,7 @@ impl AsFormat for rome_js_syntax::JsTemplateChunkElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsTemplateChunkElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsTemplateChunkElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsTemplateChunkElement,
         crate::js::expressions::template_chunk_element::FormatJsTemplateChunkElement,
@@ -2943,7 +2943,7 @@ impl FormatRule<rome_js_syntax::JsTemplateElement>
         FormatNodeRule::<rome_js_syntax::JsTemplateElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsTemplateElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsTemplateElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsTemplateElement,
@@ -2956,7 +2956,7 @@ impl AsFormat for rome_js_syntax::JsTemplateElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsTemplateElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsTemplateElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsTemplateElement,
         crate::js::expressions::template_element::FormatJsTemplateElement,
@@ -2977,7 +2977,7 @@ impl FormatRule<rome_js_syntax::JsCallArguments>
         FormatNodeRule::<rome_js_syntax::JsCallArguments>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsCallArguments {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsCallArguments {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsCallArguments,
@@ -2990,7 +2990,7 @@ impl AsFormat for rome_js_syntax::JsCallArguments {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsCallArguments {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsCallArguments {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsCallArguments,
         crate::js::expressions::call_arguments::FormatJsCallArguments,
@@ -3011,7 +3011,7 @@ impl FormatRule<rome_js_syntax::JsYieldArgument>
         FormatNodeRule::<rome_js_syntax::JsYieldArgument>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsYieldArgument {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsYieldArgument {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsYieldArgument,
@@ -3024,7 +3024,7 @@ impl AsFormat for rome_js_syntax::JsYieldArgument {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsYieldArgument {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsYieldArgument {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsYieldArgument,
         crate::js::expressions::yield_argument::FormatJsYieldArgument,
@@ -3049,7 +3049,7 @@ impl FormatRule<rome_js_syntax::TsTypeParameters>
         FormatNodeRule::<rome_js_syntax::TsTypeParameters>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeParameters {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeParameters {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeParameters,
@@ -3062,7 +3062,7 @@ impl AsFormat for rome_js_syntax::TsTypeParameters {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeParameters {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeParameters {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeParameters,
         crate::ts::bindings::type_parameters::FormatTsTypeParameters,
@@ -3083,7 +3083,7 @@ impl FormatRule<rome_js_syntax::JsParameters>
         FormatNodeRule::<rome_js_syntax::JsParameters>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsParameters {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsParameters {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsParameters,
@@ -3096,7 +3096,7 @@ impl AsFormat for rome_js_syntax::JsParameters {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsParameters {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsParameters {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsParameters,
         crate::js::bindings::parameters::FormatJsParameters,
@@ -3121,7 +3121,7 @@ impl FormatRule<rome_js_syntax::TsReturnTypeAnnotation>
         FormatNodeRule::<rome_js_syntax::TsReturnTypeAnnotation>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsReturnTypeAnnotation {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsReturnTypeAnnotation {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsReturnTypeAnnotation,
@@ -3134,7 +3134,7 @@ impl AsFormat for rome_js_syntax::TsReturnTypeAnnotation {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsReturnTypeAnnotation {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsReturnTypeAnnotation {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsReturnTypeAnnotation,
         crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation,
@@ -3155,7 +3155,7 @@ impl FormatRule<rome_js_syntax::JsFunctionBody>
         FormatNodeRule::<rome_js_syntax::JsFunctionBody>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsFunctionBody {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsFunctionBody {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsFunctionBody,
@@ -3168,7 +3168,7 @@ impl AsFormat for rome_js_syntax::JsFunctionBody {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsFunctionBody {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsFunctionBody {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsFunctionBody,
         crate::js::auxiliary::function_body::FormatJsFunctionBody,
@@ -3187,7 +3187,7 @@ impl FormatRule<rome_js_syntax::JsSpread> for crate::js::auxiliary::spread::Form
         FormatNodeRule::<rome_js_syntax::JsSpread>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsSpread {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsSpread {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsSpread,
@@ -3200,7 +3200,7 @@ impl AsFormat for rome_js_syntax::JsSpread {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSpread {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsSpread {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsSpread, crate::js::auxiliary::spread::FormatJsSpread>;
     fn into_format(self) -> Self::Format {
@@ -3219,7 +3219,7 @@ impl FormatRule<rome_js_syntax::JsArrayHole>
         FormatNodeRule::<rome_js_syntax::JsArrayHole>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsArrayHole {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrayHole {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsArrayHole,
@@ -3232,7 +3232,7 @@ impl AsFormat for rome_js_syntax::JsArrayHole {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayHole {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrayHole {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsArrayHole,
         crate::js::auxiliary::array_hole::FormatJsArrayHole,
@@ -3257,7 +3257,7 @@ impl FormatRule<rome_js_syntax::JsReferenceIdentifier>
         FormatNodeRule::<rome_js_syntax::JsReferenceIdentifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsReferenceIdentifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsReferenceIdentifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsReferenceIdentifier,
@@ -3270,7 +3270,7 @@ impl AsFormat for rome_js_syntax::JsReferenceIdentifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsReferenceIdentifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsReferenceIdentifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsReferenceIdentifier,
         crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier,
@@ -3291,7 +3291,7 @@ impl FormatRule<rome_js_syntax::JsPrivateName>
         FormatNodeRule::<rome_js_syntax::JsPrivateName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsPrivateName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsPrivateName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsPrivateName,
@@ -3304,7 +3304,7 @@ impl AsFormat for rome_js_syntax::JsPrivateName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsPrivateName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsPrivateName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsPrivateName,
         crate::js::auxiliary::private_name::FormatJsPrivateName,
@@ -3329,7 +3329,7 @@ impl FormatRule<rome_js_syntax::JsLiteralMemberName>
         FormatNodeRule::<rome_js_syntax::JsLiteralMemberName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsLiteralMemberName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsLiteralMemberName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsLiteralMemberName,
@@ -3342,7 +3342,7 @@ impl AsFormat for rome_js_syntax::JsLiteralMemberName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsLiteralMemberName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsLiteralMemberName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsLiteralMemberName,
         crate::js::objects::literal_member_name::FormatJsLiteralMemberName,
@@ -3367,7 +3367,7 @@ impl FormatRule<rome_js_syntax::JsComputedMemberName>
         FormatNodeRule::<rome_js_syntax::JsComputedMemberName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsComputedMemberName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsComputedMemberName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsComputedMemberName,
@@ -3380,7 +3380,7 @@ impl AsFormat for rome_js_syntax::JsComputedMemberName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsComputedMemberName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsComputedMemberName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsComputedMemberName,
         crate::js::objects::computed_member_name::FormatJsComputedMemberName,
@@ -3405,7 +3405,7 @@ impl FormatRule<rome_js_syntax::JsPropertyObjectMember>
         FormatNodeRule::<rome_js_syntax::JsPropertyObjectMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsPropertyObjectMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsPropertyObjectMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsPropertyObjectMember,
@@ -3418,7 +3418,7 @@ impl AsFormat for rome_js_syntax::JsPropertyObjectMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsPropertyObjectMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsPropertyObjectMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsPropertyObjectMember,
         crate::js::objects::property_object_member::FormatJsPropertyObjectMember,
@@ -3443,7 +3443,7 @@ impl FormatRule<rome_js_syntax::JsMethodObjectMember>
         FormatNodeRule::<rome_js_syntax::JsMethodObjectMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsMethodObjectMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsMethodObjectMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsMethodObjectMember,
@@ -3456,7 +3456,7 @@ impl AsFormat for rome_js_syntax::JsMethodObjectMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsMethodObjectMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsMethodObjectMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsMethodObjectMember,
         crate::js::objects::method_object_member::FormatJsMethodObjectMember,
@@ -3481,7 +3481,7 @@ impl FormatRule<rome_js_syntax::JsGetterObjectMember>
         FormatNodeRule::<rome_js_syntax::JsGetterObjectMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsGetterObjectMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsGetterObjectMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsGetterObjectMember,
@@ -3494,7 +3494,7 @@ impl AsFormat for rome_js_syntax::JsGetterObjectMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsGetterObjectMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsGetterObjectMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsGetterObjectMember,
         crate::js::objects::getter_object_member::FormatJsGetterObjectMember,
@@ -3519,7 +3519,7 @@ impl FormatRule<rome_js_syntax::JsSetterObjectMember>
         FormatNodeRule::<rome_js_syntax::JsSetterObjectMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsSetterObjectMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsSetterObjectMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsSetterObjectMember,
@@ -3532,7 +3532,7 @@ impl AsFormat for rome_js_syntax::JsSetterObjectMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSetterObjectMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsSetterObjectMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsSetterObjectMember,
         crate::js::objects::setter_object_member::FormatJsSetterObjectMember,
@@ -3557,7 +3557,7 @@ impl FormatRule<rome_js_syntax::JsShorthandPropertyObjectMember>
         FormatNodeRule::<rome_js_syntax::JsShorthandPropertyObjectMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsShorthandPropertyObjectMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsShorthandPropertyObjectMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsShorthandPropertyObjectMember,
@@ -3567,7 +3567,7 @@ impl AsFormat for rome_js_syntax::JsShorthandPropertyObjectMember {
         FormatRefWithRule :: new (self , crate :: js :: objects :: shorthand_property_object_member :: FormatJsShorthandPropertyObjectMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsShorthandPropertyObjectMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsShorthandPropertyObjectMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsShorthandPropertyObjectMember,
         crate::js::objects::shorthand_property_object_member::FormatJsShorthandPropertyObjectMember,
@@ -3585,7 +3585,7 @@ impl FormatRule<rome_js_syntax::JsExtendsClause>
         FormatNodeRule::<rome_js_syntax::JsExtendsClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExtendsClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExtendsClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExtendsClause,
@@ -3598,7 +3598,7 @@ impl AsFormat for rome_js_syntax::JsExtendsClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExtendsClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExtendsClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExtendsClause,
         crate::js::classes::extends_clause::FormatJsExtendsClause,
@@ -3623,7 +3623,7 @@ impl FormatRule<rome_js_syntax::TsImplementsClause>
         FormatNodeRule::<rome_js_syntax::TsImplementsClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsImplementsClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsImplementsClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsImplementsClause,
@@ -3636,7 +3636,7 @@ impl AsFormat for rome_js_syntax::TsImplementsClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsImplementsClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsImplementsClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsImplementsClause,
         crate::ts::auxiliary::implements_clause::FormatTsImplementsClause,
@@ -3649,13 +3649,13 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsImplementsClause {
     }
 }
 impl FormatRule < rome_js_syntax :: JsClassExportDefaultDeclaration > for crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: JsClassExportDefaultDeclaration , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsClassExportDefaultDeclaration > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::JsClassExportDefaultDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsClassExportDefaultDeclaration {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsClassExportDefaultDeclaration , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsClassExportDefaultDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsClassExportDefaultDeclaration {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsClassExportDefaultDeclaration , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration :: default ())
@@ -3674,7 +3674,7 @@ impl FormatRule<rome_js_syntax::JsPrivateClassMemberName>
         FormatNodeRule::<rome_js_syntax::JsPrivateClassMemberName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsPrivateClassMemberName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsPrivateClassMemberName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsPrivateClassMemberName,
@@ -3688,7 +3688,7 @@ impl AsFormat for rome_js_syntax::JsPrivateClassMemberName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsPrivateClassMemberName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsPrivateClassMemberName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsPrivateClassMemberName,
         crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName,
@@ -3714,7 +3714,7 @@ impl FormatRule<rome_js_syntax::JsConstructorClassMember>
         FormatNodeRule::<rome_js_syntax::JsConstructorClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsConstructorClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsConstructorClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsConstructorClassMember,
@@ -3727,7 +3727,7 @@ impl AsFormat for rome_js_syntax::JsConstructorClassMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConstructorClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsConstructorClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsConstructorClassMember,
         crate::js::classes::constructor_class_member::FormatJsConstructorClassMember,
@@ -3740,13 +3740,13 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConstructorClassMe
     }
 }
 impl FormatRule < rome_js_syntax :: JsStaticInitializationBlockClassMember > for crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: JsStaticInitializationBlockClassMember , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsStaticInitializationBlockClassMember > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::JsStaticInitializationBlockClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsStaticInitializationBlockClassMember {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsStaticInitializationBlockClassMember , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsStaticInitializationBlockClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsStaticInitializationBlockClassMember {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsStaticInitializationBlockClassMember , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember :: default ())
@@ -3765,7 +3765,7 @@ impl FormatRule<rome_js_syntax::JsPropertyClassMember>
         FormatNodeRule::<rome_js_syntax::JsPropertyClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsPropertyClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsPropertyClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsPropertyClassMember,
@@ -3778,7 +3778,7 @@ impl AsFormat for rome_js_syntax::JsPropertyClassMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsPropertyClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsPropertyClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsPropertyClassMember,
         crate::js::classes::property_class_member::FormatJsPropertyClassMember,
@@ -3803,7 +3803,7 @@ impl FormatRule<rome_js_syntax::JsMethodClassMember>
         FormatNodeRule::<rome_js_syntax::JsMethodClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsMethodClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsMethodClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsMethodClassMember,
@@ -3816,7 +3816,7 @@ impl AsFormat for rome_js_syntax::JsMethodClassMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsMethodClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsMethodClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsMethodClassMember,
         crate::js::classes::method_class_member::FormatJsMethodClassMember,
@@ -3841,7 +3841,7 @@ impl FormatRule<rome_js_syntax::JsGetterClassMember>
         FormatNodeRule::<rome_js_syntax::JsGetterClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsGetterClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsGetterClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsGetterClassMember,
@@ -3854,7 +3854,7 @@ impl AsFormat for rome_js_syntax::JsGetterClassMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsGetterClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsGetterClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsGetterClassMember,
         crate::js::classes::getter_class_member::FormatJsGetterClassMember,
@@ -3879,7 +3879,7 @@ impl FormatRule<rome_js_syntax::JsSetterClassMember>
         FormatNodeRule::<rome_js_syntax::JsSetterClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsSetterClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsSetterClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsSetterClassMember,
@@ -3892,7 +3892,7 @@ impl AsFormat for rome_js_syntax::JsSetterClassMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSetterClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsSetterClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsSetterClassMember,
         crate::js::classes::setter_class_member::FormatJsSetterClassMember,
@@ -3905,13 +3905,13 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSetterClassMember 
     }
 }
 impl FormatRule < rome_js_syntax :: TsConstructorSignatureClassMember > for crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: TsConstructorSignatureClassMember , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: TsConstructorSignatureClassMember > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::TsConstructorSignatureClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsConstructorSignatureClassMember {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: TsConstructorSignatureClassMember , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsConstructorSignatureClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsConstructorSignatureClassMember {
     type Format = FormatOwnedWithRule < rome_js_syntax :: TsConstructorSignatureClassMember , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember :: default ())
@@ -3930,7 +3930,7 @@ impl FormatRule<rome_js_syntax::TsPropertySignatureClassMember>
         FormatNodeRule::<rome_js_syntax::TsPropertySignatureClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsPropertySignatureClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsPropertySignatureClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsPropertySignatureClassMember,
@@ -3940,7 +3940,7 @@ impl AsFormat for rome_js_syntax::TsPropertySignatureClassMember {
         FormatRefWithRule :: new (self , crate :: ts :: classes :: property_signature_class_member :: FormatTsPropertySignatureClassMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPropertySignatureClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsPropertySignatureClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsPropertySignatureClassMember,
         crate::ts::classes::property_signature_class_member::FormatTsPropertySignatureClassMember,
@@ -3962,7 +3962,7 @@ impl FormatRule<rome_js_syntax::TsMethodSignatureClassMember>
         FormatNodeRule::<rome_js_syntax::TsMethodSignatureClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsMethodSignatureClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsMethodSignatureClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsMethodSignatureClassMember,
@@ -3972,7 +3972,7 @@ impl AsFormat for rome_js_syntax::TsMethodSignatureClassMember {
         FormatRefWithRule :: new (self , crate :: ts :: classes :: method_signature_class_member :: FormatTsMethodSignatureClassMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMethodSignatureClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsMethodSignatureClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsMethodSignatureClassMember,
         crate::ts::classes::method_signature_class_member::FormatTsMethodSignatureClassMember,
@@ -3994,7 +3994,7 @@ impl FormatRule<rome_js_syntax::TsGetterSignatureClassMember>
         FormatNodeRule::<rome_js_syntax::TsGetterSignatureClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsGetterSignatureClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsGetterSignatureClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsGetterSignatureClassMember,
@@ -4004,7 +4004,7 @@ impl AsFormat for rome_js_syntax::TsGetterSignatureClassMember {
         FormatRefWithRule :: new (self , crate :: ts :: classes :: getter_signature_class_member :: FormatTsGetterSignatureClassMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsGetterSignatureClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsGetterSignatureClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsGetterSignatureClassMember,
         crate::ts::classes::getter_signature_class_member::FormatTsGetterSignatureClassMember,
@@ -4026,7 +4026,7 @@ impl FormatRule<rome_js_syntax::TsSetterSignatureClassMember>
         FormatNodeRule::<rome_js_syntax::TsSetterSignatureClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsSetterSignatureClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsSetterSignatureClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsSetterSignatureClassMember,
@@ -4036,7 +4036,7 @@ impl AsFormat for rome_js_syntax::TsSetterSignatureClassMember {
         FormatRefWithRule :: new (self , crate :: ts :: classes :: setter_signature_class_member :: FormatTsSetterSignatureClassMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsSetterSignatureClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsSetterSignatureClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsSetterSignatureClassMember,
         crate::ts::classes::setter_signature_class_member::FormatTsSetterSignatureClassMember,
@@ -4058,7 +4058,7 @@ impl FormatRule<rome_js_syntax::TsIndexSignatureClassMember>
         FormatNodeRule::<rome_js_syntax::TsIndexSignatureClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsIndexSignatureClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsIndexSignatureClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsIndexSignatureClassMember,
@@ -4068,7 +4068,7 @@ impl AsFormat for rome_js_syntax::TsIndexSignatureClassMember {
         FormatRefWithRule :: new (self , crate :: ts :: classes :: index_signature_class_member :: FormatTsIndexSignatureClassMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIndexSignatureClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsIndexSignatureClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsIndexSignatureClassMember,
         crate::ts::classes::index_signature_class_member::FormatTsIndexSignatureClassMember,
@@ -4090,7 +4090,7 @@ impl FormatRule<rome_js_syntax::JsEmptyClassMember>
         FormatNodeRule::<rome_js_syntax::JsEmptyClassMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsEmptyClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsEmptyClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsEmptyClassMember,
@@ -4103,7 +4103,7 @@ impl AsFormat for rome_js_syntax::JsEmptyClassMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsEmptyClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsEmptyClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsEmptyClassMember,
         crate::js::classes::empty_class_member::FormatJsEmptyClassMember,
@@ -4128,7 +4128,7 @@ impl FormatRule<rome_js_syntax::JsStaticModifier>
         FormatNodeRule::<rome_js_syntax::JsStaticModifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsStaticModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsStaticModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsStaticModifier,
@@ -4141,7 +4141,7 @@ impl AsFormat for rome_js_syntax::JsStaticModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsStaticModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsStaticModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsStaticModifier,
         crate::js::auxiliary::static_modifier::FormatJsStaticModifier,
@@ -4166,7 +4166,7 @@ impl FormatRule<rome_js_syntax::TsDeclareModifier>
         FormatNodeRule::<rome_js_syntax::TsDeclareModifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsDeclareModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsDeclareModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsDeclareModifier,
@@ -4179,7 +4179,7 @@ impl AsFormat for rome_js_syntax::TsDeclareModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsDeclareModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsDeclareModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsDeclareModifier,
         crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier,
@@ -4204,7 +4204,7 @@ impl FormatRule<rome_js_syntax::TsReadonlyModifier>
         FormatNodeRule::<rome_js_syntax::TsReadonlyModifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsReadonlyModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsReadonlyModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsReadonlyModifier,
@@ -4217,7 +4217,7 @@ impl AsFormat for rome_js_syntax::TsReadonlyModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsReadonlyModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsReadonlyModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsReadonlyModifier,
         crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier,
@@ -4242,7 +4242,7 @@ impl FormatRule<rome_js_syntax::TsAbstractModifier>
         FormatNodeRule::<rome_js_syntax::TsAbstractModifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsAbstractModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAbstractModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAbstractModifier,
@@ -4255,7 +4255,7 @@ impl AsFormat for rome_js_syntax::TsAbstractModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAbstractModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAbstractModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAbstractModifier,
         crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier,
@@ -4280,7 +4280,7 @@ impl FormatRule<rome_js_syntax::TsOverrideModifier>
         FormatNodeRule::<rome_js_syntax::TsOverrideModifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsOverrideModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsOverrideModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsOverrideModifier,
@@ -4293,7 +4293,7 @@ impl AsFormat for rome_js_syntax::TsOverrideModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsOverrideModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsOverrideModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsOverrideModifier,
         crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier,
@@ -4318,7 +4318,7 @@ impl FormatRule<rome_js_syntax::TsAccessibilityModifier>
         FormatNodeRule::<rome_js_syntax::TsAccessibilityModifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsAccessibilityModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAccessibilityModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAccessibilityModifier,
@@ -4331,7 +4331,7 @@ impl AsFormat for rome_js_syntax::TsAccessibilityModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAccessibilityModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAccessibilityModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAccessibilityModifier,
         crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier,
@@ -4356,7 +4356,7 @@ impl FormatRule<rome_js_syntax::JsConstructorParameters>
         FormatNodeRule::<rome_js_syntax::JsConstructorParameters>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsConstructorParameters {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsConstructorParameters {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsConstructorParameters,
@@ -4369,7 +4369,7 @@ impl AsFormat for rome_js_syntax::JsConstructorParameters {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConstructorParameters {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsConstructorParameters {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsConstructorParameters,
         crate::js::bindings::constructor_parameters::FormatJsConstructorParameters,
@@ -4390,7 +4390,7 @@ impl FormatRule<rome_js_syntax::JsRestParameter>
         FormatNodeRule::<rome_js_syntax::JsRestParameter>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsRestParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsRestParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsRestParameter,
@@ -4403,7 +4403,7 @@ impl AsFormat for rome_js_syntax::JsRestParameter {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsRestParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsRestParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsRestParameter,
         crate::js::bindings::rest_parameter::FormatJsRestParameter,
@@ -4428,7 +4428,7 @@ impl FormatRule<rome_js_syntax::TsPropertyParameter>
         FormatNodeRule::<rome_js_syntax::TsPropertyParameter>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsPropertyParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsPropertyParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsPropertyParameter,
@@ -4441,7 +4441,7 @@ impl AsFormat for rome_js_syntax::TsPropertyParameter {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPropertyParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsPropertyParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsPropertyParameter,
         crate::ts::bindings::property_parameter::FormatTsPropertyParameter,
@@ -4466,7 +4466,7 @@ impl FormatRule<rome_js_syntax::JsInitializerClause>
         FormatNodeRule::<rome_js_syntax::JsInitializerClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsInitializerClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsInitializerClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsInitializerClause,
@@ -4479,7 +4479,7 @@ impl AsFormat for rome_js_syntax::JsInitializerClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsInitializerClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsInitializerClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsInitializerClause,
         crate::js::auxiliary::initializer_clause::FormatJsInitializerClause,
@@ -4504,7 +4504,7 @@ impl FormatRule<rome_js_syntax::TsOptionalPropertyAnnotation>
         FormatNodeRule::<rome_js_syntax::TsOptionalPropertyAnnotation>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsOptionalPropertyAnnotation {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsOptionalPropertyAnnotation {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsOptionalPropertyAnnotation,
@@ -4514,7 +4514,7 @@ impl AsFormat for rome_js_syntax::TsOptionalPropertyAnnotation {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: optional_property_annotation :: FormatTsOptionalPropertyAnnotation :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsOptionalPropertyAnnotation {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsOptionalPropertyAnnotation {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsOptionalPropertyAnnotation,
         crate::ts::auxiliary::optional_property_annotation::FormatTsOptionalPropertyAnnotation,
@@ -4536,7 +4536,7 @@ impl FormatRule<rome_js_syntax::TsDefinitePropertyAnnotation>
         FormatNodeRule::<rome_js_syntax::TsDefinitePropertyAnnotation>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsDefinitePropertyAnnotation {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsDefinitePropertyAnnotation {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsDefinitePropertyAnnotation,
@@ -4546,7 +4546,7 @@ impl AsFormat for rome_js_syntax::TsDefinitePropertyAnnotation {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: definite_property_annotation :: FormatTsDefinitePropertyAnnotation :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsDefinitePropertyAnnotation {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsDefinitePropertyAnnotation {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsDefinitePropertyAnnotation,
         crate::ts::auxiliary::definite_property_annotation::FormatTsDefinitePropertyAnnotation,
@@ -4568,7 +4568,7 @@ impl FormatRule<rome_js_syntax::TsIndexSignatureParameter>
         FormatNodeRule::<rome_js_syntax::TsIndexSignatureParameter>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsIndexSignatureParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsIndexSignatureParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsIndexSignatureParameter,
@@ -4578,7 +4578,7 @@ impl AsFormat for rome_js_syntax::TsIndexSignatureParameter {
         FormatRefWithRule :: new (self , crate :: ts :: bindings :: index_signature_parameter :: FormatTsIndexSignatureParameter :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIndexSignatureParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsIndexSignatureParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsIndexSignatureParameter,
         crate::ts::bindings::index_signature_parameter::FormatTsIndexSignatureParameter,
@@ -4600,7 +4600,7 @@ impl FormatRule<rome_js_syntax::JsIdentifierAssignment>
         FormatNodeRule::<rome_js_syntax::JsIdentifierAssignment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsIdentifierAssignment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsIdentifierAssignment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsIdentifierAssignment,
@@ -4613,7 +4613,7 @@ impl AsFormat for rome_js_syntax::JsIdentifierAssignment {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsIdentifierAssignment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsIdentifierAssignment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsIdentifierAssignment,
         crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment,
@@ -4638,7 +4638,7 @@ impl FormatRule<rome_js_syntax::JsStaticMemberAssignment>
         FormatNodeRule::<rome_js_syntax::JsStaticMemberAssignment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsStaticMemberAssignment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsStaticMemberAssignment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsStaticMemberAssignment,
@@ -4648,7 +4648,7 @@ impl AsFormat for rome_js_syntax::JsStaticMemberAssignment {
         FormatRefWithRule :: new (self , crate :: js :: assignments :: static_member_assignment :: FormatJsStaticMemberAssignment :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsStaticMemberAssignment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsStaticMemberAssignment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsStaticMemberAssignment,
         crate::js::assignments::static_member_assignment::FormatJsStaticMemberAssignment,
@@ -4670,7 +4670,7 @@ impl FormatRule<rome_js_syntax::JsComputedMemberAssignment>
         FormatNodeRule::<rome_js_syntax::JsComputedMemberAssignment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsComputedMemberAssignment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsComputedMemberAssignment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsComputedMemberAssignment,
@@ -4680,7 +4680,7 @@ impl AsFormat for rome_js_syntax::JsComputedMemberAssignment {
         FormatRefWithRule :: new (self , crate :: js :: assignments :: computed_member_assignment :: FormatJsComputedMemberAssignment :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsComputedMemberAssignment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsComputedMemberAssignment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsComputedMemberAssignment,
         crate::js::assignments::computed_member_assignment::FormatJsComputedMemberAssignment,
@@ -4702,7 +4702,7 @@ impl FormatRule<rome_js_syntax::JsParenthesizedAssignment>
         FormatNodeRule::<rome_js_syntax::JsParenthesizedAssignment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsParenthesizedAssignment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsParenthesizedAssignment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsParenthesizedAssignment,
@@ -4712,7 +4712,7 @@ impl AsFormat for rome_js_syntax::JsParenthesizedAssignment {
         FormatRefWithRule :: new (self , crate :: js :: assignments :: parenthesized_assignment :: FormatJsParenthesizedAssignment :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsParenthesizedAssignment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsParenthesizedAssignment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsParenthesizedAssignment,
         crate::js::assignments::parenthesized_assignment::FormatJsParenthesizedAssignment,
@@ -4734,7 +4734,7 @@ impl FormatRule<rome_js_syntax::TsNonNullAssertionAssignment>
         FormatNodeRule::<rome_js_syntax::TsNonNullAssertionAssignment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsNonNullAssertionAssignment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsNonNullAssertionAssignment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsNonNullAssertionAssignment,
@@ -4744,7 +4744,7 @@ impl AsFormat for rome_js_syntax::TsNonNullAssertionAssignment {
         FormatRefWithRule :: new (self , crate :: ts :: assignments :: non_null_assertion_assignment :: FormatTsNonNullAssertionAssignment :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsNonNullAssertionAssignment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsNonNullAssertionAssignment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsNonNullAssertionAssignment,
         crate::ts::assignments::non_null_assertion_assignment::FormatTsNonNullAssertionAssignment,
@@ -4762,7 +4762,7 @@ impl FormatRule<rome_js_syntax::TsAsAssignment>
         FormatNodeRule::<rome_js_syntax::TsAsAssignment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsAsAssignment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAsAssignment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAsAssignment,
@@ -4775,7 +4775,7 @@ impl AsFormat for rome_js_syntax::TsAsAssignment {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAsAssignment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAsAssignment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAsAssignment,
         crate::ts::assignments::as_assignment::FormatTsAsAssignment,
@@ -4800,7 +4800,7 @@ impl FormatRule<rome_js_syntax::TsTypeAssertionAssignment>
         FormatNodeRule::<rome_js_syntax::TsTypeAssertionAssignment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeAssertionAssignment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeAssertionAssignment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeAssertionAssignment,
@@ -4810,7 +4810,7 @@ impl AsFormat for rome_js_syntax::TsTypeAssertionAssignment {
         FormatRefWithRule :: new (self , crate :: ts :: assignments :: type_assertion_assignment :: FormatTsTypeAssertionAssignment :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeAssertionAssignment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeAssertionAssignment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeAssertionAssignment,
         crate::ts::assignments::type_assertion_assignment::FormatTsTypeAssertionAssignment,
@@ -4832,7 +4832,7 @@ impl FormatRule<rome_js_syntax::JsAssignmentWithDefault>
         FormatNodeRule::<rome_js_syntax::JsAssignmentWithDefault>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsAssignmentWithDefault {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAssignmentWithDefault {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAssignmentWithDefault,
@@ -4846,7 +4846,7 @@ impl AsFormat for rome_js_syntax::JsAssignmentWithDefault {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAssignmentWithDefault {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAssignmentWithDefault {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAssignmentWithDefault,
         crate::js::assignments::assignment_with_default::FormatJsAssignmentWithDefault,
@@ -4872,7 +4872,7 @@ impl FormatRule<rome_js_syntax::JsArrayAssignmentPattern>
         FormatNodeRule::<rome_js_syntax::JsArrayAssignmentPattern>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsArrayAssignmentPattern {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrayAssignmentPattern {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsArrayAssignmentPattern,
@@ -4882,7 +4882,7 @@ impl AsFormat for rome_js_syntax::JsArrayAssignmentPattern {
         FormatRefWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern :: FormatJsArrayAssignmentPattern :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayAssignmentPattern {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrayAssignmentPattern {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsArrayAssignmentPattern,
         crate::js::assignments::array_assignment_pattern::FormatJsArrayAssignmentPattern,
@@ -4904,7 +4904,7 @@ impl FormatRule<rome_js_syntax::JsObjectAssignmentPattern>
         FormatNodeRule::<rome_js_syntax::JsObjectAssignmentPattern>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsObjectAssignmentPattern {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPattern {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsObjectAssignmentPattern,
@@ -4914,7 +4914,7 @@ impl AsFormat for rome_js_syntax::JsObjectAssignmentPattern {
         FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern :: FormatJsObjectAssignmentPattern :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectAssignmentPattern {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPattern {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsObjectAssignmentPattern,
         crate::js::assignments::object_assignment_pattern::FormatJsObjectAssignmentPattern,
@@ -4924,41 +4924,39 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectAssignmentPa
     }
 }
 impl FormatRule < rome_js_syntax :: JsArrayAssignmentPatternRestElement > for crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: JsArrayAssignmentPatternRestElement , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsArrayAssignmentPatternRestElement > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::JsArrayAssignmentPatternRestElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrayAssignmentPatternRestElement {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsArrayAssignmentPatternRestElement , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayAssignmentPatternRestElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrayAssignmentPatternRestElement {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsArrayAssignmentPatternRestElement , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement :: default ())
     }
 }
 impl FormatRule < rome_js_syntax :: JsObjectAssignmentPatternShorthandProperty > for crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: JsObjectAssignmentPatternShorthandProperty , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsObjectAssignmentPatternShorthandProperty > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::JsObjectAssignmentPatternShorthandProperty {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternShorthandProperty {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsObjectAssignmentPatternShorthandProperty , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext>
-    for rome_js_syntax::JsObjectAssignmentPatternShorthandProperty
-{
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternShorthandProperty {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsObjectAssignmentPatternShorthandProperty , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty :: default ())
     }
 }
 impl FormatRule < rome_js_syntax :: JsObjectAssignmentPatternProperty > for crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: JsObjectAssignmentPatternProperty , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsObjectAssignmentPatternProperty > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::JsObjectAssignmentPatternProperty {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternProperty {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsObjectAssignmentPatternProperty , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternProperty {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternProperty {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsObjectAssignmentPatternProperty , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty :: default ())
@@ -4977,7 +4975,7 @@ impl FormatRule<rome_js_syntax::JsObjectAssignmentPatternRest>
         FormatNodeRule::<rome_js_syntax::JsObjectAssignmentPatternRest>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsObjectAssignmentPatternRest {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternRest {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsObjectAssignmentPatternRest,
@@ -4987,7 +4985,7 @@ impl AsFormat for rome_js_syntax::JsObjectAssignmentPatternRest {
         FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_rest :: FormatJsObjectAssignmentPatternRest :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternRest {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternRest {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsObjectAssignmentPatternRest,
         crate::js::assignments::object_assignment_pattern_rest::FormatJsObjectAssignmentPatternRest,
@@ -5009,7 +5007,7 @@ impl FormatRule<rome_js_syntax::JsIdentifierBinding>
         FormatNodeRule::<rome_js_syntax::JsIdentifierBinding>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsIdentifierBinding {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsIdentifierBinding {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsIdentifierBinding,
@@ -5022,7 +5020,7 @@ impl AsFormat for rome_js_syntax::JsIdentifierBinding {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsIdentifierBinding {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsIdentifierBinding {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsIdentifierBinding,
         crate::js::bindings::identifier_binding::FormatJsIdentifierBinding,
@@ -5047,7 +5045,7 @@ impl FormatRule<rome_js_syntax::JsBindingPatternWithDefault>
         FormatNodeRule::<rome_js_syntax::JsBindingPatternWithDefault>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsBindingPatternWithDefault {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsBindingPatternWithDefault {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsBindingPatternWithDefault,
@@ -5057,7 +5055,7 @@ impl AsFormat for rome_js_syntax::JsBindingPatternWithDefault {
         FormatRefWithRule :: new (self , crate :: js :: bindings :: binding_pattern_with_default :: FormatJsBindingPatternWithDefault :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsBindingPatternWithDefault {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsBindingPatternWithDefault {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsBindingPatternWithDefault,
         crate::js::bindings::binding_pattern_with_default::FormatJsBindingPatternWithDefault,
@@ -5079,7 +5077,7 @@ impl FormatRule<rome_js_syntax::JsArrayBindingPattern>
         FormatNodeRule::<rome_js_syntax::JsArrayBindingPattern>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsArrayBindingPattern {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrayBindingPattern {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsArrayBindingPattern,
@@ -5092,7 +5090,7 @@ impl AsFormat for rome_js_syntax::JsArrayBindingPattern {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayBindingPattern {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrayBindingPattern {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsArrayBindingPattern,
         crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern,
@@ -5117,7 +5115,7 @@ impl FormatRule<rome_js_syntax::JsObjectBindingPattern>
         FormatNodeRule::<rome_js_syntax::JsObjectBindingPattern>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsObjectBindingPattern {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPattern {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsObjectBindingPattern,
@@ -5130,7 +5128,7 @@ impl AsFormat for rome_js_syntax::JsObjectBindingPattern {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectBindingPattern {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPattern {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsObjectBindingPattern,
         crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern,
@@ -5143,13 +5141,13 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectBindingPatte
     }
 }
 impl FormatRule < rome_js_syntax :: JsArrayBindingPatternRestElement > for crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: JsArrayBindingPatternRestElement , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsArrayBindingPatternRestElement > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::JsArrayBindingPatternRestElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrayBindingPatternRestElement {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsArrayBindingPatternRestElement , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayBindingPatternRestElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrayBindingPatternRestElement {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsArrayBindingPatternRestElement , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement :: default ())
@@ -5168,7 +5166,7 @@ impl FormatRule<rome_js_syntax::JsObjectBindingPatternProperty>
         FormatNodeRule::<rome_js_syntax::JsObjectBindingPatternProperty>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsObjectBindingPatternProperty {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPatternProperty {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsObjectBindingPatternProperty,
@@ -5178,7 +5176,7 @@ impl AsFormat for rome_js_syntax::JsObjectBindingPatternProperty {
         FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_property :: FormatJsObjectBindingPatternProperty :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectBindingPatternProperty {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPatternProperty {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsObjectBindingPatternProperty,
         crate::js::bindings::object_binding_pattern_property::FormatJsObjectBindingPatternProperty,
@@ -5200,7 +5198,7 @@ impl FormatRule<rome_js_syntax::JsObjectBindingPatternRest>
         FormatNodeRule::<rome_js_syntax::JsObjectBindingPatternRest>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsObjectBindingPatternRest {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPatternRest {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsObjectBindingPatternRest,
@@ -5210,7 +5208,7 @@ impl AsFormat for rome_js_syntax::JsObjectBindingPatternRest {
         FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_rest :: FormatJsObjectBindingPatternRest :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectBindingPatternRest {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPatternRest {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsObjectBindingPatternRest,
         crate::js::bindings::object_binding_pattern_rest::FormatJsObjectBindingPatternRest,
@@ -5220,15 +5218,13 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectBindingPatte
     }
 }
 impl FormatRule < rome_js_syntax :: JsObjectBindingPatternShorthandProperty > for crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: JsObjectBindingPatternShorthandProperty , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsObjectBindingPatternShorthandProperty > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::JsObjectBindingPatternShorthandProperty {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPatternShorthandProperty {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsObjectBindingPatternShorthandProperty , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext>
-    for rome_js_syntax::JsObjectBindingPatternShorthandProperty
-{
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPatternShorthandProperty {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsObjectBindingPatternShorthandProperty , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty :: default ())
@@ -5247,7 +5243,7 @@ impl FormatRule<rome_js_syntax::JsStringLiteralExpression>
         FormatNodeRule::<rome_js_syntax::JsStringLiteralExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsStringLiteralExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsStringLiteralExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsStringLiteralExpression,
@@ -5257,7 +5253,7 @@ impl AsFormat for rome_js_syntax::JsStringLiteralExpression {
         FormatRefWithRule :: new (self , crate :: js :: expressions :: string_literal_expression :: FormatJsStringLiteralExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsStringLiteralExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsStringLiteralExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsStringLiteralExpression,
         crate::js::expressions::string_literal_expression::FormatJsStringLiteralExpression,
@@ -5279,7 +5275,7 @@ impl FormatRule<rome_js_syntax::JsNumberLiteralExpression>
         FormatNodeRule::<rome_js_syntax::JsNumberLiteralExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsNumberLiteralExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsNumberLiteralExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsNumberLiteralExpression,
@@ -5289,7 +5285,7 @@ impl AsFormat for rome_js_syntax::JsNumberLiteralExpression {
         FormatRefWithRule :: new (self , crate :: js :: expressions :: number_literal_expression :: FormatJsNumberLiteralExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsNumberLiteralExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsNumberLiteralExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsNumberLiteralExpression,
         crate::js::expressions::number_literal_expression::FormatJsNumberLiteralExpression,
@@ -5311,7 +5307,7 @@ impl FormatRule<rome_js_syntax::JsBigIntLiteralExpression>
         FormatNodeRule::<rome_js_syntax::JsBigIntLiteralExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsBigIntLiteralExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsBigIntLiteralExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsBigIntLiteralExpression,
@@ -5321,7 +5317,7 @@ impl AsFormat for rome_js_syntax::JsBigIntLiteralExpression {
         FormatRefWithRule :: new (self , crate :: js :: expressions :: big_int_literal_expression :: FormatJsBigIntLiteralExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsBigIntLiteralExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsBigIntLiteralExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsBigIntLiteralExpression,
         crate::js::expressions::big_int_literal_expression::FormatJsBigIntLiteralExpression,
@@ -5343,7 +5339,7 @@ impl FormatRule<rome_js_syntax::JsBooleanLiteralExpression>
         FormatNodeRule::<rome_js_syntax::JsBooleanLiteralExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsBooleanLiteralExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsBooleanLiteralExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsBooleanLiteralExpression,
@@ -5353,7 +5349,7 @@ impl AsFormat for rome_js_syntax::JsBooleanLiteralExpression {
         FormatRefWithRule :: new (self , crate :: js :: expressions :: boolean_literal_expression :: FormatJsBooleanLiteralExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsBooleanLiteralExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsBooleanLiteralExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsBooleanLiteralExpression,
         crate::js::expressions::boolean_literal_expression::FormatJsBooleanLiteralExpression,
@@ -5375,7 +5371,7 @@ impl FormatRule<rome_js_syntax::JsNullLiteralExpression>
         FormatNodeRule::<rome_js_syntax::JsNullLiteralExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsNullLiteralExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsNullLiteralExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsNullLiteralExpression,
@@ -5389,7 +5385,7 @@ impl AsFormat for rome_js_syntax::JsNullLiteralExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsNullLiteralExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsNullLiteralExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsNullLiteralExpression,
         crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression,
@@ -5415,7 +5411,7 @@ impl FormatRule<rome_js_syntax::JsRegexLiteralExpression>
         FormatNodeRule::<rome_js_syntax::JsRegexLiteralExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsRegexLiteralExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsRegexLiteralExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsRegexLiteralExpression,
@@ -5425,7 +5421,7 @@ impl AsFormat for rome_js_syntax::JsRegexLiteralExpression {
         FormatRefWithRule :: new (self , crate :: js :: expressions :: regex_literal_expression :: FormatJsRegexLiteralExpression :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsRegexLiteralExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsRegexLiteralExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsRegexLiteralExpression,
         crate::js::expressions::regex_literal_expression::FormatJsRegexLiteralExpression,
@@ -5447,7 +5443,7 @@ impl FormatRule<rome_js_syntax::JsVariableDeclarationClause>
         FormatNodeRule::<rome_js_syntax::JsVariableDeclarationClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsVariableDeclarationClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsVariableDeclarationClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsVariableDeclarationClause,
@@ -5457,7 +5453,7 @@ impl AsFormat for rome_js_syntax::JsVariableDeclarationClause {
         FormatRefWithRule :: new (self , crate :: js :: auxiliary :: variable_declaration_clause :: FormatJsVariableDeclarationClause :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsVariableDeclarationClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsVariableDeclarationClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsVariableDeclarationClause,
         crate::js::auxiliary::variable_declaration_clause::FormatJsVariableDeclarationClause,
@@ -5479,7 +5475,7 @@ impl FormatRule<rome_js_syntax::TsDefiniteVariableAnnotation>
         FormatNodeRule::<rome_js_syntax::TsDefiniteVariableAnnotation>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsDefiniteVariableAnnotation {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsDefiniteVariableAnnotation {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsDefiniteVariableAnnotation,
@@ -5489,7 +5485,7 @@ impl AsFormat for rome_js_syntax::TsDefiniteVariableAnnotation {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: definite_variable_annotation :: FormatTsDefiniteVariableAnnotation :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsDefiniteVariableAnnotation {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsDefiniteVariableAnnotation {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsDefiniteVariableAnnotation,
         crate::ts::auxiliary::definite_variable_annotation::FormatTsDefiniteVariableAnnotation,
@@ -5505,14 +5501,14 @@ impl FormatRule<rome_js_syntax::JsExport> for crate::js::module::export::FormatJ
         FormatNodeRule::<rome_js_syntax::JsExport>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExport {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExport {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsExport, crate::js::module::export::FormatJsExport>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::js::module::export::FormatJsExport::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExport {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExport {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsExport, crate::js::module::export::FormatJsExport>;
     fn into_format(self) -> Self::Format {
@@ -5526,14 +5522,14 @@ impl FormatRule<rome_js_syntax::JsImport> for crate::js::module::import::FormatJ
         FormatNodeRule::<rome_js_syntax::JsImport>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsImport {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsImport {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsImport, crate::js::module::import::FormatJsImport>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::js::module::import::FormatJsImport::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImport {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsImport {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsImport, crate::js::module::import::FormatJsImport>;
     fn into_format(self) -> Self::Format {
@@ -5553,7 +5549,7 @@ impl FormatRule<rome_js_syntax::JsImportBareClause>
         FormatNodeRule::<rome_js_syntax::JsImportBareClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsImportBareClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsImportBareClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsImportBareClause,
@@ -5566,7 +5562,7 @@ impl AsFormat for rome_js_syntax::JsImportBareClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportBareClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsImportBareClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsImportBareClause,
         crate::js::module::import_bare_clause::FormatJsImportBareClause,
@@ -5591,7 +5587,7 @@ impl FormatRule<rome_js_syntax::JsImportNamedClause>
         FormatNodeRule::<rome_js_syntax::JsImportNamedClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsImportNamedClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsImportNamedClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsImportNamedClause,
@@ -5604,7 +5600,7 @@ impl AsFormat for rome_js_syntax::JsImportNamedClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportNamedClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsImportNamedClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsImportNamedClause,
         crate::js::module::import_named_clause::FormatJsImportNamedClause,
@@ -5629,7 +5625,7 @@ impl FormatRule<rome_js_syntax::JsImportDefaultClause>
         FormatNodeRule::<rome_js_syntax::JsImportDefaultClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsImportDefaultClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsImportDefaultClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsImportDefaultClause,
@@ -5642,7 +5638,7 @@ impl AsFormat for rome_js_syntax::JsImportDefaultClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportDefaultClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsImportDefaultClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsImportDefaultClause,
         crate::js::module::import_default_clause::FormatJsImportDefaultClause,
@@ -5667,7 +5663,7 @@ impl FormatRule<rome_js_syntax::JsImportNamespaceClause>
         FormatNodeRule::<rome_js_syntax::JsImportNamespaceClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsImportNamespaceClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsImportNamespaceClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsImportNamespaceClause,
@@ -5680,7 +5676,7 @@ impl AsFormat for rome_js_syntax::JsImportNamespaceClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportNamespaceClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsImportNamespaceClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsImportNamespaceClause,
         crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause,
@@ -5701,7 +5697,7 @@ impl FormatRule<rome_js_syntax::JsModuleSource>
         FormatNodeRule::<rome_js_syntax::JsModuleSource>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsModuleSource {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsModuleSource {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsModuleSource,
@@ -5714,7 +5710,7 @@ impl AsFormat for rome_js_syntax::JsModuleSource {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsModuleSource {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsModuleSource {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsModuleSource,
         crate::js::module::module_source::FormatJsModuleSource,
@@ -5739,7 +5735,7 @@ impl FormatRule<rome_js_syntax::JsImportAssertion>
         FormatNodeRule::<rome_js_syntax::JsImportAssertion>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsImportAssertion {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsImportAssertion {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsImportAssertion,
@@ -5752,7 +5748,7 @@ impl AsFormat for rome_js_syntax::JsImportAssertion {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportAssertion {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsImportAssertion {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsImportAssertion,
         crate::js::module::import_assertion::FormatJsImportAssertion,
@@ -5777,7 +5773,7 @@ impl FormatRule<rome_js_syntax::JsDefaultImportSpecifier>
         FormatNodeRule::<rome_js_syntax::JsDefaultImportSpecifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsDefaultImportSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsDefaultImportSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsDefaultImportSpecifier,
@@ -5790,7 +5786,7 @@ impl AsFormat for rome_js_syntax::JsDefaultImportSpecifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsDefaultImportSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsDefaultImportSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsDefaultImportSpecifier,
         crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier,
@@ -5815,7 +5811,7 @@ impl FormatRule<rome_js_syntax::JsNamedImportSpecifiers>
         FormatNodeRule::<rome_js_syntax::JsNamedImportSpecifiers>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsNamedImportSpecifiers {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsNamedImportSpecifiers {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsNamedImportSpecifiers,
@@ -5828,7 +5824,7 @@ impl AsFormat for rome_js_syntax::JsNamedImportSpecifiers {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsNamedImportSpecifiers {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsNamedImportSpecifiers {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsNamedImportSpecifiers,
         crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers,
@@ -5853,7 +5849,7 @@ impl FormatRule<rome_js_syntax::JsNamespaceImportSpecifier>
         FormatNodeRule::<rome_js_syntax::JsNamespaceImportSpecifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsNamespaceImportSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsNamespaceImportSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsNamespaceImportSpecifier,
@@ -5863,7 +5859,7 @@ impl AsFormat for rome_js_syntax::JsNamespaceImportSpecifier {
         FormatRefWithRule :: new (self , crate :: js :: module :: namespace_import_specifier :: FormatJsNamespaceImportSpecifier :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsNamespaceImportSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsNamespaceImportSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsNamespaceImportSpecifier,
         crate::js::module::namespace_import_specifier::FormatJsNamespaceImportSpecifier,
@@ -5885,7 +5881,7 @@ impl FormatRule<rome_js_syntax::JsShorthandNamedImportSpecifier>
         FormatNodeRule::<rome_js_syntax::JsShorthandNamedImportSpecifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsShorthandNamedImportSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsShorthandNamedImportSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsShorthandNamedImportSpecifier,
@@ -5895,7 +5891,7 @@ impl AsFormat for rome_js_syntax::JsShorthandNamedImportSpecifier {
         FormatRefWithRule :: new (self , crate :: js :: module :: shorthand_named_import_specifier :: FormatJsShorthandNamedImportSpecifier :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsShorthandNamedImportSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsShorthandNamedImportSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsShorthandNamedImportSpecifier,
         crate::js::module::shorthand_named_import_specifier::FormatJsShorthandNamedImportSpecifier,
@@ -5917,7 +5913,7 @@ impl FormatRule<rome_js_syntax::JsNamedImportSpecifier>
         FormatNodeRule::<rome_js_syntax::JsNamedImportSpecifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsNamedImportSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsNamedImportSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsNamedImportSpecifier,
@@ -5930,7 +5926,7 @@ impl AsFormat for rome_js_syntax::JsNamedImportSpecifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsNamedImportSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsNamedImportSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsNamedImportSpecifier,
         crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier,
@@ -5955,7 +5951,7 @@ impl FormatRule<rome_js_syntax::JsLiteralExportName>
         FormatNodeRule::<rome_js_syntax::JsLiteralExportName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsLiteralExportName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsLiteralExportName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsLiteralExportName,
@@ -5968,7 +5964,7 @@ impl AsFormat for rome_js_syntax::JsLiteralExportName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsLiteralExportName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsLiteralExportName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsLiteralExportName,
         crate::js::module::literal_export_name::FormatJsLiteralExportName,
@@ -5993,7 +5989,7 @@ impl FormatRule<rome_js_syntax::JsImportAssertionEntry>
         FormatNodeRule::<rome_js_syntax::JsImportAssertionEntry>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsImportAssertionEntry {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsImportAssertionEntry {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsImportAssertionEntry,
@@ -6006,7 +6002,7 @@ impl AsFormat for rome_js_syntax::JsImportAssertionEntry {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportAssertionEntry {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsImportAssertionEntry {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsImportAssertionEntry,
         crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry,
@@ -6031,13 +6027,13 @@ impl FormatRule<rome_js_syntax::JsExportDefaultDeclarationClause>
         FormatNodeRule::<rome_js_syntax::JsExportDefaultDeclarationClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExportDefaultDeclarationClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportDefaultDeclarationClause {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsExportDefaultDeclarationClause , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportDefaultDeclarationClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportDefaultDeclarationClause {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsExportDefaultDeclarationClause , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause :: default ())
@@ -6056,7 +6052,7 @@ impl FormatRule<rome_js_syntax::JsExportDefaultExpressionClause>
         FormatNodeRule::<rome_js_syntax::JsExportDefaultExpressionClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExportDefaultExpressionClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportDefaultExpressionClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportDefaultExpressionClause,
@@ -6066,7 +6062,7 @@ impl AsFormat for rome_js_syntax::JsExportDefaultExpressionClause {
         FormatRefWithRule :: new (self , crate :: js :: module :: export_default_expression_clause :: FormatJsExportDefaultExpressionClause :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportDefaultExpressionClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportDefaultExpressionClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportDefaultExpressionClause,
         crate::js::module::export_default_expression_clause::FormatJsExportDefaultExpressionClause,
@@ -6088,7 +6084,7 @@ impl FormatRule<rome_js_syntax::JsExportNamedClause>
         FormatNodeRule::<rome_js_syntax::JsExportNamedClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExportNamedClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportNamedClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportNamedClause,
@@ -6101,7 +6097,7 @@ impl AsFormat for rome_js_syntax::JsExportNamedClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportNamedClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportNamedClause,
         crate::js::module::export_named_clause::FormatJsExportNamedClause,
@@ -6126,7 +6122,7 @@ impl FormatRule<rome_js_syntax::JsExportFromClause>
         FormatNodeRule::<rome_js_syntax::JsExportFromClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExportFromClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportFromClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportFromClause,
@@ -6139,7 +6135,7 @@ impl AsFormat for rome_js_syntax::JsExportFromClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportFromClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportFromClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportFromClause,
         crate::js::module::export_from_clause::FormatJsExportFromClause,
@@ -6164,7 +6160,7 @@ impl FormatRule<rome_js_syntax::JsExportNamedFromClause>
         FormatNodeRule::<rome_js_syntax::JsExportNamedFromClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExportNamedFromClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportNamedFromClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportNamedFromClause,
@@ -6177,7 +6173,7 @@ impl AsFormat for rome_js_syntax::JsExportNamedFromClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedFromClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportNamedFromClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportNamedFromClause,
         crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause,
@@ -6202,7 +6198,7 @@ impl FormatRule<rome_js_syntax::TsExportAsNamespaceClause>
         FormatNodeRule::<rome_js_syntax::TsExportAsNamespaceClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsExportAsNamespaceClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsExportAsNamespaceClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsExportAsNamespaceClause,
@@ -6216,7 +6212,7 @@ impl AsFormat for rome_js_syntax::TsExportAsNamespaceClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsExportAsNamespaceClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsExportAsNamespaceClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsExportAsNamespaceClause,
         crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause,
@@ -6242,7 +6238,7 @@ impl FormatRule<rome_js_syntax::TsExportAssignmentClause>
         FormatNodeRule::<rome_js_syntax::TsExportAssignmentClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsExportAssignmentClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsExportAssignmentClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsExportAssignmentClause,
@@ -6255,7 +6251,7 @@ impl AsFormat for rome_js_syntax::TsExportAssignmentClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsExportAssignmentClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsExportAssignmentClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsExportAssignmentClause,
         crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause,
@@ -6280,7 +6276,7 @@ impl FormatRule<rome_js_syntax::TsExportDeclareClause>
         FormatNodeRule::<rome_js_syntax::TsExportDeclareClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsExportDeclareClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsExportDeclareClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsExportDeclareClause,
@@ -6293,7 +6289,7 @@ impl AsFormat for rome_js_syntax::TsExportDeclareClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsExportDeclareClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsExportDeclareClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsExportDeclareClause,
         crate::ts::module::export_declare_clause::FormatTsExportDeclareClause,
@@ -6306,28 +6302,26 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsExportDeclareClaus
     }
 }
 impl FormatRule < rome_js_syntax :: JsFunctionExportDefaultDeclaration > for crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: JsFunctionExportDefaultDeclaration , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: JsFunctionExportDefaultDeclaration > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::JsFunctionExportDefaultDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsFunctionExportDefaultDeclaration {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsFunctionExportDefaultDeclaration , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsFunctionExportDefaultDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsFunctionExportDefaultDeclaration {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsFunctionExportDefaultDeclaration , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration :: default ())
     }
 }
 impl FormatRule < rome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration > for crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::TsDeclareFunctionExportDefaultDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsDeclareFunctionExportDefaultDeclaration {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext>
-    for rome_js_syntax::TsDeclareFunctionExportDefaultDeclaration
-{
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsDeclareFunctionExportDefaultDeclaration {
     type Format = FormatOwnedWithRule < rome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration :: default ())
@@ -6346,7 +6340,7 @@ impl FormatRule<rome_js_syntax::JsExportNamedShorthandSpecifier>
         FormatNodeRule::<rome_js_syntax::JsExportNamedShorthandSpecifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExportNamedShorthandSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportNamedShorthandSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportNamedShorthandSpecifier,
@@ -6356,7 +6350,7 @@ impl AsFormat for rome_js_syntax::JsExportNamedShorthandSpecifier {
         FormatRefWithRule :: new (self , crate :: js :: module :: export_named_shorthand_specifier :: FormatJsExportNamedShorthandSpecifier :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedShorthandSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportNamedShorthandSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportNamedShorthandSpecifier,
         crate::js::module::export_named_shorthand_specifier::FormatJsExportNamedShorthandSpecifier,
@@ -6378,7 +6372,7 @@ impl FormatRule<rome_js_syntax::JsExportNamedSpecifier>
         FormatNodeRule::<rome_js_syntax::JsExportNamedSpecifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExportNamedSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportNamedSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportNamedSpecifier,
@@ -6391,7 +6385,7 @@ impl AsFormat for rome_js_syntax::JsExportNamedSpecifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportNamedSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportNamedSpecifier,
         crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier,
@@ -6416,7 +6410,7 @@ impl FormatRule<rome_js_syntax::JsExportAsClause>
         FormatNodeRule::<rome_js_syntax::JsExportAsClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExportAsClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportAsClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportAsClause,
@@ -6429,7 +6423,7 @@ impl AsFormat for rome_js_syntax::JsExportAsClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportAsClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportAsClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportAsClause,
         crate::js::module::export_as_clause::FormatJsExportAsClause,
@@ -6454,7 +6448,7 @@ impl FormatRule<rome_js_syntax::JsExportNamedFromSpecifier>
         FormatNodeRule::<rome_js_syntax::JsExportNamedFromSpecifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsExportNamedFromSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportNamedFromSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportNamedFromSpecifier,
@@ -6464,7 +6458,7 @@ impl AsFormat for rome_js_syntax::JsExportNamedFromSpecifier {
         FormatRefWithRule :: new (self , crate :: js :: module :: export_named_from_specifier :: FormatJsExportNamedFromSpecifier :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedFromSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportNamedFromSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportNamedFromSpecifier,
         crate::js::module::export_named_from_specifier::FormatJsExportNamedFromSpecifier,
@@ -6480,14 +6474,14 @@ impl FormatRule<rome_js_syntax::JsName> for crate::js::auxiliary::name::FormatJs
         FormatNodeRule::<rome_js_syntax::JsName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsName {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsName, crate::js::auxiliary::name::FormatJsName>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::js::auxiliary::name::FormatJsName::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsName {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsName, crate::js::auxiliary::name::FormatJsName>;
     fn into_format(self) -> Self::Format {
@@ -6507,7 +6501,7 @@ impl FormatRule<rome_js_syntax::JsFormalParameter>
         FormatNodeRule::<rome_js_syntax::JsFormalParameter>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsFormalParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsFormalParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsFormalParameter,
@@ -6520,7 +6514,7 @@ impl AsFormat for rome_js_syntax::JsFormalParameter {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsFormalParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsFormalParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsFormalParameter,
         crate::js::bindings::formal_parameter::FormatJsFormalParameter,
@@ -6541,7 +6535,7 @@ impl FormatRule<rome_js_syntax::TsThisParameter>
         FormatNodeRule::<rome_js_syntax::TsThisParameter>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsThisParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsThisParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsThisParameter,
@@ -6554,7 +6548,7 @@ impl AsFormat for rome_js_syntax::TsThisParameter {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsThisParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsThisParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsThisParameter,
         crate::ts::bindings::this_parameter::FormatTsThisParameter,
@@ -6573,7 +6567,7 @@ impl FormatRule<rome_js_syntax::TsAnyType> for crate::ts::types::any_type::Forma
         FormatNodeRule::<rome_js_syntax::TsAnyType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyType,
@@ -6583,7 +6577,7 @@ impl AsFormat for rome_js_syntax::TsAnyType {
         FormatRefWithRule::new(self, crate::ts::types::any_type::FormatTsAnyType::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyType {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::TsAnyType, crate::ts::types::any_type::FormatTsAnyType>;
     fn into_format(self) -> Self::Format {
@@ -6599,7 +6593,7 @@ impl FormatRule<rome_js_syntax::TsUnknownType>
         FormatNodeRule::<rome_js_syntax::TsUnknownType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsUnknownType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsUnknownType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsUnknownType,
@@ -6612,7 +6606,7 @@ impl AsFormat for rome_js_syntax::TsUnknownType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsUnknownType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsUnknownType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsUnknownType,
         crate::ts::types::unknown_type::FormatTsUnknownType,
@@ -6633,7 +6627,7 @@ impl FormatRule<rome_js_syntax::TsNumberType>
         FormatNodeRule::<rome_js_syntax::TsNumberType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsNumberType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsNumberType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsNumberType,
@@ -6646,7 +6640,7 @@ impl AsFormat for rome_js_syntax::TsNumberType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsNumberType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsNumberType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsNumberType,
         crate::ts::types::number_type::FormatTsNumberType,
@@ -6667,7 +6661,7 @@ impl FormatRule<rome_js_syntax::TsBooleanType>
         FormatNodeRule::<rome_js_syntax::TsBooleanType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsBooleanType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsBooleanType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsBooleanType,
@@ -6680,7 +6674,7 @@ impl AsFormat for rome_js_syntax::TsBooleanType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsBooleanType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsBooleanType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsBooleanType,
         crate::ts::types::boolean_type::FormatTsBooleanType,
@@ -6701,7 +6695,7 @@ impl FormatRule<rome_js_syntax::TsBigintType>
         FormatNodeRule::<rome_js_syntax::TsBigintType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsBigintType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsBigintType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsBigintType,
@@ -6714,7 +6708,7 @@ impl AsFormat for rome_js_syntax::TsBigintType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsBigintType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsBigintType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsBigintType,
         crate::ts::types::bigint_type::FormatTsBigintType,
@@ -6735,7 +6729,7 @@ impl FormatRule<rome_js_syntax::TsStringType>
         FormatNodeRule::<rome_js_syntax::TsStringType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsStringType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsStringType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsStringType,
@@ -6748,7 +6742,7 @@ impl AsFormat for rome_js_syntax::TsStringType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsStringType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsStringType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsStringType,
         crate::ts::types::string_type::FormatTsStringType,
@@ -6769,7 +6763,7 @@ impl FormatRule<rome_js_syntax::TsSymbolType>
         FormatNodeRule::<rome_js_syntax::TsSymbolType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsSymbolType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsSymbolType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsSymbolType,
@@ -6782,7 +6776,7 @@ impl AsFormat for rome_js_syntax::TsSymbolType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsSymbolType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsSymbolType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsSymbolType,
         crate::ts::types::symbol_type::FormatTsSymbolType,
@@ -6801,7 +6795,7 @@ impl FormatRule<rome_js_syntax::TsVoidType> for crate::ts::types::void_type::For
         FormatNodeRule::<rome_js_syntax::TsVoidType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsVoidType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsVoidType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsVoidType,
@@ -6814,7 +6808,7 @@ impl AsFormat for rome_js_syntax::TsVoidType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsVoidType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsVoidType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsVoidType,
         crate::ts::types::void_type::FormatTsVoidType,
@@ -6835,7 +6829,7 @@ impl FormatRule<rome_js_syntax::TsUndefinedType>
         FormatNodeRule::<rome_js_syntax::TsUndefinedType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsUndefinedType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsUndefinedType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsUndefinedType,
@@ -6848,7 +6842,7 @@ impl AsFormat for rome_js_syntax::TsUndefinedType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsUndefinedType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsUndefinedType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsUndefinedType,
         crate::ts::types::undefined_type::FormatTsUndefinedType,
@@ -6867,7 +6861,7 @@ impl FormatRule<rome_js_syntax::TsNeverType> for crate::ts::types::never_type::F
         FormatNodeRule::<rome_js_syntax::TsNeverType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsNeverType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsNeverType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsNeverType,
@@ -6880,7 +6874,7 @@ impl AsFormat for rome_js_syntax::TsNeverType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsNeverType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsNeverType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsNeverType,
         crate::ts::types::never_type::FormatTsNeverType,
@@ -6905,7 +6899,7 @@ impl FormatRule<rome_js_syntax::TsParenthesizedType>
         FormatNodeRule::<rome_js_syntax::TsParenthesizedType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsParenthesizedType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsParenthesizedType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsParenthesizedType,
@@ -6918,7 +6912,7 @@ impl AsFormat for rome_js_syntax::TsParenthesizedType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsParenthesizedType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsParenthesizedType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsParenthesizedType,
         crate::ts::types::parenthesized_type::FormatTsParenthesizedType,
@@ -6939,7 +6933,7 @@ impl FormatRule<rome_js_syntax::TsReferenceType>
         FormatNodeRule::<rome_js_syntax::TsReferenceType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsReferenceType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsReferenceType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsReferenceType,
@@ -6952,7 +6946,7 @@ impl AsFormat for rome_js_syntax::TsReferenceType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsReferenceType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsReferenceType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsReferenceType,
         crate::ts::types::reference_type::FormatTsReferenceType,
@@ -6971,7 +6965,7 @@ impl FormatRule<rome_js_syntax::TsArrayType> for crate::ts::types::array_type::F
         FormatNodeRule::<rome_js_syntax::TsArrayType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsArrayType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsArrayType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsArrayType,
@@ -6984,7 +6978,7 @@ impl AsFormat for rome_js_syntax::TsArrayType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsArrayType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsArrayType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsArrayType,
         crate::ts::types::array_type::FormatTsArrayType,
@@ -7003,7 +6997,7 @@ impl FormatRule<rome_js_syntax::TsTupleType> for crate::ts::types::tuple_type::F
         FormatNodeRule::<rome_js_syntax::TsTupleType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTupleType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTupleType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTupleType,
@@ -7016,7 +7010,7 @@ impl AsFormat for rome_js_syntax::TsTupleType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTupleType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTupleType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTupleType,
         crate::ts::types::tuple_type::FormatTsTupleType,
@@ -7037,7 +7031,7 @@ impl FormatRule<rome_js_syntax::TsTypeofType>
         FormatNodeRule::<rome_js_syntax::TsTypeofType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeofType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeofType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeofType,
@@ -7050,7 +7044,7 @@ impl AsFormat for rome_js_syntax::TsTypeofType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeofType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeofType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeofType,
         crate::ts::types::typeof_type::FormatTsTypeofType,
@@ -7071,7 +7065,7 @@ impl FormatRule<rome_js_syntax::TsImportType>
         FormatNodeRule::<rome_js_syntax::TsImportType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsImportType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsImportType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsImportType,
@@ -7084,7 +7078,7 @@ impl AsFormat for rome_js_syntax::TsImportType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsImportType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsImportType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsImportType,
         crate::ts::module::import_type::FormatTsImportType,
@@ -7109,7 +7103,7 @@ impl FormatRule<rome_js_syntax::TsTypeOperatorType>
         FormatNodeRule::<rome_js_syntax::TsTypeOperatorType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeOperatorType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeOperatorType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeOperatorType,
@@ -7122,7 +7116,7 @@ impl AsFormat for rome_js_syntax::TsTypeOperatorType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeOperatorType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeOperatorType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeOperatorType,
         crate::ts::types::type_operator_type::FormatTsTypeOperatorType,
@@ -7147,7 +7141,7 @@ impl FormatRule<rome_js_syntax::TsIndexedAccessType>
         FormatNodeRule::<rome_js_syntax::TsIndexedAccessType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsIndexedAccessType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsIndexedAccessType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsIndexedAccessType,
@@ -7160,7 +7154,7 @@ impl AsFormat for rome_js_syntax::TsIndexedAccessType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIndexedAccessType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsIndexedAccessType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsIndexedAccessType,
         crate::ts::types::indexed_access_type::FormatTsIndexedAccessType,
@@ -7181,7 +7175,7 @@ impl FormatRule<rome_js_syntax::TsMappedType>
         FormatNodeRule::<rome_js_syntax::TsMappedType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsMappedType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsMappedType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsMappedType,
@@ -7194,7 +7188,7 @@ impl AsFormat for rome_js_syntax::TsMappedType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMappedType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsMappedType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsMappedType,
         crate::ts::types::mapped_type::FormatTsMappedType,
@@ -7215,7 +7209,7 @@ impl FormatRule<rome_js_syntax::TsObjectType>
         FormatNodeRule::<rome_js_syntax::TsObjectType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsObjectType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsObjectType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsObjectType,
@@ -7228,7 +7222,7 @@ impl AsFormat for rome_js_syntax::TsObjectType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsObjectType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsObjectType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsObjectType,
         crate::ts::types::object_type::FormatTsObjectType,
@@ -7253,7 +7247,7 @@ impl FormatRule<rome_js_syntax::TsNonPrimitiveType>
         FormatNodeRule::<rome_js_syntax::TsNonPrimitiveType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsNonPrimitiveType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsNonPrimitiveType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsNonPrimitiveType,
@@ -7266,7 +7260,7 @@ impl AsFormat for rome_js_syntax::TsNonPrimitiveType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsNonPrimitiveType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsNonPrimitiveType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsNonPrimitiveType,
         crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType,
@@ -7285,7 +7279,7 @@ impl FormatRule<rome_js_syntax::TsThisType> for crate::ts::types::this_type::For
         FormatNodeRule::<rome_js_syntax::TsThisType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsThisType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsThisType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsThisType,
@@ -7298,7 +7292,7 @@ impl AsFormat for rome_js_syntax::TsThisType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsThisType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsThisType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsThisType,
         crate::ts::types::this_type::FormatTsThisType,
@@ -7323,7 +7317,7 @@ impl FormatRule<rome_js_syntax::TsNumberLiteralType>
         FormatNodeRule::<rome_js_syntax::TsNumberLiteralType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsNumberLiteralType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsNumberLiteralType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsNumberLiteralType,
@@ -7336,7 +7330,7 @@ impl AsFormat for rome_js_syntax::TsNumberLiteralType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsNumberLiteralType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsNumberLiteralType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsNumberLiteralType,
         crate::ts::types::number_literal_type::FormatTsNumberLiteralType,
@@ -7361,7 +7355,7 @@ impl FormatRule<rome_js_syntax::TsBigIntLiteralType>
         FormatNodeRule::<rome_js_syntax::TsBigIntLiteralType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsBigIntLiteralType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsBigIntLiteralType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsBigIntLiteralType,
@@ -7374,7 +7368,7 @@ impl AsFormat for rome_js_syntax::TsBigIntLiteralType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsBigIntLiteralType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsBigIntLiteralType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsBigIntLiteralType,
         crate::ts::types::big_int_literal_type::FormatTsBigIntLiteralType,
@@ -7399,7 +7393,7 @@ impl FormatRule<rome_js_syntax::TsStringLiteralType>
         FormatNodeRule::<rome_js_syntax::TsStringLiteralType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsStringLiteralType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsStringLiteralType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsStringLiteralType,
@@ -7412,7 +7406,7 @@ impl AsFormat for rome_js_syntax::TsStringLiteralType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsStringLiteralType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsStringLiteralType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsStringLiteralType,
         crate::ts::types::string_literal_type::FormatTsStringLiteralType,
@@ -7437,7 +7431,7 @@ impl FormatRule<rome_js_syntax::TsNullLiteralType>
         FormatNodeRule::<rome_js_syntax::TsNullLiteralType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsNullLiteralType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsNullLiteralType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsNullLiteralType,
@@ -7450,7 +7444,7 @@ impl AsFormat for rome_js_syntax::TsNullLiteralType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsNullLiteralType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsNullLiteralType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsNullLiteralType,
         crate::ts::types::null_literal_type::FormatTsNullLiteralType,
@@ -7475,7 +7469,7 @@ impl FormatRule<rome_js_syntax::TsBooleanLiteralType>
         FormatNodeRule::<rome_js_syntax::TsBooleanLiteralType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsBooleanLiteralType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsBooleanLiteralType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsBooleanLiteralType,
@@ -7488,7 +7482,7 @@ impl AsFormat for rome_js_syntax::TsBooleanLiteralType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsBooleanLiteralType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsBooleanLiteralType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsBooleanLiteralType,
         crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType,
@@ -7513,7 +7507,7 @@ impl FormatRule<rome_js_syntax::TsTemplateLiteralType>
         FormatNodeRule::<rome_js_syntax::TsTemplateLiteralType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTemplateLiteralType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTemplateLiteralType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTemplateLiteralType,
@@ -7526,7 +7520,7 @@ impl AsFormat for rome_js_syntax::TsTemplateLiteralType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTemplateLiteralType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTemplateLiteralType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTemplateLiteralType,
         crate::ts::expressions::template_literal_type::FormatTsTemplateLiteralType,
@@ -7545,7 +7539,7 @@ impl FormatRule<rome_js_syntax::TsInferType> for crate::ts::types::infer_type::F
         FormatNodeRule::<rome_js_syntax::TsInferType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsInferType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsInferType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsInferType,
@@ -7558,7 +7552,7 @@ impl AsFormat for rome_js_syntax::TsInferType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsInferType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsInferType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsInferType,
         crate::ts::types::infer_type::FormatTsInferType,
@@ -7583,7 +7577,7 @@ impl FormatRule<rome_js_syntax::TsIntersectionType>
         FormatNodeRule::<rome_js_syntax::TsIntersectionType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsIntersectionType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsIntersectionType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsIntersectionType,
@@ -7596,7 +7590,7 @@ impl AsFormat for rome_js_syntax::TsIntersectionType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIntersectionType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsIntersectionType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsIntersectionType,
         crate::ts::types::intersection_type::FormatTsIntersectionType,
@@ -7615,7 +7609,7 @@ impl FormatRule<rome_js_syntax::TsUnionType> for crate::ts::types::union_type::F
         FormatNodeRule::<rome_js_syntax::TsUnionType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsUnionType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsUnionType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsUnionType,
@@ -7628,7 +7622,7 @@ impl AsFormat for rome_js_syntax::TsUnionType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsUnionType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsUnionType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsUnionType,
         crate::ts::types::union_type::FormatTsUnionType,
@@ -7649,7 +7643,7 @@ impl FormatRule<rome_js_syntax::TsFunctionType>
         FormatNodeRule::<rome_js_syntax::TsFunctionType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsFunctionType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsFunctionType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsFunctionType,
@@ -7662,7 +7656,7 @@ impl AsFormat for rome_js_syntax::TsFunctionType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsFunctionType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsFunctionType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsFunctionType,
         crate::ts::types::function_type::FormatTsFunctionType,
@@ -7687,7 +7681,7 @@ impl FormatRule<rome_js_syntax::TsConstructorType>
         FormatNodeRule::<rome_js_syntax::TsConstructorType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsConstructorType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsConstructorType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsConstructorType,
@@ -7700,7 +7694,7 @@ impl AsFormat for rome_js_syntax::TsConstructorType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsConstructorType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsConstructorType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsConstructorType,
         crate::ts::types::constructor_type::FormatTsConstructorType,
@@ -7725,7 +7719,7 @@ impl FormatRule<rome_js_syntax::TsConditionalType>
         FormatNodeRule::<rome_js_syntax::TsConditionalType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsConditionalType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsConditionalType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsConditionalType,
@@ -7738,7 +7732,7 @@ impl AsFormat for rome_js_syntax::TsConditionalType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsConditionalType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsConditionalType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsConditionalType,
         crate::ts::types::conditional_type::FormatTsConditionalType,
@@ -7763,7 +7757,7 @@ impl FormatRule<rome_js_syntax::TsIdentifierBinding>
         FormatNodeRule::<rome_js_syntax::TsIdentifierBinding>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsIdentifierBinding {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsIdentifierBinding {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsIdentifierBinding,
@@ -7776,7 +7770,7 @@ impl AsFormat for rome_js_syntax::TsIdentifierBinding {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIdentifierBinding {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsIdentifierBinding {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsIdentifierBinding,
         crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding,
@@ -7797,7 +7791,7 @@ impl FormatRule<rome_js_syntax::TsEnumMember>
         FormatNodeRule::<rome_js_syntax::TsEnumMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsEnumMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsEnumMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsEnumMember,
@@ -7810,7 +7804,7 @@ impl AsFormat for rome_js_syntax::TsEnumMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsEnumMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsEnumMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsEnumMember,
         crate::ts::auxiliary::enum_member::FormatTsEnumMember,
@@ -7835,7 +7829,7 @@ impl FormatRule<rome_js_syntax::TsExternalModuleReference>
         FormatNodeRule::<rome_js_syntax::TsExternalModuleReference>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsExternalModuleReference {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsExternalModuleReference {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsExternalModuleReference,
@@ -7845,7 +7839,7 @@ impl AsFormat for rome_js_syntax::TsExternalModuleReference {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: external_module_reference :: FormatTsExternalModuleReference :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsExternalModuleReference {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsExternalModuleReference {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsExternalModuleReference,
         crate::ts::auxiliary::external_module_reference::FormatTsExternalModuleReference,
@@ -7863,7 +7857,7 @@ impl FormatRule<rome_js_syntax::TsModuleBlock>
         FormatNodeRule::<rome_js_syntax::TsModuleBlock>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsModuleBlock {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsModuleBlock {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsModuleBlock,
@@ -7876,7 +7870,7 @@ impl AsFormat for rome_js_syntax::TsModuleBlock {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsModuleBlock {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsModuleBlock {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsModuleBlock,
         crate::ts::auxiliary::module_block::FormatTsModuleBlock,
@@ -7901,7 +7895,7 @@ impl FormatRule<rome_js_syntax::TsQualifiedModuleName>
         FormatNodeRule::<rome_js_syntax::TsQualifiedModuleName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsQualifiedModuleName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsQualifiedModuleName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsQualifiedModuleName,
@@ -7914,7 +7908,7 @@ impl AsFormat for rome_js_syntax::TsQualifiedModuleName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsQualifiedModuleName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsQualifiedModuleName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsQualifiedModuleName,
         crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName,
@@ -7927,13 +7921,13 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsQualifiedModuleNam
     }
 }
 impl FormatRule < rome_js_syntax :: TsEmptyExternalModuleDeclarationBody > for crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: TsEmptyExternalModuleDeclarationBody , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: TsEmptyExternalModuleDeclarationBody > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::TsEmptyExternalModuleDeclarationBody {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsEmptyExternalModuleDeclarationBody {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: TsEmptyExternalModuleDeclarationBody , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsEmptyExternalModuleDeclarationBody {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsEmptyExternalModuleDeclarationBody {
     type Format = FormatOwnedWithRule < rome_js_syntax :: TsEmptyExternalModuleDeclarationBody , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody :: default ())
@@ -7952,7 +7946,7 @@ impl FormatRule<rome_js_syntax::TsTypeParameterName>
         FormatNodeRule::<rome_js_syntax::TsTypeParameterName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeParameterName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeParameterName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeParameterName,
@@ -7965,7 +7959,7 @@ impl AsFormat for rome_js_syntax::TsTypeParameterName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeParameterName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeParameterName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeParameterName,
         crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName,
@@ -7990,7 +7984,7 @@ impl FormatRule<rome_js_syntax::TsPredicateReturnType>
         FormatNodeRule::<rome_js_syntax::TsPredicateReturnType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsPredicateReturnType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsPredicateReturnType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsPredicateReturnType,
@@ -8003,7 +7997,7 @@ impl AsFormat for rome_js_syntax::TsPredicateReturnType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPredicateReturnType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsPredicateReturnType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsPredicateReturnType,
         crate::ts::types::predicate_return_type::FormatTsPredicateReturnType,
@@ -8028,7 +8022,7 @@ impl FormatRule<rome_js_syntax::TsAssertsReturnType>
         FormatNodeRule::<rome_js_syntax::TsAssertsReturnType>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsAssertsReturnType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAssertsReturnType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAssertsReturnType,
@@ -8041,7 +8035,7 @@ impl AsFormat for rome_js_syntax::TsAssertsReturnType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAssertsReturnType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAssertsReturnType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAssertsReturnType,
         crate::ts::types::asserts_return_type::FormatTsAssertsReturnType,
@@ -8066,7 +8060,7 @@ impl FormatRule<rome_js_syntax::TsAssertsCondition>
         FormatNodeRule::<rome_js_syntax::TsAssertsCondition>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsAssertsCondition {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAssertsCondition {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAssertsCondition,
@@ -8079,7 +8073,7 @@ impl AsFormat for rome_js_syntax::TsAssertsCondition {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAssertsCondition {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAssertsCondition {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAssertsCondition,
         crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition,
@@ -8100,7 +8094,7 @@ impl FormatRule<rome_js_syntax::TsTypeParameter>
         FormatNodeRule::<rome_js_syntax::TsTypeParameter>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeParameter,
@@ -8113,7 +8107,7 @@ impl AsFormat for rome_js_syntax::TsTypeParameter {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeParameter,
         crate::ts::bindings::type_parameter::FormatTsTypeParameter,
@@ -8138,7 +8132,7 @@ impl FormatRule<rome_js_syntax::TsTypeConstraintClause>
         FormatNodeRule::<rome_js_syntax::TsTypeConstraintClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeConstraintClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeConstraintClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeConstraintClause,
@@ -8151,7 +8145,7 @@ impl AsFormat for rome_js_syntax::TsTypeConstraintClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeConstraintClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeConstraintClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeConstraintClause,
         crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause,
@@ -8176,7 +8170,7 @@ impl FormatRule<rome_js_syntax::TsDefaultTypeClause>
         FormatNodeRule::<rome_js_syntax::TsDefaultTypeClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsDefaultTypeClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsDefaultTypeClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsDefaultTypeClause,
@@ -8189,7 +8183,7 @@ impl AsFormat for rome_js_syntax::TsDefaultTypeClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsDefaultTypeClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsDefaultTypeClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsDefaultTypeClause,
         crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause,
@@ -8210,7 +8204,7 @@ impl FormatRule<rome_js_syntax::TsExtendsClause>
         FormatNodeRule::<rome_js_syntax::TsExtendsClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsExtendsClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsExtendsClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsExtendsClause,
@@ -8223,7 +8217,7 @@ impl AsFormat for rome_js_syntax::TsExtendsClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsExtendsClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsExtendsClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsExtendsClause,
         crate::ts::classes::extends_clause::FormatTsExtendsClause,
@@ -8248,7 +8242,7 @@ impl FormatRule<rome_js_syntax::TsNameWithTypeArguments>
         FormatNodeRule::<rome_js_syntax::TsNameWithTypeArguments>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsNameWithTypeArguments {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsNameWithTypeArguments {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsNameWithTypeArguments,
@@ -8258,7 +8252,7 @@ impl AsFormat for rome_js_syntax::TsNameWithTypeArguments {
         FormatRefWithRule :: new (self , crate :: ts :: expressions :: name_with_type_arguments :: FormatTsNameWithTypeArguments :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsNameWithTypeArguments {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsNameWithTypeArguments {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsNameWithTypeArguments,
         crate::ts::expressions::name_with_type_arguments::FormatTsNameWithTypeArguments,
@@ -8280,7 +8274,7 @@ impl FormatRule<rome_js_syntax::TsCallSignatureTypeMember>
         FormatNodeRule::<rome_js_syntax::TsCallSignatureTypeMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsCallSignatureTypeMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsCallSignatureTypeMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsCallSignatureTypeMember,
@@ -8290,7 +8284,7 @@ impl AsFormat for rome_js_syntax::TsCallSignatureTypeMember {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: call_signature_type_member :: FormatTsCallSignatureTypeMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsCallSignatureTypeMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsCallSignatureTypeMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsCallSignatureTypeMember,
         crate::ts::auxiliary::call_signature_type_member::FormatTsCallSignatureTypeMember,
@@ -8312,7 +8306,7 @@ impl FormatRule<rome_js_syntax::TsPropertySignatureTypeMember>
         FormatNodeRule::<rome_js_syntax::TsPropertySignatureTypeMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsPropertySignatureTypeMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsPropertySignatureTypeMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsPropertySignatureTypeMember,
@@ -8322,7 +8316,7 @@ impl AsFormat for rome_js_syntax::TsPropertySignatureTypeMember {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: property_signature_type_member :: FormatTsPropertySignatureTypeMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPropertySignatureTypeMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsPropertySignatureTypeMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsPropertySignatureTypeMember,
         crate::ts::auxiliary::property_signature_type_member::FormatTsPropertySignatureTypeMember,
@@ -8344,7 +8338,7 @@ impl FormatRule<rome_js_syntax::TsConstructSignatureTypeMember>
         FormatNodeRule::<rome_js_syntax::TsConstructSignatureTypeMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsConstructSignatureTypeMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsConstructSignatureTypeMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsConstructSignatureTypeMember,
@@ -8354,7 +8348,7 @@ impl AsFormat for rome_js_syntax::TsConstructSignatureTypeMember {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: construct_signature_type_member :: FormatTsConstructSignatureTypeMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsConstructSignatureTypeMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsConstructSignatureTypeMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsConstructSignatureTypeMember,
         crate::ts::auxiliary::construct_signature_type_member::FormatTsConstructSignatureTypeMember,
@@ -8376,7 +8370,7 @@ impl FormatRule<rome_js_syntax::TsMethodSignatureTypeMember>
         FormatNodeRule::<rome_js_syntax::TsMethodSignatureTypeMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsMethodSignatureTypeMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsMethodSignatureTypeMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsMethodSignatureTypeMember,
@@ -8386,7 +8380,7 @@ impl AsFormat for rome_js_syntax::TsMethodSignatureTypeMember {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: method_signature_type_member :: FormatTsMethodSignatureTypeMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMethodSignatureTypeMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsMethodSignatureTypeMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsMethodSignatureTypeMember,
         crate::ts::auxiliary::method_signature_type_member::FormatTsMethodSignatureTypeMember,
@@ -8408,7 +8402,7 @@ impl FormatRule<rome_js_syntax::TsGetterSignatureTypeMember>
         FormatNodeRule::<rome_js_syntax::TsGetterSignatureTypeMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsGetterSignatureTypeMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsGetterSignatureTypeMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsGetterSignatureTypeMember,
@@ -8418,7 +8412,7 @@ impl AsFormat for rome_js_syntax::TsGetterSignatureTypeMember {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: getter_signature_type_member :: FormatTsGetterSignatureTypeMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsGetterSignatureTypeMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsGetterSignatureTypeMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsGetterSignatureTypeMember,
         crate::ts::auxiliary::getter_signature_type_member::FormatTsGetterSignatureTypeMember,
@@ -8440,7 +8434,7 @@ impl FormatRule<rome_js_syntax::TsSetterSignatureTypeMember>
         FormatNodeRule::<rome_js_syntax::TsSetterSignatureTypeMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsSetterSignatureTypeMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsSetterSignatureTypeMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsSetterSignatureTypeMember,
@@ -8450,7 +8444,7 @@ impl AsFormat for rome_js_syntax::TsSetterSignatureTypeMember {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: setter_signature_type_member :: FormatTsSetterSignatureTypeMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsSetterSignatureTypeMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsSetterSignatureTypeMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsSetterSignatureTypeMember,
         crate::ts::auxiliary::setter_signature_type_member::FormatTsSetterSignatureTypeMember,
@@ -8472,7 +8466,7 @@ impl FormatRule<rome_js_syntax::TsIndexSignatureTypeMember>
         FormatNodeRule::<rome_js_syntax::TsIndexSignatureTypeMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsIndexSignatureTypeMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsIndexSignatureTypeMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsIndexSignatureTypeMember,
@@ -8482,7 +8476,7 @@ impl AsFormat for rome_js_syntax::TsIndexSignatureTypeMember {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: index_signature_type_member :: FormatTsIndexSignatureTypeMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIndexSignatureTypeMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsIndexSignatureTypeMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsIndexSignatureTypeMember,
         crate::ts::auxiliary::index_signature_type_member::FormatTsIndexSignatureTypeMember,
@@ -8492,13 +8486,13 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIndexSignatureType
     }
 }
 impl FormatRule < rome_js_syntax :: TsMappedTypeReadonlyModifierClause > for crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: TsMappedTypeReadonlyModifierClause , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: TsMappedTypeReadonlyModifierClause > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::TsMappedTypeReadonlyModifierClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsMappedTypeReadonlyModifierClause {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: TsMappedTypeReadonlyModifierClause , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMappedTypeReadonlyModifierClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsMappedTypeReadonlyModifierClause {
     type Format = FormatOwnedWithRule < rome_js_syntax :: TsMappedTypeReadonlyModifierClause , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause :: default ())
@@ -8517,7 +8511,7 @@ impl FormatRule<rome_js_syntax::TsMappedTypeAsClause>
         FormatNodeRule::<rome_js_syntax::TsMappedTypeAsClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsMappedTypeAsClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsMappedTypeAsClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsMappedTypeAsClause,
@@ -8530,7 +8524,7 @@ impl AsFormat for rome_js_syntax::TsMappedTypeAsClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMappedTypeAsClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsMappedTypeAsClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsMappedTypeAsClause,
         crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause,
@@ -8543,13 +8537,13 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMappedTypeAsClause
     }
 }
 impl FormatRule < rome_js_syntax :: TsMappedTypeOptionalModifierClause > for crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause { type Context = JsFormatContext ; # [inline (always)] fn fmt (& self , node : & rome_js_syntax :: TsMappedTypeOptionalModifierClause , f : & mut JsFormatter) -> FormatResult < () > { FormatNodeRule :: < rome_js_syntax :: TsMappedTypeOptionalModifierClause > :: fmt (self , node , f) } }
-impl AsFormat for rome_js_syntax::TsMappedTypeOptionalModifierClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsMappedTypeOptionalModifierClause {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: TsMappedTypeOptionalModifierClause , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMappedTypeOptionalModifierClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsMappedTypeOptionalModifierClause {
     type Format = FormatOwnedWithRule < rome_js_syntax :: TsMappedTypeOptionalModifierClause , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause :: default ())
@@ -8568,7 +8562,7 @@ impl FormatRule<rome_js_syntax::TsImportTypeQualifier>
         FormatNodeRule::<rome_js_syntax::TsImportTypeQualifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsImportTypeQualifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsImportTypeQualifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsImportTypeQualifier,
@@ -8581,7 +8575,7 @@ impl AsFormat for rome_js_syntax::TsImportTypeQualifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsImportTypeQualifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsImportTypeQualifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsImportTypeQualifier,
         crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier,
@@ -8606,7 +8600,7 @@ impl FormatRule<rome_js_syntax::TsNamedTupleTypeElement>
         FormatNodeRule::<rome_js_syntax::TsNamedTupleTypeElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsNamedTupleTypeElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsNamedTupleTypeElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsNamedTupleTypeElement,
@@ -8620,7 +8614,7 @@ impl AsFormat for rome_js_syntax::TsNamedTupleTypeElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsNamedTupleTypeElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsNamedTupleTypeElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsNamedTupleTypeElement,
         crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement,
@@ -8646,7 +8640,7 @@ impl FormatRule<rome_js_syntax::TsRestTupleTypeElement>
         FormatNodeRule::<rome_js_syntax::TsRestTupleTypeElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsRestTupleTypeElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsRestTupleTypeElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsRestTupleTypeElement,
@@ -8659,7 +8653,7 @@ impl AsFormat for rome_js_syntax::TsRestTupleTypeElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsRestTupleTypeElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsRestTupleTypeElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsRestTupleTypeElement,
         crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement,
@@ -8684,7 +8678,7 @@ impl FormatRule<rome_js_syntax::TsOptionalTupleTypeElement>
         FormatNodeRule::<rome_js_syntax::TsOptionalTupleTypeElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsOptionalTupleTypeElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsOptionalTupleTypeElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsOptionalTupleTypeElement,
@@ -8694,7 +8688,7 @@ impl AsFormat for rome_js_syntax::TsOptionalTupleTypeElement {
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: optional_tuple_type_element :: FormatTsOptionalTupleTypeElement :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsOptionalTupleTypeElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsOptionalTupleTypeElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsOptionalTupleTypeElement,
         crate::ts::auxiliary::optional_tuple_type_element::FormatTsOptionalTupleTypeElement,
@@ -8716,7 +8710,7 @@ impl FormatRule<rome_js_syntax::TsTemplateChunkElement>
         FormatNodeRule::<rome_js_syntax::TsTemplateChunkElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTemplateChunkElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTemplateChunkElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTemplateChunkElement,
@@ -8729,7 +8723,7 @@ impl AsFormat for rome_js_syntax::TsTemplateChunkElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTemplateChunkElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTemplateChunkElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTemplateChunkElement,
         crate::ts::expressions::template_chunk_element::FormatTsTemplateChunkElement,
@@ -8754,7 +8748,7 @@ impl FormatRule<rome_js_syntax::TsTemplateElement>
         FormatNodeRule::<rome_js_syntax::TsTemplateElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsTemplateElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTemplateElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTemplateElement,
@@ -8767,7 +8761,7 @@ impl AsFormat for rome_js_syntax::TsTemplateElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTemplateElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTemplateElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTemplateElement,
         crate::ts::expressions::template_element::FormatTsTemplateElement,
@@ -8788,7 +8782,7 @@ impl FormatRule<rome_js_syntax::TsQualifiedName>
         FormatNodeRule::<rome_js_syntax::TsQualifiedName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::TsQualifiedName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsQualifiedName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsQualifiedName,
@@ -8801,7 +8795,7 @@ impl AsFormat for rome_js_syntax::TsQualifiedName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsQualifiedName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsQualifiedName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsQualifiedName,
         crate::ts::auxiliary::qualified_name::FormatTsQualifiedName,
@@ -8820,7 +8814,7 @@ impl FormatRule<rome_js_syntax::JsxElement> for crate::jsx::tag::element::Format
         FormatNodeRule::<rome_js_syntax::JsxElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxElement,
@@ -8830,7 +8824,7 @@ impl AsFormat for rome_js_syntax::JsxElement {
         FormatRefWithRule::new(self, crate::jsx::tag::element::FormatJsxElement::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxElement {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsxElement, crate::jsx::tag::element::FormatJsxElement>;
     fn into_format(self) -> Self::Format {
@@ -8850,7 +8844,7 @@ impl FormatRule<rome_js_syntax::JsxSelfClosingElement>
         FormatNodeRule::<rome_js_syntax::JsxSelfClosingElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxSelfClosingElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxSelfClosingElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxSelfClosingElement,
@@ -8863,7 +8857,7 @@ impl AsFormat for rome_js_syntax::JsxSelfClosingElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxSelfClosingElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxSelfClosingElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxSelfClosingElement,
         crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement,
@@ -8882,7 +8876,7 @@ impl FormatRule<rome_js_syntax::JsxFragment> for crate::jsx::tag::fragment::Form
         FormatNodeRule::<rome_js_syntax::JsxFragment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxFragment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxFragment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxFragment,
@@ -8895,7 +8889,7 @@ impl AsFormat for rome_js_syntax::JsxFragment {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxFragment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxFragment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxFragment,
         crate::jsx::tag::fragment::FormatJsxFragment,
@@ -8920,7 +8914,7 @@ impl FormatRule<rome_js_syntax::JsxOpeningElement>
         FormatNodeRule::<rome_js_syntax::JsxOpeningElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxOpeningElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxOpeningElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxOpeningElement,
@@ -8933,7 +8927,7 @@ impl AsFormat for rome_js_syntax::JsxOpeningElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxOpeningElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxOpeningElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxOpeningElement,
         crate::jsx::tag::opening_element::FormatJsxOpeningElement,
@@ -8958,7 +8952,7 @@ impl FormatRule<rome_js_syntax::JsxClosingElement>
         FormatNodeRule::<rome_js_syntax::JsxClosingElement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxClosingElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxClosingElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxClosingElement,
@@ -8971,7 +8965,7 @@ impl AsFormat for rome_js_syntax::JsxClosingElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxClosingElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxClosingElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxClosingElement,
         crate::jsx::tag::closing_element::FormatJsxClosingElement,
@@ -8996,7 +8990,7 @@ impl FormatRule<rome_js_syntax::JsxOpeningFragment>
         FormatNodeRule::<rome_js_syntax::JsxOpeningFragment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxOpeningFragment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxOpeningFragment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxOpeningFragment,
@@ -9009,7 +9003,7 @@ impl AsFormat for rome_js_syntax::JsxOpeningFragment {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxOpeningFragment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxOpeningFragment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxOpeningFragment,
         crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment,
@@ -9034,7 +9028,7 @@ impl FormatRule<rome_js_syntax::JsxClosingFragment>
         FormatNodeRule::<rome_js_syntax::JsxClosingFragment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxClosingFragment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxClosingFragment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxClosingFragment,
@@ -9047,7 +9041,7 @@ impl AsFormat for rome_js_syntax::JsxClosingFragment {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxClosingFragment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxClosingFragment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxClosingFragment,
         crate::jsx::tag::closing_fragment::FormatJsxClosingFragment,
@@ -9066,14 +9060,14 @@ impl FormatRule<rome_js_syntax::JsxName> for crate::jsx::auxiliary::name::Format
         FormatNodeRule::<rome_js_syntax::JsxName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxName {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsxName, crate::jsx::auxiliary::name::FormatJsxName>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::jsx::auxiliary::name::FormatJsxName::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxName {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsxName, crate::jsx::auxiliary::name::FormatJsxName>;
     fn into_format(self) -> Self::Format {
@@ -9093,7 +9087,7 @@ impl FormatRule<rome_js_syntax::JsxReferenceIdentifier>
         FormatNodeRule::<rome_js_syntax::JsxReferenceIdentifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxReferenceIdentifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxReferenceIdentifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxReferenceIdentifier,
@@ -9106,7 +9100,7 @@ impl AsFormat for rome_js_syntax::JsxReferenceIdentifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxReferenceIdentifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxReferenceIdentifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxReferenceIdentifier,
         crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier,
@@ -9131,7 +9125,7 @@ impl FormatRule<rome_js_syntax::JsxNamespaceName>
         FormatNodeRule::<rome_js_syntax::JsxNamespaceName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxNamespaceName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxNamespaceName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxNamespaceName,
@@ -9144,7 +9138,7 @@ impl AsFormat for rome_js_syntax::JsxNamespaceName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxNamespaceName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxNamespaceName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxNamespaceName,
         crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName,
@@ -9165,7 +9159,7 @@ impl FormatRule<rome_js_syntax::JsxMemberName>
         FormatNodeRule::<rome_js_syntax::JsxMemberName>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxMemberName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxMemberName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxMemberName,
@@ -9178,7 +9172,7 @@ impl AsFormat for rome_js_syntax::JsxMemberName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxMemberName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxMemberName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxMemberName,
         crate::jsx::objects::member_name::FormatJsxMemberName,
@@ -9199,7 +9193,7 @@ impl FormatRule<rome_js_syntax::JsxAttribute>
         FormatNodeRule::<rome_js_syntax::JsxAttribute>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxAttribute {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAttribute {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxAttribute,
@@ -9212,7 +9206,7 @@ impl AsFormat for rome_js_syntax::JsxAttribute {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAttribute {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAttribute {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxAttribute,
         crate::jsx::attribute::attribute::FormatJsxAttribute,
@@ -9237,7 +9231,7 @@ impl FormatRule<rome_js_syntax::JsxSpreadAttribute>
         FormatNodeRule::<rome_js_syntax::JsxSpreadAttribute>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxSpreadAttribute {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxSpreadAttribute {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxSpreadAttribute,
@@ -9250,7 +9244,7 @@ impl AsFormat for rome_js_syntax::JsxSpreadAttribute {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxSpreadAttribute {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxSpreadAttribute {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxSpreadAttribute,
         crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute,
@@ -9275,7 +9269,7 @@ impl FormatRule<rome_js_syntax::JsxAttributeInitializerClause>
         FormatNodeRule::<rome_js_syntax::JsxAttributeInitializerClause>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxAttributeInitializerClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAttributeInitializerClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxAttributeInitializerClause,
@@ -9285,7 +9279,7 @@ impl AsFormat for rome_js_syntax::JsxAttributeInitializerClause {
         FormatRefWithRule :: new (self , crate :: jsx :: attribute :: attribute_initializer_clause :: FormatJsxAttributeInitializerClause :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAttributeInitializerClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAttributeInitializerClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxAttributeInitializerClause,
         crate::jsx::attribute::attribute_initializer_clause::FormatJsxAttributeInitializerClause,
@@ -9301,7 +9295,7 @@ impl FormatRule<rome_js_syntax::JsxString> for crate::jsx::auxiliary::string::Fo
         FormatNodeRule::<rome_js_syntax::JsxString>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxString {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxString {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxString,
@@ -9314,7 +9308,7 @@ impl AsFormat for rome_js_syntax::JsxString {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxString {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxString {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxString,
         crate::jsx::auxiliary::string::FormatJsxString,
@@ -9339,7 +9333,7 @@ impl FormatRule<rome_js_syntax::JsxExpressionAttributeValue>
         FormatNodeRule::<rome_js_syntax::JsxExpressionAttributeValue>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxExpressionAttributeValue {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxExpressionAttributeValue {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxExpressionAttributeValue,
@@ -9349,7 +9343,7 @@ impl AsFormat for rome_js_syntax::JsxExpressionAttributeValue {
         FormatRefWithRule :: new (self , crate :: jsx :: attribute :: expression_attribute_value :: FormatJsxExpressionAttributeValue :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxExpressionAttributeValue {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxExpressionAttributeValue {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxExpressionAttributeValue,
         crate::jsx::attribute::expression_attribute_value::FormatJsxExpressionAttributeValue,
@@ -9365,14 +9359,14 @@ impl FormatRule<rome_js_syntax::JsxText> for crate::jsx::auxiliary::text::Format
         FormatNodeRule::<rome_js_syntax::JsxText>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxText {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxText {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsxText, crate::jsx::auxiliary::text::FormatJsxText>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::jsx::auxiliary::text::FormatJsxText::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxText {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxText {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsxText, crate::jsx::auxiliary::text::FormatJsxText>;
     fn into_format(self) -> Self::Format {
@@ -9392,7 +9386,7 @@ impl FormatRule<rome_js_syntax::JsxExpressionChild>
         FormatNodeRule::<rome_js_syntax::JsxExpressionChild>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxExpressionChild {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxExpressionChild {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxExpressionChild,
@@ -9405,7 +9399,7 @@ impl AsFormat for rome_js_syntax::JsxExpressionChild {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxExpressionChild {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxExpressionChild {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxExpressionChild,
         crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild,
@@ -9426,7 +9420,7 @@ impl FormatRule<rome_js_syntax::JsxSpreadChild>
         FormatNodeRule::<rome_js_syntax::JsxSpreadChild>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsxSpreadChild {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxSpreadChild {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxSpreadChild,
@@ -9439,7 +9433,7 @@ impl AsFormat for rome_js_syntax::JsxSpreadChild {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxSpreadChild {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxSpreadChild {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxSpreadChild,
         crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild,
@@ -9451,31 +9445,31 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxSpreadChild {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsArrayAssignmentPatternElementList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrayAssignmentPatternElementList {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsArrayAssignmentPatternElementList , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayAssignmentPatternElementList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrayAssignmentPatternElementList {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsArrayAssignmentPatternElementList , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsArrayBindingPatternElementList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrayBindingPatternElementList {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsArrayBindingPatternElementList , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayBindingPatternElementList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrayBindingPatternElementList {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsArrayBindingPatternElementList , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsArrayElementList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsArrayElementList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsArrayElementList,
@@ -9488,7 +9482,7 @@ impl AsFormat for rome_js_syntax::JsArrayElementList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayElementList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsArrayElementList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsArrayElementList,
         crate::js::lists::array_element_list::FormatJsArrayElementList,
@@ -9500,7 +9494,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsArrayElementList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsCallArgumentList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsCallArgumentList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsCallArgumentList,
@@ -9513,7 +9507,7 @@ impl AsFormat for rome_js_syntax::JsCallArgumentList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsCallArgumentList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsCallArgumentList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsCallArgumentList,
         crate::js::lists::call_argument_list::FormatJsCallArgumentList,
@@ -9525,7 +9519,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsCallArgumentList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsClassMemberList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsClassMemberList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsClassMemberList,
@@ -9538,7 +9532,7 @@ impl AsFormat for rome_js_syntax::JsClassMemberList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsClassMemberList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsClassMemberList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsClassMemberList,
         crate::js::lists::class_member_list::FormatJsClassMemberList,
@@ -9550,7 +9544,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsClassMemberList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsConstructorModifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsConstructorModifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsConstructorModifierList,
@@ -9563,7 +9557,7 @@ impl AsFormat for rome_js_syntax::JsConstructorModifierList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConstructorModifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsConstructorModifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsConstructorModifierList,
         crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList,
@@ -9575,7 +9569,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConstructorModifie
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsConstructorParameterList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsConstructorParameterList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsConstructorParameterList,
@@ -9589,7 +9583,7 @@ impl AsFormat for rome_js_syntax::JsConstructorParameterList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConstructorParameterList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsConstructorParameterList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsConstructorParameterList,
         crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList,
@@ -9602,7 +9596,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsConstructorParamet
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsDirectiveList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsDirectiveList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsDirectiveList,
@@ -9615,7 +9609,7 @@ impl AsFormat for rome_js_syntax::JsDirectiveList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsDirectiveList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsDirectiveList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsDirectiveList,
         crate::js::lists::directive_list::FormatJsDirectiveList,
@@ -9627,7 +9621,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsDirectiveList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsExportNamedFromSpecifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportNamedFromSpecifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportNamedFromSpecifierList,
@@ -9637,7 +9631,7 @@ impl AsFormat for rome_js_syntax::JsExportNamedFromSpecifierList {
         FormatRefWithRule :: new (self , crate :: js :: lists :: export_named_from_specifier_list :: FormatJsExportNamedFromSpecifierList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedFromSpecifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportNamedFromSpecifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportNamedFromSpecifierList,
         crate::js::lists::export_named_from_specifier_list::FormatJsExportNamedFromSpecifierList,
@@ -9646,7 +9640,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedFromSpe
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: export_named_from_specifier_list :: FormatJsExportNamedFromSpecifierList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsExportNamedSpecifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsExportNamedSpecifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsExportNamedSpecifierList,
@@ -9656,7 +9650,7 @@ impl AsFormat for rome_js_syntax::JsExportNamedSpecifierList {
         FormatRefWithRule :: new (self , crate :: js :: lists :: export_named_specifier_list :: FormatJsExportNamedSpecifierList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedSpecifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsExportNamedSpecifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsExportNamedSpecifierList,
         crate::js::lists::export_named_specifier_list::FormatJsExportNamedSpecifierList,
@@ -9665,7 +9659,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsExportNamedSpecifi
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: export_named_specifier_list :: FormatJsExportNamedSpecifierList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsImportAssertionEntryList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsImportAssertionEntryList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsImportAssertionEntryList,
@@ -9675,7 +9669,7 @@ impl AsFormat for rome_js_syntax::JsImportAssertionEntryList {
         FormatRefWithRule :: new (self , crate :: js :: lists :: import_assertion_entry_list :: FormatJsImportAssertionEntryList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportAssertionEntryList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsImportAssertionEntryList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsImportAssertionEntryList,
         crate::js::lists::import_assertion_entry_list::FormatJsImportAssertionEntryList,
@@ -9684,7 +9678,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsImportAssertionEnt
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: import_assertion_entry_list :: FormatJsImportAssertionEntryList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsMethodModifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsMethodModifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsMethodModifierList,
@@ -9697,7 +9691,7 @@ impl AsFormat for rome_js_syntax::JsMethodModifierList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsMethodModifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsMethodModifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsMethodModifierList,
         crate::js::lists::method_modifier_list::FormatJsMethodModifierList,
@@ -9709,7 +9703,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsMethodModifierList
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsModuleItemList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsModuleItemList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsModuleItemList,
@@ -9722,7 +9716,7 @@ impl AsFormat for rome_js_syntax::JsModuleItemList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsModuleItemList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsModuleItemList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsModuleItemList,
         crate::js::lists::module_item_list::FormatJsModuleItemList,
@@ -9734,7 +9728,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsModuleItemList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsNamedImportSpecifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsNamedImportSpecifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsNamedImportSpecifierList,
@@ -9744,7 +9738,7 @@ impl AsFormat for rome_js_syntax::JsNamedImportSpecifierList {
         FormatRefWithRule :: new (self , crate :: js :: lists :: named_import_specifier_list :: FormatJsNamedImportSpecifierList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsNamedImportSpecifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsNamedImportSpecifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsNamedImportSpecifierList,
         crate::js::lists::named_import_specifier_list::FormatJsNamedImportSpecifierList,
@@ -9753,31 +9747,31 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsNamedImportSpecifi
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: named_import_specifier_list :: FormatJsNamedImportSpecifierList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsObjectAssignmentPatternPropertyList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternPropertyList {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsObjectAssignmentPatternPropertyList , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternPropertyList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectAssignmentPatternPropertyList {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsObjectAssignmentPatternPropertyList , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsObjectBindingPatternPropertyList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPatternPropertyList {
     type Format < 'a > = FormatRefWithRule < 'a , rome_js_syntax :: JsObjectBindingPatternPropertyList , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList > ;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule :: new (self , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectBindingPatternPropertyList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectBindingPatternPropertyList {
     type Format = FormatOwnedWithRule < rome_js_syntax :: JsObjectBindingPatternPropertyList , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList > ;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsObjectMemberList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsObjectMemberList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsObjectMemberList,
@@ -9790,7 +9784,7 @@ impl AsFormat for rome_js_syntax::JsObjectMemberList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectMemberList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsObjectMemberList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsObjectMemberList,
         crate::js::lists::object_member_list::FormatJsObjectMemberList,
@@ -9802,7 +9796,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsObjectMemberList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsParameterList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsParameterList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsParameterList,
@@ -9815,7 +9809,7 @@ impl AsFormat for rome_js_syntax::JsParameterList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsParameterList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsParameterList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsParameterList,
         crate::js::lists::parameter_list::FormatJsParameterList,
@@ -9827,7 +9821,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsParameterList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsPropertyModifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsPropertyModifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsPropertyModifierList,
@@ -9840,7 +9834,7 @@ impl AsFormat for rome_js_syntax::JsPropertyModifierList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsPropertyModifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsPropertyModifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsPropertyModifierList,
         crate::js::lists::property_modifier_list::FormatJsPropertyModifierList,
@@ -9852,7 +9846,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsPropertyModifierLi
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsStatementList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsStatementList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsStatementList,
@@ -9865,7 +9859,7 @@ impl AsFormat for rome_js_syntax::JsStatementList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsStatementList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsStatementList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsStatementList,
         crate::js::lists::statement_list::FormatJsStatementList,
@@ -9877,7 +9871,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsStatementList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsSwitchCaseList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsSwitchCaseList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsSwitchCaseList,
@@ -9890,7 +9884,7 @@ impl AsFormat for rome_js_syntax::JsSwitchCaseList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSwitchCaseList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsSwitchCaseList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsSwitchCaseList,
         crate::js::lists::switch_case_list::FormatJsSwitchCaseList,
@@ -9902,7 +9896,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsSwitchCaseList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsTemplateElementList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsTemplateElementList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsTemplateElementList,
@@ -9915,7 +9909,7 @@ impl AsFormat for rome_js_syntax::JsTemplateElementList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsTemplateElementList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsTemplateElementList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsTemplateElementList,
         crate::js::lists::template_element_list::FormatJsTemplateElementList,
@@ -9927,7 +9921,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsTemplateElementLis
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsVariableDeclaratorList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsVariableDeclaratorList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsVariableDeclaratorList,
@@ -9940,7 +9934,7 @@ impl AsFormat for rome_js_syntax::JsVariableDeclaratorList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsVariableDeclaratorList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsVariableDeclaratorList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsVariableDeclaratorList,
         crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList,
@@ -9952,7 +9946,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsVariableDeclarator
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsxAttributeList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAttributeList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxAttributeList,
@@ -9965,7 +9959,7 @@ impl AsFormat for rome_js_syntax::JsxAttributeList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAttributeList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAttributeList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxAttributeList,
         crate::jsx::lists::attribute_list::FormatJsxAttributeList,
@@ -9977,7 +9971,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAttributeList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsxChildList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxChildList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxChildList,
@@ -9990,7 +9984,7 @@ impl AsFormat for rome_js_syntax::JsxChildList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxChildList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxChildList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxChildList,
         crate::jsx::lists::child_list::FormatJsxChildList,
@@ -10002,7 +9996,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxChildList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsEnumMemberList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsEnumMemberList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsEnumMemberList,
@@ -10015,7 +10009,7 @@ impl AsFormat for rome_js_syntax::TsEnumMemberList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsEnumMemberList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsEnumMemberList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsEnumMemberList,
         crate::ts::lists::enum_member_list::FormatTsEnumMemberList,
@@ -10027,7 +10021,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsEnumMemberList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsIndexSignatureModifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsIndexSignatureModifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsIndexSignatureModifierList,
@@ -10037,7 +10031,7 @@ impl AsFormat for rome_js_syntax::TsIndexSignatureModifierList {
         FormatRefWithRule :: new (self , crate :: ts :: lists :: index_signature_modifier_list :: FormatTsIndexSignatureModifierList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIndexSignatureModifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsIndexSignatureModifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsIndexSignatureModifierList,
         crate::ts::lists::index_signature_modifier_list::FormatTsIndexSignatureModifierList,
@@ -10046,7 +10040,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIndexSignatureModi
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: index_signature_modifier_list :: FormatTsIndexSignatureModifierList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::TsIntersectionTypeElementList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsIntersectionTypeElementList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsIntersectionTypeElementList,
@@ -10056,7 +10050,7 @@ impl AsFormat for rome_js_syntax::TsIntersectionTypeElementList {
         FormatRefWithRule :: new (self , crate :: ts :: lists :: intersection_type_element_list :: FormatTsIntersectionTypeElementList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIntersectionTypeElementList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsIntersectionTypeElementList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsIntersectionTypeElementList,
         crate::ts::lists::intersection_type_element_list::FormatTsIntersectionTypeElementList,
@@ -10065,7 +10059,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsIntersectionTypeEl
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: intersection_type_element_list :: FormatTsIntersectionTypeElementList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::TsMethodSignatureModifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsMethodSignatureModifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsMethodSignatureModifierList,
@@ -10075,7 +10069,7 @@ impl AsFormat for rome_js_syntax::TsMethodSignatureModifierList {
         FormatRefWithRule :: new (self , crate :: ts :: lists :: method_signature_modifier_list :: FormatTsMethodSignatureModifierList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMethodSignatureModifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsMethodSignatureModifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsMethodSignatureModifierList,
         crate::ts::lists::method_signature_modifier_list::FormatTsMethodSignatureModifierList,
@@ -10084,7 +10078,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsMethodSignatureMod
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: method_signature_modifier_list :: FormatTsMethodSignatureModifierList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::TsPropertyParameterModifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsPropertyParameterModifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsPropertyParameterModifierList,
@@ -10094,7 +10088,7 @@ impl AsFormat for rome_js_syntax::TsPropertyParameterModifierList {
         FormatRefWithRule :: new (self , crate :: ts :: lists :: property_parameter_modifier_list :: FormatTsPropertyParameterModifierList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPropertyParameterModifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsPropertyParameterModifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsPropertyParameterModifierList,
         crate::ts::lists::property_parameter_modifier_list::FormatTsPropertyParameterModifierList,
@@ -10103,7 +10097,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPropertyParameterM
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_parameter_modifier_list :: FormatTsPropertyParameterModifierList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::TsPropertySignatureModifierList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsPropertySignatureModifierList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsPropertySignatureModifierList,
@@ -10113,7 +10107,7 @@ impl AsFormat for rome_js_syntax::TsPropertySignatureModifierList {
         FormatRefWithRule :: new (self , crate :: ts :: lists :: property_signature_modifier_list :: FormatTsPropertySignatureModifierList :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPropertySignatureModifierList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsPropertySignatureModifierList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsPropertySignatureModifierList,
         crate::ts::lists::property_signature_modifier_list::FormatTsPropertySignatureModifierList,
@@ -10122,7 +10116,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsPropertySignatureM
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_signature_modifier_list :: FormatTsPropertySignatureModifierList :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::TsTemplateElementList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTemplateElementList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTemplateElementList,
@@ -10135,7 +10129,7 @@ impl AsFormat for rome_js_syntax::TsTemplateElementList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTemplateElementList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTemplateElementList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTemplateElementList,
         crate::ts::lists::template_element_list::FormatTsTemplateElementList,
@@ -10147,7 +10141,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTemplateElementLis
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsTupleTypeElementList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTupleTypeElementList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTupleTypeElementList,
@@ -10160,7 +10154,7 @@ impl AsFormat for rome_js_syntax::TsTupleTypeElementList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTupleTypeElementList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTupleTypeElementList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTupleTypeElementList,
         crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList,
@@ -10172,7 +10166,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTupleTypeElementLi
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeArgumentList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeArgumentList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeArgumentList,
@@ -10185,7 +10179,7 @@ impl AsFormat for rome_js_syntax::TsTypeArgumentList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeArgumentList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeArgumentList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeArgumentList,
         crate::ts::lists::type_argument_list::FormatTsTypeArgumentList,
@@ -10197,7 +10191,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeArgumentList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeList,
@@ -10210,7 +10204,7 @@ impl AsFormat for rome_js_syntax::TsTypeList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeList,
         crate::ts::lists::type_list::FormatTsTypeList,
@@ -10222,7 +10216,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeMemberList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeMemberList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeMemberList,
@@ -10235,7 +10229,7 @@ impl AsFormat for rome_js_syntax::TsTypeMemberList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeMemberList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeMemberList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeMemberList,
         crate::ts::lists::type_member_list::FormatTsTypeMemberList,
@@ -10247,7 +10241,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeMemberList {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsTypeParameterList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsTypeParameterList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsTypeParameterList,
@@ -10260,7 +10254,7 @@ impl AsFormat for rome_js_syntax::TsTypeParameterList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeParameterList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsTypeParameterList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsTypeParameterList,
         crate::ts::lists::type_parameter_list::FormatTsTypeParameterList,
@@ -10272,7 +10266,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsTypeParameterList 
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsUnionTypeVariantList {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsUnionTypeVariantList {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsUnionTypeVariantList,
@@ -10285,7 +10279,7 @@ impl AsFormat for rome_js_syntax::TsUnionTypeVariantList {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsUnionTypeVariantList {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsUnionTypeVariantList {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsUnionTypeVariantList,
         crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList,
@@ -10304,7 +10298,7 @@ impl FormatRule<rome_js_syntax::JsUnknown> for crate::js::unknown::unknown::Form
         FormatUnknownNodeRule::<rome_js_syntax::JsUnknown>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnknown {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnknown {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnknown,
@@ -10317,7 +10311,7 @@ impl AsFormat for rome_js_syntax::JsUnknown {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknown {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnknown {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnknown,
         crate::js::unknown::unknown::FormatJsUnknown,
@@ -10342,7 +10336,7 @@ impl FormatRule<rome_js_syntax::JsUnknownStatement>
         FormatUnknownNodeRule::<rome_js_syntax::JsUnknownStatement>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnknownStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnknownStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnknownStatement,
@@ -10355,7 +10349,7 @@ impl AsFormat for rome_js_syntax::JsUnknownStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknownStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnknownStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnknownStatement,
         crate::js::unknown::unknown_statement::FormatJsUnknownStatement,
@@ -10380,7 +10374,7 @@ impl FormatRule<rome_js_syntax::JsUnknownExpression>
         FormatUnknownNodeRule::<rome_js_syntax::JsUnknownExpression>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnknownExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnknownExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnknownExpression,
@@ -10393,7 +10387,7 @@ impl AsFormat for rome_js_syntax::JsUnknownExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknownExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnknownExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnknownExpression,
         crate::js::unknown::unknown_expression::FormatJsUnknownExpression,
@@ -10414,7 +10408,7 @@ impl FormatRule<rome_js_syntax::JsUnknownMember>
         FormatUnknownNodeRule::<rome_js_syntax::JsUnknownMember>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnknownMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnknownMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnknownMember,
@@ -10427,7 +10421,7 @@ impl AsFormat for rome_js_syntax::JsUnknownMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknownMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnknownMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnknownMember,
         crate::js::unknown::unknown_member::FormatJsUnknownMember,
@@ -10452,7 +10446,7 @@ impl FormatRule<rome_js_syntax::JsUnknownBinding>
         FormatUnknownNodeRule::<rome_js_syntax::JsUnknownBinding>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnknownBinding {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnknownBinding {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnknownBinding,
@@ -10465,7 +10459,7 @@ impl AsFormat for rome_js_syntax::JsUnknownBinding {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknownBinding {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnknownBinding {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnknownBinding,
         crate::js::unknown::unknown_binding::FormatJsUnknownBinding,
@@ -10490,7 +10484,7 @@ impl FormatRule<rome_js_syntax::JsUnknownAssignment>
         FormatUnknownNodeRule::<rome_js_syntax::JsUnknownAssignment>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnknownAssignment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnknownAssignment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnknownAssignment,
@@ -10503,7 +10497,7 @@ impl AsFormat for rome_js_syntax::JsUnknownAssignment {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknownAssignment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnknownAssignment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnknownAssignment,
         crate::js::unknown::unknown_assignment::FormatJsUnknownAssignment,
@@ -10528,7 +10522,7 @@ impl FormatRule<rome_js_syntax::JsUnknownParameter>
         FormatUnknownNodeRule::<rome_js_syntax::JsUnknownParameter>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnknownParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnknownParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnknownParameter,
@@ -10541,7 +10535,7 @@ impl AsFormat for rome_js_syntax::JsUnknownParameter {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknownParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnknownParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnknownParameter,
         crate::js::unknown::unknown_parameter::FormatJsUnknownParameter,
@@ -10566,7 +10560,7 @@ impl FormatRule<rome_js_syntax::JsUnknownImportAssertionEntry>
         FormatUnknownNodeRule::<rome_js_syntax::JsUnknownImportAssertionEntry>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnknownImportAssertionEntry {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnknownImportAssertionEntry {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnknownImportAssertionEntry,
@@ -10576,7 +10570,7 @@ impl AsFormat for rome_js_syntax::JsUnknownImportAssertionEntry {
         FormatRefWithRule :: new (self , crate :: js :: unknown :: unknown_import_assertion_entry :: FormatJsUnknownImportAssertionEntry :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknownImportAssertionEntry {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnknownImportAssertionEntry {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnknownImportAssertionEntry,
         crate::js::unknown::unknown_import_assertion_entry::FormatJsUnknownImportAssertionEntry,
@@ -10598,7 +10592,7 @@ impl FormatRule<rome_js_syntax::JsUnknownNamedImportSpecifier>
         FormatUnknownNodeRule::<rome_js_syntax::JsUnknownNamedImportSpecifier>::fmt(self, node, f)
     }
 }
-impl AsFormat for rome_js_syntax::JsUnknownNamedImportSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsUnknownNamedImportSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsUnknownNamedImportSpecifier,
@@ -10608,7 +10602,7 @@ impl AsFormat for rome_js_syntax::JsUnknownNamedImportSpecifier {
         FormatRefWithRule :: new (self , crate :: js :: unknown :: unknown_named_import_specifier :: FormatJsUnknownNamedImportSpecifier :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknownNamedImportSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsUnknownNamedImportSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsUnknownNamedImportSpecifier,
         crate::js::unknown::unknown_named_import_specifier::FormatJsUnknownNamedImportSpecifier,
@@ -10617,21 +10611,21 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsUnknownNamedImport
         FormatOwnedWithRule :: new (self , crate :: js :: unknown :: unknown_named_import_specifier :: FormatJsUnknownNamedImportSpecifier :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyRoot {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyRoot {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsAnyRoot, crate::js::any::root::FormatJsAnyRoot>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::js::any::root::FormatJsAnyRoot::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyRoot {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyRoot {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsAnyRoot, crate::js::any::root::FormatJsAnyRoot>;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, crate::js::any::root::FormatJsAnyRoot::default())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyExpression,
@@ -10644,7 +10638,7 @@ impl AsFormat for rome_js_syntax::JsAnyExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyExpression,
         crate::js::any::expression::FormatJsAnyExpression,
@@ -10656,7 +10650,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyExpression {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyStatement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyStatement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyStatement,
@@ -10669,7 +10663,7 @@ impl AsFormat for rome_js_syntax::JsAnyStatement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyStatement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyStatement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyStatement,
         crate::js::any::statement::FormatJsAnyStatement,
@@ -10681,7 +10675,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyStatement {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyForInitializer {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyForInitializer {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyForInitializer,
@@ -10694,7 +10688,7 @@ impl AsFormat for rome_js_syntax::JsAnyForInitializer {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyForInitializer {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyForInitializer {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyForInitializer,
         crate::js::any::for_initializer::FormatJsAnyForInitializer,
@@ -10706,7 +10700,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyForInitializer 
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyForInOrOfInitializer {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyForInOrOfInitializer {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyForInOrOfInitializer,
@@ -10719,7 +10713,7 @@ impl AsFormat for rome_js_syntax::JsAnyForInOrOfInitializer {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyForInOrOfInitializer {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyForInOrOfInitializer {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyForInOrOfInitializer,
         crate::js::any::for_in_or_of_initializer::FormatJsAnyForInOrOfInitializer,
@@ -10731,7 +10725,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyForInOrOfInitia
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyAssignmentPattern {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyAssignmentPattern {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyAssignmentPattern,
@@ -10744,7 +10738,7 @@ impl AsFormat for rome_js_syntax::JsAnyAssignmentPattern {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyAssignmentPattern {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyAssignmentPattern {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyAssignmentPattern,
         crate::js::any::assignment_pattern::FormatJsAnyAssignmentPattern,
@@ -10756,7 +10750,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyAssignmentPatte
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnySwitchClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnySwitchClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnySwitchClause,
@@ -10769,7 +10763,7 @@ impl AsFormat for rome_js_syntax::JsAnySwitchClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnySwitchClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnySwitchClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnySwitchClause,
         crate::js::any::switch_clause::FormatJsAnySwitchClause,
@@ -10781,7 +10775,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnySwitchClause {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyBindingPattern {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyBindingPattern {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyBindingPattern,
@@ -10794,7 +10788,7 @@ impl AsFormat for rome_js_syntax::JsAnyBindingPattern {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyBindingPattern {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyBindingPattern {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyBindingPattern,
         crate::js::any::binding_pattern::FormatJsAnyBindingPattern,
@@ -10806,7 +10800,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyBindingPattern 
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyDeclarationClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyDeclarationClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyDeclarationClause,
@@ -10819,7 +10813,7 @@ impl AsFormat for rome_js_syntax::JsAnyDeclarationClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyDeclarationClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyDeclarationClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyDeclarationClause,
         crate::js::any::declaration_clause::FormatJsAnyDeclarationClause,
@@ -10831,7 +10825,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyDeclarationClau
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyLiteralExpression {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyLiteralExpression {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyLiteralExpression,
@@ -10844,7 +10838,7 @@ impl AsFormat for rome_js_syntax::JsAnyLiteralExpression {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyLiteralExpression {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyLiteralExpression {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyLiteralExpression,
         crate::js::any::literal_expression::FormatJsAnyLiteralExpression,
@@ -10856,7 +10850,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyLiteralExpressi
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyTemplateElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyTemplateElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyTemplateElement,
@@ -10869,7 +10863,7 @@ impl AsFormat for rome_js_syntax::JsAnyTemplateElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyTemplateElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyTemplateElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyTemplateElement,
         crate::js::any::template_element::FormatJsAnyTemplateElement,
@@ -10881,7 +10875,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyTemplateElement
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyBinding {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyBinding {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyBinding,
@@ -10891,7 +10885,7 @@ impl AsFormat for rome_js_syntax::JsAnyBinding {
         FormatRefWithRule::new(self, crate::js::any::binding::FormatJsAnyBinding::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyBinding {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyBinding {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyBinding,
         crate::js::any::binding::FormatJsAnyBinding,
@@ -10900,7 +10894,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyBinding {
         FormatOwnedWithRule::new(self, crate::js::any::binding::FormatJsAnyBinding::default())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyArrowFunctionParameters {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyArrowFunctionParameters {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyArrowFunctionParameters,
@@ -10914,7 +10908,7 @@ impl AsFormat for rome_js_syntax::JsAnyArrowFunctionParameters {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyArrowFunctionParameters {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyArrowFunctionParameters {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyArrowFunctionParameters,
         crate::js::any::arrow_function_parameters::FormatJsAnyArrowFunctionParameters,
@@ -10927,7 +10921,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyArrowFunctionPa
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyFunctionBody {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyFunctionBody {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyFunctionBody,
@@ -10940,7 +10934,7 @@ impl AsFormat for rome_js_syntax::JsAnyFunctionBody {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyFunctionBody {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyFunctionBody {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyFunctionBody,
         crate::js::any::function_body::FormatJsAnyFunctionBody,
@@ -10952,7 +10946,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyFunctionBody {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyArrayElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyArrayElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyArrayElement,
@@ -10965,7 +10959,7 @@ impl AsFormat for rome_js_syntax::JsAnyArrayElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyArrayElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyArrayElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyArrayElement,
         crate::js::any::array_element::FormatJsAnyArrayElement,
@@ -10977,21 +10971,21 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyArrayElement {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyName {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsAnyName, crate::js::any::name::FormatJsAnyName>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::js::any::name::FormatJsAnyName::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyName {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsAnyName, crate::js::any::name::FormatJsAnyName>;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, crate::js::any::name::FormatJsAnyName::default())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyInProperty {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyInProperty {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyInProperty,
@@ -11004,7 +10998,7 @@ impl AsFormat for rome_js_syntax::JsAnyInProperty {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyInProperty {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyInProperty {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyInProperty,
         crate::js::any::in_property::FormatJsAnyInProperty,
@@ -11016,7 +11010,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyInProperty {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyAssignment {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyAssignment {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyAssignment,
@@ -11029,7 +11023,7 @@ impl AsFormat for rome_js_syntax::JsAnyAssignment {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyAssignment {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyAssignment {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyAssignment,
         crate::js::any::assignment::FormatJsAnyAssignment,
@@ -11041,7 +11035,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyAssignment {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyObjectMemberName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyObjectMemberName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyObjectMemberName,
@@ -11054,7 +11048,7 @@ impl AsFormat for rome_js_syntax::JsAnyObjectMemberName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyObjectMemberName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyObjectMemberName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyObjectMemberName,
         crate::js::any::object_member_name::FormatJsAnyObjectMemberName,
@@ -11066,7 +11060,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyObjectMemberNam
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyObjectMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyObjectMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyObjectMember,
@@ -11079,7 +11073,7 @@ impl AsFormat for rome_js_syntax::JsAnyObjectMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyObjectMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyObjectMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyObjectMember,
         crate::js::any::object_member::FormatJsAnyObjectMember,
@@ -11091,7 +11085,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyObjectMember {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyFormalParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyFormalParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyFormalParameter,
@@ -11104,7 +11098,7 @@ impl AsFormat for rome_js_syntax::JsAnyFormalParameter {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyFormalParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyFormalParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyFormalParameter,
         crate::js::any::formal_parameter::FormatJsAnyFormalParameter,
@@ -11116,7 +11110,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyFormalParameter
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyClassMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyClassMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyClassMember,
@@ -11129,7 +11123,7 @@ impl AsFormat for rome_js_syntax::JsAnyClassMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyClassMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyClassMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyClassMember,
         crate::js::any::class_member::FormatJsAnyClassMember,
@@ -11141,21 +11135,21 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyClassMember {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyClass {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyClass {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsAnyClass, crate::js::any::class::FormatJsAnyClass>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::js::any::class::FormatJsAnyClass::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyClass {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyClass {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsAnyClass, crate::js::any::class::FormatJsAnyClass>;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, crate::js::any::class::FormatJsAnyClass::default())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyClassMemberName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyClassMemberName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyClassMemberName,
@@ -11168,7 +11162,7 @@ impl AsFormat for rome_js_syntax::JsAnyClassMemberName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyClassMemberName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyClassMemberName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyClassMemberName,
         crate::js::any::class_member_name::FormatJsAnyClassMemberName,
@@ -11180,7 +11174,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyClassMemberName
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyConstructorParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyConstructorParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyConstructorParameter,
@@ -11193,7 +11187,7 @@ impl AsFormat for rome_js_syntax::JsAnyConstructorParameter {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyConstructorParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyConstructorParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyConstructorParameter,
         crate::js::any::constructor_parameter::FormatJsAnyConstructorParameter,
@@ -11205,7 +11199,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyConstructorPara
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyPropertyParameterModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyPropertyParameterModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyPropertyParameterModifier,
@@ -11215,7 +11209,7 @@ impl AsFormat for rome_js_syntax::TsAnyPropertyParameterModifier {
         FormatRefWithRule :: new (self , crate :: ts :: any :: property_parameter_modifier :: FormatTsAnyPropertyParameterModifier :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyPropertyParameterModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyPropertyParameterModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyPropertyParameterModifier,
         crate::ts::any::property_parameter_modifier::FormatTsAnyPropertyParameterModifier,
@@ -11224,7 +11218,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyPropertyParamet
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: property_parameter_modifier :: FormatTsAnyPropertyParameterModifier :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyPropertyAnnotation {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyPropertyAnnotation {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyPropertyAnnotation,
@@ -11237,7 +11231,7 @@ impl AsFormat for rome_js_syntax::TsAnyPropertyAnnotation {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyPropertyAnnotation {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyPropertyAnnotation {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyPropertyAnnotation,
         crate::ts::any::property_annotation::FormatTsAnyPropertyAnnotation,
@@ -11249,7 +11243,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyPropertyAnnotat
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyPropertyModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyPropertyModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyPropertyModifier,
@@ -11262,7 +11256,7 @@ impl AsFormat for rome_js_syntax::JsAnyPropertyModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyPropertyModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyPropertyModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyPropertyModifier,
         crate::js::any::property_modifier::FormatJsAnyPropertyModifier,
@@ -11274,7 +11268,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyPropertyModifie
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyPropertySignatureAnnotation {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyPropertySignatureAnnotation {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyPropertySignatureAnnotation,
@@ -11284,7 +11278,7 @@ impl AsFormat for rome_js_syntax::TsAnyPropertySignatureAnnotation {
         FormatRefWithRule :: new (self , crate :: ts :: any :: property_signature_annotation :: FormatTsAnyPropertySignatureAnnotation :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyPropertySignatureAnnotation {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyPropertySignatureAnnotation {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyPropertySignatureAnnotation,
         crate::ts::any::property_signature_annotation::FormatTsAnyPropertySignatureAnnotation,
@@ -11293,7 +11287,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyPropertySignatu
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: property_signature_annotation :: FormatTsAnyPropertySignatureAnnotation :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyPropertySignatureModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyPropertySignatureModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyPropertySignatureModifier,
@@ -11303,7 +11297,7 @@ impl AsFormat for rome_js_syntax::TsAnyPropertySignatureModifier {
         FormatRefWithRule :: new (self , crate :: ts :: any :: property_signature_modifier :: FormatTsAnyPropertySignatureModifier :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyPropertySignatureModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyPropertySignatureModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyPropertySignatureModifier,
         crate::ts::any::property_signature_modifier::FormatTsAnyPropertySignatureModifier,
@@ -11312,7 +11306,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyPropertySignatu
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: property_signature_modifier :: FormatTsAnyPropertySignatureModifier :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyMethodModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyMethodModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyMethodModifier,
@@ -11325,7 +11319,7 @@ impl AsFormat for rome_js_syntax::JsAnyMethodModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyMethodModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyMethodModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyMethodModifier,
         crate::js::any::method_modifier::FormatJsAnyMethodModifier,
@@ -11337,7 +11331,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyMethodModifier 
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyMethodSignatureModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyMethodSignatureModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyMethodSignatureModifier,
@@ -11351,7 +11345,7 @@ impl AsFormat for rome_js_syntax::TsAnyMethodSignatureModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyMethodSignatureModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyMethodSignatureModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyMethodSignatureModifier,
         crate::ts::any::method_signature_modifier::FormatTsAnyMethodSignatureModifier,
@@ -11364,7 +11358,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyMethodSignature
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyIndexSignatureModifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyIndexSignatureModifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyIndexSignatureModifier,
@@ -11377,7 +11371,7 @@ impl AsFormat for rome_js_syntax::TsAnyIndexSignatureModifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyIndexSignatureModifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyIndexSignatureModifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyIndexSignatureModifier,
         crate::ts::any::index_signature_modifier::FormatTsAnyIndexSignatureModifier,
@@ -11389,21 +11383,21 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyIndexSignatureM
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsType {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::TsType, crate::ts::any::ts_type::FormatTsType>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::ts::any::ts_type::FormatTsType::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsType {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::TsType, crate::ts::any::ts_type::FormatTsType>;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, crate::ts::any::ts_type::FormatTsType::default())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyArrayAssignmentPatternElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyArrayAssignmentPatternElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyArrayAssignmentPatternElement,
@@ -11413,7 +11407,7 @@ impl AsFormat for rome_js_syntax::JsAnyArrayAssignmentPatternElement {
         FormatRefWithRule :: new (self , crate :: js :: any :: array_assignment_pattern_element :: FormatJsAnyArrayAssignmentPatternElement :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyArrayAssignmentPatternElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyArrayAssignmentPatternElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyArrayAssignmentPatternElement,
         crate::js::any::array_assignment_pattern_element::FormatJsAnyArrayAssignmentPatternElement,
@@ -11422,7 +11416,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyArrayAssignment
         FormatOwnedWithRule :: new (self , crate :: js :: any :: array_assignment_pattern_element :: FormatJsAnyArrayAssignmentPatternElement :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyObjectAssignmentPatternMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyObjectAssignmentPatternMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyObjectAssignmentPatternMember,
@@ -11432,7 +11426,7 @@ impl AsFormat for rome_js_syntax::JsAnyObjectAssignmentPatternMember {
         FormatRefWithRule :: new (self , crate :: js :: any :: object_assignment_pattern_member :: FormatJsAnyObjectAssignmentPatternMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyObjectAssignmentPatternMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyObjectAssignmentPatternMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyObjectAssignmentPatternMember,
         crate::js::any::object_assignment_pattern_member::FormatJsAnyObjectAssignmentPatternMember,
@@ -11441,7 +11435,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyObjectAssignmen
         FormatOwnedWithRule :: new (self , crate :: js :: any :: object_assignment_pattern_member :: FormatJsAnyObjectAssignmentPatternMember :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyArrayBindingPatternElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyArrayBindingPatternElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyArrayBindingPatternElement,
@@ -11451,7 +11445,7 @@ impl AsFormat for rome_js_syntax::JsAnyArrayBindingPatternElement {
         FormatRefWithRule :: new (self , crate :: js :: any :: array_binding_pattern_element :: FormatJsAnyArrayBindingPatternElement :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyArrayBindingPatternElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyArrayBindingPatternElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyArrayBindingPatternElement,
         crate::js::any::array_binding_pattern_element::FormatJsAnyArrayBindingPatternElement,
@@ -11460,7 +11454,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyArrayBindingPat
         FormatOwnedWithRule :: new (self , crate :: js :: any :: array_binding_pattern_element :: FormatJsAnyArrayBindingPatternElement :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyObjectBindingPatternMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyObjectBindingPatternMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyObjectBindingPatternMember,
@@ -11470,7 +11464,7 @@ impl AsFormat for rome_js_syntax::JsAnyObjectBindingPatternMember {
         FormatRefWithRule :: new (self , crate :: js :: any :: object_binding_pattern_member :: FormatJsAnyObjectBindingPatternMember :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyObjectBindingPatternMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyObjectBindingPatternMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyObjectBindingPatternMember,
         crate::js::any::object_binding_pattern_member::FormatJsAnyObjectBindingPatternMember,
@@ -11479,7 +11473,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyObjectBindingPa
         FormatOwnedWithRule :: new (self , crate :: js :: any :: object_binding_pattern_member :: FormatJsAnyObjectBindingPatternMember :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyDeclaration,
@@ -11492,7 +11486,7 @@ impl AsFormat for rome_js_syntax::JsAnyDeclaration {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyDeclaration,
         crate::js::any::declaration::FormatJsAnyDeclaration,
@@ -11504,7 +11498,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyDeclaration {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyReturnType {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyReturnType {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyReturnType,
@@ -11517,7 +11511,7 @@ impl AsFormat for rome_js_syntax::TsAnyReturnType {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyReturnType {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyReturnType {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyReturnType,
         crate::ts::any::return_type::FormatTsAnyReturnType,
@@ -11529,7 +11523,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyReturnType {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyVariableAnnotation {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyVariableAnnotation {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyVariableAnnotation,
@@ -11542,7 +11536,7 @@ impl AsFormat for rome_js_syntax::TsAnyVariableAnnotation {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyVariableAnnotation {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyVariableAnnotation {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyVariableAnnotation,
         crate::ts::any::variable_annotation::FormatTsAnyVariableAnnotation,
@@ -11554,7 +11548,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyVariableAnnotat
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyModuleItem {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyModuleItem {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyModuleItem,
@@ -11567,7 +11561,7 @@ impl AsFormat for rome_js_syntax::JsAnyModuleItem {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyModuleItem {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyModuleItem {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyModuleItem,
         crate::js::any::module_item::FormatJsAnyModuleItem,
@@ -11579,7 +11573,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyModuleItem {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyImportClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyImportClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyImportClause,
@@ -11592,7 +11586,7 @@ impl AsFormat for rome_js_syntax::JsAnyImportClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyImportClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyImportClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyImportClause,
         crate::js::any::import_clause::FormatJsAnyImportClause,
@@ -11604,7 +11598,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyImportClause {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyNamedImport {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyNamedImport {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyNamedImport,
@@ -11617,7 +11611,7 @@ impl AsFormat for rome_js_syntax::JsAnyNamedImport {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyNamedImport {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyNamedImport {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyNamedImport,
         crate::js::any::named_import::FormatJsAnyNamedImport,
@@ -11629,7 +11623,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyNamedImport {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyNamedImportSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyNamedImportSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyNamedImportSpecifier,
@@ -11642,7 +11636,7 @@ impl AsFormat for rome_js_syntax::JsAnyNamedImportSpecifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyNamedImportSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyNamedImportSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyNamedImportSpecifier,
         crate::js::any::named_import_specifier::FormatJsAnyNamedImportSpecifier,
@@ -11654,7 +11648,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyNamedImportSpec
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyImportAssertionEntry {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyImportAssertionEntry {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyImportAssertionEntry,
@@ -11667,7 +11661,7 @@ impl AsFormat for rome_js_syntax::JsAnyImportAssertionEntry {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyImportAssertionEntry {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyImportAssertionEntry {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyImportAssertionEntry,
         crate::js::any::import_assertion_entry::FormatJsAnyImportAssertionEntry,
@@ -11679,7 +11673,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyImportAssertion
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyExportClause {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyExportClause {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyExportClause,
@@ -11692,7 +11686,7 @@ impl AsFormat for rome_js_syntax::JsAnyExportClause {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyExportClause {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyExportClause {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyExportClause,
         crate::js::any::export_clause::FormatJsAnyExportClause,
@@ -11704,7 +11698,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyExportClause {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyExportDefaultDeclaration {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyExportDefaultDeclaration {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyExportDefaultDeclaration,
@@ -11714,7 +11708,7 @@ impl AsFormat for rome_js_syntax::JsAnyExportDefaultDeclaration {
         FormatRefWithRule :: new (self , crate :: js :: any :: export_default_declaration :: FormatJsAnyExportDefaultDeclaration :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyExportDefaultDeclaration {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyExportDefaultDeclaration {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyExportDefaultDeclaration,
         crate::js::any::export_default_declaration::FormatJsAnyExportDefaultDeclaration,
@@ -11723,7 +11717,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyExportDefaultDe
         FormatOwnedWithRule :: new (self , crate :: js :: any :: export_default_declaration :: FormatJsAnyExportDefaultDeclaration :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyExportNamedSpecifier {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyExportNamedSpecifier {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyExportNamedSpecifier,
@@ -11736,7 +11730,7 @@ impl AsFormat for rome_js_syntax::JsAnyExportNamedSpecifier {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyExportNamedSpecifier {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyExportNamedSpecifier {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyExportNamedSpecifier,
         crate::js::any::export_named_specifier::FormatJsAnyExportNamedSpecifier,
@@ -11748,7 +11742,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyExportNamedSpec
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyFunction {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyFunction {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyFunction,
@@ -11761,7 +11755,7 @@ impl AsFormat for rome_js_syntax::JsAnyFunction {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyFunction {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyFunction {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyFunction,
         crate::js::any::function::FormatJsAnyFunction,
@@ -11773,7 +11767,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyFunction {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyParameter {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyParameter {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyParameter,
@@ -11786,7 +11780,7 @@ impl AsFormat for rome_js_syntax::JsAnyParameter {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyParameter {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyParameter {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyParameter,
         crate::js::any::parameter::FormatJsAnyParameter,
@@ -11798,7 +11792,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyParameter {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsAnyCallArgument {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsAnyCallArgument {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsAnyCallArgument,
@@ -11811,7 +11805,7 @@ impl AsFormat for rome_js_syntax::JsAnyCallArgument {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyCallArgument {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsAnyCallArgument {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsAnyCallArgument,
         crate::js::any::call_argument::FormatJsAnyCallArgument,
@@ -11823,21 +11817,21 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsAnyCallArgument {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyName {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::TsAnyName, crate::ts::any::name::FormatTsAnyName>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::ts::any::name::FormatTsAnyName::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyName {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::TsAnyName, crate::ts::any::name::FormatTsAnyName>;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, crate::ts::any::name::FormatTsAnyName::default())
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyModuleReference {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyModuleReference {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyModuleReference,
@@ -11850,7 +11844,7 @@ impl AsFormat for rome_js_syntax::TsAnyModuleReference {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyModuleReference {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyModuleReference {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyModuleReference,
         crate::ts::any::module_reference::FormatTsAnyModuleReference,
@@ -11862,7 +11856,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyModuleReference
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyModuleName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyModuleName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyModuleName,
@@ -11875,7 +11869,7 @@ impl AsFormat for rome_js_syntax::TsAnyModuleName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyModuleName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyModuleName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyModuleName,
         crate::ts::any::module_name::FormatTsAnyModuleName,
@@ -11887,7 +11881,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyModuleName {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyExternalModuleDeclarationBody {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyExternalModuleDeclarationBody {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyExternalModuleDeclarationBody,
@@ -11897,7 +11891,7 @@ impl AsFormat for rome_js_syntax::TsAnyExternalModuleDeclarationBody {
         FormatRefWithRule :: new (self , crate :: ts :: any :: external_module_declaration_body :: FormatTsAnyExternalModuleDeclarationBody :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyExternalModuleDeclarationBody {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyExternalModuleDeclarationBody {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyExternalModuleDeclarationBody,
         crate::ts::any::external_module_declaration_body::FormatTsAnyExternalModuleDeclarationBody,
@@ -11906,7 +11900,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyExternalModuleD
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: external_module_declaration_body :: FormatTsAnyExternalModuleDeclarationBody :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyTypePredicateParameterName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyTypePredicateParameterName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyTypePredicateParameterName,
@@ -11916,7 +11910,7 @@ impl AsFormat for rome_js_syntax::TsAnyTypePredicateParameterName {
         FormatRefWithRule :: new (self , crate :: ts :: any :: type_predicate_parameter_name :: FormatTsAnyTypePredicateParameterName :: default ())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyTypePredicateParameterName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyTypePredicateParameterName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyTypePredicateParameterName,
         crate::ts::any::type_predicate_parameter_name::FormatTsAnyTypePredicateParameterName,
@@ -11925,7 +11919,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyTypePredicatePa
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: type_predicate_parameter_name :: FormatTsAnyTypePredicateParameterName :: default ())
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyTypeMember {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyTypeMember {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyTypeMember,
@@ -11938,7 +11932,7 @@ impl AsFormat for rome_js_syntax::TsAnyTypeMember {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyTypeMember {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyTypeMember {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyTypeMember,
         crate::ts::any::type_member::FormatTsAnyTypeMember,
@@ -11950,7 +11944,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyTypeMember {
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyTupleTypeElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyTupleTypeElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyTupleTypeElement,
@@ -11963,7 +11957,7 @@ impl AsFormat for rome_js_syntax::TsAnyTupleTypeElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyTupleTypeElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyTupleTypeElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyTupleTypeElement,
         crate::ts::any::tuple_type_element::FormatTsAnyTupleTypeElement,
@@ -11975,7 +11969,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyTupleTypeElemen
         )
     }
 }
-impl AsFormat for rome_js_syntax::TsAnyTemplateElement {
+impl AsFormat<JsFormatContext> for rome_js_syntax::TsAnyTemplateElement {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::TsAnyTemplateElement,
@@ -11988,7 +11982,7 @@ impl AsFormat for rome_js_syntax::TsAnyTemplateElement {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyTemplateElement {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::TsAnyTemplateElement {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::TsAnyTemplateElement,
         crate::ts::any::template_element::FormatTsAnyTemplateElement,
@@ -12000,21 +11994,21 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::TsAnyTemplateElement
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsxAnyTag {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAnyTag {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsxAnyTag, crate::jsx::any::tag::FormatJsxAnyTag>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::jsx::any::tag::FormatJsxAnyTag::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyTag {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAnyTag {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsxAnyTag, crate::jsx::any::tag::FormatJsxAnyTag>;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, crate::jsx::any::tag::FormatJsxAnyTag::default())
     }
 }
-impl AsFormat for rome_js_syntax::JsxAnyElementName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAnyElementName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxAnyElementName,
@@ -12027,7 +12021,7 @@ impl AsFormat for rome_js_syntax::JsxAnyElementName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyElementName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAnyElementName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxAnyElementName,
         crate::jsx::any::element_name::FormatJsxAnyElementName,
@@ -12039,7 +12033,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyElementName {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsxAnyObjectName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAnyObjectName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxAnyObjectName,
@@ -12052,7 +12046,7 @@ impl AsFormat for rome_js_syntax::JsxAnyObjectName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyObjectName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAnyObjectName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxAnyObjectName,
         crate::jsx::any::object_name::FormatJsxAnyObjectName,
@@ -12064,21 +12058,21 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyObjectName {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsxAnyName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAnyName {
     type Format<'a> =
         FormatRefWithRule<'a, rome_js_syntax::JsxAnyName, crate::jsx::any::name::FormatJsxAnyName>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, crate::jsx::any::name::FormatJsxAnyName::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAnyName {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsxAnyName, crate::jsx::any::name::FormatJsxAnyName>;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, crate::jsx::any::name::FormatJsxAnyName::default())
     }
 }
-impl AsFormat for rome_js_syntax::JsxAnyAttribute {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAnyAttribute {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxAnyAttribute,
@@ -12091,7 +12085,7 @@ impl AsFormat for rome_js_syntax::JsxAnyAttribute {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyAttribute {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAnyAttribute {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxAnyAttribute,
         crate::jsx::any::attribute::FormatJsxAnyAttribute,
@@ -12103,7 +12097,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyAttribute {
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsxAnyAttributeName {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAnyAttributeName {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxAnyAttributeName,
@@ -12116,7 +12110,7 @@ impl AsFormat for rome_js_syntax::JsxAnyAttributeName {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyAttributeName {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAnyAttributeName {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxAnyAttributeName,
         crate::jsx::any::attribute_name::FormatJsxAnyAttributeName,
@@ -12128,7 +12122,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyAttributeName 
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsxAnyAttributeValue {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAnyAttributeValue {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxAnyAttributeValue,
@@ -12141,7 +12135,7 @@ impl AsFormat for rome_js_syntax::JsxAnyAttributeValue {
         )
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyAttributeValue {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAnyAttributeValue {
     type Format = FormatOwnedWithRule<
         rome_js_syntax::JsxAnyAttributeValue,
         crate::jsx::any::attribute_value::FormatJsxAnyAttributeValue,
@@ -12153,7 +12147,7 @@ impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyAttributeValue
         )
     }
 }
-impl AsFormat for rome_js_syntax::JsxAnyChild {
+impl AsFormat<JsFormatContext> for rome_js_syntax::JsxAnyChild {
     type Format<'a> = FormatRefWithRule<
         'a,
         rome_js_syntax::JsxAnyChild,
@@ -12163,7 +12157,7 @@ impl AsFormat for rome_js_syntax::JsxAnyChild {
         FormatRefWithRule::new(self, crate::jsx::any::child::FormatJsxAnyChild::default())
     }
 }
-impl IntoFormat<crate::JsFormatContext> for rome_js_syntax::JsxAnyChild {
+impl IntoFormat<JsFormatContext> for rome_js_syntax::JsxAnyChild {
     type Format =
         FormatOwnedWithRule<rome_js_syntax::JsxAnyChild, crate::jsx::any::child::FormatJsxAnyChild>;
     fn into_format(self) -> Self::Format {

--- a/crates/rome_js_formatter/src/generated.rs
+++ b/crates/rome_js_formatter/src/generated.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::{
     AsFormat, FormatNodeRule, FormatUnknownNodeRule, IntoFormat, JsFormatContext, JsFormatter,

--- a/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayAssignmentPatternElement;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyArrayAssignmentPatternElement;
+pub(crate) struct FormatJsAnyArrayAssignmentPatternElement;
 impl FormatRule<JsAnyArrayAssignmentPatternElement> for FormatJsAnyArrayAssignmentPatternElement {
     type Context = JsFormatContext;
     fn fmt(

--- a/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayAssignmentPatternElement;

--- a/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayBindingPatternElement;

--- a/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_binding_pattern_element.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayBindingPatternElement;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyArrayBindingPatternElement;
+pub(crate) struct FormatJsAnyArrayBindingPatternElement;
 impl FormatRule<JsAnyArrayBindingPatternElement> for FormatJsAnyArrayBindingPatternElement {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyArrayBindingPatternElement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/array_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_element.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayElement;

--- a/crates/rome_js_formatter/src/js/any/array_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_element.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrayElement;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyArrayElement;
+pub(crate) struct FormatJsAnyArrayElement;
 impl FormatRule<JsAnyArrayElement> for FormatJsAnyArrayElement {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyArrayElement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
+++ b/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrowFunctionParameters;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyArrowFunctionParameters;
+pub(crate) struct FormatJsAnyArrowFunctionParameters;
 impl FormatRule<JsAnyArrowFunctionParameters> for FormatJsAnyArrowFunctionParameters {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyArrowFunctionParameters, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
+++ b/crates/rome_js_formatter/src/js/any/arrow_function_parameters.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyArrowFunctionParameters;

--- a/crates/rome_js_formatter/src/js/any/assignment.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyAssignment;

--- a/crates/rome_js_formatter/src/js/any/assignment.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyAssignment;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyAssignment;
+pub(crate) struct FormatJsAnyAssignment;
 impl FormatRule<JsAnyAssignment> for FormatJsAnyAssignment {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyAssignment, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyAssignmentPattern;

--- a/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/assignment_pattern.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyAssignmentPattern;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyAssignmentPattern;
+pub(crate) struct FormatJsAnyAssignmentPattern;
 impl FormatRule<JsAnyAssignmentPattern> for FormatJsAnyAssignmentPattern {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyAssignmentPattern, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/binding.rs
+++ b/crates/rome_js_formatter/src/js/any/binding.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyBinding;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyBinding;
+pub(crate) struct FormatJsAnyBinding;
 impl FormatRule<JsAnyBinding> for FormatJsAnyBinding {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyBinding, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/binding.rs
+++ b/crates/rome_js_formatter/src/js/any/binding.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyBinding;

--- a/crates/rome_js_formatter/src/js/any/binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/binding_pattern.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyBindingPattern;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyBindingPattern;
+pub(crate) struct FormatJsAnyBindingPattern;
 impl FormatRule<JsAnyBindingPattern> for FormatJsAnyBindingPattern {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyBindingPattern, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/any/binding_pattern.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyBindingPattern;

--- a/crates/rome_js_formatter/src/js/any/call_argument.rs
+++ b/crates/rome_js_formatter/src/js/any/call_argument.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyCallArgument;

--- a/crates/rome_js_formatter/src/js/any/call_argument.rs
+++ b/crates/rome_js_formatter/src/js/any/call_argument.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyCallArgument;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyCallArgument;
+pub(crate) struct FormatJsAnyCallArgument;
 impl FormatRule<JsAnyCallArgument> for FormatJsAnyCallArgument {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyCallArgument, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/class.rs
+++ b/crates/rome_js_formatter/src/js/any/class.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClass;

--- a/crates/rome_js_formatter/src/js/any/class.rs
+++ b/crates/rome_js_formatter/src/js/any/class.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClass;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyClass;
+pub(crate) struct FormatJsAnyClass;
 impl FormatRule<JsAnyClass> for FormatJsAnyClass {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyClass, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/class_member.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClassMember;

--- a/crates/rome_js_formatter/src/js/any/class_member.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClassMember;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyClassMember;
+pub(crate) struct FormatJsAnyClassMember;
 impl FormatRule<JsAnyClassMember> for FormatJsAnyClassMember {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyClassMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/class_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member_name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClassMemberName;

--- a/crates/rome_js_formatter/src/js/any/class_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/class_member_name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyClassMemberName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyClassMemberName;
+pub(crate) struct FormatJsAnyClassMemberName;
 impl FormatRule<JsAnyClassMemberName> for FormatJsAnyClassMemberName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyClassMemberName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyConstructorParameter;

--- a/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/constructor_parameter.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyConstructorParameter;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyConstructorParameter;
+pub(crate) struct FormatJsAnyConstructorParameter;
 impl FormatRule<JsAnyConstructorParameter> for FormatJsAnyConstructorParameter {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyConstructorParameter, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyDeclaration;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyDeclaration;
+pub(crate) struct FormatJsAnyDeclaration;
 impl FormatRule<JsAnyDeclaration> for FormatJsAnyDeclaration {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyDeclaration, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyDeclaration;

--- a/crates/rome_js_formatter/src/js/any/declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration_clause.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyDeclarationClause;

--- a/crates/rome_js_formatter/src/js/any/declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/declaration_clause.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyDeclarationClause;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyDeclarationClause;
+pub(crate) struct FormatJsAnyDeclarationClause;
 impl FormatRule<JsAnyDeclarationClause> for FormatJsAnyDeclarationClause {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyDeclarationClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/export_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/export_clause.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportClause;

--- a/crates/rome_js_formatter/src/js/any/export_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/export_clause.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportClause;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyExportClause;
+pub(crate) struct FormatJsAnyExportClause;
 impl FormatRule<JsAnyExportClause> for FormatJsAnyExportClause {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyExportClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportDefaultDeclaration;

--- a/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/any/export_default_declaration.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportDefaultDeclaration;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyExportDefaultDeclaration;
+pub(crate) struct FormatJsAnyExportDefaultDeclaration;
 impl FormatRule<JsAnyExportDefaultDeclaration> for FormatJsAnyExportDefaultDeclaration {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyExportDefaultDeclaration, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportNamedSpecifier;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyExportNamedSpecifier;
+pub(crate) struct FormatJsAnyExportNamedSpecifier;
 impl FormatRule<JsAnyExportNamedSpecifier> for FormatJsAnyExportNamedSpecifier {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyExportNamedSpecifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/export_named_specifier.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExportNamedSpecifier;

--- a/crates/rome_js_formatter/src/js/any/expression.rs
+++ b/crates/rome_js_formatter/src/js/any/expression.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExpression;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyExpression;
+pub(crate) struct FormatJsAnyExpression;
 impl FormatRule<JsAnyExpression> for FormatJsAnyExpression {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/expression.rs
+++ b/crates/rome_js_formatter/src/js/any/expression.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyExpression;

--- a/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyForInOrOfInitializer;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyForInOrOfInitializer;
+pub(crate) struct FormatJsAnyForInOrOfInitializer;
 impl FormatRule<JsAnyForInOrOfInitializer> for FormatJsAnyForInOrOfInitializer {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyForInOrOfInitializer, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_in_or_of_initializer.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyForInOrOfInitializer;

--- a/crates/rome_js_formatter/src/js/any/for_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_initializer.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyForInitializer;

--- a/crates/rome_js_formatter/src/js/any/for_initializer.rs
+++ b/crates/rome_js_formatter/src/js/any/for_initializer.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyForInitializer;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyForInitializer;
+pub(crate) struct FormatJsAnyForInitializer;
 impl FormatRule<JsAnyForInitializer> for FormatJsAnyForInitializer {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyForInitializer, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/formal_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/formal_parameter.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFormalParameter;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyFormalParameter;
+pub(crate) struct FormatJsAnyFormalParameter;
 impl FormatRule<JsAnyFormalParameter> for FormatJsAnyFormalParameter {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyFormalParameter, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/formal_parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/formal_parameter.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFormalParameter;

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFunction;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyFunction;
+pub(crate) struct FormatJsAnyFunction;
 impl FormatRule<JsAnyFunction> for FormatJsAnyFunction {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyFunction, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/function.rs
+++ b/crates/rome_js_formatter/src/js/any/function.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFunction;

--- a/crates/rome_js_formatter/src/js/any/function_body.rs
+++ b/crates/rome_js_formatter/src/js/any/function_body.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFunctionBody;

--- a/crates/rome_js_formatter/src/js/any/function_body.rs
+++ b/crates/rome_js_formatter/src/js/any/function_body.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyFunctionBody;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyFunctionBody;
+pub(crate) struct FormatJsAnyFunctionBody;
 impl FormatRule<JsAnyFunctionBody> for FormatJsAnyFunctionBody {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyFunctionBody, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyImportAssertionEntry;

--- a/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/any/import_assertion_entry.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyImportAssertionEntry;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyImportAssertionEntry;
+pub(crate) struct FormatJsAnyImportAssertionEntry;
 impl FormatRule<JsAnyImportAssertionEntry> for FormatJsAnyImportAssertionEntry {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyImportAssertionEntry, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/import_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/import_clause.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyImportClause;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyImportClause;
+pub(crate) struct FormatJsAnyImportClause;
 impl FormatRule<JsAnyImportClause> for FormatJsAnyImportClause {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyImportClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/import_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/import_clause.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyImportClause;

--- a/crates/rome_js_formatter/src/js/any/in_property.rs
+++ b/crates/rome_js_formatter/src/js/any/in_property.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyInProperty;

--- a/crates/rome_js_formatter/src/js/any/in_property.rs
+++ b/crates/rome_js_formatter/src/js/any/in_property.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyInProperty;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyInProperty;
+pub(crate) struct FormatJsAnyInProperty;
 impl FormatRule<JsAnyInProperty> for FormatJsAnyInProperty {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyInProperty, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/any/literal_expression.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyLiteralExpression;

--- a/crates/rome_js_formatter/src/js/any/literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/any/literal_expression.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyLiteralExpression;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyLiteralExpression;
+pub(crate) struct FormatJsAnyLiteralExpression;
 impl FormatRule<JsAnyLiteralExpression> for FormatJsAnyLiteralExpression {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyLiteralExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/method_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/method_modifier.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyMethodModifier;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyMethodModifier;
+pub(crate) struct FormatJsAnyMethodModifier;
 impl FormatRule<JsAnyMethodModifier> for FormatJsAnyMethodModifier {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyMethodModifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/method_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/method_modifier.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyMethodModifier;

--- a/crates/rome_js_formatter/src/js/any/mod.rs
+++ b/crates/rome_js_formatter/src/js/any/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod array_assignment_pattern_element;
 pub(crate) mod array_binding_pattern_element;

--- a/crates/rome_js_formatter/src/js/any/mod.rs
+++ b/crates/rome_js_formatter/src/js/any/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod array_assignment_pattern_element;
 pub(crate) mod array_binding_pattern_element;

--- a/crates/rome_js_formatter/src/js/any/module_item.rs
+++ b/crates/rome_js_formatter/src/js/any/module_item.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyModuleItem;

--- a/crates/rome_js_formatter/src/js/any/module_item.rs
+++ b/crates/rome_js_formatter/src/js/any/module_item.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyModuleItem;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyModuleItem;
+pub(crate) struct FormatJsAnyModuleItem;
 impl FormatRule<JsAnyModuleItem> for FormatJsAnyModuleItem {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyModuleItem, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/name.rs
+++ b/crates/rome_js_formatter/src/js/any/name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyName;

--- a/crates/rome_js_formatter/src/js/any/name.rs
+++ b/crates/rome_js_formatter/src/js/any/name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyName;
+pub(crate) struct FormatJsAnyName;
 impl FormatRule<JsAnyName> for FormatJsAnyName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/named_import.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyNamedImport;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyNamedImport;
+pub(crate) struct FormatJsAnyNamedImport;
 impl FormatRule<JsAnyNamedImport> for FormatJsAnyNamedImport {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyNamedImport, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/named_import.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyNamedImport;

--- a/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyNamedImportSpecifier;

--- a/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/any/named_import_specifier.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyNamedImportSpecifier;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyNamedImportSpecifier;
+pub(crate) struct FormatJsAnyNamedImportSpecifier;
 impl FormatRule<JsAnyNamedImportSpecifier> for FormatJsAnyNamedImportSpecifier {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyNamedImportSpecifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectAssignmentPatternMember;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyObjectAssignmentPatternMember;
+pub(crate) struct FormatJsAnyObjectAssignmentPatternMember;
 impl FormatRule<JsAnyObjectAssignmentPatternMember> for FormatJsAnyObjectAssignmentPatternMember {
     type Context = JsFormatContext;
     fn fmt(

--- a/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_assignment_pattern_member.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectAssignmentPatternMember;

--- a/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectBindingPatternMember;

--- a/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_binding_pattern_member.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectBindingPatternMember;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyObjectBindingPatternMember;
+pub(crate) struct FormatJsAnyObjectBindingPatternMember;
 impl FormatRule<JsAnyObjectBindingPatternMember> for FormatJsAnyObjectBindingPatternMember {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyObjectBindingPatternMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/object_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectMember;

--- a/crates/rome_js_formatter/src/js/any/object_member.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectMember;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyObjectMember;
+pub(crate) struct FormatJsAnyObjectMember;
 impl FormatRule<JsAnyObjectMember> for FormatJsAnyObjectMember {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyObjectMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/object_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member_name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectMemberName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyObjectMemberName;
+pub(crate) struct FormatJsAnyObjectMemberName;
 impl FormatRule<JsAnyObjectMemberName> for FormatJsAnyObjectMemberName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyObjectMemberName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/object_member_name.rs
+++ b/crates/rome_js_formatter/src/js/any/object_member_name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyObjectMemberName;

--- a/crates/rome_js_formatter/src/js/any/parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/parameter.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyParameter;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyParameter;
+pub(crate) struct FormatJsAnyParameter;
 impl FormatRule<JsAnyParameter> for FormatJsAnyParameter {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyParameter, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/parameter.rs
+++ b/crates/rome_js_formatter/src/js/any/parameter.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyParameter;

--- a/crates/rome_js_formatter/src/js/any/property_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/property_modifier.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyPropertyModifier;

--- a/crates/rome_js_formatter/src/js/any/property_modifier.rs
+++ b/crates/rome_js_formatter/src/js/any/property_modifier.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyPropertyModifier;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyPropertyModifier;
+pub(crate) struct FormatJsAnyPropertyModifier;
 impl FormatRule<JsAnyPropertyModifier> for FormatJsAnyPropertyModifier {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyPropertyModifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/root.rs
+++ b/crates/rome_js_formatter/src/js/any/root.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyRoot;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyRoot;
+pub(crate) struct FormatJsAnyRoot;
 impl FormatRule<JsAnyRoot> for FormatJsAnyRoot {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyRoot, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/root.rs
+++ b/crates/rome_js_formatter/src/js/any/root.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyRoot;

--- a/crates/rome_js_formatter/src/js/any/statement.rs
+++ b/crates/rome_js_formatter/src/js/any/statement.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyStatement;

--- a/crates/rome_js_formatter/src/js/any/statement.rs
+++ b/crates/rome_js_formatter/src/js/any/statement.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyStatement;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyStatement;
+pub(crate) struct FormatJsAnyStatement;
 impl FormatRule<JsAnyStatement> for FormatJsAnyStatement {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/switch_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/switch_clause.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnySwitchClause;

--- a/crates/rome_js_formatter/src/js/any/switch_clause.rs
+++ b/crates/rome_js_formatter/src/js/any/switch_clause.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnySwitchClause;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnySwitchClause;
+pub(crate) struct FormatJsAnySwitchClause;
 impl FormatRule<JsAnySwitchClause> for FormatJsAnySwitchClause {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnySwitchClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/any/template_element.rs
+++ b/crates/rome_js_formatter/src/js/any/template_element.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyTemplateElement;

--- a/crates/rome_js_formatter/src/js/any/template_element.rs
+++ b/crates/rome_js_formatter/src/js/any/template_element.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsAnyTemplateElement;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAnyTemplateElement;
+pub(crate) struct FormatJsAnyTemplateElement;
 impl FormatRule<JsAnyTemplateElement> for FormatJsAnyTemplateElement {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsAnyTemplateElement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsArrayAssignmentPattern;
 use rome_js_syntax::{JsArrayAssignmentPatternFields, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsArrayAssignmentPattern;
+pub(crate) struct FormatJsArrayAssignmentPattern;
 
 impl FormatNodeRule<JsArrayAssignmentPattern> for FormatJsArrayAssignmentPattern {
     fn fmt_fields(&self, node: &JsArrayAssignmentPattern, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
+++ b/crates/rome_js_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsArrayAssignmentPatternRestElement;
 use rome_js_syntax::JsArrayAssignmentPatternRestElementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsArrayAssignmentPatternRestElement;
+pub(crate) struct FormatJsArrayAssignmentPatternRestElement;
 
 impl FormatNodeRule<JsArrayAssignmentPatternRestElement>
     for FormatJsArrayAssignmentPatternRestElement

--- a/crates/rome_js_formatter/src/js/assignments/assignment_with_default.rs
+++ b/crates/rome_js_formatter/src/js/assignments/assignment_with_default.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsAssignmentWithDefault;
 use rome_js_syntax::JsAssignmentWithDefaultFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAssignmentWithDefault;
+pub(crate) struct FormatJsAssignmentWithDefault;
 
 impl FormatNodeRule<JsAssignmentWithDefault> for FormatJsAssignmentWithDefault {
     fn fmt_fields(&self, node: &JsAssignmentWithDefault, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/assignments/computed_member_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/computed_member_assignment.rs
@@ -5,7 +5,7 @@ use crate::parentheses::NeedsParentheses;
 use rome_js_syntax::{JsComputedMemberAssignment, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsComputedMemberAssignment;
+pub(crate) struct FormatJsComputedMemberAssignment;
 
 impl FormatNodeRule<JsComputedMemberAssignment> for FormatJsComputedMemberAssignment {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/assignments/identifier_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/identifier_assignment.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsForOfStatement, JsIdentifierAssignmentFields};
 use rome_js_syntax::{JsIdentifierAssignment, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsIdentifierAssignment;
+pub(crate) struct FormatJsIdentifierAssignment;
 
 impl FormatNodeRule<JsIdentifierAssignment> for FormatJsIdentifierAssignment {
     fn fmt_fields(&self, node: &JsIdentifierAssignment, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/assignments/mod.rs
+++ b/crates/rome_js_formatter/src/js/assignments/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod array_assignment_pattern;
 pub(crate) mod array_assignment_pattern_rest_element;

--- a/crates/rome_js_formatter/src/js/assignments/mod.rs
+++ b/crates/rome_js_formatter/src/js/assignments/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod array_assignment_pattern;
 pub(crate) mod array_assignment_pattern_rest_element;

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern.rs
@@ -5,7 +5,7 @@ use rome_formatter::write;
 use rome_js_syntax::{JsObjectAssignmentPattern, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectAssignmentPattern;
+pub(crate) struct FormatJsObjectAssignmentPattern;
 
 impl FormatNodeRule<JsObjectAssignmentPattern> for FormatJsObjectAssignmentPattern {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_property.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_property.rs
@@ -4,7 +4,7 @@ use rome_formatter::write;
 use rome_js_syntax::JsObjectAssignmentPatternProperty;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectAssignmentPatternProperty;
+pub(crate) struct FormatJsObjectAssignmentPatternProperty;
 
 impl FormatNodeRule<JsObjectAssignmentPatternProperty> for FormatJsObjectAssignmentPatternProperty {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_rest.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_rest.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsObjectAssignmentPatternRest;
 use rome_js_syntax::JsObjectAssignmentPatternRestFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectAssignmentPatternRest;
+pub(crate) struct FormatJsObjectAssignmentPatternRest;
 
 impl FormatNodeRule<JsObjectAssignmentPatternRest> for FormatJsObjectAssignmentPatternRest {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
+++ b/crates/rome_js_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsObjectAssignmentPatternShorthandProperty;
 use rome_js_syntax::JsObjectAssignmentPatternShorthandPropertyFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectAssignmentPatternShorthandProperty;
+pub(crate) struct FormatJsObjectAssignmentPatternShorthandProperty;
 
 impl FormatNodeRule<JsObjectAssignmentPatternShorthandProperty>
     for FormatJsObjectAssignmentPatternShorthandProperty

--- a/crates/rome_js_formatter/src/js/assignments/parenthesized_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/parenthesized_assignment.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsParenthesizedAssignment;
 use rome_js_syntax::{JsParenthesizedAssignmentFields, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsParenthesizedAssignment;
+pub(crate) struct FormatJsParenthesizedAssignment;
 
 impl FormatNodeRule<JsParenthesizedAssignment> for FormatJsParenthesizedAssignment {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/assignments/static_member_assignment.rs
+++ b/crates/rome_js_formatter/src/js/assignments/static_member_assignment.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 use rome_js_syntax::{JsStaticMemberAssignment, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsStaticMemberAssignment;
+pub(crate) struct FormatJsStaticMemberAssignment;
 
 impl FormatNodeRule<JsStaticMemberAssignment> for FormatJsStaticMemberAssignment {
     fn fmt_fields(&self, node: &JsStaticMemberAssignment, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/array_hole.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/array_hole.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use rome_js_syntax::JsArrayHole;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsArrayHole;
+pub(crate) struct FormatJsArrayHole;
 
 impl FormatNodeRule<JsArrayHole> for FormatJsArrayHole {
     fn fmt_fields(&self, _: &JsArrayHole, _: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsCaseClauseFields;
 use rome_rowan::AstNodeList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsCaseClause;
+pub(crate) struct FormatJsCaseClause;
 
 impl FormatNodeRule<JsCaseClause> for FormatJsCaseClause {
     fn fmt_fields(&self, node: &JsCaseClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/catch_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/catch_clause.rs
@@ -4,7 +4,7 @@ use rome_js_syntax::JsCatchClause;
 use rome_js_syntax::JsCatchClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsCatchClause;
+pub(crate) struct FormatJsCatchClause;
 
 impl FormatNodeRule<JsCatchClause> for FormatJsCatchClause {
     fn fmt_fields(&self, node: &JsCatchClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsAnyStatement, JsDefaultClauseFields};
 use rome_rowan::AstNodeList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsDefaultClause;
+pub(crate) struct FormatJsDefaultClause;
 
 impl FormatNodeRule<JsDefaultClause> for FormatJsDefaultClause {
     fn fmt_fields(&self, node: &JsDefaultClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/directive.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/directive.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsDirective;
 use rome_js_syntax::JsDirectiveFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsDirective;
+pub(crate) struct FormatJsDirective;
 
 impl FormatNodeRule<JsDirective> for FormatJsDirective {
     fn fmt_fields(&self, node: &JsDirective, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/else_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/else_clause.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsElseClause;
 use rome_js_syntax::JsElseClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsElseClause;
+pub(crate) struct FormatJsElseClause;
 
 impl FormatNodeRule<JsElseClause> for FormatJsElseClause {
     fn fmt_fields(&self, node: &JsElseClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/expression_snipped.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/expression_snipped.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsExpressionSnipped;
 use rome_js_syntax::JsExpressionSnippedFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExpressionSnipped;
+pub(crate) struct FormatJsExpressionSnipped;
 
 impl FormatNodeRule<JsExpressionSnipped> for FormatJsExpressionSnipped {
     fn fmt_fields(&self, node: &JsExpressionSnipped, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/finally_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/finally_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsFinallyClause;
 use rome_js_syntax::JsFinallyClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsFinallyClause;
+pub(crate) struct FormatJsFinallyClause;
 
 impl FormatNodeRule<JsFinallyClause> for FormatJsFinallyClause {
     fn fmt_fields(&self, node: &JsFinallyClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/function_body.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsFunctionBody;
 use rome_js_syntax::JsFunctionBodyFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsFunctionBody;
+pub(crate) struct FormatJsFunctionBody;
 
 impl FormatNodeRule<JsFunctionBody> for FormatJsFunctionBody {
     fn fmt_fields(&self, node: &JsFunctionBody, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/initializer_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/initializer_clause.rs
@@ -6,12 +6,12 @@ use rome_js_syntax::JsInitializerClause;
 use rome_js_syntax::JsInitializerClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsInitializerClause {
+pub(crate) struct FormatJsInitializerClause {
     assignment_layout: Option<AssignmentLikeLayout>,
 }
 
 #[derive(Default, Debug)]
-pub struct FormatJsInitializerClauseOptions {
+pub(crate) struct FormatJsInitializerClauseOptions {
     pub(crate) assignment_layout: Option<AssignmentLikeLayout>,
 }
 

--- a/crates/rome_js_formatter/src/js/auxiliary/mod.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod array_hole;
 pub(crate) mod case_clause;

--- a/crates/rome_js_formatter/src/js/auxiliary/mod.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod array_hole;
 pub(crate) mod case_clause;

--- a/crates/rome_js_formatter/src/js/auxiliary/module.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/module.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsModule;
 use rome_js_syntax::JsModuleFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsModule;
+pub(crate) struct FormatJsModule;
 
 impl FormatNodeRule<JsModule> for FormatJsModule {
     fn fmt_fields(&self, node: &JsModule, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/name.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsName;
 use rome_js_syntax::JsNameFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsName;
+pub(crate) struct FormatJsName;
 
 impl FormatNodeRule<JsName> for FormatJsName {
     fn fmt_fields(&self, node: &JsName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/new_target.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/new_target.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::NewTargetFields;
 use rome_js_syntax::{JsSyntaxNode, NewTarget};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatNewTarget;
+pub(crate) struct FormatNewTarget;
 
 impl FormatNodeRule<NewTarget> for FormatNewTarget {
     fn fmt_fields(&self, node: &NewTarget, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/private_name.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/private_name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsPrivateName;
 use rome_js_syntax::JsPrivateNameFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsPrivateName;
+pub(crate) struct FormatJsPrivateName;
 
 impl FormatNodeRule<JsPrivateName> for FormatJsPrivateName {
     fn fmt_fields(&self, node: &JsPrivateName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/reference_identifier.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/reference_identifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsReferenceIdentifier;
 use rome_js_syntax::JsReferenceIdentifierFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsReferenceIdentifier;
+pub(crate) struct FormatJsReferenceIdentifier;
 
 impl FormatNodeRule<JsReferenceIdentifier> for FormatJsReferenceIdentifier {
     fn fmt_fields(&self, node: &JsReferenceIdentifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/script.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/script.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsScript;
 use rome_js_syntax::JsScriptFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsScript;
+pub(crate) struct FormatJsScript;
 
 impl FormatNodeRule<JsScript> for FormatJsScript {
     fn fmt_fields(&self, node: &JsScript, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/spread.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/spread.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsSpread;
 use rome_js_syntax::JsSpreadFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsSpread;
+pub(crate) struct FormatJsSpread;
 
 impl FormatNodeRule<JsSpread> for FormatJsSpread {
     fn fmt_fields(&self, node: &JsSpread, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/static_modifier.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/static_modifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsStaticModifier;
 use rome_js_syntax::JsStaticModifierFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsStaticModifier;
+pub(crate) struct FormatJsStaticModifier;
 
 impl FormatNodeRule<JsStaticModifier> for FormatJsStaticModifier {
     fn fmt_fields(&self, node: &JsStaticModifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/auxiliary/variable_declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/variable_declaration_clause.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsVariableDeclarationClause;
 use rome_js_syntax::JsVariableDeclarationClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsVariableDeclarationClause;
+pub(crate) struct FormatJsVariableDeclarationClause;
 
 impl FormatNodeRule<JsVariableDeclarationClause> for FormatJsVariableDeclarationClause {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/variable_declarator.rs
@@ -4,7 +4,7 @@ use rome_formatter::write;
 use rome_js_syntax::JsVariableDeclarator;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsVariableDeclarator;
+pub(crate) struct FormatJsVariableDeclarator;
 
 impl FormatNodeRule<JsVariableDeclarator> for FormatJsVariableDeclarator {
     fn fmt_fields(&self, node: &JsVariableDeclarator, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/array_binding_pattern.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsArrayBindingPattern;
 use rome_js_syntax::JsArrayBindingPatternFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsArrayBindingPattern;
+pub(crate) struct FormatJsArrayBindingPattern;
 
 impl FormatNodeRule<JsArrayBindingPattern> for FormatJsArrayBindingPattern {
     fn fmt_fields(&self, node: &JsArrayBindingPattern, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
+++ b/crates/rome_js_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsArrayBindingPatternRestElement;
 use rome_js_syntax::JsArrayBindingPatternRestElementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsArrayBindingPatternRestElement;
+pub(crate) struct FormatJsArrayBindingPatternRestElement;
 
 impl FormatNodeRule<JsArrayBindingPatternRestElement> for FormatJsArrayBindingPatternRestElement {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/bindings/binding_pattern_with_default.rs
+++ b/crates/rome_js_formatter/src/js/bindings/binding_pattern_with_default.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsBindingPatternWithDefault;
 use rome_js_syntax::JsBindingPatternWithDefaultFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsBindingPatternWithDefault;
+pub(crate) struct FormatJsBindingPatternWithDefault;
 
 impl FormatNodeRule<JsBindingPatternWithDefault> for FormatJsBindingPatternWithDefault {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/constructor_parameters.rs
@@ -4,7 +4,7 @@ use crate::js::bindings::parameters::FormatJsAnyParameters;
 use rome_js_syntax::JsConstructorParameters;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsConstructorParameters;
+pub(crate) struct FormatJsConstructorParameters;
 
 impl FormatNodeRule<JsConstructorParameters> for FormatJsConstructorParameters {
     fn fmt_fields(&self, node: &JsConstructorParameters, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/bindings/formal_parameter.rs
+++ b/crates/rome_js_formatter/src/js/bindings/formal_parameter.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsFormalParameterFields;
 use rome_js_syntax::{JsAnyBindingPattern, JsFormalParameter};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsFormalParameter;
+pub(crate) struct FormatJsFormalParameter;
 
 impl FormatNodeRule<JsFormalParameter> for FormatJsFormalParameter {
     fn fmt_fields(&self, node: &JsFormalParameter, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/bindings/identifier_binding.rs
+++ b/crates/rome_js_formatter/src/js/bindings/identifier_binding.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsIdentifierBinding;
 use rome_js_syntax::JsIdentifierBindingFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsIdentifierBinding;
+pub(crate) struct FormatJsIdentifierBinding;
 
 impl FormatNodeRule<JsIdentifierBinding> for FormatJsIdentifierBinding {
     fn fmt_fields(&self, node: &JsIdentifierBinding, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/bindings/mod.rs
+++ b/crates/rome_js_formatter/src/js/bindings/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod array_binding_pattern;
 pub(crate) mod array_binding_pattern_rest_element;

--- a/crates/rome_js_formatter/src/js/bindings/mod.rs
+++ b/crates/rome_js_formatter/src/js/bindings/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod array_binding_pattern;
 pub(crate) mod array_binding_pattern_rest_element;

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
@@ -4,7 +4,7 @@ use rome_formatter::write;
 use rome_js_syntax::JsObjectBindingPattern;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectBindingPattern;
+pub(crate) struct FormatJsObjectBindingPattern;
 
 impl FormatNodeRule<JsObjectBindingPattern> for FormatJsObjectBindingPattern {
     fn fmt_fields(&self, node: &JsObjectBindingPattern, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_property.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsObjectBindingPatternProperty;
 use rome_js_syntax::JsObjectBindingPatternPropertyFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectBindingPatternProperty;
+pub(crate) struct FormatJsObjectBindingPatternProperty;
 
 impl FormatNodeRule<JsObjectBindingPatternProperty> for FormatJsObjectBindingPatternProperty {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_rest.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_rest.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsObjectBindingPatternRest;
 use rome_js_syntax::JsObjectBindingPatternRestFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectBindingPatternRest;
+pub(crate) struct FormatJsObjectBindingPatternRest;
 
 impl FormatNodeRule<JsObjectBindingPatternRest> for FormatJsObjectBindingPatternRest {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsObjectBindingPatternShorthandProperty;
 use rome_js_syntax::JsObjectBindingPatternShorthandPropertyFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectBindingPatternShorthandProperty;
+pub(crate) struct FormatJsObjectBindingPatternShorthandProperty;
 
 impl FormatNodeRule<JsObjectBindingPatternShorthandProperty>
     for FormatJsObjectBindingPatternShorthandProperty

--- a/crates/rome_js_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/parameters.rs
@@ -13,7 +13,7 @@ use rome_js_syntax::{
 use rome_rowan::{declare_node_union, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsParameters;
+pub(crate) struct FormatJsParameters;
 
 impl FormatNodeRule<JsParameters> for FormatJsParameters {
     fn fmt_fields(&self, node: &JsParameters, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/bindings/rest_parameter.rs
+++ b/crates/rome_js_formatter/src/js/bindings/rest_parameter.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsRestParameter;
 use rome_js_syntax::JsRestParameterFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsRestParameter;
+pub(crate) struct FormatJsRestParameter;
 
 impl FormatNodeRule<JsRestParameter> for FormatJsRestParameter {
     fn fmt_fields(&self, node: &JsRestParameter, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/constructor_class_member.rs
@@ -5,7 +5,7 @@ use rome_formatter::write;
 use rome_js_syntax::JsConstructorClassMember;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsConstructorClassMember;
+pub(crate) struct FormatJsConstructorClassMember;
 
 impl FormatNodeRule<JsConstructorClassMember> for FormatJsConstructorClassMember {
     fn fmt_fields(&self, node: &JsConstructorClassMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/empty_class_member.rs
@@ -4,7 +4,7 @@ use rome_js_syntax::JsEmptyClassMember;
 use rome_js_syntax::JsEmptyClassMemberFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsEmptyClassMember;
+pub(crate) struct FormatJsEmptyClassMember;
 
 impl FormatNodeRule<JsEmptyClassMember> for FormatJsEmptyClassMember {
     fn fmt_fields(&self, node: &JsEmptyClassMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/classes/extends_clause.rs
+++ b/crates/rome_js_formatter/src/js/classes/extends_clause.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsExtendsClauseFields;
 use rome_js_syntax::JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExtendsClause;
+pub(crate) struct FormatJsExtendsClause;
 
 impl FormatNodeRule<JsExtendsClause> for FormatJsExtendsClause {
     fn fmt_fields(&self, node: &JsExtendsClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/getter_class_member.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsGetterClassMember;
 use rome_js_syntax::JsGetterClassMemberFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsGetterClassMember;
+pub(crate) struct FormatJsGetterClassMember;
 
 impl FormatNodeRule<JsGetterClassMember> for FormatJsGetterClassMember {
     fn fmt_fields(&self, node: &JsGetterClassMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/classes/method_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/method_class_member.rs
@@ -11,7 +11,7 @@ use rome_js_syntax::{JsMethodClassMember, JsMethodObjectMember, JsSyntaxToken};
 use rome_rowan::{declare_node_union, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsMethodClassMember;
+pub(crate) struct FormatJsMethodClassMember;
 
 impl FormatNodeRule<JsMethodClassMember> for FormatJsMethodClassMember {
     fn fmt_fields(&self, node: &JsMethodClassMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/classes/mod.rs
+++ b/crates/rome_js_formatter/src/js/classes/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod constructor_class_member;
 pub(crate) mod empty_class_member;

--- a/crates/rome_js_formatter/src/js/classes/mod.rs
+++ b/crates/rome_js_formatter/src/js/classes/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod constructor_class_member;
 pub(crate) mod empty_class_member;

--- a/crates/rome_js_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/property_class_member.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{
 use rome_rowan::{declare_node_union, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsPropertyClassMember;
+pub(crate) struct FormatJsPropertyClassMember;
 
 impl FormatNodeRule<JsPropertyClassMember> for FormatJsPropertyClassMember {
     fn fmt_fields(&self, node: &JsPropertyClassMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/setter_class_member.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsSetterClassMember;
 use rome_js_syntax::JsSetterClassMemberFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsSetterClassMember;
+pub(crate) struct FormatJsSetterClassMember;
 
 impl FormatNodeRule<JsSetterClassMember> for FormatJsSetterClassMember {
     fn fmt_fields(&self, node: &JsSetterClassMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
+++ b/crates/rome_js_formatter/src/js/classes/static_initialization_block_class_member.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsStaticInitializationBlockClassMember;
 use rome_js_syntax::JsStaticInitializationBlockClassMemberFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsStaticInitializationBlockClassMember;
+pub(crate) struct FormatJsStaticInitializationBlockClassMember;
 
 impl FormatNodeRule<JsStaticInitializationBlockClassMember>
     for FormatJsStaticInitializationBlockClassMember

--- a/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/catch_declaration.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsCatchDeclaration;
 use rome_js_syntax::JsCatchDeclarationFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsCatchDeclaration;
+pub(crate) struct FormatJsCatchDeclaration;
 
 impl FormatNodeRule<JsCatchDeclaration> for FormatJsCatchDeclaration {
     fn fmt_fields(&self, node: &JsCatchDeclaration, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/declarations/class_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/class_declaration.rs
@@ -4,7 +4,7 @@ use crate::utils::format_class::FormatClass;
 use rome_js_syntax::JsClassDeclaration;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsClassDeclaration;
+pub(crate) struct FormatJsClassDeclaration;
 
 impl FormatNodeRule<JsClassDeclaration> for FormatJsClassDeclaration {
     fn fmt_fields(&self, node: &JsClassDeclaration, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/declarations/class_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/class_export_default_declaration.rs
@@ -4,7 +4,7 @@ use crate::utils::format_class::FormatClass;
 use rome_js_syntax::JsClassExportDefaultDeclaration;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsClassExportDefaultDeclaration;
+pub(crate) struct FormatJsClassExportDefaultDeclaration;
 
 impl FormatNodeRule<JsClassExportDefaultDeclaration> for FormatJsClassExportDefaultDeclaration {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/declarations/for_variable_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/for_variable_declaration.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsForVariableDeclaration;
 use rome_js_syntax::JsForVariableDeclarationFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsForVariableDeclaration;
+pub(crate) struct FormatJsForVariableDeclaration;
 
 impl FormatNodeRule<JsForVariableDeclaration> for FormatJsForVariableDeclaration {
     fn fmt_fields(&self, node: &JsForVariableDeclaration, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_declaration.rs
@@ -12,7 +12,7 @@ use rome_js_syntax::{
 use rome_rowan::{declare_node_union, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsFunctionDeclaration;
+pub(crate) struct FormatJsFunctionDeclaration;
 
 impl FormatNodeRule<JsFunctionDeclaration> for FormatJsFunctionDeclaration {
     fn fmt_fields(&self, node: &JsFunctionDeclaration, f: &mut JsFormatter) -> FormatResult<()> {
@@ -30,7 +30,7 @@ declare_node_union! {
 }
 
 #[derive(Copy, Clone, Debug, Default)]
-pub struct FormatFunctionOptions {
+pub(crate) struct FormatFunctionOptions {
     pub call_argument_layout: Option<GroupedCallArgumentLayout>,
     pub body_cache_mode: FunctionBodyCacheMode,
 }

--- a/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/function_export_default_declaration.rs
@@ -5,7 +5,7 @@ use crate::js::declarations::function_declaration::FormatFunction;
 use rome_js_syntax::JsFunctionExportDefaultDeclaration;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsFunctionExportDefaultDeclaration;
+pub(crate) struct FormatJsFunctionExportDefaultDeclaration;
 
 impl FormatNodeRule<JsFunctionExportDefaultDeclaration>
     for FormatJsFunctionExportDefaultDeclaration

--- a/crates/rome_js_formatter/src/js/declarations/mod.rs
+++ b/crates/rome_js_formatter/src/js/declarations/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod catch_declaration;
 pub(crate) mod class_declaration;

--- a/crates/rome_js_formatter/src/js/declarations/mod.rs
+++ b/crates/rome_js_formatter/src/js/declarations/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod catch_declaration;
 pub(crate) mod class_declaration;

--- a/crates/rome_js_formatter/src/js/declarations/variable_declaration.rs
+++ b/crates/rome_js_formatter/src/js/declarations/variable_declaration.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsVariableDeclaration;
 use rome_js_syntax::JsVariableDeclarationFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsVariableDeclaration;
+pub(crate) struct FormatJsVariableDeclaration;
 
 impl FormatNodeRule<JsVariableDeclaration> for FormatJsVariableDeclaration {
     fn fmt_fields(&self, node: &JsVariableDeclaration, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/array_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/array_expression.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{JsArrayExpression, JsSyntaxNode};
 use rome_rowan::SyntaxResult;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsArrayExpression {
+pub(crate) struct FormatJsArrayExpression {
     options: FormatJsArrayExpressionOptions,
 }
 
@@ -75,7 +75,7 @@ impl FormatNodeRule<JsArrayExpression> for FormatJsArrayExpression {
 }
 
 #[derive(Debug, Copy, Clone, Default)]
-pub struct FormatJsArrayExpressionOptions {
+pub(crate) struct FormatJsArrayExpressionOptions {
     pub(crate) is_force_flat_mode: bool,
 }
 

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -21,12 +21,12 @@ use rome_js_syntax::{
 use rome_rowan::{SyntaxNodeOptionExt, SyntaxResult};
 
 #[derive(Debug, Copy, Clone, Default)]
-pub struct FormatJsArrowFunctionExpression {
+pub(crate) struct FormatJsArrowFunctionExpression {
     options: FormatJsArrowFunctionExpressionOptions,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-pub struct FormatJsArrowFunctionExpressionOptions {
+pub(crate) struct FormatJsArrowFunctionExpressionOptions {
     pub assignment_layout: Option<AssignmentLikeLayout>,
     pub call_arg_layout: Option<GroupedCallArgumentLayout>,
     pub body_cache_mode: FunctionBodyCacheMode,

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -14,7 +14,7 @@ use rome_js_syntax::{
 use rome_rowan::{match_ast, AstNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAssignmentExpression;
+pub(crate) struct FormatJsAssignmentExpression;
 
 impl FormatNodeRule<JsAssignmentExpression> for FormatJsAssignmentExpression {
     fn fmt_fields(&self, node: &JsAssignmentExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/await_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/await_expression.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::{JsAwaitExpression, JsSyntaxNode};
 use rome_js_syntax::{JsAwaitExpressionFields, JsSyntaxKind};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsAwaitExpression;
+pub(crate) struct FormatJsAwaitExpression;
 
 impl FormatNodeRule<JsAwaitExpression> for FormatJsAwaitExpression {
     fn fmt_fields(&self, node: &JsAwaitExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/big_int_literal_expression.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::JsBigIntLiteralExpressionFields;
 use rome_js_syntax::{JsBigIntLiteralExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsBigIntLiteralExpression;
+pub(crate) struct FormatJsBigIntLiteralExpression;
 
 impl FormatNodeRule<JsBigIntLiteralExpression> for FormatJsBigIntLiteralExpression {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
@@ -5,7 +5,7 @@ use crate::parentheses::NeedsParentheses;
 use rome_js_syntax::{JsBinaryExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsBinaryExpression;
+pub(crate) struct FormatJsBinaryExpression;
 
 impl FormatNodeRule<JsBinaryExpression> for FormatJsBinaryExpression {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/boolean_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/boolean_literal_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsBooleanLiteralExpressionFields;
 use rome_js_syntax::{JsBooleanLiteralExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsBooleanLiteralExpression;
+pub(crate) struct FormatJsBooleanLiteralExpression;
 
 impl FormatNodeRule<JsBooleanLiteralExpression> for FormatJsBooleanLiteralExpression {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_arguments.rs
@@ -18,7 +18,7 @@ use rome_js_syntax::{
 use rome_rowan::{AstSeparatedElement, AstSeparatedList, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsCallArguments;
+pub(crate) struct FormatJsCallArguments;
 
 impl FormatNodeRule<JsCallArguments> for FormatJsCallArguments {
     fn fmt_fields(&self, node: &JsCallArguments, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/call_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/call_expression.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::{
 };
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsCallExpression;
+pub(crate) struct FormatJsCallExpression;
 
 impl FormatNodeRule<JsCallExpression> for FormatJsCallExpression {
     fn fmt_fields(&self, node: &JsCallExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/class_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/class_expression.rs
@@ -7,7 +7,7 @@ use crate::parentheses::{
 use rome_js_syntax::{JsClassExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsClassExpression;
+pub(crate) struct FormatJsClassExpression;
 
 impl FormatNodeRule<JsClassExpression> for FormatJsClassExpression {
     fn fmt_fields(&self, node: &JsClassExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/computed_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/computed_member_expression.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::{
 use rome_rowan::{declare_node_union, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsComputedMemberExpression;
+pub(crate) struct FormatJsComputedMemberExpression;
 
 impl FormatNodeRule<JsComputedMemberExpression> for FormatJsComputedMemberExpression {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
@@ -9,7 +9,7 @@ use crate::parentheses::{
 use rome_js_syntax::{JsConditionalExpression, JsSyntaxKind, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsConditionalExpression {
+pub(crate) struct FormatJsConditionalExpression {
     jsx_chain: ConditionalJsxChain,
 }
 

--- a/crates/rome_js_formatter/src/js/expressions/function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/function_expression.rs
@@ -9,7 +9,7 @@ use rome_formatter::FormatRuleWithOptions;
 use rome_js_syntax::{JsFunctionExpression, JsSyntaxNode};
 
 #[derive(Debug, Copy, Clone, Default)]
-pub struct FormatJsFunctionExpression {
+pub(crate) struct FormatJsFunctionExpression {
     options: FormatFunctionOptions,
 }
 

--- a/crates/rome_js_formatter/src/js/expressions/identifier_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/identifier_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsIdentifierExpressionFields;
 use rome_js_syntax::{JsIdentifierExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsIdentifierExpression;
+pub(crate) struct FormatJsIdentifierExpression;
 
 impl FormatNodeRule<JsIdentifierExpression> for FormatJsIdentifierExpression {
     fn fmt_fields(&self, node: &JsIdentifierExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/import_call_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/import_call_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsImportCallExpressionFields;
 use rome_js_syntax::{JsImportCallExpression, JsSyntaxKind, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImportCallExpression;
+pub(crate) struct FormatJsImportCallExpression;
 
 impl FormatNodeRule<JsImportCallExpression> for FormatJsImportCallExpression {
     fn fmt_fields(&self, node: &JsImportCallExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/in_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{JsAnyStatement, JsForStatement, JsInExpression, JsSyntaxNod
 use rome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsInExpression;
+pub(crate) struct FormatJsInExpression;
 
 impl FormatNodeRule<JsInExpression> for FormatJsInExpression {
     fn fmt_fields(&self, node: &JsInExpression, formatter: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -5,7 +5,7 @@ use crate::parentheses::NeedsParentheses;
 use rome_js_syntax::{JsInstanceofExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsInstanceofExpression;
+pub(crate) struct FormatJsInstanceofExpression;
 
 impl FormatNodeRule<JsInstanceofExpression> for FormatJsInstanceofExpression {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsLogicalExpression, JsSyntaxNode};
 use rome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsLogicalExpression;
+pub(crate) struct FormatJsLogicalExpression;
 
 impl FormatNodeRule<JsLogicalExpression> for FormatJsLogicalExpression {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/mod.rs
+++ b/crates/rome_js_formatter/src/js/expressions/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod array_expression;
 pub(crate) mod arrow_function_expression;

--- a/crates/rome_js_formatter/src/js/expressions/mod.rs
+++ b/crates/rome_js_formatter/src/js/expressions/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod array_expression;
 pub(crate) mod arrow_function_expression;

--- a/crates/rome_js_formatter/src/js/expressions/new_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/new_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsNewExpression, JsSyntaxKind};
 use rome_js_syntax::{JsNewExpressionFields, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsNewExpression;
+pub(crate) struct FormatJsNewExpression;
 
 impl FormatNodeRule<JsNewExpression> for FormatJsNewExpression {
     fn fmt_fields(&self, node: &JsNewExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/null_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/null_literal_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsNullLiteralExpressionFields;
 use rome_js_syntax::{JsNullLiteralExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsNullLiteralExpression;
+pub(crate) struct FormatJsNullLiteralExpression;
 
 impl FormatNodeRule<JsNullLiteralExpression> for FormatJsNullLiteralExpression {
     fn fmt_fields(&self, node: &JsNullLiteralExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/number_literal_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsNumberLiteralExpression;
 use rome_js_syntax::{JsNumberLiteralExpressionFields, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsNumberLiteralExpression;
+pub(crate) struct FormatJsNumberLiteralExpression;
 
 impl FormatNodeRule<JsNumberLiteralExpression> for FormatJsNumberLiteralExpression {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/object_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/object_expression.rs
@@ -5,7 +5,7 @@ use rome_formatter::write;
 use rome_js_syntax::{JsObjectExpression, JsSyntaxKind, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectExpression;
+pub(crate) struct FormatJsObjectExpression;
 
 impl FormatNodeRule<JsObjectExpression> for FormatJsObjectExpression {
     fn fmt_fields(&self, node: &JsObjectExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/parenthesized_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{
 };
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsParenthesizedExpression;
+pub(crate) struct FormatJsParenthesizedExpression;
 
 impl FormatNodeRule<JsParenthesizedExpression> for FormatJsParenthesizedExpression {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsPostUpdateExpressionFields;
 use rome_js_syntax::{JsPostUpdateExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsPostUpdateExpression;
+pub(crate) struct FormatJsPostUpdateExpression;
 
 impl FormatNodeRule<JsPostUpdateExpression> for FormatJsPostUpdateExpression {
     fn fmt_fields(&self, node: &JsPostUpdateExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{
 use rome_rowan::match_ast;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsPreUpdateExpression;
+pub(crate) struct FormatJsPreUpdateExpression;
 
 impl FormatNodeRule<JsPreUpdateExpression> for FormatJsPreUpdateExpression {
     fn fmt_fields(&self, node: &JsPreUpdateExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/regex_literal_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsRegexLiteralExpressionFields;
 use rome_js_syntax::{JsRegexLiteralExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsRegexLiteralExpression;
+pub(crate) struct FormatJsRegexLiteralExpression;
 
 impl FormatNodeRule<JsRegexLiteralExpression> for FormatJsRegexLiteralExpression {
     fn fmt_fields(&self, node: &JsRegexLiteralExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{
 use rome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsSequenceExpression;
+pub(crate) struct FormatJsSequenceExpression;
 
 impl FormatNodeRule<JsSequenceExpression> for FormatJsSequenceExpression {
     fn fmt_fields(&self, node: &JsSequenceExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -12,7 +12,7 @@ use rome_js_syntax::{
 use rome_rowan::{declare_node_union, AstNode, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsStaticMemberExpression;
+pub(crate) struct FormatJsStaticMemberExpression;
 
 impl FormatNodeRule<JsStaticMemberExpression> for FormatJsStaticMemberExpression {
     fn fmt_fields(&self, node: &JsStaticMemberExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{JsStringLiteralExpression, JsSyntaxNode};
 use rome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsStringLiteralExpression;
+pub(crate) struct FormatJsStringLiteralExpression;
 
 impl FormatNodeRule<JsStringLiteralExpression> for FormatJsStringLiteralExpression {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/super_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/super_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsSuperExpressionFields;
 use rome_js_syntax::{JsSuperExpression, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsSuperExpression;
+pub(crate) struct FormatJsSuperExpression;
 
 impl FormatNodeRule<JsSuperExpression> for FormatJsSuperExpression {
     fn fmt_fields(&self, node: &JsSuperExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/template.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::{JsSyntaxToken, TsTypeArguments};
 use rome_rowan::{declare_node_union, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsTemplate;
+pub(crate) struct FormatJsTemplate;
 
 impl FormatNodeRule<JsTemplate> for FormatJsTemplate {
     fn fmt_fields(&self, node: &JsTemplate, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/template_chunk_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_chunk_element.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsSyntaxToken, JsTemplateChunkElement, TsTemplateChunkEleme
 use rome_rowan::{declare_node_union, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsTemplateChunkElement;
+pub(crate) struct FormatJsTemplateChunkElement;
 
 impl FormatNodeRule<JsTemplateChunkElement> for FormatJsTemplateChunkElement {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/expressions/template_element.rs
+++ b/crates/rome_js_formatter/src/js/expressions/template_element.rs
@@ -13,7 +13,7 @@ use rome_js_syntax::{
 use rome_rowan::{declare_node_union, AstNode, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsTemplateElement {
+pub(crate) struct FormatJsTemplateElement {
     options: TemplateElementOptions,
 }
 

--- a/crates/rome_js_formatter/src/js/expressions/this_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/this_expression.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsThisExpressionFields;
 use rome_js_syntax::{JsSyntaxNode, JsThisExpression};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsThisExpression;
+pub(crate) struct FormatJsThisExpression;
 
 impl FormatNodeRule<JsThisExpression> for FormatJsThisExpression {
     fn fmt_fields(&self, node: &JsThisExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/unary_expression.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{JsUnaryExpressionFields, JsUnaryOperator};
 use rome_rowan::match_ast;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnaryExpression;
+pub(crate) struct FormatJsUnaryExpression;
 
 impl FormatNodeRule<JsUnaryExpression> for FormatJsUnaryExpression {
     fn fmt_fields(&self, node: &JsUnaryExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/yield_argument.rs
+++ b/crates/rome_js_formatter/src/js/expressions/yield_argument.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsYieldArgument;
 use rome_js_syntax::JsYieldArgumentFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsYieldArgument;
+pub(crate) struct FormatJsYieldArgument;
 
 impl FormatNodeRule<JsYieldArgument> for FormatJsYieldArgument {
     fn fmt_fields(&self, node: &JsYieldArgument, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/expressions/yield_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/yield_expression.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{JsSyntaxKind, JsYieldExpressionFields};
 use rome_js_syntax::{JsSyntaxNode, JsYieldExpression};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsYieldExpression;
+pub(crate) struct FormatJsYieldExpression;
 
 impl FormatNodeRule<JsYieldExpression> for FormatJsYieldExpression {
     fn fmt_fields(&self, node: &JsYieldExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_assignment_pattern_element_list.rs
@@ -3,7 +3,7 @@ use crate::utils::array::write_array_node;
 use rome_js_syntax::JsArrayAssignmentPatternElementList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsArrayAssignmentPatternElementList;
+pub(crate) struct FormatJsArrayAssignmentPatternElementList;
 
 impl FormatRule<JsArrayAssignmentPatternElementList> for FormatJsArrayAssignmentPatternElementList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_binding_pattern_element_list.rs
@@ -3,7 +3,7 @@ use crate::utils::array::write_array_node;
 use rome_js_syntax::JsArrayBindingPatternElementList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsArrayBindingPatternElementList;
+pub(crate) struct FormatJsArrayBindingPatternElementList;
 
 impl FormatRule<JsArrayBindingPatternElementList> for FormatJsArrayBindingPatternElementList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsArrayElementList;
 use rome_rowan::{AstNode, AstSeparatedList};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsArrayElementList {
+pub(crate) struct FormatJsArrayElementList {
     group_id: Option<GroupId>,
 }
 

--- a/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/call_argument_list.rs
@@ -4,7 +4,7 @@ use rome_formatter::write;
 use rome_js_syntax::JsCallArgumentList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsCallArgumentList;
+pub(crate) struct FormatJsCallArgumentList;
 
 impl FormatRule<JsCallArgumentList> for FormatJsCallArgumentList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/class_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/class_member_list.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use rome_js_syntax::JsClassMemberList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsClassMemberList;
+pub(crate) struct FormatJsClassMemberList;
 
 impl FormatRule<JsClassMemberList> for FormatJsClassMemberList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_modifier_list.rs
@@ -3,7 +3,7 @@ use rome_js_syntax::JsConstructorModifierList;
 use rome_rowan::AstNodeList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsConstructorModifierList;
+pub(crate) struct FormatJsConstructorModifierList;
 
 impl FormatRule<JsConstructorModifierList> for FormatJsConstructorModifierList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/constructor_parameter_list.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 use rome_js_syntax::JsConstructorParameterList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsConstructorParameterList;
+pub(crate) struct FormatJsConstructorParameterList;
 
 impl FormatRule<JsConstructorParameterList> for FormatJsConstructorParameterList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/directive_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/directive_list.rs
@@ -4,7 +4,7 @@ use rome_js_syntax::JsDirectiveList;
 use rome_rowan::{AstNode, AstNodeList};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsDirectiveList;
+pub(crate) struct FormatJsDirectiveList;
 
 impl FormatRule<JsDirectiveList> for FormatJsDirectiveList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_from_specifier_list.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use rome_js_syntax::JsExportNamedFromSpecifierList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportNamedFromSpecifierList;
+pub(crate) struct FormatJsExportNamedFromSpecifierList;
 
 impl FormatRule<JsExportNamedFromSpecifierList> for FormatJsExportNamedFromSpecifierList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/export_named_specifier_list.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use rome_js_syntax::JsExportNamedSpecifierList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportNamedSpecifierList;
+pub(crate) struct FormatJsExportNamedSpecifierList;
 
 impl FormatRule<JsExportNamedSpecifierList> for FormatJsExportNamedSpecifierList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/import_assertion_entry_list.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use rome_js_syntax::JsImportAssertionEntryList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImportAssertionEntryList;
+pub(crate) struct FormatJsImportAssertionEntryList;
 
 impl FormatRule<JsImportAssertionEntryList> for FormatJsImportAssertionEntryList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/method_modifier_list.rs
@@ -3,7 +3,7 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::JsMethodModifierList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsMethodModifierList;
+pub(crate) struct FormatJsMethodModifierList;
 
 impl FormatRule<JsMethodModifierList> for FormatJsMethodModifierList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/mod.rs
+++ b/crates/rome_js_formatter/src/js/lists/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod array_assignment_pattern_element_list;
 pub(crate) mod array_binding_pattern_element_list;

--- a/crates/rome_js_formatter/src/js/lists/mod.rs
+++ b/crates/rome_js_formatter/src/js/lists/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod array_assignment_pattern_element_list;
 pub(crate) mod array_binding_pattern_element_list;

--- a/crates/rome_js_formatter/src/js/lists/module_item_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/module_item_list.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use rome_js_syntax::{JsAnyModuleItem, JsAnyStatement, JsModuleItemList};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsModuleItemList;
+pub(crate) struct FormatJsModuleItemList;
 
 impl FormatRule<JsModuleItemList> for FormatJsModuleItemList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/named_import_specifier_list.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use rome_js_syntax::JsNamedImportSpecifierList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsNamedImportSpecifierList;
+pub(crate) struct FormatJsNamedImportSpecifierList;
 
 impl FormatRule<JsNamedImportSpecifierList> for FormatJsNamedImportSpecifierList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_assignment_pattern_property_list.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use rome_js_syntax::{JsAnyObjectAssignmentPatternMember, JsObjectAssignmentPatternPropertyList};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectAssignmentPatternPropertyList;
+pub(crate) struct FormatJsObjectAssignmentPatternPropertyList;
 
 impl FormatRule<JsObjectAssignmentPatternPropertyList>
     for FormatJsObjectAssignmentPatternPropertyList

--- a/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_binding_pattern_property_list.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use rome_js_syntax::{JsAnyObjectBindingPatternMember, JsObjectBindingPatternPropertyList};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectBindingPatternPropertyList;
+pub(crate) struct FormatJsObjectBindingPatternPropertyList;
 
 impl FormatRule<JsObjectBindingPatternPropertyList> for FormatJsObjectBindingPatternPropertyList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/object_member_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/object_member_list.rs
@@ -4,7 +4,7 @@ use rome_js_syntax::JsObjectMemberList;
 use rome_rowan::{AstNode, AstSeparatedList};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsObjectMemberList;
+pub(crate) struct FormatJsObjectMemberList;
 
 impl FormatRule<JsObjectMemberList> for FormatJsObjectMemberList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/parameter_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/parameter_list.rs
@@ -9,7 +9,7 @@ use rome_js_syntax::{
 use rome_rowan::{declare_node_union, AstSeparatedListNodesIterator, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsParameterList;
+pub(crate) struct FormatJsParameterList;
 
 impl FormatRule<JsParameterList> for FormatJsParameterList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/property_modifier_list.rs
@@ -3,7 +3,7 @@ use crate::utils::sort_modifiers_by_precedence;
 use rome_js_syntax::JsPropertyModifierList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsPropertyModifierList;
+pub(crate) struct FormatJsPropertyModifierList;
 
 impl FormatRule<JsPropertyModifierList> for FormatJsPropertyModifierList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/statement_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/statement_list.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use rome_js_syntax::{JsAnyStatement, JsStatementList};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsStatementList;
+pub(crate) struct FormatJsStatementList;
 
 impl FormatRule<JsStatementList> for FormatJsStatementList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/switch_case_list.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use rome_js_syntax::JsSwitchCaseList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsSwitchCaseList;
+pub(crate) struct FormatJsSwitchCaseList;
 
 impl FormatRule<JsSwitchCaseList> for FormatJsSwitchCaseList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/lists/template_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/template_element_list.rs
@@ -12,7 +12,7 @@ use rome_rowan::{declare_node_union, AstNodeListIterator, SyntaxResult};
 use std::iter::FusedIterator;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsTemplateElementList {
+pub(crate) struct FormatJsTemplateElementList {
     options: FormatJsTemplateElementListOptions,
 }
 
@@ -38,7 +38,7 @@ impl FormatRule<JsTemplateElementList> for FormatJsTemplateElementList {
 }
 
 #[derive(Debug, Copy, Clone, Default)]
-pub struct FormatJsTemplateElementListOptions {
+pub(crate) struct FormatJsTemplateElementListOptions {
     pub(crate) is_test_each_pattern: bool,
 }
 

--- a/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/variable_declarator_list.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsSyntaxKind, JsVariableDeclaratorList};
 use rome_rowan::AstSeparatedList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsVariableDeclaratorList;
+pub(crate) struct FormatJsVariableDeclaratorList;
 
 impl FormatRule<JsVariableDeclaratorList> for FormatJsVariableDeclaratorList {
     type Context = JsFormatContext;

--- a/crates/rome_js_formatter/src/js/mod.rs
+++ b/crates/rome_js_formatter/src/js/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod any;
 pub(crate) mod assignments;

--- a/crates/rome_js_formatter/src/js/mod.rs
+++ b/crates/rome_js_formatter/src/js/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod any;
 pub(crate) mod assignments;

--- a/crates/rome_js_formatter/src/js/module/default_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/default_import_specifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsDefaultImportSpecifier;
 use rome_js_syntax::JsDefaultImportSpecifierFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsDefaultImportSpecifier;
+pub(crate) struct FormatJsDefaultImportSpecifier;
 
 impl FormatNodeRule<JsDefaultImportSpecifier> for FormatJsDefaultImportSpecifier {
     fn fmt_fields(&self, node: &JsDefaultImportSpecifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/export.rs
+++ b/crates/rome_js_formatter/src/js/module/export.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsExport;
 use rome_js_syntax::JsExportFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExport;
+pub(crate) struct FormatJsExport;
 
 impl FormatNodeRule<JsExport> for FormatJsExport {
     fn fmt_fields(&self, node: &JsExport, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/export_as_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_as_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsExportAsClause;
 use rome_js_syntax::JsExportAsClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportAsClause;
+pub(crate) struct FormatJsExportAsClause;
 
 impl FormatNodeRule<JsExportAsClause> for FormatJsExportAsClause {
     fn fmt_fields(&self, node: &JsExportAsClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/export_default_declaration_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_default_declaration_clause.rs
@@ -4,7 +4,7 @@ use rome_formatter::write;
 use rome_js_syntax::{JsExportDefaultDeclarationClause, JsExportDefaultDeclarationClauseFields};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportDefaultDeclarationClause;
+pub(crate) struct FormatJsExportDefaultDeclarationClause;
 
 impl FormatNodeRule<JsExportDefaultDeclarationClause> for FormatJsExportDefaultDeclarationClause {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/module/export_default_expression_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_default_expression_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportDefaultExpressionClause;
 use rome_js_syntax::JsExportDefaultExpressionClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportDefaultExpressionClause;
+pub(crate) struct FormatJsExportDefaultExpressionClause;
 
 impl FormatNodeRule<JsExportDefaultExpressionClause> for FormatJsExportDefaultExpressionClause {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/module/export_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_from_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportFromClause;
 use rome_js_syntax::JsExportFromClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportFromClause;
+pub(crate) struct FormatJsExportFromClause;
 
 impl FormatNodeRule<JsExportFromClause> for FormatJsExportFromClause {
     fn fmt_fields(&self, node: &JsExportFromClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/export_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportNamedClause;
 use rome_js_syntax::JsExportNamedClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportNamedClause;
+pub(crate) struct FormatJsExportNamedClause;
 
 impl FormatNodeRule<JsExportNamedClause> for FormatJsExportNamedClause {
     fn fmt_fields(&self, node: &JsExportNamedClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsExportNamedFromClauseFields;
 use rome_rowan::{AstNode, AstSeparatedElement};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportNamedFromClause;
+pub(crate) struct FormatJsExportNamedFromClause;
 
 impl FormatNodeRule<JsExportNamedFromClause> for FormatJsExportNamedFromClause {
     fn fmt_fields(&self, node: &JsExportNamedFromClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/export_named_from_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_specifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsExportNamedFromSpecifier;
 use rome_js_syntax::JsExportNamedFromSpecifierFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportNamedFromSpecifier;
+pub(crate) struct FormatJsExportNamedFromSpecifier;
 
 impl FormatNodeRule<JsExportNamedFromSpecifier> for FormatJsExportNamedFromSpecifier {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/module/export_named_shorthand_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_shorthand_specifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsExportNamedShorthandSpecifier;
 use rome_js_syntax::JsExportNamedShorthandSpecifierFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportNamedShorthandSpecifier;
+pub(crate) struct FormatJsExportNamedShorthandSpecifier;
 
 impl FormatNodeRule<JsExportNamedShorthandSpecifier> for FormatJsExportNamedShorthandSpecifier {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/module/export_named_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_specifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsExportNamedSpecifier;
 use rome_js_syntax::JsExportNamedSpecifierFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExportNamedSpecifier;
+pub(crate) struct FormatJsExportNamedSpecifier;
 
 impl FormatNodeRule<JsExportNamedSpecifier> for FormatJsExportNamedSpecifier {
     fn fmt_fields(&self, node: &JsExportNamedSpecifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/import.rs
+++ b/crates/rome_js_formatter/src/js/module/import.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImport;
 use rome_js_syntax::JsImportFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImport;
+pub(crate) struct FormatJsImport;
 
 impl FormatNodeRule<JsImport> for FormatJsImport {
     fn fmt_fields(&self, node: &JsImport, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/import_assertion.rs
+++ b/crates/rome_js_formatter/src/js/module/import_assertion.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsImportAssertion;
 use rome_js_syntax::JsImportAssertionFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImportAssertion;
+pub(crate) struct FormatJsImportAssertion;
 
 impl FormatNodeRule<JsImportAssertion> for FormatJsImportAssertion {
     fn fmt_fields(&self, node: &JsImportAssertion, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/module/import_assertion_entry.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsImportAssertionEntryFields;
 use rome_js_syntax::{JsImportAssertionEntry, JsSyntaxKind};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImportAssertionEntry;
+pub(crate) struct FormatJsImportAssertionEntry;
 
 impl FormatNodeRule<JsImportAssertionEntry> for FormatJsImportAssertionEntry {
     fn fmt_fields(&self, node: &JsImportAssertionEntry, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/import_bare_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_bare_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsImportBareClause;
 use rome_js_syntax::JsImportBareClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImportBareClause;
+pub(crate) struct FormatJsImportBareClause;
 
 impl FormatNodeRule<JsImportBareClause> for FormatJsImportBareClause {
     fn fmt_fields(&self, node: &JsImportBareClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/import_default_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_default_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsImportDefaultClause;
 use rome_js_syntax::JsImportDefaultClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImportDefaultClause;
+pub(crate) struct FormatJsImportDefaultClause;
 
 impl FormatNodeRule<JsImportDefaultClause> for FormatJsImportDefaultClause {
     fn fmt_fields(&self, node: &JsImportDefaultClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/import_meta.rs
+++ b/crates/rome_js_formatter/src/js/module/import_meta.rs
@@ -6,10 +6,10 @@ use rome_js_syntax::ImportMetaFields;
 use rome_js_syntax::{ImportMeta, JsSyntaxNode};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatImportMeta;
+pub(crate) struct FormatImportMeta;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImportMeta;
+pub(crate) struct FormatJsImportMeta;
 
 impl FormatNodeRule<ImportMeta> for FormatImportMeta {
     fn fmt_fields(&self, node: &ImportMeta, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/import_named_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_named_clause.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsImportNamedClauseFields;
 use rome_js_syntax::JsNamedImportSpecifiersFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImportNamedClause;
+pub(crate) struct FormatJsImportNamedClause;
 
 impl FormatNodeRule<JsImportNamedClause> for FormatJsImportNamedClause {
     fn fmt_fields(&self, node: &JsImportNamedClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/import_namespace_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/import_namespace_clause.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsImportNamespaceClause;
 use rome_js_syntax::JsImportNamespaceClauseFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsImportNamespaceClause;
+pub(crate) struct FormatJsImportNamespaceClause;
 
 impl FormatNodeRule<JsImportNamespaceClause> for FormatJsImportNamespaceClause {
     fn fmt_fields(&self, node: &JsImportNamespaceClause, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/literal_export_name.rs
+++ b/crates/rome_js_formatter/src/js/module/literal_export_name.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsLiteralExportNameFields;
 use rome_js_syntax::JsSyntaxKind::JS_STRING_LITERAL;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsLiteralExportName;
+pub(crate) struct FormatJsLiteralExportName;
 
 impl FormatNodeRule<JsLiteralExportName> for FormatJsLiteralExportName {
     fn fmt_fields(&self, node: &JsLiteralExportName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/mod.rs
+++ b/crates/rome_js_formatter/src/js/module/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod default_import_specifier;
 pub(crate) mod export;

--- a/crates/rome_js_formatter/src/js/module/mod.rs
+++ b/crates/rome_js_formatter/src/js/module/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod default_import_specifier;
 pub(crate) mod export;

--- a/crates/rome_js_formatter/src/js/module/module_source.rs
+++ b/crates/rome_js_formatter/src/js/module/module_source.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsModuleSource;
 use rome_js_syntax::JsModuleSourceFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsModuleSource;
+pub(crate) struct FormatJsModuleSource;
 
 impl FormatNodeRule<JsModuleSource> for FormatJsModuleSource {
     fn fmt_fields(&self, node: &JsModuleSource, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/named_import_specifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsNamedImportSpecifier;
 use rome_js_syntax::JsNamedImportSpecifierFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsNamedImportSpecifier;
+pub(crate) struct FormatJsNamedImportSpecifier;
 
 impl FormatNodeRule<JsNamedImportSpecifier> for FormatJsNamedImportSpecifier {
     fn fmt_fields(&self, node: &JsNamedImportSpecifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
+++ b/crates/rome_js_formatter/src/js/module/named_import_specifiers.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsNamedImportSpecifiers;
 use rome_js_syntax::JsNamedImportSpecifiersFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsNamedImportSpecifiers;
+pub(crate) struct FormatJsNamedImportSpecifiers;
 
 impl FormatNodeRule<JsNamedImportSpecifiers> for FormatJsNamedImportSpecifiers {
     fn fmt_fields(&self, node: &JsNamedImportSpecifiers, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/module/namespace_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/namespace_import_specifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsNamespaceImportSpecifier;
 use rome_js_syntax::JsNamespaceImportSpecifierFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsNamespaceImportSpecifier;
+pub(crate) struct FormatJsNamespaceImportSpecifier;
 
 impl FormatNodeRule<JsNamespaceImportSpecifier> for FormatJsNamespaceImportSpecifier {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/module/shorthand_named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/module/shorthand_named_import_specifier.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsShorthandNamedImportSpecifier;
 use rome_js_syntax::JsShorthandNamedImportSpecifierFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsShorthandNamedImportSpecifier;
+pub(crate) struct FormatJsShorthandNamedImportSpecifier;
 
 impl FormatNodeRule<JsShorthandNamedImportSpecifier> for FormatJsShorthandNamedImportSpecifier {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/objects/computed_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/computed_member_name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsComputedMemberName;
 use rome_js_syntax::JsComputedMemberNameFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsComputedMemberName;
+pub(crate) struct FormatJsComputedMemberName;
 
 impl FormatNodeRule<JsComputedMemberName> for FormatJsComputedMemberName {
     fn fmt_fields(&self, node: &JsComputedMemberName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/objects/getter_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/getter_object_member.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsGetterObjectMember;
 use rome_js_syntax::JsGetterObjectMemberFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsGetterObjectMember;
+pub(crate) struct FormatJsGetterObjectMember;
 
 impl FormatNodeRule<JsGetterObjectMember> for FormatJsGetterObjectMember {
     fn fmt_fields(&self, node: &JsGetterObjectMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/literal_member_name.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsLiteralMemberNameFields;
 use rome_js_syntax::{JsLiteralMemberName, JsSyntaxKind};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsLiteralMemberName;
+pub(crate) struct FormatJsLiteralMemberName;
 
 impl FormatNodeRule<JsLiteralMemberName> for FormatJsLiteralMemberName {
     fn fmt_fields(&self, node: &JsLiteralMemberName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/objects/method_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/method_object_member.rs
@@ -4,7 +4,7 @@ use crate::js::classes::method_class_member::FormatJsAnyMethodMember;
 use rome_js_syntax::JsMethodObjectMember;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsMethodObjectMember;
+pub(crate) struct FormatJsMethodObjectMember;
 
 impl FormatNodeRule<JsMethodObjectMember> for FormatJsMethodObjectMember {
     fn fmt_fields(&self, node: &JsMethodObjectMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/objects/mod.rs
+++ b/crates/rome_js_formatter/src/js/objects/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod computed_member_name;
 pub(crate) mod getter_object_member;

--- a/crates/rome_js_formatter/src/js/objects/mod.rs
+++ b/crates/rome_js_formatter/src/js/objects/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod computed_member_name;
 pub(crate) mod getter_object_member;

--- a/crates/rome_js_formatter/src/js/objects/private_class_member_name.rs
+++ b/crates/rome_js_formatter/src/js/objects/private_class_member_name.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsPrivateClassMemberName;
 use rome_js_syntax::JsPrivateClassMemberNameFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsPrivateClassMemberName;
+pub(crate) struct FormatJsPrivateClassMemberName;
 
 impl FormatNodeRule<JsPrivateClassMemberName> for FormatJsPrivateClassMemberName {
     fn fmt_fields(&self, node: &JsPrivateClassMemberName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/objects/property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/property_object_member.rs
@@ -5,7 +5,7 @@ use rome_formatter::write;
 use rome_js_syntax::JsPropertyObjectMember;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsPropertyObjectMember;
+pub(crate) struct FormatJsPropertyObjectMember;
 
 impl FormatNodeRule<JsPropertyObjectMember> for FormatJsPropertyObjectMember {
     fn fmt_fields(&self, node: &JsPropertyObjectMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/objects/setter_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/setter_object_member.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsSetterObjectMember;
 use rome_js_syntax::JsSetterObjectMemberFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsSetterObjectMember;
+pub(crate) struct FormatJsSetterObjectMember;
 
 impl FormatNodeRule<JsSetterObjectMember> for FormatJsSetterObjectMember {
     fn fmt_fields(&self, node: &JsSetterObjectMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/objects/shorthand_property_object_member.rs
+++ b/crates/rome_js_formatter/src/js/objects/shorthand_property_object_member.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsShorthandPropertyObjectMember;
 use rome_js_syntax::JsShorthandPropertyObjectMemberFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsShorthandPropertyObjectMember;
+pub(crate) struct FormatJsShorthandPropertyObjectMember;
 
 impl FormatNodeRule<JsShorthandPropertyObjectMember> for FormatJsShorthandPropertyObjectMember {
     fn fmt_fields(

--- a/crates/rome_js_formatter/src/js/statements/block_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/block_statement.rs
@@ -8,7 +8,7 @@ use rome_js_syntax::JsSyntaxKind;
 use rome_rowan::{AstNode, AstNodeList, SyntaxNodeOptionExt};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsBlockStatement;
+pub(crate) struct FormatJsBlockStatement;
 
 impl FormatNodeRule<JsBlockStatement> for FormatJsBlockStatement {
     fn fmt_fields(&self, node: &JsBlockStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/break_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/break_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsBreakStatement;
 use rome_js_syntax::JsBreakStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsBreakStatement;
+pub(crate) struct FormatJsBreakStatement;
 
 impl FormatNodeRule<JsBreakStatement> for FormatJsBreakStatement {
     fn fmt_fields(&self, node: &JsBreakStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/continue_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/continue_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsContinueStatement;
 use rome_js_syntax::JsContinueStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsContinueStatement;
+pub(crate) struct FormatJsContinueStatement;
 
 impl FormatNodeRule<JsContinueStatement> for FormatJsContinueStatement {
     fn fmt_fields(&self, node: &JsContinueStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/debugger_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/debugger_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsDebuggerStatement;
 use rome_js_syntax::JsDebuggerStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsDebuggerStatement;
+pub(crate) struct FormatJsDebuggerStatement;
 
 impl FormatNodeRule<JsDebuggerStatement> for FormatJsDebuggerStatement {
     fn fmt_fields(&self, node: &JsDebuggerStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/do_while_statement.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsDoWhileStatementFields;
 use rome_js_syntax::{JsAnyStatement, JsDoWhileStatement};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsDoWhileStatement;
+pub(crate) struct FormatJsDoWhileStatement;
 
 impl FormatNodeRule<JsDoWhileStatement> for FormatJsDoWhileStatement {
     fn fmt_fields(&self, node: &JsDoWhileStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/empty_statement.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsEmptyStatement, JsEmptyStatementFields, JsSyntaxKind};
 use rome_rowan::{AstNode, SyntaxNodeOptionExt};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsEmptyStatement;
+pub(crate) struct FormatJsEmptyStatement;
 
 impl FormatNodeRule<JsEmptyStatement> for FormatJsEmptyStatement {
     fn fmt_fields(&self, node: &JsEmptyStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/expression_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/expression_statement.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::{JsAnyLiteralExpression, JsExpressionStatementFields};
 use rome_rowan::SyntaxNodeOptionExt;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsExpressionStatement;
+pub(crate) struct FormatJsExpressionStatement;
 
 impl FormatNodeRule<JsExpressionStatement> for FormatJsExpressionStatement {
     fn fmt_node(&self, node: &JsExpressionStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_in_statement.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsForInStatement;
 use rome_js_syntax::JsForInStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsForInStatement;
+pub(crate) struct FormatJsForInStatement;
 
 impl FormatNodeRule<JsForInStatement> for FormatJsForInStatement {
     fn fmt_fields(&self, node: &JsForInStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_of_statement.rs
@@ -6,7 +6,7 @@ use crate::utils::FormatStatementBody;
 use rome_js_syntax::JsForOfStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsForOfStatement;
+pub(crate) struct FormatJsForOfStatement;
 
 impl FormatNodeRule<JsForOfStatement> for FormatJsForOfStatement {
     fn fmt_fields(&self, node: &JsForOfStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/for_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/for_statement.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsForStatement;
 use rome_js_syntax::JsForStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsForStatement;
+pub(crate) struct FormatJsForStatement;
 
 impl FormatNodeRule<JsForStatement> for FormatJsForStatement {
     fn fmt_fields(&self, node: &JsForStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/if_statement.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsIfStatement;
 use rome_js_syntax::JsIfStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsIfStatement;
+pub(crate) struct FormatJsIfStatement;
 
 impl FormatNodeRule<JsIfStatement> for FormatJsIfStatement {
     fn fmt_fields(&self, node: &JsIfStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/labeled_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/labeled_statement.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsLabeledStatementFields;
 use rome_js_syntax::{JsAnyStatement, JsLabeledStatement};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsLabeledStatement;
+pub(crate) struct FormatJsLabeledStatement;
 
 impl FormatNodeRule<JsLabeledStatement> for FormatJsLabeledStatement {
     fn fmt_fields(&self, node: &JsLabeledStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/mod.rs
+++ b/crates/rome_js_formatter/src/js/statements/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod block_statement;
 pub(crate) mod break_statement;

--- a/crates/rome_js_formatter/src/js/statements/mod.rs
+++ b/crates/rome_js_formatter/src/js/statements/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod block_statement;
 pub(crate) mod break_statement;

--- a/crates/rome_js_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/return_statement.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::{
 use rome_rowan::{declare_node_union, SyntaxResult};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsReturnStatement;
+pub(crate) struct FormatJsReturnStatement;
 
 impl FormatNodeRule<JsReturnStatement> for FormatJsReturnStatement {
     fn fmt_fields(&self, node: &JsReturnStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/switch_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/switch_statement.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{JsSwitchStatement, JsSwitchStatementFields};
 use rome_rowan::AstNodeList;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsSwitchStatement;
+pub(crate) struct FormatJsSwitchStatement;
 
 impl FormatNodeRule<JsSwitchStatement> for FormatJsSwitchStatement {
     fn fmt_fields(&self, node: &JsSwitchStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/throw_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/throw_statement.rs
@@ -4,7 +4,7 @@ use crate::js::statements::return_statement::JsAnyStatementWithArgument;
 use rome_js_syntax::JsThrowStatement;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsThrowStatement;
+pub(crate) struct FormatJsThrowStatement;
 
 impl FormatNodeRule<JsThrowStatement> for FormatJsThrowStatement {
     fn fmt_fields(&self, node: &JsThrowStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/try_finally_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/try_finally_statement.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsTryFinallyStatement;
 use rome_js_syntax::JsTryFinallyStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsTryFinallyStatement;
+pub(crate) struct FormatJsTryFinallyStatement;
 
 impl FormatNodeRule<JsTryFinallyStatement> for FormatJsTryFinallyStatement {
     fn fmt_fields(&self, node: &JsTryFinallyStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/try_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/try_statement.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::JsTryStatement;
 use rome_js_syntax::JsTryStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsTryStatement;
+pub(crate) struct FormatJsTryStatement;
 
 impl FormatNodeRule<JsTryStatement> for FormatJsTryStatement {
     fn fmt_fields(&self, node: &JsTryStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/variable_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/variable_statement.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::JsVariableStatement;
 use rome_js_syntax::JsVariableStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsVariableStatement;
+pub(crate) struct FormatJsVariableStatement;
 
 impl FormatNodeRule<JsVariableStatement> for FormatJsVariableStatement {
     fn fmt_fields(&self, node: &JsVariableStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/while_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/while_statement.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsWhileStatement;
 use rome_js_syntax::JsWhileStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsWhileStatement;
+pub(crate) struct FormatJsWhileStatement;
 
 impl FormatNodeRule<JsWhileStatement> for FormatJsWhileStatement {
     fn fmt_fields(&self, node: &JsWhileStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/statements/with_statement.rs
+++ b/crates/rome_js_formatter/src/js/statements/with_statement.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::JsWithStatement;
 use rome_js_syntax::JsWithStatementFields;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsWithStatement;
+pub(crate) struct FormatJsWithStatement;
 
 impl FormatNodeRule<JsWithStatement> for FormatJsWithStatement {
     fn fmt_fields(&self, node: &JsWithStatement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/js/unknown/mod.rs
+++ b/crates/rome_js_formatter/src/js/unknown/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 #[allow(clippy::module_inception)]
 pub(crate) mod unknown;

--- a/crates/rome_js_formatter/src/js/unknown/mod.rs
+++ b/crates/rome_js_formatter/src/js/unknown/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 #[allow(clippy::module_inception)]
 pub(crate) mod unknown;

--- a/crates/rome_js_formatter/src/js/unknown/unknown.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown.rs
@@ -2,6 +2,6 @@ use crate::FormatUnknownNodeRule;
 use rome_js_syntax::JsUnknown;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnknown;
+pub(crate) struct FormatJsUnknown;
 
 impl FormatUnknownNodeRule<JsUnknown> for FormatJsUnknown {}

--- a/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_assignment.rs
@@ -3,7 +3,7 @@ use crate::FormatUnknownNodeRule;
 use rome_js_syntax::{JsSyntaxNode, JsUnknownAssignment};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnknownAssignment;
+pub(crate) struct FormatJsUnknownAssignment;
 
 impl FormatUnknownNodeRule<JsUnknownAssignment> for FormatJsUnknownAssignment {}
 

--- a/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_binding.rs
@@ -2,6 +2,6 @@ use crate::FormatUnknownNodeRule;
 use rome_js_syntax::JsUnknownBinding;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnknownBinding;
+pub(crate) struct FormatJsUnknownBinding;
 
 impl FormatUnknownNodeRule<JsUnknownBinding> for FormatJsUnknownBinding {}

--- a/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_expression.rs
@@ -3,7 +3,7 @@ use crate::FormatUnknownNodeRule;
 use rome_js_syntax::{JsSyntaxNode, JsUnknownExpression};
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnknownExpression;
+pub(crate) struct FormatJsUnknownExpression;
 
 impl FormatUnknownNodeRule<JsUnknownExpression> for FormatJsUnknownExpression {}
 

--- a/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_import_assertion_entry.rs
@@ -2,6 +2,6 @@ use crate::FormatUnknownNodeRule;
 use rome_js_syntax::JsUnknownImportAssertionEntry;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnknownImportAssertionEntry;
+pub(crate) struct FormatJsUnknownImportAssertionEntry;
 
 impl FormatUnknownNodeRule<JsUnknownImportAssertionEntry> for FormatJsUnknownImportAssertionEntry {}

--- a/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_member.rs
@@ -2,6 +2,6 @@ use crate::FormatUnknownNodeRule;
 use rome_js_syntax::JsUnknownMember;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnknownMember;
+pub(crate) struct FormatJsUnknownMember;
 
 impl FormatUnknownNodeRule<JsUnknownMember> for FormatJsUnknownMember {}

--- a/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_named_import_specifier.rs
@@ -2,6 +2,6 @@ use crate::FormatUnknownNodeRule;
 use rome_js_syntax::JsUnknownNamedImportSpecifier;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnknownNamedImportSpecifier;
+pub(crate) struct FormatJsUnknownNamedImportSpecifier;
 
 impl FormatUnknownNodeRule<JsUnknownNamedImportSpecifier> for FormatJsUnknownNamedImportSpecifier {}

--- a/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_parameter.rs
@@ -2,6 +2,6 @@ use crate::FormatUnknownNodeRule;
 use rome_js_syntax::JsUnknownParameter;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnknownParameter;
+pub(crate) struct FormatJsUnknownParameter;
 
 impl FormatUnknownNodeRule<JsUnknownParameter> for FormatJsUnknownParameter {}

--- a/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
+++ b/crates/rome_js_formatter/src/js/unknown/unknown_statement.rs
@@ -2,6 +2,6 @@ use crate::FormatUnknownNodeRule;
 use rome_js_syntax::JsUnknownStatement;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsUnknownStatement;
+pub(crate) struct FormatJsUnknownStatement;
 
 impl FormatUnknownNodeRule<JsUnknownStatement> for FormatJsUnknownStatement {}

--- a/crates/rome_js_formatter/src/jsx/any/attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttribute;

--- a/crates/rome_js_formatter/src/jsx/any/attribute.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttribute;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsxAnyAttribute;
+pub(crate) struct FormatJsxAnyAttribute;
 impl FormatRule<JsxAnyAttribute> for FormatJsxAnyAttribute {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsxAnyAttribute, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttributeName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsxAnyAttributeName;
+pub(crate) struct FormatJsxAnyAttributeName;
 impl FormatRule<JsxAnyAttributeName> for FormatJsxAnyAttributeName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsxAnyAttributeName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttributeName;

--- a/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttributeValue;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsxAnyAttributeValue;
+pub(crate) struct FormatJsxAnyAttributeValue;
 impl FormatRule<JsxAnyAttributeValue> for FormatJsxAnyAttributeValue {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsxAnyAttributeValue, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
+++ b/crates/rome_js_formatter/src/jsx/any/attribute_value.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyAttributeValue;

--- a/crates/rome_js_formatter/src/jsx/any/child.rs
+++ b/crates/rome_js_formatter/src/jsx/any/child.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyChild;

--- a/crates/rome_js_formatter/src/jsx/any/child.rs
+++ b/crates/rome_js_formatter/src/jsx/any/child.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyChild;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsxAnyChild;
+pub(crate) struct FormatJsxAnyChild;
 impl FormatRule<JsxAnyChild> for FormatJsxAnyChild {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsxAnyChild, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/jsx/any/element_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/element_name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyElementName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsxAnyElementName;
+pub(crate) struct FormatJsxAnyElementName;
 impl FormatRule<JsxAnyElementName> for FormatJsxAnyElementName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsxAnyElementName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/jsx/any/element_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/element_name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyElementName;

--- a/crates/rome_js_formatter/src/jsx/any/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/any/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod attribute;
 pub(crate) mod attribute_name;

--- a/crates/rome_js_formatter/src/jsx/any/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/any/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod attribute;
 pub(crate) mod attribute_name;

--- a/crates/rome_js_formatter/src/jsx/any/name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyName;

--- a/crates/rome_js_formatter/src/jsx/any/name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsxAnyName;
+pub(crate) struct FormatJsxAnyName;
 impl FormatRule<JsxAnyName> for FormatJsxAnyName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsxAnyName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/jsx/any/object_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/object_name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyObjectName;

--- a/crates/rome_js_formatter/src/jsx/any/object_name.rs
+++ b/crates/rome_js_formatter/src/jsx/any/object_name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyObjectName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsxAnyObjectName;
+pub(crate) struct FormatJsxAnyObjectName;
 impl FormatRule<JsxAnyObjectName> for FormatJsxAnyObjectName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsxAnyObjectName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/jsx/any/tag.rs
+++ b/crates/rome_js_formatter/src/jsx/any/tag.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyTag;

--- a/crates/rome_js_formatter/src/jsx/any/tag.rs
+++ b/crates/rome_js_formatter/src/jsx/any/tag.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::JsxAnyTag;
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsxAnyTag;
+pub(crate) struct FormatJsxAnyTag;
 impl FormatRule<JsxAnyTag> for FormatJsxAnyTag {
     type Context = JsFormatContext;
     fn fmt(&self, node: &JsxAnyTag, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/jsx/attribute/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 #[allow(clippy::module_inception)]
 pub(crate) mod attribute;

--- a/crates/rome_js_formatter/src/jsx/attribute/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/attribute/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 #[allow(clippy::module_inception)]
 pub(crate) mod attribute;

--- a/crates/rome_js_formatter/src/jsx/auxiliary/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod expression_child;
 pub(crate) mod name;

--- a/crates/rome_js_formatter/src/jsx/auxiliary/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/auxiliary/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod expression_child;
 pub(crate) mod name;

--- a/crates/rome_js_formatter/src/jsx/expressions/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/expressions/mod.rs
@@ -1,3 +1,3 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod tag_expression;

--- a/crates/rome_js_formatter/src/jsx/expressions/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/expressions/mod.rs
@@ -1,3 +1,3 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod tag_expression;

--- a/crates/rome_js_formatter/src/jsx/lists/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod attribute_list;
 pub(crate) mod child_list;

--- a/crates/rome_js_formatter/src/jsx/lists/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/lists/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod attribute_list;
 pub(crate) mod child_list;

--- a/crates/rome_js_formatter/src/jsx/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod any;
 pub(crate) mod attribute;

--- a/crates/rome_js_formatter/src/jsx/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod any;
 pub(crate) mod attribute;

--- a/crates/rome_js_formatter/src/jsx/objects/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/objects/mod.rs
@@ -1,3 +1,3 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod member_name;

--- a/crates/rome_js_formatter/src/jsx/objects/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/objects/mod.rs
@@ -1,3 +1,3 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod member_name;

--- a/crates/rome_js_formatter/src/jsx/tag/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod closing_element;
 pub(crate) mod closing_fragment;

--- a/crates/rome_js_formatter/src/jsx/tag/mod.rs
+++ b/crates/rome_js_formatter/src/jsx/tag/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod closing_element;
 pub(crate) mod closing_fragment;

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -167,7 +167,7 @@
 mod cst;
 mod js;
 mod jsx;
-pub mod prelude;
+mod prelude;
 mod ts;
 pub mod utils;
 

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -184,13 +184,13 @@ mod syntax_rewriter;
 
 use rome_formatter::prelude::*;
 use rome_formatter::{
-    comments::Comments, write, CstFormatContext, Format, FormatLanguage, TransformSourceMap,
+    comments::Comments, write, CstFormatContext, Format, FormatLanguage, FormatToken,
+    TransformSourceMap,
 };
 use rome_formatter::{Buffer, FormatOwnedWithRule, FormatRefWithRule, Formatted, Printed};
 use rome_js_syntax::{
     JsAnyDeclaration, JsAnyStatement, JsLanguage, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
 };
-use rome_rowan::SyntaxResult;
 use rome_rowan::TextRange;
 use rome_rowan::{AstNode, SyntaxNode};
 
@@ -198,154 +198,13 @@ use crate::comments::JsCommentStyle;
 use crate::context::{JsFormatContext, JsFormatOptions};
 use crate::cst::FormatJsSyntaxNode;
 use crate::syntax_rewriter::transform;
-use rome_formatter::trivia::format_skipped_token_trivia;
-use std::iter::FusedIterator;
-use std::marker::PhantomData;
+
+include!("../../rome_formatter/shared_traits.rs");
 
 pub(crate) type JsFormatter<'buf> = Formatter<'buf, JsFormatContext>;
 
-// Per Crate
-
-/// Used to get an object that knows how to format this object.
-pub trait AsFormat {
-    type Format<'a>: Format<JsFormatContext>
-    where
-        Self: 'a;
-
-    /// Returns an object that is able to format this object.
-    fn format(&self) -> Self::Format<'_>;
-}
-
-/// Implement [AsFormat] for references to types that implement [AsFormat].
-impl<T> AsFormat for &T
-where
-    T: AsFormat,
-{
-    type Format<'a> = T::Format<'a> where Self: 'a;
-
-    fn format(&self) -> Self::Format<'_> {
-        AsFormat::format(&**self)
-    }
-}
-
-/// Implement [AsFormat] for [SyntaxResult] where `T` implements [AsFormat].
-///
-/// Useful to format mandatory AST fields without having to unwrap the value first.
-impl<T> AsFormat for SyntaxResult<T>
-where
-    T: AsFormat,
-{
-    type Format<'a> = SyntaxResult<T::Format<'a>> where Self: 'a;
-
-    fn format(&self) -> Self::Format<'_> {
-        match self {
-            Ok(value) => Ok(value.format()),
-            Err(err) => Err(*err),
-        }
-    }
-}
-
-/// Implement [AsFormat] for [Option] when `T` implements [AsFormat]
-///
-/// Allows to call format on optional AST fields without having to unwrap the field first.
-impl<T> AsFormat for Option<T>
-where
-    T: AsFormat,
-{
-    type Format<'a> = Option<T::Format<'a>> where Self: 'a;
-
-    fn format(&self) -> Self::Format<'_> {
-        self.as_ref().map(|value| value.format())
-    }
-}
-
-/// Used to convert this object into an object that can be formatted.
-///
-/// The difference to [AsFormat] is that this trait takes ownership of `self`.
-pub trait IntoFormat<Context> {
-    type Format: Format<Context>;
-
-    fn into_format(self) -> Self::Format;
-}
-
-impl<T, Context> IntoFormat<Context> for SyntaxResult<T>
-where
-    T: IntoFormat<Context>,
-{
-    type Format = SyntaxResult<T::Format>;
-
-    fn into_format(self) -> Self::Format {
-        self.map(IntoFormat::into_format)
-    }
-}
-
-/// Implement [IntoFormat] for [Option] when `T` implements [IntoFormat]
-///
-/// Allows to call format on optional AST fields without having to unwrap the field first.
-impl<T, Context> IntoFormat<Context> for Option<T>
-where
-    T: IntoFormat<Context>,
-{
-    type Format = Option<T::Format>;
-
-    fn into_format(self) -> Self::Format {
-        self.map(IntoFormat::into_format)
-    }
-}
-
-/// Formatting specific [Iterator] extensions
-pub trait FormattedIterExt {
-    /// Converts every item to an object that knows how to format it.
-    fn formatted<Context>(self) -> FormattedIter<Self, Self::Item, Context>
-    where
-        Self: Iterator + Sized,
-        Self::Item: IntoFormat<Context>,
-    {
-        FormattedIter {
-            inner: self,
-            options: PhantomData,
-        }
-    }
-}
-
-impl<I> FormattedIterExt for I where I: Iterator {}
-
-pub struct FormattedIter<Iter, Item, Context>
-where
-    Iter: Iterator<Item = Item>,
-{
-    inner: Iter,
-    options: PhantomData<Context>,
-}
-
-impl<Iter, Item, Context> Iterator for FormattedIter<Iter, Item, Context>
-where
-    Iter: Iterator<Item = Item>,
-    Item: IntoFormat<Context>,
-{
-    type Item = Item::Format;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        Some(self.inner.next()?.into_format())
-    }
-}
-
-impl<Iter, Item, Context> FusedIterator for FormattedIter<Iter, Item, Context>
-where
-    Iter: FusedIterator<Item = Item>,
-    Item: IntoFormat<Context>,
-{
-}
-
-impl<Iter, Item, Context> ExactSizeIterator for FormattedIter<Iter, Item, Context>
-where
-    Iter: Iterator<Item = Item> + ExactSizeIterator,
-    Item: IntoFormat<Context>,
-{
-}
-
 /// Rule for formatting a JavaScript [AstNode].
-pub trait FormatNodeRule<N>
+pub(crate) trait FormatNodeRule<N>
 where
     N: AstNode<Language = JsLanguage>,
 {
@@ -422,7 +281,7 @@ where
 }
 
 /// Rule for formatting an unknown node.
-pub trait FormatUnknownNodeRule<N>
+pub(crate) trait FormatUnknownNodeRule<N>
 where
     N: AstNode<Language = JsLanguage>,
 {
@@ -432,29 +291,13 @@ where
 }
 
 /// Format implementation specific to JavaScript tokens.
-pub struct FormatJsSyntaxToken;
+pub(crate) type FormatJsSyntaxToken = FormatToken<JsFormatContext>;
 
-impl FormatRule<JsSyntaxToken> for FormatJsSyntaxToken {
-    type Context = JsFormatContext;
-
-    fn fmt(&self, token: &JsSyntaxToken, f: &mut JsFormatter) -> FormatResult<()> {
-        f.state_mut().track_token(token);
-
-        write!(
-            f,
-            [
-                format_skipped_token_trivia(token),
-                format_trimmed_token(token),
-            ]
-        )
-    }
-}
-
-impl AsFormat for JsSyntaxToken {
+impl AsFormat<JsFormatContext> for JsSyntaxToken {
     type Format<'a> = FormatRefWithRule<'a, JsSyntaxToken, FormatJsSyntaxToken>;
 
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, FormatJsSyntaxToken)
+        FormatRefWithRule::new(self, FormatJsSyntaxToken::default())
     }
 }
 
@@ -462,7 +305,7 @@ impl IntoFormat<JsFormatContext> for JsSyntaxToken {
     type Format = FormatOwnedWithRule<JsSyntaxToken, FormatJsSyntaxToken>;
 
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, FormatJsSyntaxToken)
+        FormatOwnedWithRule::new(self, FormatJsSyntaxToken::default())
     }
 }
 
@@ -478,7 +321,6 @@ impl JsFormatLanguage {
 impl FormatLanguage for JsFormatLanguage {
     type SyntaxLanguage = JsLanguage;
     type Context = JsFormatContext;
-    type CommentStyle = JsCommentStyle;
     type FormatRule = FormatJsSyntaxNode;
 
     fn transform(
@@ -510,9 +352,10 @@ impl FormatLanguage for JsFormatLanguage {
 
     fn create_context(
         self,
-        comments: Comments<Self::SyntaxLanguage>,
+        root: &JsSyntaxNode,
         source_map: Option<TransformSourceMap>,
     ) -> Self::Context {
+        let comments = Comments::from_node(root, &JsCommentStyle, source_map.as_ref());
         JsFormatContext::new(self.options, comments).with_source_map(source_map)
     }
 }

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -8,6 +8,4 @@ pub(crate) use crate::{
 pub use rome_formatter::prelude::*;
 pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
 
-pub use crate::separated::{
-    FormatAstSeparatedListExtension, FormatSeparatedOptions, TrailingSeparator,
-};
+pub use crate::separated::{FormatAstSeparatedListExtension, TrailingSeparator};

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -1,5 +1,5 @@
 //! This module provides important and useful traits to help to format tokens and nodes
-//! when implementing the [crate::FormatNodeRule] trait.
+//! when implementing a syntax formatter.
 
 pub(crate) use crate::{
     builders::format_or_verbatim, comments::JsComments, AsFormat as _, FormatNodeRule,

--- a/crates/rome_js_formatter/src/separated.rs
+++ b/crates/rome_js_formatter/src/separated.rs
@@ -27,7 +27,7 @@ impl<L: Language, N: AstNode<Language = L>> FormatSeparatedElement<L, N> {
 
 impl<N> Format<JsFormatContext> for FormatSeparatedElement<JsLanguage, N>
 where
-    N: AstNode<Language = JsLanguage> + AsFormat,
+    N: AstNode<Language = JsLanguage> + AsFormat<JsFormatContext>,
 {
     fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
         let node = self.element.node()?;

--- a/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
+++ b/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyExternalModuleDeclarationBody;

--- a/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
+++ b/crates/rome_js_formatter/src/ts/any/external_module_declaration_body.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyExternalModuleDeclarationBody;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyExternalModuleDeclarationBody;
+pub(crate) struct FormatTsAnyExternalModuleDeclarationBody;
 impl FormatRule<TsAnyExternalModuleDeclarationBody> for FormatTsAnyExternalModuleDeclarationBody {
     type Context = JsFormatContext;
     fn fmt(

--- a/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyIndexSignatureModifier;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyIndexSignatureModifier;
+pub(crate) struct FormatTsAnyIndexSignatureModifier;
 impl FormatRule<TsAnyIndexSignatureModifier> for FormatTsAnyIndexSignatureModifier {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyIndexSignatureModifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/index_signature_modifier.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyIndexSignatureModifier;

--- a/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyMethodSignatureModifier;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyMethodSignatureModifier;
+pub(crate) struct FormatTsAnyMethodSignatureModifier;
 impl FormatRule<TsAnyMethodSignatureModifier> for FormatTsAnyMethodSignatureModifier {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyMethodSignatureModifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/method_signature_modifier.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyMethodSignatureModifier;

--- a/crates/rome_js_formatter/src/ts/any/mod.rs
+++ b/crates/rome_js_formatter/src/ts/any/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod external_module_declaration_body;
 pub(crate) mod index_signature_modifier;

--- a/crates/rome_js_formatter/src/ts/any/mod.rs
+++ b/crates/rome_js_formatter/src/ts/any/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod external_module_declaration_body;
 pub(crate) mod index_signature_modifier;

--- a/crates/rome_js_formatter/src/ts/any/module_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyModuleName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyModuleName;
+pub(crate) struct FormatTsAnyModuleName;
 impl FormatRule<TsAnyModuleName> for FormatTsAnyModuleName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyModuleName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/module_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyModuleName;

--- a/crates/rome_js_formatter/src/ts/any/module_reference.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_reference.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyModuleReference;

--- a/crates/rome_js_formatter/src/ts/any/module_reference.rs
+++ b/crates/rome_js_formatter/src/ts/any/module_reference.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyModuleReference;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyModuleReference;
+pub(crate) struct FormatTsAnyModuleReference;
 impl FormatRule<TsAnyModuleReference> for FormatTsAnyModuleReference {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyModuleReference, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/name.rs
+++ b/crates/rome_js_formatter/src/ts/any/name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyName;

--- a/crates/rome_js_formatter/src/ts/any/name.rs
+++ b/crates/rome_js_formatter/src/ts/any/name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyName;
+pub(crate) struct FormatTsAnyName;
 impl FormatRule<TsAnyName> for FormatTsAnyName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_annotation.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertyAnnotation;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyPropertyAnnotation;
+pub(crate) struct FormatTsAnyPropertyAnnotation;
 impl FormatRule<TsAnyPropertyAnnotation> for FormatTsAnyPropertyAnnotation {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyPropertyAnnotation, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/property_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_annotation.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertyAnnotation;

--- a/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertyParameterModifier;

--- a/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_parameter_modifier.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertyParameterModifier;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyPropertyParameterModifier;
+pub(crate) struct FormatTsAnyPropertyParameterModifier;
 impl FormatRule<TsAnyPropertyParameterModifier> for FormatTsAnyPropertyParameterModifier {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyPropertyParameterModifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertySignatureAnnotation;

--- a/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_annotation.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertySignatureAnnotation;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyPropertySignatureAnnotation;
+pub(crate) struct FormatTsAnyPropertySignatureAnnotation;
 impl FormatRule<TsAnyPropertySignatureAnnotation> for FormatTsAnyPropertySignatureAnnotation {
     type Context = JsFormatContext;
     fn fmt(

--- a/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertySignatureModifier;

--- a/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
+++ b/crates/rome_js_formatter/src/ts/any/property_signature_modifier.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyPropertySignatureModifier;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyPropertySignatureModifier;
+pub(crate) struct FormatTsAnyPropertySignatureModifier;
 impl FormatRule<TsAnyPropertySignatureModifier> for FormatTsAnyPropertySignatureModifier {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyPropertySignatureModifier, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/return_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/return_type.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyReturnType;

--- a/crates/rome_js_formatter/src/ts/any/return_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/return_type.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyReturnType;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyReturnType;
+pub(crate) struct FormatTsAnyReturnType;
 impl FormatRule<TsAnyReturnType> for FormatTsAnyReturnType {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyReturnType, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/template_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/template_element.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTemplateElement;

--- a/crates/rome_js_formatter/src/ts/any/template_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/template_element.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTemplateElement;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyTemplateElement;
+pub(crate) struct FormatTsAnyTemplateElement;
 impl FormatRule<TsAnyTemplateElement> for FormatTsAnyTemplateElement {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyTemplateElement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/ts_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/ts_type.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsType;

--- a/crates/rome_js_formatter/src/ts/any/ts_type.rs
+++ b/crates/rome_js_formatter/src/ts/any/ts_type.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsType;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsType;
+pub(crate) struct FormatTsType;
 impl FormatRule<TsType> for FormatTsType {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsType, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTupleTypeElement;

--- a/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
+++ b/crates/rome_js_formatter/src/ts/any/tuple_type_element.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTupleTypeElement;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyTupleTypeElement;
+pub(crate) struct FormatTsAnyTupleTypeElement;
 impl FormatRule<TsAnyTupleTypeElement> for FormatTsAnyTupleTypeElement {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyTupleTypeElement, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/type_member.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_member.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTypeMember;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyTypeMember;
+pub(crate) struct FormatTsAnyTypeMember;
 impl FormatRule<TsAnyTypeMember> for FormatTsAnyTypeMember {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyTypeMember, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/type_member.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_member.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTypeMember;

--- a/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTypePredicateParameterName;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyTypePredicateParameterName;
+pub(crate) struct FormatTsAnyTypePredicateParameterName;
 impl FormatRule<TsAnyTypePredicateParameterName> for FormatTsAnyTypePredicateParameterName {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyTypePredicateParameterName, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
+++ b/crates/rome_js_formatter/src/ts/any/type_predicate_parameter_name.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyTypePredicateParameterName;

--- a/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
@@ -1,9 +1,9 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyVariableAnnotation;
 #[derive(Debug, Clone, Default)]
-pub struct FormatTsAnyVariableAnnotation;
+pub(crate) struct FormatTsAnyVariableAnnotation;
 impl FormatRule<TsAnyVariableAnnotation> for FormatTsAnyVariableAnnotation {
     type Context = JsFormatContext;
     fn fmt(&self, node: &TsAnyVariableAnnotation, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
+++ b/crates/rome_js_formatter/src/ts/any/variable_annotation.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_js_syntax::TsAnyVariableAnnotation;

--- a/crates/rome_js_formatter/src/ts/assignments/mod.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod as_assignment;
 pub(crate) mod non_null_assertion_assignment;

--- a/crates/rome_js_formatter/src/ts/assignments/mod.rs
+++ b/crates/rome_js_formatter/src/ts/assignments/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod as_assignment;
 pub(crate) mod non_null_assertion_assignment;

--- a/crates/rome_js_formatter/src/ts/auxiliary/mod.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod abstract_modifier;
 pub(crate) mod accessibility_modifier;

--- a/crates/rome_js_formatter/src/ts/auxiliary/mod.rs
+++ b/crates/rome_js_formatter/src/ts/auxiliary/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod abstract_modifier;
 pub(crate) mod accessibility_modifier;

--- a/crates/rome_js_formatter/src/ts/bindings/mod.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod identifier_binding;
 pub(crate) mod index_signature_parameter;

--- a/crates/rome_js_formatter/src/ts/bindings/mod.rs
+++ b/crates/rome_js_formatter/src/ts/bindings/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod identifier_binding;
 pub(crate) mod index_signature_parameter;

--- a/crates/rome_js_formatter/src/ts/classes/mod.rs
+++ b/crates/rome_js_formatter/src/ts/classes/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod constructor_signature_class_member;
 pub(crate) mod extends_clause;

--- a/crates/rome_js_formatter/src/ts/classes/mod.rs
+++ b/crates/rome_js_formatter/src/ts/classes/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod constructor_signature_class_member;
 pub(crate) mod extends_clause;

--- a/crates/rome_js_formatter/src/ts/declarations/mod.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod declare_function_declaration;
 pub(crate) mod declare_function_export_default_declaration;

--- a/crates/rome_js_formatter/src/ts/declarations/mod.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod declare_function_declaration;
 pub(crate) mod declare_function_export_default_declaration;

--- a/crates/rome_js_formatter/src/ts/expressions/mod.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod as_expression;
 pub(crate) mod instantiation_expression;

--- a/crates/rome_js_formatter/src/ts/expressions/mod.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod as_expression;
 pub(crate) mod instantiation_expression;

--- a/crates/rome_js_formatter/src/ts/lists/mod.rs
+++ b/crates/rome_js_formatter/src/ts/lists/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod enum_member_list;
 pub(crate) mod index_signature_modifier_list;

--- a/crates/rome_js_formatter/src/ts/lists/mod.rs
+++ b/crates/rome_js_formatter/src/ts/lists/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod enum_member_list;
 pub(crate) mod index_signature_modifier_list;

--- a/crates/rome_js_formatter/src/ts/mod.rs
+++ b/crates/rome_js_formatter/src/ts/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod any;
 pub(crate) mod assignments;

--- a/crates/rome_js_formatter/src/ts/mod.rs
+++ b/crates/rome_js_formatter/src/ts/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod any;
 pub(crate) mod assignments;

--- a/crates/rome_js_formatter/src/ts/module/mod.rs
+++ b/crates/rome_js_formatter/src/ts/module/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod export_as_namespace_clause;
 pub(crate) mod export_assignment_clause;

--- a/crates/rome_js_formatter/src/ts/module/mod.rs
+++ b/crates/rome_js_formatter/src/ts/module/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod export_as_namespace_clause;
 pub(crate) mod export_assignment_clause;

--- a/crates/rome_js_formatter/src/ts/statements/mod.rs
+++ b/crates/rome_js_formatter/src/ts/statements/mod.rs
@@ -1,3 +1,3 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod declare_statement;

--- a/crates/rome_js_formatter/src/ts/statements/mod.rs
+++ b/crates/rome_js_formatter/src/ts/statements/mod.rs
@@ -1,3 +1,3 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod declare_statement;

--- a/crates/rome_js_formatter/src/ts/types/mod.rs
+++ b/crates/rome_js_formatter/src/ts/types/mod.rs
@@ -1,4 +1,4 @@
-//! Generated file, do not edit by hand, see `xtask/codegen`
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
 
 pub(crate) mod any_type;
 pub(crate) mod array_type;

--- a/crates/rome_js_formatter/src/ts/types/mod.rs
+++ b/crates/rome_js_formatter/src/ts/types/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod any_type;
 pub(crate) mod array_type;

--- a/crates/rome_js_formatter/src/utils/array.rs
+++ b/crates/rome_js_formatter/src/utils/array.rs
@@ -13,7 +13,7 @@ use rome_rowan::{AstNode, AstSeparatedList};
 pub(crate) fn write_array_node<N, I>(node: &N, f: &mut JsFormatter) -> FormatResult<()>
 where
     N: AstSeparatedList<Language = JsLanguage, Node = I>,
-    I: ArrayNodeElement + AsFormat,
+    I: ArrayNodeElement + AsFormat<JsFormatContext>,
 {
     let trailing_separator = FormatTrailingComma::ES5.trailing_separator(f.options());
 

--- a/crates/rome_js_formatter/src/utils/conditional.rs
+++ b/crates/rome_js_formatter/src/utils/conditional.rs
@@ -18,7 +18,7 @@ declare_node_union! {
     pub JsAnyConditional = JsConditionalExpression | TsConditionalType
 }
 
-impl AsFormat for JsAnyConditional {
+impl AsFormat<JsFormatContext> for JsAnyConditional {
     type Format<'a> = FormatRefWithRule<'a, JsAnyConditional, FormatJsAnyConditionalRule>;
 
     fn format(&self) -> Self::Format<'_> {

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -2,8 +2,8 @@ pub(crate) mod array;
 mod assignment_like;
 mod binary_like_expression;
 mod conditional;
-pub mod number_utils;
-pub mod string_utils;
+pub(crate) mod number_utils;
+pub(crate) mod string_utils;
 
 pub(crate) mod format_class;
 pub(crate) mod function_body;
@@ -71,7 +71,7 @@ pub(crate) fn is_long_curried_call(expression: Option<&JsCallExpression>) -> boo
 /// We can have two kind of separators: `,`, `;` or ASI.
 /// Because of how the grammar crafts the nodes, the parent will add the separator to the node.
 /// So here, we create - on purpose - an empty node.
-pub struct FormatTypeMemberSeparator<'a> {
+pub(crate) struct FormatTypeMemberSeparator<'a> {
     token: Option<&'a JsSyntaxToken>,
 }
 
@@ -92,7 +92,7 @@ impl Format<JsFormatContext> for FormatTypeMemberSeparator<'_> {
 }
 
 /// Utility function to format the node [rome_js_syntax::JsInitializerClause]
-pub struct FormatInitializerClause<'a> {
+pub(crate) struct FormatInitializerClause<'a> {
     initializer: Option<&'a JsInitializerClause>,
 }
 
@@ -112,7 +112,7 @@ impl Format<JsFormatContext> for FormatInitializerClause<'_> {
     }
 }
 
-pub struct FormatInterpreterToken<'a> {
+pub(crate) struct FormatInterpreterToken<'a> {
     token: Option<&'a JsSyntaxToken>,
 }
 
@@ -242,7 +242,7 @@ impl Format<JsFormatContext> for FormatOptionalSemicolon<'_> {
 /// Format some code followed by an optional semicolon.
 /// Performs semicolon insertion if it is missing in the input source, the [semicolons option](crate::JsFormatOptions::semicolons) is [Semicolons::Always], and the
 /// preceding element isn't an unknown node
-pub struct FormatSemicolon<'a> {
+pub(crate) struct FormatSemicolon<'a> {
     semicolon: Option<&'a JsSyntaxToken>,
 }
 

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -3,7 +3,7 @@ mod assignment_like;
 mod binary_like_expression;
 mod conditional;
 pub(crate) mod number_utils;
-pub(crate) mod string_utils;
+pub mod string_utils;
 
 pub(crate) mod format_class;
 pub(crate) mod function_body;

--- a/crates/rome_js_formatter/src/utils/number_utils.rs
+++ b/crates/rome_js_formatter/src/utils/number_utils.rs
@@ -11,7 +11,7 @@ use rome_js_syntax::JsSyntaxToken;
 use std::borrow::Cow;
 use std::num::NonZeroUsize;
 
-pub struct CleanedNumberLiteralText<'token> {
+pub(crate) struct CleanedNumberLiteralText<'token> {
     token: &'token JsSyntaxToken,
     text: Cow<'token, str>,
 }

--- a/crates/rome_js_formatter/src/utils/string_utils.rs
+++ b/crates/rome_js_formatter/src/utils/string_utils.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsSyntaxToken, SourceType};
 use std::borrow::Cow;
 use unicode_width::UnicodeWidthStr;
 
-pub trait ToAsciiLowercaseCow {
+pub(crate) trait ToAsciiLowercaseCow {
     /// Returns the same value as String::to_lowercase. The only difference
     /// is that this functions returns ```Cow``` and does not allocate
     /// if the string is already in lowercase.
@@ -91,7 +91,7 @@ impl<'token> FormatLiteralStringToken<'token> {
     }
 }
 
-pub struct CleanedStringLiteralText<'a> {
+pub(crate) struct CleanedStringLiteralText<'a> {
     token: &'a JsSyntaxToken,
     text: Cow<'a, str>,
     width: usize,

--- a/crates/rome_js_formatter/src/utils/string_utils.rs
+++ b/crates/rome_js_formatter/src/utils/string_utils.rs
@@ -6,7 +6,7 @@ use rome_js_syntax::{JsSyntaxToken, SourceType};
 use std::borrow::Cow;
 use unicode_width::UnicodeWidthStr;
 
-pub(crate) trait ToAsciiLowercaseCow {
+pub trait ToAsciiLowercaseCow {
     /// Returns the same value as String::to_lowercase. The only difference
     /// is that this functions returns ```Cow``` and does not allocate
     /// if the string is already in lowercase.

--- a/crates/rome_js_parser/src/lib.rs
+++ b/crates/rome_js_parser/src/lib.rs
@@ -132,7 +132,6 @@ pub use crate::{
     parse::*,
 };
 pub(crate) use parser::{JsParser, ParseRecovery};
-use rome_diagnostics::console::markup;
 use rome_js_factory::JsSyntaxFactory;
 use rome_js_syntax::{JsLanguage, JsSyntaxKind, LanguageVariant};
 use rome_parser::tree_sink::LosslessTreeSink;

--- a/crates/rome_js_parser/src/test_utils.rs
+++ b/crates/rome_js_parser/src/test_utils.rs
@@ -1,11 +1,11 @@
+use crate::Parse;
 use rome_console::fmt::{Formatter, Termcolor};
+use rome_console::markup;
 use rome_diagnostics::DiagnosticExt;
 use rome_diagnostics::{termcolor::Buffer, PrintDiagnostic};
 use rome_js_syntax::{JsLanguage, JsSyntaxNode};
 use rome_rowan::{AstNode, SyntaxKind, SyntaxSlot};
 use std::{fmt::Debug, path::Path};
-
-use crate::{markup, Parse};
 
 /// This check is used in the parser test to ensure it doesn't emit
 /// unknown nodes without diagnostics, and in the analyzer tests to

--- a/crates/rome_js_parser/src/tests.rs
+++ b/crates/rome_js_parser/src/tests.rs
@@ -1,6 +1,7 @@
-use crate::{markup, parse, parse_module, test_utils::assert_errors_are_absent, Parse};
+use crate::{parse, parse_module, test_utils::assert_errors_are_absent, Parse};
 use expect_test::expect_file;
 use rome_console::fmt::{Formatter, Termcolor};
+use rome_console::markup;
 use rome_diagnostics::location::FileId;
 use rome_diagnostics::DiagnosticExt;
 use rome_diagnostics::PrintDiagnostic;

--- a/crates/rome_js_unicode_table/src/tables.rs
+++ b/crates/rome_js_unicode_table/src/tables.rs
@@ -787,9 +787,7 @@ pub mod derived_property {
         ('\u{31350}', '\u{323af}'),
         ('\u{e0100}', '\u{e01ef}'),
     ];
-    pub fn ID_Continue(c: char) -> bool {
-        super::bsearch_range_table(c, ID_Continue_table)
-    }
+    pub fn ID_Continue(c: char) -> bool { super::bsearch_range_table(c, ID_Continue_table) }
     pub const ID_Start_table: &[(char, char)] = &[
         ('A', 'Z'),
         ('a', 'z'),
@@ -1451,7 +1449,5 @@ pub mod derived_property {
         ('𰀀', '𱍊'),
         ('\u{31350}', '\u{323af}'),
     ];
-    pub fn ID_Start(c: char) -> bool {
-        super::bsearch_range_table(c, ID_Start_table)
-    }
+    pub fn ID_Start(c: char) -> bool { super::bsearch_range_table(c, ID_Start_table) }
 }

--- a/crates/rome_js_unicode_table/src/tables.rs
+++ b/crates/rome_js_unicode_table/src/tables.rs
@@ -787,7 +787,9 @@ pub mod derived_property {
         ('\u{31350}', '\u{323af}'),
         ('\u{e0100}', '\u{e01ef}'),
     ];
-    pub fn ID_Continue(c: char) -> bool { super::bsearch_range_table(c, ID_Continue_table) }
+    pub fn ID_Continue(c: char) -> bool {
+        super::bsearch_range_table(c, ID_Continue_table)
+    }
     pub const ID_Start_table: &[(char, char)] = &[
         ('A', 'Z'),
         ('a', 'z'),
@@ -1449,5 +1451,7 @@ pub mod derived_property {
         ('𰀀', '𱍊'),
         ('\u{31350}', '\u{323af}'),
     ];
-    pub fn ID_Start(c: char) -> bool { super::bsearch_range_table(c, ID_Start_table) }
+    pub fn ID_Start(c: char) -> bool {
+        super::bsearch_range_table(c, ID_Start_table)
+    }
 }

--- a/crates/rome_json_formatter/Cargo.toml
+++ b/crates/rome_json_formatter/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rome_json_formatter"
+version = "0.1.0"
+edition = "2021"
+authors = ["Rome Tools Developers and Contributors"]
+repository = "https://github.com/rome/tools"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rome_json_syntax = { path = "../rome_json_syntax" }
+rome_formatter = { path = "../rome_formatter" }
+rome_rowan = { path = "../rome_rowan" }
+
+[dev-dependencies]
+rome_json_parser = { path = "../rome_json_parser" }
+insta = { version="1.18.2", features = ["glob"] }
+rome_diagnostics = { path = "../rome_diagnostics" }

--- a/crates/rome_json_formatter/Cargo.toml
+++ b/crates/rome_json_formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rome_json_formatter"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 authors = ["Rome Tools Developers and Contributors"]
 repository = "https://github.com/rome/tools"

--- a/crates/rome_json_formatter/src/context.rs
+++ b/crates/rome_json_formatter/src/context.rs
@@ -1,0 +1,85 @@
+use crate::JsonCommentStyle;
+use rome_formatter::prelude::*;
+use rome_formatter::{
+    CstFormatContext, FormatContext, FormatOptions, IndentStyle, LineWidth, TransformSourceMap,
+};
+
+use rome_formatter::comments::{Comments, FormatPlainComment};
+use rome_json_syntax::JsonLanguage;
+use std::fmt;
+
+#[derive(Debug)]
+pub struct JsonFormatContext {
+    options: JsonFormatOptions,
+    comments: Comments<JsonLanguage>,
+}
+
+impl JsonFormatContext {
+    pub fn new(options: JsonFormatOptions) -> Self {
+        Self {
+            options,
+            comments: Comments::default(),
+        }
+    }
+}
+
+impl FormatContext for JsonFormatContext {
+    type Options = JsonFormatOptions;
+
+    fn options(&self) -> &Self::Options {
+        &self.options
+    }
+
+    fn source_map(&self) -> Option<&TransformSourceMap> {
+        None
+    }
+}
+
+impl CstFormatContext for JsonFormatContext {
+    type Language = JsonLanguage;
+    type Style = JsonCommentStyle;
+    type CommentRule = FormatPlainComment<Self>;
+
+    fn comments(&self) -> &Comments<Self::Language> {
+        &self.comments
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct JsonFormatOptions {
+    indent_style: IndentStyle,
+    line_width: LineWidth,
+}
+
+impl JsonFormatOptions {
+    pub fn with_indent_style(mut self, indent_style: IndentStyle) -> Self {
+        self.indent_style = indent_style;
+        self
+    }
+
+    pub fn with_line_width(mut self, line_width: LineWidth) -> Self {
+        self.line_width = line_width;
+        self
+    }
+}
+
+impl FormatOptions for JsonFormatOptions {
+    fn indent_style(&self) -> IndentStyle {
+        self.indent_style
+    }
+
+    fn line_width(&self) -> LineWidth {
+        self.line_width
+    }
+
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions::from(self)
+    }
+}
+
+impl fmt::Display for JsonFormatOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Indent style: {}", self.indent_style)?;
+        writeln!(f, "Line width: {}", self.line_width.value())
+    }
+}

--- a/crates/rome_json_formatter/src/cst.rs
+++ b/crates/rome_json_formatter/src/cst.rs
@@ -1,0 +1,30 @@
+use crate::prelude::*;
+use rome_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatResult};
+use rome_json_syntax::{map_syntax_node, JsonSyntaxNode};
+
+#[derive(Debug, Copy, Clone, Default)]
+pub(crate) struct FormatJsonSyntaxNode;
+
+impl FormatRule<JsonSyntaxNode> for FormatJsonSyntaxNode {
+    type Context = JsonFormatContext;
+
+    fn fmt(&self, node: &JsonSyntaxNode, f: &mut JsonFormatter) -> FormatResult<()> {
+        map_syntax_node!(node.clone(), node => node.format().fmt(f))
+    }
+}
+
+impl AsFormat<JsonFormatContext> for JsonSyntaxNode {
+    type Format<'a> = FormatRefWithRule<'a, JsonSyntaxNode, FormatJsonSyntaxNode>;
+
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, FormatJsonSyntaxNode)
+    }
+}
+
+impl IntoFormat<JsonFormatContext> for JsonSyntaxNode {
+    type Format = FormatOwnedWithRule<JsonSyntaxNode, FormatJsonSyntaxNode>;
+
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, FormatJsonSyntaxNode)
+    }
+}

--- a/crates/rome_json_formatter/src/generated.rs
+++ b/crates/rome_json_formatter/src/generated.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::{
     AsFormat, FormatNodeRule, FormatUnknownNodeRule, IntoFormat, JsonFormatContext, JsonFormatter,

--- a/crates/rome_json_formatter/src/generated.rs
+++ b/crates/rome_json_formatter/src/generated.rs
@@ -1,0 +1,348 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+
+use crate::{
+    AsFormat, FormatNodeRule, FormatUnknownNodeRule, IntoFormat, JsonFormatContext, JsonFormatter,
+};
+use rome_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatResult, FormatRule};
+impl FormatRule<rome_json_syntax::JsonRoot> for crate::json::auxiliary::root::FormatJsonRoot {
+    type Context = JsonFormatContext;
+    #[inline(always)]
+    fn fmt(&self, node: &rome_json_syntax::JsonRoot, f: &mut JsonFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_json_syntax::JsonRoot>::fmt(self, node, f)
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonRoot {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonRoot,
+        crate::json::auxiliary::root::FormatJsonRoot,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::json::auxiliary::root::FormatJsonRoot::default(),
+        )
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonRoot {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonRoot,
+        crate::json::auxiliary::root::FormatJsonRoot,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::auxiliary::root::FormatJsonRoot::default(),
+        )
+    }
+}
+impl FormatRule<rome_json_syntax::JsonString> for crate::json::value::string::FormatJsonString {
+    type Context = JsonFormatContext;
+    #[inline(always)]
+    fn fmt(&self, node: &rome_json_syntax::JsonString, f: &mut JsonFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_json_syntax::JsonString>::fmt(self, node, f)
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonString {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonString,
+        crate::json::value::string::FormatJsonString,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::json::value::string::FormatJsonString::default(),
+        )
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonString {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonString,
+        crate::json::value::string::FormatJsonString,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::value::string::FormatJsonString::default(),
+        )
+    }
+}
+impl FormatRule<rome_json_syntax::JsonBoolean> for crate::json::value::boolean::FormatJsonBoolean {
+    type Context = JsonFormatContext;
+    #[inline(always)]
+    fn fmt(&self, node: &rome_json_syntax::JsonBoolean, f: &mut JsonFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_json_syntax::JsonBoolean>::fmt(self, node, f)
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonBoolean {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonBoolean,
+        crate::json::value::boolean::FormatJsonBoolean,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::json::value::boolean::FormatJsonBoolean::default(),
+        )
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonBoolean {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonBoolean,
+        crate::json::value::boolean::FormatJsonBoolean,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::value::boolean::FormatJsonBoolean::default(),
+        )
+    }
+}
+impl FormatRule<rome_json_syntax::JsonNull> for crate::json::value::null::FormatJsonNull {
+    type Context = JsonFormatContext;
+    #[inline(always)]
+    fn fmt(&self, node: &rome_json_syntax::JsonNull, f: &mut JsonFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_json_syntax::JsonNull>::fmt(self, node, f)
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonNull {
+    type Format<'a> =
+        FormatRefWithRule<'a, rome_json_syntax::JsonNull, crate::json::value::null::FormatJsonNull>;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, crate::json::value::null::FormatJsonNull::default())
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonNull {
+    type Format =
+        FormatOwnedWithRule<rome_json_syntax::JsonNull, crate::json::value::null::FormatJsonNull>;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, crate::json::value::null::FormatJsonNull::default())
+    }
+}
+impl FormatRule<rome_json_syntax::JsonNumber> for crate::json::value::number::FormatJsonNumber {
+    type Context = JsonFormatContext;
+    #[inline(always)]
+    fn fmt(&self, node: &rome_json_syntax::JsonNumber, f: &mut JsonFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_json_syntax::JsonNumber>::fmt(self, node, f)
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonNumber {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonNumber,
+        crate::json::value::number::FormatJsonNumber,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::json::value::number::FormatJsonNumber::default(),
+        )
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonNumber {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonNumber,
+        crate::json::value::number::FormatJsonNumber,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::value::number::FormatJsonNumber::default(),
+        )
+    }
+}
+impl FormatRule<rome_json_syntax::JsonArray> for crate::json::value::array::FormatJsonArray {
+    type Context = JsonFormatContext;
+    #[inline(always)]
+    fn fmt(&self, node: &rome_json_syntax::JsonArray, f: &mut JsonFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_json_syntax::JsonArray>::fmt(self, node, f)
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonArray {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonArray,
+        crate::json::value::array::FormatJsonArray,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, crate::json::value::array::FormatJsonArray::default())
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonArray {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonArray,
+        crate::json::value::array::FormatJsonArray,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, crate::json::value::array::FormatJsonArray::default())
+    }
+}
+impl FormatRule<rome_json_syntax::JsonObject> for crate::json::value::object::FormatJsonObject {
+    type Context = JsonFormatContext;
+    #[inline(always)]
+    fn fmt(&self, node: &rome_json_syntax::JsonObject, f: &mut JsonFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_json_syntax::JsonObject>::fmt(self, node, f)
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonObject {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonObject,
+        crate::json::value::object::FormatJsonObject,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::json::value::object::FormatJsonObject::default(),
+        )
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonObject {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonObject,
+        crate::json::value::object::FormatJsonObject,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::value::object::FormatJsonObject::default(),
+        )
+    }
+}
+impl FormatRule<rome_json_syntax::JsonMember> for crate::json::auxiliary::member::FormatJsonMember {
+    type Context = JsonFormatContext;
+    #[inline(always)]
+    fn fmt(&self, node: &rome_json_syntax::JsonMember, f: &mut JsonFormatter) -> FormatResult<()> {
+        FormatNodeRule::<rome_json_syntax::JsonMember>::fmt(self, node, f)
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonMember {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonMember,
+        crate::json::auxiliary::member::FormatJsonMember,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::json::auxiliary::member::FormatJsonMember::default(),
+        )
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonMember {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonMember,
+        crate::json::auxiliary::member::FormatJsonMember,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::auxiliary::member::FormatJsonMember::default(),
+        )
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonArrayElementList {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonArrayElementList,
+        crate::json::lists::array_element_list::FormatJsonArrayElementList,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::json::lists::array_element_list::FormatJsonArrayElementList::default(),
+        )
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonArrayElementList {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonArrayElementList,
+        crate::json::lists::array_element_list::FormatJsonArrayElementList,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::lists::array_element_list::FormatJsonArrayElementList::default(),
+        )
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonMemberList {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonMemberList,
+        crate::json::lists::member_list::FormatJsonMemberList,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::json::lists::member_list::FormatJsonMemberList::default(),
+        )
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonMemberList {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonMemberList,
+        crate::json::lists::member_list::FormatJsonMemberList,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::lists::member_list::FormatJsonMemberList::default(),
+        )
+    }
+}
+impl FormatRule<rome_json_syntax::JsonUnknown>
+    for crate::json::unknown::unknown::FormatJsonUnknown
+{
+    type Context = JsonFormatContext;
+    #[inline(always)]
+    fn fmt(&self, node: &rome_json_syntax::JsonUnknown, f: &mut JsonFormatter) -> FormatResult<()> {
+        FormatUnknownNodeRule::<rome_json_syntax::JsonUnknown>::fmt(self, node, f)
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonUnknown {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonUnknown,
+        crate::json::unknown::unknown::FormatJsonUnknown,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::json::unknown::unknown::FormatJsonUnknown::default(),
+        )
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonUnknown {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonUnknown,
+        crate::json::unknown::unknown::FormatJsonUnknown,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::json::unknown::unknown::FormatJsonUnknown::default(),
+        )
+    }
+}
+impl AsFormat<JsonFormatContext> for rome_json_syntax::JsonAnyValue {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        rome_json_syntax::JsonAnyValue,
+        crate::json::any::value::FormatJsonAnyValue,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, crate::json::any::value::FormatJsonAnyValue::default())
+    }
+}
+impl IntoFormat<JsonFormatContext> for rome_json_syntax::JsonAnyValue {
+    type Format = FormatOwnedWithRule<
+        rome_json_syntax::JsonAnyValue,
+        crate::json::any::value::FormatJsonAnyValue,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, crate::json::any::value::FormatJsonAnyValue::default())
+    }
+}

--- a/crates/rome_json_formatter/src/json/any/mod.rs
+++ b/crates/rome_json_formatter/src/json/any/mod.rs
@@ -1,0 +1,3 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+
+pub(crate) mod value;

--- a/crates/rome_json_formatter/src/json/any/mod.rs
+++ b/crates/rome_json_formatter/src/json/any/mod.rs
@@ -1,3 +1,3 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod value;

--- a/crates/rome_json_formatter/src/json/any/value.rs
+++ b/crates/rome_json_formatter/src/json/any/value.rs
@@ -1,0 +1,20 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+
+use crate::prelude::*;
+use rome_json_syntax::JsonAnyValue;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonAnyValue;
+impl FormatRule<JsonAnyValue> for FormatJsonAnyValue {
+    type Context = JsonFormatContext;
+    fn fmt(&self, node: &JsonAnyValue, f: &mut JsonFormatter) -> FormatResult<()> {
+        match node {
+            JsonAnyValue::JsonString(node) => node.format().fmt(f),
+            JsonAnyValue::JsonBoolean(node) => node.format().fmt(f),
+            JsonAnyValue::JsonNull(node) => node.format().fmt(f),
+            JsonAnyValue::JsonNumber(node) => node.format().fmt(f),
+            JsonAnyValue::JsonArray(node) => node.format().fmt(f),
+            JsonAnyValue::JsonObject(node) => node.format().fmt(f),
+            JsonAnyValue::JsonUnknown(node) => node.format().fmt(f),
+        }
+    }
+}

--- a/crates/rome_json_formatter/src/json/any/value.rs
+++ b/crates/rome_json_formatter/src/json/any/value.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 use crate::prelude::*;
 use rome_json_syntax::JsonAnyValue;

--- a/crates/rome_json_formatter/src/json/auxiliary/member.rs
+++ b/crates/rome_json_formatter/src/json/auxiliary/member.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+use rome_json_syntax::JsonMember;
+use rome_rowan::AstNode;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonMember;
+
+impl FormatNodeRule<JsonMember> for FormatJsonMember {
+    fn fmt_fields(&self, node: &JsonMember, f: &mut JsonFormatter) -> FormatResult<()> {
+        format_verbatim_node(node.syntax()).fmt(f)
+    }
+}

--- a/crates/rome_json_formatter/src/json/auxiliary/mod.rs
+++ b/crates/rome_json_formatter/src/json/auxiliary/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod member;
 pub(crate) mod root;

--- a/crates/rome_json_formatter/src/json/auxiliary/mod.rs
+++ b/crates/rome_json_formatter/src/json/auxiliary/mod.rs
@@ -1,0 +1,4 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+
+pub(crate) mod member;
+pub(crate) mod root;

--- a/crates/rome_json_formatter/src/json/auxiliary/root.rs
+++ b/crates/rome_json_formatter/src/json/auxiliary/root.rs
@@ -1,0 +1,21 @@
+use crate::prelude::*;
+use rome_formatter::write;
+use rome_json_syntax::{JsonRoot, JsonRootFields};
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonRoot;
+
+impl FormatNodeRule<JsonRoot> for FormatJsonRoot {
+    fn fmt_fields(&self, node: &JsonRoot, f: &mut JsonFormatter) -> FormatResult<()> {
+        let JsonRootFields { value, eof_token } = node.as_fields();
+
+        write!(
+            f,
+            [
+                value.format(),
+                format_removed(&eof_token?),
+                hard_line_break()
+            ]
+        )
+    }
+}

--- a/crates/rome_json_formatter/src/json/lists/array_element_list.rs
+++ b/crates/rome_json_formatter/src/json/lists/array_element_list.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+use rome_json_syntax::JsonArrayElementList;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonArrayElementList;
+
+impl FormatRule<JsonArrayElementList> for FormatJsonArrayElementList {
+    type Context = JsonFormatContext;
+    fn fmt(&self, node: &JsonArrayElementList, f: &mut JsonFormatter) -> FormatResult<()> {
+        format_verbatim_node(node.syntax()).fmt(f)
+    }
+}

--- a/crates/rome_json_formatter/src/json/lists/member_list.rs
+++ b/crates/rome_json_formatter/src/json/lists/member_list.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+use rome_json_syntax::JsonMemberList;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonMemberList;
+
+impl FormatRule<JsonMemberList> for FormatJsonMemberList {
+    type Context = JsonFormatContext;
+    fn fmt(&self, node: &JsonMemberList, f: &mut JsonFormatter) -> FormatResult<()> {
+        format_verbatim_node(node.syntax()).fmt(f)
+    }
+}

--- a/crates/rome_json_formatter/src/json/lists/mod.rs
+++ b/crates/rome_json_formatter/src/json/lists/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod array_element_list;
 pub(crate) mod member_list;

--- a/crates/rome_json_formatter/src/json/lists/mod.rs
+++ b/crates/rome_json_formatter/src/json/lists/mod.rs
@@ -1,0 +1,4 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+
+pub(crate) mod array_element_list;
+pub(crate) mod member_list;

--- a/crates/rome_json_formatter/src/json/mod.rs
+++ b/crates/rome_json_formatter/src/json/mod.rs
@@ -1,0 +1,7 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+
+pub(crate) mod any;
+pub(crate) mod auxiliary;
+pub(crate) mod lists;
+pub(crate) mod unknown;
+pub(crate) mod value;

--- a/crates/rome_json_formatter/src/json/mod.rs
+++ b/crates/rome_json_formatter/src/json/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod any;
 pub(crate) mod auxiliary;

--- a/crates/rome_json_formatter/src/json/unknown/mod.rs
+++ b/crates/rome_json_formatter/src/json/unknown/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 #[allow(clippy::module_inception)]
 pub(crate) mod unknown;

--- a/crates/rome_json_formatter/src/json/unknown/mod.rs
+++ b/crates/rome_json_formatter/src/json/unknown/mod.rs
@@ -1,0 +1,4 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+
+#[allow(clippy::module_inception)]
+pub(crate) mod unknown;

--- a/crates/rome_json_formatter/src/json/unknown/unknown.rs
+++ b/crates/rome_json_formatter/src/json/unknown/unknown.rs
@@ -1,0 +1,7 @@
+use crate::FormatUnknownNodeRule;
+use rome_json_syntax::JsonUnknown;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonUnknown;
+
+impl FormatUnknownNodeRule<JsonUnknown> for FormatJsonUnknown {}

--- a/crates/rome_json_formatter/src/json/value/array.rs
+++ b/crates/rome_json_formatter/src/json/value/array.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+use rome_json_syntax::JsonArray;
+use rome_rowan::AstNode;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonArray;
+
+impl FormatNodeRule<JsonArray> for FormatJsonArray {
+    fn fmt_fields(&self, node: &JsonArray, f: &mut JsonFormatter) -> FormatResult<()> {
+        format_verbatim_node(node.syntax()).fmt(f)
+    }
+}

--- a/crates/rome_json_formatter/src/json/value/boolean.rs
+++ b/crates/rome_json_formatter/src/json/value/boolean.rs
@@ -1,0 +1,11 @@
+use crate::prelude::*;
+use rome_json_syntax::JsonBoolean;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonBoolean;
+
+impl FormatNodeRule<JsonBoolean> for FormatJsonBoolean {
+    fn fmt_fields(&self, node: &JsonBoolean, f: &mut JsonFormatter) -> FormatResult<()> {
+        node.value_token()?.format().fmt(f)
+    }
+}

--- a/crates/rome_json_formatter/src/json/value/mod.rs
+++ b/crates/rome_json_formatter/src/json/value/mod.rs
@@ -1,0 +1,8 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+
+pub(crate) mod array;
+pub(crate) mod boolean;
+pub(crate) mod null;
+pub(crate) mod number;
+pub(crate) mod object;
+pub(crate) mod string;

--- a/crates/rome_json_formatter/src/json/value/mod.rs
+++ b/crates/rome_json_formatter/src/json/value/mod.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file. 
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
 pub(crate) mod array;
 pub(crate) mod boolean;

--- a/crates/rome_json_formatter/src/json/value/null.rs
+++ b/crates/rome_json_formatter/src/json/value/null.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+use rome_json_syntax::JsonNull;
+use rome_rowan::AstNode;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonNull;
+
+impl FormatNodeRule<JsonNull> for FormatJsonNull {
+    fn fmt_fields(&self, node: &JsonNull, f: &mut JsonFormatter) -> FormatResult<()> {
+        format_verbatim_node(node.syntax()).fmt(f)
+    }
+}

--- a/crates/rome_json_formatter/src/json/value/number.rs
+++ b/crates/rome_json_formatter/src/json/value/number.rs
@@ -1,0 +1,11 @@
+use crate::prelude::*;
+use rome_json_syntax::JsonNumber;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonNumber;
+
+impl FormatNodeRule<JsonNumber> for FormatJsonNumber {
+    fn fmt_fields(&self, node: &JsonNumber, f: &mut JsonFormatter) -> FormatResult<()> {
+        node.value_token()?.format().fmt(f)
+    }
+}

--- a/crates/rome_json_formatter/src/json/value/object.rs
+++ b/crates/rome_json_formatter/src/json/value/object.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+use rome_json_syntax::JsonObject;
+use rome_rowan::AstNode;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonObject;
+
+impl FormatNodeRule<JsonObject> for FormatJsonObject {
+    fn fmt_fields(&self, node: &JsonObject, f: &mut JsonFormatter) -> FormatResult<()> {
+        format_verbatim_node(node.syntax()).fmt(f)
+    }
+}

--- a/crates/rome_json_formatter/src/json/value/string.rs
+++ b/crates/rome_json_formatter/src/json/value/string.rs
@@ -1,0 +1,11 @@
+use crate::prelude::*;
+use rome_json_syntax::JsonString;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatJsonString;
+
+impl FormatNodeRule<JsonString> for FormatJsonString {
+    fn fmt_fields(&self, node: &JsonString, f: &mut JsonFormatter) -> FormatResult<()> {
+        node.value_token()?.format().fmt(f)
+    }
+}

--- a/crates/rome_json_formatter/src/lib.rs
+++ b/crates/rome_json_formatter/src/lib.rs
@@ -1,0 +1,187 @@
+pub mod context;
+mod cst;
+mod generated;
+mod json;
+mod prelude;
+
+pub(crate) use crate::context::JsonFormatContext;
+use crate::context::JsonFormatOptions;
+use crate::cst::FormatJsonSyntaxNode;
+use rome_formatter::comments::{CommentKind, CommentStyle};
+use rome_formatter::prelude::*;
+use rome_formatter::{
+    FormatContext, FormatLanguage, FormatOwnedWithRule, FormatRefWithRule, FormatToken,
+    TransformSourceMap,
+};
+use rome_formatter::{Formatted, Printed};
+use rome_json_syntax::{JsonAnyValue, JsonLanguage, JsonSyntaxNode, JsonSyntaxToken};
+use rome_rowan::{AstNode, SyntaxNode, SyntaxTriviaPieceComments, TextRange};
+
+include!("../../rome_formatter/shared_traits.rs");
+
+pub(crate) type JsonFormatter<'buf> = Formatter<'buf, JsonFormatContext>;
+
+pub(crate) trait FormatNodeRule<N>
+where
+    N: AstNode<Language = JsonLanguage>,
+{
+    fn fmt(&self, node: &N, f: &mut JsonFormatter) -> FormatResult<()> {
+        self.fmt_fields(node, f)
+    }
+
+    fn fmt_fields(&self, node: &N, f: &mut JsonFormatter) -> FormatResult<()>;
+}
+
+/// Rule for formatting an unknown node.
+pub(crate) trait FormatUnknownNodeRule<N>
+where
+    N: AstNode<Language = JsonLanguage>,
+{
+    fn fmt(&self, node: &N, f: &mut JsonFormatter) -> FormatResult<()> {
+        format_unknown_node(node.syntax()).fmt(f)
+    }
+}
+
+pub(crate) struct JsonFormatLanguage {
+    options: JsonFormatOptions,
+}
+
+impl JsonFormatLanguage {
+    fn new(options: JsonFormatOptions) -> Self {
+        Self { options }
+    }
+}
+
+impl FormatLanguage for JsonFormatLanguage {
+    type SyntaxLanguage = JsonLanguage;
+    type Context = JsonFormatContext;
+    type FormatRule = FormatJsonSyntaxNode;
+
+    fn is_range_formatting_node(&self, node: &SyntaxNode<Self::SyntaxLanguage>) -> bool {
+        JsonAnyValue::can_cast(node.kind())
+    }
+
+    fn options(&self) -> &<Self::Context as FormatContext>::Options {
+        &self.options
+    }
+
+    fn create_context(
+        self,
+        _root: &JsonSyntaxNode,
+        _source_map: Option<TransformSourceMap>,
+    ) -> Self::Context {
+        JsonFormatContext::new(self.options)
+    }
+}
+
+#[derive(Default)]
+pub struct JsonCommentStyle;
+
+impl CommentStyle for JsonCommentStyle {
+    type Language = JsonLanguage;
+
+    fn get_comment_kind(_: &SyntaxTriviaPieceComments<Self::Language>) -> CommentKind {
+        CommentKind::Line
+    }
+}
+
+/// Format implementation specific to JavaScript tokens.
+pub(crate) type FormatJsonSyntaxToken = FormatToken<JsonFormatContext>;
+
+impl AsFormat<JsonFormatContext> for JsonSyntaxToken {
+    type Format<'a> = FormatRefWithRule<'a, JsonSyntaxToken, FormatJsonSyntaxToken>;
+
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, FormatJsonSyntaxToken::default())
+    }
+}
+
+impl IntoFormat<JsonFormatContext> for JsonSyntaxToken {
+    type Format = FormatOwnedWithRule<JsonSyntaxToken, FormatJsonSyntaxToken>;
+
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, FormatJsonSyntaxToken::default())
+    }
+}
+
+/// Formats a range within a file, supported by Rome
+///
+/// This runs a simple heuristic to determine the initial indentation
+/// level of the node based on the provided [JsonFormatOptions], which
+/// must match currently the current initial of the file. Additionally,
+/// because the reformatting happens only locally the resulting code
+/// will be indented with the same level as the original selection,
+/// even if it's a mismatch from the rest of the block the selection is in
+///
+/// It returns a [Printed] result with a range corresponding to the
+/// range of the input that was effectively overwritten by the formatter
+pub fn format_range(
+    options: JsonFormatOptions,
+    root: &JsonSyntaxNode,
+    range: TextRange,
+) -> FormatResult<Printed> {
+    rome_formatter::format_range(root, range, JsonFormatLanguage::new(options))
+}
+
+/// Formats a JSON syntax tree.
+///
+/// It returns the [Formatted] document that can be printed to a string.
+pub fn format_node(
+    options: JsonFormatOptions,
+    root: &JsonSyntaxNode,
+) -> FormatResult<Formatted<JsonFormatContext>> {
+    rome_formatter::format_node(root, JsonFormatLanguage::new(options))
+}
+
+/// Formats a single node within a file, supported by Rome.
+///
+/// This runs a simple heuristic to determine the initial indentation
+/// level of the node based on the provided [JsonFormatOptions], which
+/// must match currently the current initial of the file. Additionally,
+/// because the reformatting happens only locally the resulting code
+/// will be indented with the same level as the original selection,
+/// even if it's a mismatch from the rest of the block the selection is in
+///
+/// Returns the [Printed] code.
+pub fn format_sub_tree(options: JsonFormatOptions, root: &JsonSyntaxNode) -> FormatResult<Printed> {
+    rome_formatter::format_sub_tree(root, JsonFormatLanguage::new(options))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::context::JsonFormatOptions;
+    use crate::format_node;
+    use rome_diagnostics::FileId;
+    use rome_json_parser::parse_json;
+
+    #[test]
+    fn smoke_test() {
+        let src = r#"
+{
+    "a": 5,
+    "b": [1, 2, 3, 4],
+    "c": null,
+    "d": true,
+    "e": false
+}
+"#;
+        let parse = parse_json(src, FileId::zero());
+        let options = JsonFormatOptions::default();
+        let result = format_node(options, &parse.syntax())
+            .unwrap()
+            .print()
+            .unwrap();
+
+        assert_eq!(
+            result.as_code(),
+            r#"{
+    "a": 5,
+    "b": [1, 2, 3, 4],
+    "c": null,
+    "d": true,
+    "e": false
+}
+"#
+        );
+    }
+}

--- a/crates/rome_json_formatter/src/prelude.rs
+++ b/crates/rome_json_formatter/src/prelude.rs
@@ -5,5 +5,6 @@
 pub(crate) use crate::{
     AsFormat, FormatNodeRule, FormattedIterExt as _, IntoFormat, JsonFormatContext, JsonFormatter,
 };
-pub use rome_formatter::prelude::*;
-pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
+pub(crate) use rome_formatter::prelude::*;
+#[allow(unused_imports)]
+pub(crate) use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};

--- a/crates/rome_json_formatter/src/prelude.rs
+++ b/crates/rome_json_formatter/src/prelude.rs
@@ -1,0 +1,9 @@
+//! This module provides important and useful traits to help to format tokens and nodes
+//! when implementing the [crate::FormatNodeRule] trait.
+
+#[allow(unused_imports)]
+pub(crate) use crate::{
+    AsFormat, FormatNodeRule, FormattedIterExt as _, IntoFormat, JsonFormatContext, JsonFormatter,
+};
+pub use rome_formatter::prelude::*;
+pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};

--- a/crates/rome_parser/src/diagnostic.rs
+++ b/crates/rome_parser/src/diagnostic.rs
@@ -322,12 +322,12 @@ where
     }
 }
 
-/// Creates a diagnostic saying that the node [name] was expected at range
+/// Creates a diagnostic saying that the node `name` was expected at range
 pub fn expected_node(name: &str, range: TextRange) -> ExpectedNodeDiagnosticBuilder {
     ExpectedNodeDiagnosticBuilder::with_single_node(name, range)
 }
 
-/// Creates a diagnostic saying that any of the nodes in [names] was expected at range
+/// Creates a diagnostic saying that any of the nodes in `names` was expected at range
 pub fn expected_any(names: &[&str], range: TextRange) -> ExpectedNodeDiagnosticBuilder {
     ExpectedNodeDiagnosticBuilder::with_any(names, range)
 }

--- a/crates/rome_parser/src/lib.rs
+++ b/crates/rome_parser/src/lib.rs
@@ -377,10 +377,10 @@ pub trait Parser: Sized {
     type Kind: SyntaxKind;
     type Source: TokenSource<Kind = Self::Kind>;
 
-    /// Returns a reference to the [`ParsingContext`](ParsingContext)
+    /// Returns a reference to the [`ParserContext`](ParserContext)
     fn context(&self) -> &ParserContext<Self::Kind>;
 
-    /// Returns a mutable reference to the [`ParsingContext`](ParsingContext).
+    /// Returns a mutable reference to the [`ParserContext`](ParserContext).
     fn context_mut(&mut self) -> &mut ParserContext<Self::Kind>;
 
     /// Returns a reference to the [`TokenSource``](TokenSource]

--- a/crates/rome_parser/src/parse_lists.rs
+++ b/crates/rome_parser/src/parse_lists.rs
@@ -6,8 +6,6 @@ use rome_rowan::SyntaxKind;
 
 /// Use this trait to parse simple lists that don't have particular requirements.
 ///
-/// In order to use this trait, you need to implement the [List] trait too.
-///
 /// ```rust,ignore
 /// use rome_js_parser::{ParseSeparatedList};
 ///
@@ -75,8 +73,6 @@ pub trait ParseNodeList {
 
 /// A trait to parse lists that will be separated by a recurring element
 ///
-/// In order to use this trait, you need to implement the [List] trait too.
-///
 /// ```rust,ignore
 /// use rome_js_parser::{ParseSeparatedList};
 ///
@@ -128,7 +124,7 @@ pub trait ParseSeparatedList {
     /// Method called at each iteration of the the loop and checks if the expected
     /// separator is present.
     ///
-    /// If present, it [parses](Self::parse_separating_element) it and continues with loop.
+    /// If present, it [parses](Self::separating_element_kind) it and continues with loop.
     /// If not present, it adds a missing marker.
     fn expect_separator(&mut self, p: &mut Self::Parser<'_>) -> bool {
         p.expect(self.separating_element_kind())

--- a/crates/rome_parser/src/tree_sink.rs
+++ b/crates/rome_parser/src/tree_sink.rs
@@ -95,7 +95,7 @@ where
 
     /// Finishes the tree and return the root node with possible parser errors.
     ///
-    /// If tree is finished without a [rome_js_syntax::JsSyntaxKind::EOF], one will be generated and all pending trivia
+    /// If tree is finished without a [rome_rowan::SyntaxKind::EOF], one will be generated and all pending trivia
     /// will be appended to its leading trivia.
     pub fn finish(self) -> (SyntaxNode<L>, Vec<ParseDiagnostic>) {
         (self.inner.finish(), self.errors)

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -53,11 +53,7 @@ pub fn generate_ast(mode: Mode, language_kind_list: Vec<String>) -> Result<()> {
             ),
             Color::Green,
         );
-        let mut ast = match kind {
-            LanguageKind::Js => load_js_ast(),
-            LanguageKind::Css => load_css_ast(),
-            LanguageKind::Json => load_json_ast(),
-        };
+        let mut ast = load_ast(kind);
         ast.sort();
         generate_syntax(ast, &mode, kind)?;
     }
@@ -65,57 +61,51 @@ pub fn generate_ast(mode: Mode, language_kind_list: Vec<String>) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn load_ast(language: LanguageKind) -> AstSrc {
+    match language {
+        LanguageKind::Js => load_js_ast(),
+        LanguageKind::Css => load_css_ast(),
+        LanguageKind::Json => load_json_ast(),
+    }
+}
+
 pub(crate) fn generate_syntax(ast: AstSrc, mode: &Mode, language_kind: LanguageKind) -> Result<()> {
-    let (nodes, nodes_mut, kinds, factory, node_factory, macros, kind_src) = match language_kind {
-        LanguageKind::Js => (
-            crate::JS_AST_NODES,
-            crate::JS_AST_NODES_MUT,
-            crate::JS_SYNTAX_KINDS,
-            crate::JS_SYNTAX_FACTORY,
-            crate::JS_NODE_FACTORY,
-            crate::JS_AST_MACROS,
-            JS_KINDS_SRC,
-        ),
-        LanguageKind::Css => (
-            crate::CSS_AST_NODES,
-            crate::CSS_AST_NODES_MUT,
-            crate::CSS_SYNTAX_KINDS,
-            crate::CSS_SYNTAX_FACTORY,
-            crate::CSS_NODE_FACTORY,
-            crate::CSS_AST_MACROS,
-            CSS_KINDS_SRC,
-        ),
-        LanguageKind::Json => (
-            crate::JSON_AST_NODES,
-            crate::JSON_AST_NODES_MUT,
-            crate::JSON_SYNTAX_KINDS,
-            crate::JSON_SYNTAX_FACTORY,
-            crate::JSON_NODE_FACTORY,
-            crate::JSON_AST_MACROS,
-            JSON_KINDS_SRC,
-        ),
+    let syntax_generated_path = project_root()
+        .join("crates")
+        .join(language_kind.syntax_crate_name())
+        .join("src/generated");
+    let factory_generated_path = project_root()
+        .join("crates")
+        .join(language_kind.factory_crate_name())
+        .join("src/generated");
+
+    let kind_src = match language_kind {
+        LanguageKind::Js => JS_KINDS_SRC,
+        LanguageKind::Css => CSS_KINDS_SRC,
+        LanguageKind::Json => JSON_KINDS_SRC,
     };
-    let ast_nodes_file = project_root().join(nodes);
+
+    let ast_nodes_file = syntax_generated_path.join("nodes.rs");
     let contents = generate_nodes(&ast, language_kind)?;
     update(ast_nodes_file.as_path(), &contents, mode)?;
 
-    let ast_nodes_mut_file = project_root().join(nodes_mut);
+    let ast_nodes_mut_file = syntax_generated_path.join("nodes_mut.rs");
     let contents = generate_nodes_mut(&ast, language_kind)?;
     update(ast_nodes_mut_file.as_path(), &contents, mode)?;
 
-    let syntax_kinds_file = project_root().join(kinds);
+    let syntax_kinds_file = syntax_generated_path.join("kind.rs");
     let contents = generate_syntax_kinds(kind_src, language_kind)?;
     update(syntax_kinds_file.as_path(), &contents, mode)?;
 
-    let syntax_factory_file = project_root().join(factory);
+    let syntax_factory_file = factory_generated_path.join("syntax_factory.rs");
     let contents = generate_syntax_factory(&ast, language_kind)?;
     update(syntax_factory_file.as_path(), &contents, mode)?;
 
-    let node_factory_file = project_root().join(node_factory);
+    let node_factory_file = factory_generated_path.join("node_factory.rs");
     let contents = generate_node_factory(&ast, language_kind)?;
     update(node_factory_file.as_path(), &contents, mode)?;
 
-    let ast_macros_file = project_root().join(macros);
+    let ast_macros_file = syntax_generated_path.join("macros.rs");
     let contents = generate_macros(&ast, language_kind)?;
     update(ast_macros_file.as_path(), &contents, mode)?;
 

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -297,7 +297,7 @@ fn generate_formatter(repo: &GitRepo, language_kind: LanguageKind) {
     for (kind, name) in names {
         let module = name_to_module(&kind, &name, language_kind);
         let path = module.as_path();
-        modules.insert(&repo, &path);
+        modules.insert(repo, &path);
 
         let node_id = Ident::new(&name, Span::call_site());
         let format_id = Ident::new(&format!("Format{name}"), Span::call_site());

--- a/xtask/codegen/src/generate_node_factory.rs
+++ b/xtask/codegen/src/generate_node_factory.rs
@@ -5,7 +5,7 @@ use quote::{format_ident, quote};
 use xtask::Result;
 
 pub fn generate_node_factory(ast: &AstSrc, language_kind: LanguageKind) -> Result<String> {
-    let syntax_crate = language_kind.syntax_crate();
+    let syntax_crate = language_kind.syntax_crate_ident();
     let syntax_kind = language_kind.syntax_kind();
     let syntax_token = language_kind.syntax_token();
     let syntax_node = language_kind.syntax_node();

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -15,7 +15,7 @@ mod kinds_src;
 mod parser_tests;
 mod termcolorful;
 mod unicode;
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use std::path::Path;
 use std::str::FromStr;
@@ -23,31 +23,10 @@ use std::str::FromStr;
 use xtask::{glue::fs2, Mode, Result};
 
 pub use self::ast::generate_ast;
-pub use self::formatter::generate_formatter;
+pub use self::formatter::generate_formatters;
 pub use self::generate_analyzer::generate_analyzer;
 pub use self::parser_tests::generate_parser_tests;
 pub use self::unicode::generate_tables;
-
-const JS_SYNTAX_KINDS: &str = "crates/rome_js_syntax/src/generated/kind.rs";
-const JS_AST_NODES: &str = "crates/rome_js_syntax/src/generated/nodes.rs";
-const JS_AST_NODES_MUT: &str = "crates/rome_js_syntax/src/generated/nodes_mut.rs";
-const JS_SYNTAX_FACTORY: &str = "crates/rome_js_factory/src/generated/syntax_factory.rs";
-const JS_NODE_FACTORY: &str = "crates/rome_js_factory/src/generated/node_factory.rs";
-const JS_AST_MACROS: &str = "crates/rome_js_syntax/src/generated/macros.rs";
-
-const CSS_SYNTAX_KINDS: &str = "crates/rome_css_syntax/src/generated/kind.rs";
-const CSS_AST_NODES: &str = "crates/rome_css_syntax/src/generated/nodes.rs";
-const CSS_AST_NODES_MUT: &str = "crates/rome_css_syntax/src/generated/nodes_mut.rs";
-const CSS_SYNTAX_FACTORY: &str = "crates/rome_css_factory/src/generated/syntax_factory.rs";
-const CSS_NODE_FACTORY: &str = "crates/rome_css_factory/src/generated/node_factory.rs";
-const CSS_AST_MACROS: &str = "crates/rome_css_syntax/src/generated/macros.rs";
-
-const JSON_SYNTAX_KINDS: &str = "crates/rome_json_syntax/src/generated/kind.rs";
-const JSON_AST_NODES: &str = "crates/rome_json_syntax/src/generated/nodes.rs";
-const JSON_AST_NODES_MUT: &str = "crates/rome_json_syntax/src/generated/nodes_mut.rs";
-const JSON_SYNTAX_FACTORY: &str = "crates/rome_json_factory/src/generated/syntax_factory.rs";
-const JSON_NODE_FACTORY: &str = "crates/rome_json_factory/src/generated/node_factory.rs";
-const JSON_AST_MACROS: &str = "crates/rome_json_syntax/src/generated/macros.rs";
 
 pub enum UpdateResult {
     NotUpdated,
@@ -91,12 +70,8 @@ impl FromStr for LanguageKind {
 }
 
 impl LanguageKind {
-    pub(crate) fn syntax_crate(&self) -> TokenStream {
-        match self {
-            LanguageKind::Js => quote! { rome_js_syntax },
-            LanguageKind::Css => quote! { rome_css_syntax },
-            LanguageKind::Json => quote! { rome_json_syntax },
-        }
+    pub(crate) fn syntax_crate_ident(&self) -> Ident {
+        Ident::new(self.syntax_crate_name(), Span::call_site())
     }
 
     pub(crate) fn syntax_kind(&self) -> TokenStream {
@@ -152,6 +127,30 @@ impl LanguageKind {
             LanguageKind::Js => quote! { JsLanguage },
             LanguageKind::Css => quote! { CssLanguage },
             LanguageKind::Json => quote! { JsonLanguage },
+        }
+    }
+
+    pub fn formatter_crate_name(&self) -> &'static str {
+        match self {
+            LanguageKind::Js => "rome_js_formatter",
+            LanguageKind::Css => "rome_css_formatter",
+            LanguageKind::Json => "rome_json_formatter",
+        }
+    }
+
+    pub fn syntax_crate_name(&self) -> &'static str {
+        match self {
+            LanguageKind::Js => "rome_js_syntax",
+            LanguageKind::Css => "rome_css_syntax",
+            LanguageKind::Json => "rome_json_syntax",
+        }
+    }
+
+    pub fn factory_crate_name(&self) -> &'static str {
+        match self {
+            LanguageKind::Js => "rome_js_factory",
+            LanguageKind::Css => "rome_css_factory",
+            LanguageKind::Json => "rome_json_factory",
         }
     }
 }

--- a/xtask/codegen/src/main.rs
+++ b/xtask/codegen/src/main.rs
@@ -15,7 +15,7 @@ use crate::generate_configuration::generate_rules_configuration;
 #[cfg(feature = "schema")]
 use crate::generate_schema::generate_configuration_schema;
 use xtask_codegen::{
-    generate_analyzer, generate_ast, generate_formatter, generate_parser_tests, generate_tables,
+    generate_analyzer, generate_ast, generate_formatters, generate_parser_tests, generate_tables,
 };
 
 fn main() -> Result<()> {
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
             Ok(())
         }
         "formatter" => {
-            generate_formatter();
+            generate_formatters();
             Ok(())
         }
         "test" => {
@@ -63,7 +63,7 @@ fn main() -> Result<()> {
             generate_tables()?;
             generate_grammar(args);
             generate_parser_tests(Mode::Overwrite)?;
-            generate_formatter();
+            generate_formatters();
             generate_analyzer()?;
             #[cfg(feature = "configuration")]
             generate_rules_configuration(Mode::Overwrite)?;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -43,6 +43,12 @@ pub fn reformat(text: impl Display) -> Result<String> {
     reformat_without_preamble(text).map(prepend_generated_preamble)
 }
 
+pub fn reformat_with_command(text: impl Display, command: impl Display) -> Result<String> {
+    reformat_without_preamble(text).map(|formatted| {
+        format!("//! This is a generated file. Don't modify it by hand! Run '{}' to re-generate the file. \n\n{}", command, formatted)
+    })
+}
+
 pub const PREAMBLE: &str = "Generated file, do not edit by hand, see `xtask/codegen`";
 pub fn prepend_generated_preamble(content: impl Display) -> String {
     format!("//! {}\n\n{}", PREAMBLE, content)

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -45,7 +45,7 @@ pub fn reformat(text: impl Display) -> Result<String> {
 
 pub fn reformat_with_command(text: impl Display, command: impl Display) -> Result<String> {
     reformat_without_preamble(text).map(|formatted| {
-        format!("//! This is a generated file. Don't modify it by hand! Run '{}' to re-generate the file. \n\n{}", command, formatted)
+        format!("//! This is a generated file. Don't modify it by hand! Run '{}' to re-generate the file.\n\n{}", command, formatted)
     })
 }
 


### PR DESCRIPTION
## Summary

This PR sets up the new `rome_json_formatter` crate with the "default" implementation for all formatters except literals (trivial) and the root. 

It adds:

* The `JsonFormatContext` and `JsonFormatOptions`
* The `JsonFormatter` 
* The formatters for `JsonSyntaxNode` and blank implementations for each AST node. 
* ~~It enables json formatting support for **debug builds only**~~ (There's an issue with the CLI now emitting linting is unsupported for JSON files. I'm going to tackle this in a dedicated PR)

It changes:
* The visibility of all `Format*` nodes to `pub(crate)`. These are implementation details and shouldn't be public 
* Extracted the common traits that each formatter has into a `traits_shared.rs` file in `rome_formatter` and included it with the `include` macro in `rome_json_formatter` and `rome_js_formatter`

## Test Plan

I added a smoke test that calls into the formatter. A next step is to set up integration tests and prettier tests. 
