### PR TITLE
fix(js-api): fix the JS API tests

### DIFF
--- a/npm/js-api/src/index.ts
+++ b/npm/js-api/src/index.ts
@@ -89,22 +89,11 @@ export interface PrintDiagnosticsOptions {
 	verbose?: boolean;
 }
 
-// If `FinalizationRegistry` is supported, use it as a safety measure to ensure
-// Workspace instances get deallocated in case `shutdown` isn't called
-let registry: FinalizationRegistry<Workspace> | null = null;
-if (typeof FinalizationRegistry === "function") {
-	registry = new FinalizationRegistry((workspace) => {
-		workspace.free();
-	});
-}
-
 export class Rome {
 	private constructor(
 		private readonly module: WasmModule,
 		private readonly workspace: Workspace,
-	) {
-		registry?.register(this, workspace);
-	}
+	) {}
 
 	/**
 	 * It creates a new instance of the class {Rome}.
@@ -122,7 +111,6 @@ export class Rome {
 	 * unusable as calling any method on it will fail
 	 */
 	public shutdown() {
-		registry?.unregister(this);
 		this.workspace.free();
 	}
 

--- a/npm/js-api/tests/__snapshots__/lintContent.test.ts.snap
+++ b/npm/js-api/tests/__snapshots__/lintContent.test.ts.snap
@@ -30,11 +30,7 @@ exports[`Rome WebAssembly lintContent > should lint content > lint diagnostics 1
         },
         {
           "Frame": {
-            "path": {
-              "File": {
-                "FileId": 0,
-              },
-            },
+            "path": null,
             "source_code": null,
             "span": [
               6,
@@ -125,10 +121,7 @@ exports[`Rome WebAssembly lintContent > should lint content > lint diagnostics 1
     "location": {
       "path": {
         "File": {
-          "PathAndId": {
-            "file_id": 0,
-            "path": "example.js",
-          },
+          "Path": "example.js",
         },
       },
       "source_code": null,

--- a/npm/js-api/tsconfig.json
+++ b/npm/js-api/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ES2020", "ESNext.WeakRef"],
     "module": "commonjs",                                /* Specify what module code is generated. */
     "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     "declarationMap": true,                           /* Create sourcemaps for d.ts files. */


### PR DESCRIPTION
## Summary

This fixes the tests for the JS API by removing the experimental use of `FinalizationRegistry` as it caused the test runner to hang, and updating the diagnostics snapshot to account for the changes in #3843

## Test Plan

The JS API tests should now pass
