### PR TITLE
fix(playground): Script Type

### DIFF
--- a/website/src/playground/utils.ts
+++ b/website/src/playground/utils.ts
@@ -275,7 +275,12 @@ export function classnames(...names: (undefined | boolean | string)[]): string {
 }
 
 export function isTypeScriptFilename(filename: string): boolean {
-	return filename.endsWith(".ts") || filename.endsWith(".tsx");
+	return (
+		filename.endsWith(".ts") ||
+		filename.endsWith(".tsx") ||
+		filename.endsWith(".mts") ||
+		filename.endsWith(".cts")
+	);
 }
 
 export function isJSXFilename(filename: string): boolean {
@@ -283,7 +288,16 @@ export function isJSXFilename(filename: string): boolean {
 }
 
 export function isScriptFilename(filename: string): boolean {
-	return filename.endsWith(".js");
+	return filename.endsWith(".cjs") || filename.endsWith(".cts");
+}
+
+export function isModuleFilename(filename: string): boolean {
+	return (
+		filename.endsWith(".mjs") ||
+		filename.endsWith(".mts") ||
+		filename.endsWith(".js") ||
+		filename.endsWith(".ts")
+	);
 }
 
 export function modifyFilename(
@@ -307,9 +321,9 @@ export function getExtension(opts: ExtensionOptions): string {
 	let ext = "";
 
 	if (opts.script) {
-		ext = "js";
+		ext = "cjs";
 	} else {
-		ext = "mjs";
+		ext = "js";
 	}
 
 	if (opts.typescript) {
@@ -328,6 +342,7 @@ export function getExtension(opts: ExtensionOptions): string {
 export function isValidExtension(filename: string): boolean {
 	return (
 		isScriptFilename(filename) ||
+		isModuleFilename(filename) ||
 		isTypeScriptFilename(filename) ||
 		isJSXFilename(filename)
 	);


### PR DESCRIPTION


## Summary

This PR fixes the Source Type `Script` option on the playground.

The issue is that Rome only parses `cjs` and `cts` files as scripts and all other extensions as modules. This PR updates the playground's extension mapping to correctly use `cjs` and `cts` for scripts


