### PR TITLE
feat(rome_js_analyze): sort imports using natural ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1675,7 @@ dependencies = [
  "insta",
  "json_comments",
  "lazy_static",
+ "natord",
  "roaring",
  "rome_analyze",
  "rome_aria",

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -21,6 +21,7 @@ rustc-hash = { workspace = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["raw_value"] }
 lazy_static = "1.4.0"
+natord = "1.0.9"
 
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }

--- a/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -19,7 +19,8 @@ use rome_rowan::{
 use crate::JsRuleAction;
 
 declare_rule! {
-    /// Provides a whole-source code action to sort the imports in the file alphabetically
+    /// Provides a whole-source code action to sort the imports in the file
+    /// using natural ordering
     ///
     /// ## Examples
     ///
@@ -273,7 +274,7 @@ struct ImportGroup {
     /// The import that was at the start of the group before sorting
     first_node: JsImport,
     /// Multimap storing all the imports for each import source in the group,
-    /// sorted in alphabetical order
+    /// sorted in natural order
     nodes: BTreeMap<ImportKey, Vec<JsImport>>,
 }
 
@@ -281,7 +282,7 @@ impl ImportGroup {
     /// Returns true if the nodes in the group are already sorted in the file
     fn is_sorted(&self) -> bool {
         // The imports are sorted if the start of each node in the `BTreeMap`
-        // (sorted alphabetically) is higher or equal to the previous item in
+        // (sorted in natural order) is higher or equal to the previous item in
         // the sequence
         let mut iter = self
             .nodes
@@ -307,9 +308,8 @@ struct ImportKey(SyntaxTokenText);
 
 impl Ord for ImportKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Sort imports alphabetically by defering to the string ordering logic
-        // of the standard library
-        (*self.0).cmp(&*other.0)
+        // Sort imports using natural ordering
+        natord::compare(&self.0, &other.0)
     }
 }
 

--- a/crates/rome_js_analyze/tests/specs/correctness/organizeImports/natural-sort.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/organizeImports/natural-sort.js
@@ -1,0 +1,5 @@
+import a1 from 'a1';
+import a10 from 'a10';
+import a100 from 'a100';
+import a2 from 'a2';
+import a20 from 'a20';

--- a/crates/rome_js_analyze/tests/specs/correctness/organizeImports/natural-sort.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/organizeImports/natural-sort.js.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: natural-sort.js
+---
+# Input
+```js
+import a1 from 'a1';
+import a10 from 'a10';
+import a100 from 'a100';
+import a2 from 'a2';
+import a20 from 'a20';
+
+```
+
+# Actions
+```diff
+@@ -1,5 +1,5 @@
+ import a1 from 'a1';
++import a2 from 'a2';
+ import a10 from 'a10';
++import a20 from 'a20';
+ import a100 from 'a100';
+-import a2 from 'a2';
+-import a20 from 'a20';
+
+```
+
+


### PR DESCRIPTION
## Summary

This change the sorting algorithm using by the `organizeImports` action to use natural ordering (provided by the `natord` crate) instead of alphabetical ordering.

## Test Plan

I've added an additional test case demonstrating the new ordering.
