### PR TITLE
feat(rome_json_formatter): Enable JSON formatting for debug builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,6 +1883,7 @@ dependencies = [
  "rome_js_parser",
  "rome_js_semantic",
  "rome_js_syntax",
+ "rome_json_formatter",
  "rome_json_parser",
  "rome_json_syntax",
  "rome_parser",

--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -95,15 +95,15 @@ impl Execution {
         }
     }
 
-    pub(crate) fn is_ci(&self) -> bool {
+    pub(crate) const fn is_ci(&self) -> bool {
         matches!(self.traversal_mode, TraversalMode::CI { .. })
     }
 
-    pub(crate) fn is_check(&self) -> bool {
+    pub(crate) const fn is_check(&self) -> bool {
         matches!(self.traversal_mode, TraversalMode::Check { .. })
     }
 
-    pub(crate) fn is_format(&self) -> bool {
+    pub(crate) const fn is_format(&self) -> bool {
         matches!(self.traversal_mode, TraversalMode::Format { .. })
     }
 

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -644,6 +644,14 @@ impl<'ctx, 'app> TraversalOptions<'ctx, 'app> {
     }
 }
 
+// enum CanHandle {
+//     /// Rome supports the requested operation
+//     Yes,
+//     /// Rome supports parsing the file but not the requested operation.
+//     MissingHandler,
+//
+// }
+
 impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
     fn interner(&self) -> &PathInterner {
         &self.interner

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -644,14 +644,6 @@ impl<'ctx, 'app> TraversalOptions<'ctx, 'app> {
     }
 }
 
-// enum CanHandle {
-//     /// Rome supports the requested operation
-//     Yes,
-//     /// Rome supports parsing the file but not the requested operation.
-//     MissingHandler,
-//
-// }
-
 impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
     fn interner(&self) -> &PathInterner {
         &self.interner

--- a/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
@@ -29,7 +29,7 @@ statement();
 # Emitted Messages
 
 ```block
-Formatted 1 file(s) in <TIME>
+Formatted 2 file(s) in <TIME>
 ```
 
 

--- a/crates/rome_json_formatter/src/lib.rs
+++ b/crates/rome_json_formatter/src/lib.rs
@@ -26,6 +26,8 @@ where
     N: AstNode<Language = JsonLanguage>,
 {
     fn fmt(&self, node: &N, f: &mut JsonFormatter) -> FormatResult<()> {
+        f.comments().mark_suppression_checked(node.syntax());
+
         self.fmt_fields(node, f)
     }
 

--- a/crates/rome_json_parser/src/syntax.rs
+++ b/crates/rome_json_parser/src/syntax.rs
@@ -311,7 +311,6 @@ fn parse_rest(p: &mut JsonParser, value: ParsedSyntax) {
         let range = match parse_value(p) {
             Present(value) => value.range(p),
             Absent => ParseRecovery::new(JSON_BOGUS_VALUE, VALUE_START)
-                .enable_recovery_on_line_break()
                 .recover(p)
                 .expect("Expect recovery to succeed because parser isn't at EOF nor at a value.")
                 .range(p),

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -26,6 +26,7 @@ rome_js_formatter = { path = "../rome_js_formatter", features = ["serde"] }
 rome_js_semantic = { path = "../rome_js_semantic" }
 rome_json_parser = { path = "../rome_json_parser" }
 rome_json_syntax = { path = "../rome_json_syntax" }
+rome_json_formatter = { path = "../rome_json_formatter" }
 rome_rowan = { path = "../rome_rowan", features = ["serde"] }
 rome_text_edit = { path = "../rome_text_edit" }
 indexmap = { workspace = true, features = ["serde"] }

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -53,8 +53,8 @@ pub struct JsLinterSettings {
 
 impl Language for JsLanguage {
     type FormatterSettings = JsFormatterSettings;
-    type FormatOptions = JsFormatOptions;
     type LinterSettings = JsLinterSettings;
+    type FormatOptions = JsFormatOptions;
 
     fn lookup_settings(languages: &LanguagesSettings) -> &LanguageSettings<Self> {
         &languages.javascript

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -19,19 +19,13 @@ use rome_json_syntax::{JsonLanguage, JsonRoot, JsonSyntaxNode};
 use rome_rowan::{TextRange, TextSize, TokenAtOffset};
 use tracing::debug;
 
-const JSON_SETTINGS: LanguageSettings<JsonLanguage> = LanguageSettings {
-    formatter: (),
-    linter: (),
-    globals: None,
-};
-
 impl Language for JsonLanguage {
     type FormatterSettings = ();
     type LinterSettings = ();
     type FormatOptions = JsonFormatOptions;
 
-    fn lookup_settings(_: &LanguagesSettings) -> &LanguageSettings<Self> {
-        &JSON_SETTINGS
+    fn lookup_settings(language: &LanguagesSettings) -> &LanguageSettings<Self> {
+        &language.json
     }
 
     fn resolve_format_options(

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -7,12 +7,15 @@ use crate::settings::{
 use crate::workspace::server::AnyParse;
 use crate::workspace::GetSyntaxTreeResult;
 use crate::RomeError;
-use rome_formatter::{FormatError, Printed};
+#[cfg(debug_assertions)]
+use rome_formatter::FormatError;
+use rome_formatter::Printed;
 use rome_fs::RomePath;
 use rome_json_formatter::context::JsonFormatOptions;
 use rome_json_formatter::format_node;
 use rome_json_parser::JsonParse;
 use rome_json_syntax::{JsonLanguage, JsonRoot, JsonSyntaxNode};
+#[cfg(debug_assertions)]
 use rome_rowan::{TextRange, TextSize, TokenAtOffset};
 use tracing::debug;
 
@@ -135,6 +138,7 @@ fn format(
     }
 }
 
+#[cfg(debug_assertions)]
 fn format_range(
     rome_path: &RomePath,
     parse: AnyParse,
@@ -148,6 +152,7 @@ fn format_range(
     Ok(printed)
 }
 
+#[cfg(debug_assertions)]
 fn format_on_type(
     rome_path: &RomePath,
     parse: AnyParse,

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -7,6 +7,7 @@ use rome_diagnostics::Category;
 use rome_formatter::{IndentStyle, LineWidth};
 use rome_fs::RomePath;
 use rome_js_syntax::JsLanguage;
+use rome_json_syntax::JsonLanguage;
 use std::{
     num::NonZeroU64,
     sync::{RwLock, RwLockReadGuard},
@@ -152,6 +153,7 @@ impl Default for LinterSettings {
 #[derive(Debug, Default)]
 pub struct LanguagesSettings {
     pub javascript: LanguageSettings<JsLanguage>,
+    pub json: LanguageSettings<JsonLanguage>,
 }
 
 pub trait Language: rome_rowan::Language {


### PR DESCRIPTION
## Summary

This PR enables the formatting capability for JSON for debug builds. 

Enabling the JSON formatter for debug builds is useful to integrate it into the prettier test suite (that uses `App`) and to test rome locally. 

Why not `rome_flags.is_unstable`: We may want to use the unstable flag shortly when at least some formatting is implemented. However, the formatter isn't doing any formatting yet.

## Test Plan

* Ran `rome format rome.json` in the root directory: Rome reports that the file has been formatted
* Ran `rome check rome.json`: Rome emits a diagnostic that linting isn't supported
* Ran `rome ci rome.json`: Rome reports that it checked one file
* Running any of the above commands in release mode reports that the file type isn't supported