### PR TITLE
fix(rome_js_analyze): fix noShoutyConstants with empty string

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
@@ -66,6 +66,10 @@ fn is_id_and_string_literal_inner_text_equal(
         .as_js_string_literal_expression()?;
     let literal_text = literal.inner_string_text().ok()?;
 
+	if literal_text == "" {
+		return None;
+	}
+
     for (from_id, from_literal) in id_text.chars().zip(literal_text.chars()) {
         if from_id != from_literal {
             return None;

--- a/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
@@ -66,9 +66,9 @@ fn is_id_and_string_literal_inner_text_equal(
         .as_js_string_literal_expression()?;
     let literal_text = literal.inner_string_text().ok()?;
 
-	if id_text.len() != usize::from(literal_text.len()) {
-		return None;
-	}
+    if id_text.len() != usize::from(literal_text.len()) {
+        return None;
+    }
 
     for (from_id, from_literal) in id_text.chars().zip(literal_text.chars()) {
         if from_id != from_literal || from_id.is_lowercase() {

--- a/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
@@ -71,10 +71,7 @@ fn is_id_and_string_literal_inner_text_equal(
 	}
 
     for (from_id, from_literal) in id_text.chars().zip(literal_text.chars()) {
-        if from_id != from_literal {
-            return None;
-        }
-        if from_id.is_lowercase() || from_literal.is_lowercase() {
+        if from_id != from_literal || from_id.is_lowercase() {
             return None;
         }
     }

--- a/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
@@ -66,7 +66,7 @@ fn is_id_and_string_literal_inner_text_equal(
         .as_js_string_literal_expression()?;
     let literal_text = literal.inner_string_text().ok()?;
 
-	if literal_text == "" {
+	if id_text.len() != usize::from(literal_text.len()) {
 		return None;
 	}
 

--- a/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js
+++ b/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js
@@ -36,3 +36,9 @@ export const F = NotMatching;
 
 const matchingLowercase = "matchingLowercase";
 export const G = matchingLowercase;
+
+const AL = "ALPHA"
+export const H = AL;
+
+const ALPHA = "AL"
+export const I = ALPHA;

--- a/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js
+++ b/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js
@@ -27,3 +27,12 @@ const D ="D";
 export const e = {
 	D
 };
+
+const Empty = "";
+export const E = Empty
+
+const NotMatching = "DoesNotMatch";
+export const F = NotMatching
+
+const matchingLowercase = "matchingLowercase"
+export const G = matchingLowercase

--- a/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js
+++ b/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js
@@ -29,10 +29,10 @@ export const e = {
 };
 
 const Empty = "";
-export const E = Empty
+export const E = Empty;
 
 const NotMatching = "DoesNotMatch";
-export const F = NotMatching
+export const F = NotMatching;
 
-const matchingLowercase = "matchingLowercase"
-export const G = matchingLowercase
+const matchingLowercase = "matchingLowercase";
+export const G = matchingLowercase;

--- a/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js
+++ b/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js
@@ -37,8 +37,8 @@ export const F = NotMatching;
 const matchingLowercase = "matchingLowercase";
 export const G = matchingLowercase;
 
-const AL = "ALPHA"
+const AL = "ALPHA";
 export const H = AL;
 
-const ALPHA = "AL"
+const ALPHA = "AL";
 export const I = ALPHA;

--- a/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js.snap
+++ b/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js.snap
@@ -44,10 +44,10 @@ export const F = NotMatching;
 const matchingLowercase = "matchingLowercase";
 export const G = matchingLowercase;
 
-const AL = "ALPHA"
+const AL = "ALPHA";
 export const H = AL;
 
-const ALPHA = "AL"
+const ALPHA = "AL";
 export const I = ALPHA;
 
 ```

--- a/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js.snap
+++ b/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js.snap
@@ -44,6 +44,12 @@ export const F = NotMatching;
 const matchingLowercase = "matchingLowercase";
 export const G = matchingLowercase;
 
+const AL = "ALPHA"
+export const H = AL;
+
+const ALPHA = "AL"
+export const I = ALPHA;
+
 ```
 
 # Diagnostics

--- a/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js.snap
+++ b/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js.snap
@@ -34,6 +34,16 @@ const D ="D";
 export const e = {
 	D
 };
+
+const Empty = "";
+export const E = Empty
+
+const NotMatching = "DoesNotMatch";
+export const F = NotMatching
+
+const matchingLowercase = "matchingLowercase"
+export const G = matchingLowercase
+
 ```
 
 # Diagnostics
@@ -173,6 +183,7 @@ noShoutyConstants.js:26:7 lint/style/noShoutyConstants  FIXABLE  ━━━━━
   > 28 │ 	D
        │ 	^
     29 │ };
+    30 │ 
   
   i You should avoid declaring constants with a string that's the same
         value as the variable name. It introduces a level of unnecessary
@@ -189,6 +200,7 @@ noShoutyConstants.js:26:7 lint/style/noShoutyConstants  FIXABLE  ━━━━━
        26 │ + → 
        27 │ + → D:"D"
     29 28 │   };
+    30 29 │   
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js.snap
+++ b/crates/rome_js_analyze/tests/specs/style/noShoutyConstants.js.snap
@@ -36,13 +36,13 @@ export const e = {
 };
 
 const Empty = "";
-export const E = Empty
+export const E = Empty;
 
 const NotMatching = "DoesNotMatch";
-export const F = NotMatching
+export const F = NotMatching;
 
-const matchingLowercase = "matchingLowercase"
-export const G = matchingLowercase
+const matchingLowercase = "matchingLowercase";
+export const G = matchingLowercase;
 
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #3867

## Test Plan

> cargo test -p rome_js_analyze -- shouty

With some new test cases which were missing:

```javascript
const Empty = "";
export const E = Empty;

const NotMatching = "DoesNotMatch";
export const F = NotMatching;

const matchingLowercase = "matchingLowercase";
export const G = matchingLowercase;

const AL = "ALPHA";
export const H = AL;

const ALPHA = "AL";
export const I = ALPHA;
```
