### PR TITLE
ci: Add more clippy & dependency checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,27 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-targets --verbose -- --deny warnings
+          args: --workspace --all-targets --verbose -- --deny warnings -W clippy::cargo -W clippy::dbg_macro -A clippy::cargo_common_metadata
+
+  check-dependencies:
+    name: Check Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "check"
+      - name: Install toolchain
+        run:  rustup toolchain install nightly
+      - name: Install udeps
+        run: cargo install cargo-udeps --locked
+      - name: Run udeps
+        run: cargo +nightly udeps
+
 
   test:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "check"
+          shared-key: "dependencies"
       - name: Install toolchain
         run:  rustup toolchain install nightly
       - name: Install udeps

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "check"
+          shared-key: "dependencies"
       - name: Install toolchain
         run:  rustup toolchain install nightly
       - name: Install udeps

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,12 +49,32 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-targets --verbose -- --deny warnings
+          args: --workspace --all-targets --all-features --verbose -- --deny warnings -W clippy::cargo -W clippy::dbg_macro -A clippy::cargo_common_metadata
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --workspace --all-targets --release
+          args: --workspace --all-targets --all-features --release
+
+  check-dependencies:
+    name: Check Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "check"
+      - name: Install toolchain
+        run:  rustup toolchain install nightly
+      - name: Install udeps
+        run: cargo install cargo-udeps --locked
+      - name: Run udeps
+        run: cargo +nightly udeps
+
 
   test:
     name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_rgb"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,7 +138,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde",
 ]
 
 [[package]]
@@ -193,14 +198,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
+ "clap_lex",
+ "indexmap",
  "textwrap",
- "unicode-width",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -260,15 +302,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
+ "ciborium",
  "clap",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -277,7 +320,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -286,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -361,28 +403,6 @@ checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -856,12 +876,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
@@ -1093,6 +1107,12 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -2031,16 +2051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,7 +2078,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -2100,7 +2110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50845f68d5c693aac7d72a25415ddd21cb8182c04eafe447b73af55a05f9e1b"
 dependencies = [
  "indexmap",
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -2234,12 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -2303,7 +2310,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "libc",
  "num_threads",
 ]
@@ -2997,6 +3004,7 @@ dependencies = [
  "qp-trie",
  "regex",
  "rome_js_analyze",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,7 +3004,6 @@ dependencies = [
  "qp-trie",
  "regex",
  "rome_js_analyze",
- "smallvec",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-dbg-in-tests = true

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -43,7 +43,7 @@
 //! In the example, this only is the `|| happy`.
 //!
 //! Thus, the first group is: `[Left(some && thing && elsewhere), Right(|| happy)]`. The formatting formats the left side
-//! as is (the call will recurse into the [JsAnyBinaryLikeExpression] formatting again) but formats the operator with the right side.
+//! as is (the call will recurse into the [AnyJsBinaryLikeExpression] formatting again) but formats the operator with the right side.
 //!
 //! Now, let's see how the implementation groups the `some && thing && elsewhere`. It first traverses to the left most binary like expression,
 //! which is `some && thing`. It then adds this as a `Left` side to the group. From here, the algorithm traverses upwards and adds all right sides
@@ -167,7 +167,7 @@ impl Format<JsFormatContext> for AnyJsBinaryLikeExpression {
 
 /// Creates a [BinaryLeftOrRightSide::Left] for the first left hand side that:
 /// * isn't a [JsBinaryLikeExpression]
-/// * is a [JsBinaryLikeExpression] but it should be formatted as its own group (see [JsAnyBinaryLikeExpression::can_flatten]).
+/// * is a [JsBinaryLikeExpression] but it should be formatted as its own group (see [AnyJsBinaryLikeExpression::can_flatten]).
 ///
 /// It then traverses upwards from the left most node and creates [BinaryLikeLeftOrRightSide::Right]s for
 /// every [JsBinaryLikeExpression] until it reaches the root again.
@@ -569,7 +569,7 @@ impl NeedsParentheses for AnyJsBinaryLikeExpression {
     }
 }
 
-/// Implements the rules when a node needs parentheses that are common across all [JsAnyBinaryLikeExpression] nodes.
+/// Implements the rules when a node needs parentheses that are common across all [AnyJsBinaryLikeExpression] nodes.
 pub(crate) fn needs_binary_like_parentheses(
     node: &AnyJsBinaryLikeExpression,
     parent: &JsSyntaxNode,
@@ -642,7 +642,7 @@ pub(crate) fn needs_binary_like_parentheses(
 }
 
 declare_node_union! {
-    /// Union type for any valid left hand side of a [JsAnyBinaryLikeExpression].
+    /// Union type for any valid left hand side of a [AnyJsBinaryLikeExpression].
     pub(crate) AnyJsBinaryLikeLeftExpression = AnyJsExpression | JsPrivateName
 }
 
@@ -771,8 +771,8 @@ enum VisitEvent {
     Exit(AnyJsBinaryLikeExpression),
 }
 
-/// Iterator that visits [JsAnyBinaryLikeExpression]s in pre-order.
-/// This is similar to [JsSyntaxNode::descendants] but it only traverses into [JsAnyBinaryLikeExpression] and their left side
+/// Iterator that visits [AnyJsBinaryLikeExpression]s in pre-order.
+/// This is similar to [JsSyntaxNode::descendants] but it only traverses into [AnyJsBinaryLikeExpression] and their left side
 /// (the right side is never visited).
 ///
 /// # Examples
@@ -805,7 +805,7 @@ enum VisitEvent {
 ///
 /// Notice how the iterator doesn't yield events for the terminal identifiers `a`, `b`, `c`, `d`, and `e`,
 /// nor for the right hand side expression `d && e`. This is because the visitor only traverses into
-/// [JsAnyBinaryLikeExpression]s and of those, only along the left side.
+/// [AnyJsBinaryLikeExpression]s and of those, only along the left side.
 struct BinaryLikePreorder {
     /// The next node to visit or [None] if the iterator passed the start node (is at its end).
     next: Option<VisitEvent>,

--- a/crates/rome_js_syntax/src/expr_ext.rs
+++ b/crates/rome_js_syntax/src/expr_ext.rs
@@ -821,14 +821,14 @@ impl JsCallExpression {
         is_optional_chain(self.clone().into())
     }
 
-    /// Get [JsAnyCallArgument] by it index inside the [JsCallExpression] argument list.
+    /// Get [AnyJsCallArgument] by it index inside the [JsCallExpression] argument list.
     ///
     /// Each index inside "indices" should be unique.
     /// "indices" must be sorted.
     ///
     /// Supports maximum of 16 indices to avoid stack overflow. Eeach argument will consume:
     ///
-    /// - 8 bytes for the [Option<JsAnyCallArgument>] result;
+    /// - 8 bytes for the [Option<AnyJsCallArgument>] result;
     /// - 8 bytes for the [usize] argument.
     pub fn get_arguments_by_index<const N: usize>(
         &self,

--- a/crates/rome_js_syntax/src/union_ext.rs
+++ b/crates/rome_js_syntax/src/union_ext.rs
@@ -109,7 +109,7 @@ impl AnyJsClassMember {
         }
     }
 
-    /// Tests if the member has a [`JsLiteralMemberName](rome_js_syntax::JsLiteralMemberName) of `name`.
+    /// Tests if the member has a [`JsLiteralMemberName`](rome_js_syntax::JsLiteralMemberName) of `name`.
     pub fn has_name(&self, name: &str) -> SyntaxResult<bool> {
         match self.name()? {
             Some(AnyJsClassMemberName::JsLiteralMemberName(literal)) => {

--- a/crates/rome_js_syntax/src/union_ext.rs
+++ b/crates/rome_js_syntax/src/union_ext.rs
@@ -109,7 +109,7 @@ impl AnyJsClassMember {
         }
     }
 
-    /// Tests if the member has a [JsLiteralMemberName] of `name`.
+    /// Tests if the member has a [`JsLiteralMemberName](rome_js_syntax::JsLiteralMemberName) of `name`.
     pub fn has_name(&self, name: &str) -> SyntaxResult<bool> {
         match self.name()? {
             Some(AnyJsClassMemberName::JsLiteralMemberName(literal)) => {

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -22,7 +22,7 @@ rome_js_analyze = { path = "../../crates/rome_js_analyze"}
 
 pico-args = { version = "0.5.0", features=["eq-separator"] }
 timing = "0.2.3"
-criterion = "0.3.5"
+criterion = "0.4.0"
 regex = "1.5.5"
 ureq = "2.4.0"
 url = "2.2.2"

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -16,7 +16,7 @@ ureq = "2.4.0"
 git2 = { version = "0.15.0", default-features = false }
 filetime = "0.2.15"
 case = "1.0.0"
-pulldown-cmark = { version = "0.9", default-features = false }
+pulldown-cmark = { version = "0.9", default-features = false, optional = true }
 
 rome_rowan = { path = "../../crates/rome_rowan", optional = true }
 rome_analyze = { path = "../../crates/rome_analyze", optional = true }
@@ -31,6 +31,6 @@ serde_json = { version = "1.0.74", optional = true }
 rome_service = { path = "../../crates/rome_service", features = ["schemars"], optional = true }
 
 [features]
-configuration = ["rome_analyze", "rome_js_analyze", "rome_js_syntax"]
+configuration = ["rome_analyze", "rome_js_analyze", "rome_js_syntax", "pulldown-cmark"]
 aria = ["rome_aria"]
 schema = ["schemars", "serde_json", "rome_rowan", "rome_service", "rome_js_syntax", "rome_js_factory", "rome_js_formatter"]

--- a/xtask/codegen/src/generate_aria.rs
+++ b/xtask/codegen/src/generate_aria.rs
@@ -73,14 +73,14 @@ fn generate_roles() -> TokenStream {
     }
 }
 
-fn generate_enums<'a>(len: usize, array: std::slice::Iter<&str>, enum_name: &str) -> TokenStream {
+fn generate_enums(len: usize, array: std::slice::Iter<&str>, enum_name: &str) -> TokenStream {
     let enum_name = Ident::new(enum_name, Span::call_site());
     let mut enum_metadata = Vec::with_capacity(len);
     let mut from_enum_metadata = Vec::with_capacity(len);
     let mut from_string_metadata = Vec::with_capacity(len);
     for property in array {
         let name = Ident::new(
-            &property.replace("-", "_").to_camel().to_string(),
+            &property.replace('-', "_").to_camel().to_string(),
             Span::call_site(),
         );
         let property = Literal::string(property);

--- a/xtask/codegen/src/generate_aria.rs
+++ b/xtask/codegen/src/generate_aria.rs
@@ -79,20 +79,15 @@ fn generate_enums(len: usize, array: std::slice::Iter<&str>, enum_name: &str) ->
     let mut from_enum_metadata = Vec::with_capacity(len);
     let mut from_string_metadata = Vec::with_capacity(len);
     for property in array {
-        let name = Ident::new(
-            &property.replace('-', "_").to_camel().to_string(),
-            Span::call_site(),
-        );
+        let name = Ident::new(&property.replace('-', "_").to_camel(), Span::call_site());
         let property = Literal::string(property);
-        enum_metadata.push(quote! {
-            #name
-        });
         from_enum_metadata.push(quote! {
             #enum_name::#name => #property
         });
         from_string_metadata.push(quote! {
             #property => Ok(#enum_name::#name)
-        })
+        });
+        enum_metadata.push(name);
     }
 
     from_string_metadata.push(quote! {

--- a/xtask/libs_bench/Cargo.toml
+++ b/xtask/libs_bench/Cargo.toml
@@ -5,14 +5,17 @@ edition = "2021"
 publish = false
 
 [dependencies]
+regex = { version = "1.6.0" }
+smallvec = "1.10.0"
+
+[dev-dependencies]
 rome_js_analyze = { path = "../../crates/rome_js_analyze" }
 case = "1.0.0"
 fastbloom-rs = "0.3.0"
 qp-trie = "0.8.0"
 fst = "0.4.7"
-criterion = "0.3.5"
+criterion = "0.4.0"
 memchr = "2.5.0"
-regex = { version = "1.6.0" }
 iai = "0.1.1"
 
 [[bench]]

--- a/xtask/libs_bench/Cargo.toml
+++ b/xtask/libs_bench/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 regex = { version = "1.6.0" }
-smallvec = "1.10.0"
 
 [dev-dependencies]
 rome_js_analyze = { path = "../../crates/rome_js_analyze" }


### PR DESCRIPTION
## Summary
* Enables the clippy cargo checks
* Disallows the use of `dbg` in non-test code
* Adds a check for unused dependencies

## Test Plan

* [Run with an unused dependency](https://github.com/rome/tools/actions/runs/3572501737/jobs/6005462718)
