### PR TITLE
feat(rome_fs): implement permission checking in the memory filesystem

### DIFF
--- a/crates/rome_cli/tests/snap_test.rs
+++ b/crates/rome_cli/tests/snap_test.rs
@@ -241,7 +241,7 @@ impl From<SnapshotPayload<'_>> for CliSnapshot {
         } = payload;
         let mut cli_snapshot = CliSnapshot::from_result(result);
         let config_path = PathBuf::from("rome.json");
-        let configuration = fs.read(&config_path).ok();
+        let configuration = fs.open(&config_path).ok();
         if let Some(mut configuration) = configuration {
             let mut buffer = String::new();
             if configuration.read_to_string(&mut buffer).is_ok() {

--- a/crates/rome_fs/src/fs/os.rs
+++ b/crates/rome_fs/src/fs/os.rs
@@ -1,6 +1,6 @@
 //! Implementation of the [FileSystem] and related traits for the underlying OS filesystem
 use super::{BoxedTraversal, ErrorKind, File, FileSystemDiagnostic};
-use crate::fs::{FileSystemExt, OpenOptions};
+use crate::fs::OpenOptions;
 use crate::{
     fs::{TraversalContext, TraversalScope},
     FileSystem, RomePath,
@@ -21,34 +21,19 @@ pub struct OsFileSystem;
 
 impl FileSystem for OsFileSystem {
     fn open_with_options(&self, path: &Path, options: OpenOptions) -> io::Result<Box<dyn File>> {
-        let mut fs_options = fs::File::options();
-        Ok(Box::new(OsFile {
-            inner: options.into_fs_options(&mut fs_options).open(path)?,
-        }))
+        tracing::debug_span!("OsFileSystem::open_with_options", path = ?path, options = ?options)
+            .in_scope(move || -> io::Result<Box<dyn File>> {
+                let mut fs_options = fs::File::options();
+                Ok(Box::new(OsFile {
+                    inner: options.into_fs_options(&mut fs_options).open(path)?,
+                }))
+            })
     }
 
     fn traversal(&self, func: BoxedTraversal) {
         OsTraversalScope::with(move |scope| {
             func(scope);
         })
-    }
-}
-
-impl FileSystemExt for OsFileSystem {
-    fn create(&self, path: &Path) -> io::Result<Box<dyn File>> {
-        tracing::debug_span!("OsFileSystem::create", path = ?path).in_scope(
-            move || -> io::Result<Box<dyn File>> {
-                self.open_with_options(path, OpenOptions::default().write(true).create_new(true))
-            },
-        )
-    }
-
-    fn open(&self, path: &Path) -> io::Result<Box<dyn File>> {
-        tracing::debug_span!("OsFileSystem::open", path = ?path).in_scope(
-            move || -> io::Result<Box<dyn File>> {
-                self.open_with_options(path, OpenOptions::default().read(true).write(true))
-            },
-        )
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds permission checks to the `MemoryFileSystem`, so that it's no longer possible to call `read_to_string` on a file that was not open with the `read` option or `set_content` on file open with the `write` option.

I've also used the opportunity to further implement the specific behavior of the `create_new` and `truncate` flags to make sure they work the same way in both `FileSystem` implementations, and remove the `append` flag since our FileSystem API doesn't support appending content to a file anyway. 

Finally I've removed the specialized implementations of the `FileSystemExt` trait in favor of a single generic implementation over any type implementing the base trait (this is the convention for Rust extension trait as it makes it possible to use those extension methods on `&dyn FileSystem` objects for instance), and adjusted the set of methods exposed by the extension trait (and the open options they use) to align them with the creation methods exposed by `std::fs::File` to make the API more accessible to contributors familiar with the Rust standard library.

## Test Plan

I've added additional tests for the memory filesystem to ensure the newly introduced checks work as expected
