### PR TITLE
chore(ci): centos7 ci container

### DIFF
--- a/.github/workflows/build_ci.yaml
+++ b/.github/workflows/build_ci.yaml
@@ -1,0 +1,20 @@
+name: build_ci
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'ci/**'
+
+jobs:
+  publish-to-docker:
+    name: Publish to Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Publish to Docker Hub
+        run: ./ci/publish.sh

--- a/.github/workflows/build_ci.yaml
+++ b/.github/workflows/build_ci.yaml
@@ -7,14 +7,15 @@ on:
       - 'ci/**'
 
 jobs:
-  publish-to-docker:
-    name: Publish to Docker
+  publish-container:
+    name: Publish Container
     runs-on: ubuntu-latest
     steps:
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Publish to Docker Hub
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Container
         run: ./ci/publish.sh

--- a/.github/workflows/publish_container_ci.yaml
+++ b/.github/workflows/publish_container_ci.yaml
@@ -1,5 +1,6 @@
-name: build_ci
+name: publish_container_ci
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/ci/publish.ps1
+++ b/ci/publish.ps1
@@ -1,0 +1,1 @@
+. ./publish.sh

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -1,0 +1,4 @@
+cd rome-ci-x86-64-centos7
+docker build . --tag rome-ci-x86-64-centos7:latest
+docker push rome-ci-x86-64-centos7:latest
+cd ..

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -1,4 +1,4 @@
 cd rome-ci-x86-64-centos7
-docker build . --tag rome-ci-x86-64-centos7:latest
-docker push rome-ci-x86-64-centos7:latest
+docker build . --tag ghcr.io/rome/rome-ci-x86-64-centos7:latest
+docker push ghcr.io/rome/rome-ci-x86-64-centos7:latest
 cd ..

--- a/ci/rome-ci-x86-64-centos7/Dockerfile
+++ b/ci/rome-ci-x86-64-centos7/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:centos7
+SHELL ["/bin/bash", "--login", "-c"]
+RUN yum update -y
+RUN yum install gcc gcc-c++ make openssl-devel git -y
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
+RUN nvm install 14
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN cargo install cargo-audit


### PR DESCRIPTION
## Summary

This PR creates the container need to build Rome using older glibc.
Will unblock https://github.com/rome/tools/pull/3650

## Test Plan

Thus github action in this PR should publish a container to our container domain inside github;
And we should be able to build rome using this container on PR https://github.com/rome/tools/pull/3650
Rome binary should depend on glibc 2.17.
Rome binary should run on a standard container using CentOS.
