### PR TITLE
feature(rome_js_analyze): implement import sorting for named specifiers

### DIFF
--- a/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -487,7 +487,7 @@ impl ImportNode {
                     let will_need_newline = sep
                         .trailing_trivia()
                         .last()
-                        .map(|piece| matches!(piece.kind(), TriviaPieceKind::SingleLineComment))
+                        .map(|piece| piece.kind().is_single_line_comment())
                         .unwrap_or(false);
 
                     (sep.clone(), will_need_newline)

--- a/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -262,7 +262,7 @@ impl Rule for OrganizeImports {
         Some(JsRuleAction {
             category: ActionCategory::Source(SourceActionKind::OrganizeImports),
             applicability: Applicability::MaybeIncorrect,
-            message: markup! { "Organize Imports" }.to_owned(),
+            message: markup! { "Organize Imports (Rome)" }.to_owned(),
             mutation,
         })
     }

--- a/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -1,6 +1,8 @@
 use std::{
+    cell::Cell,
     cmp::Ordering,
     collections::{btree_map::Entry, BTreeMap},
+    iter::once,
     mem::take,
 };
 
@@ -10,10 +12,13 @@ use rome_analyze::{
 use rome_console::markup;
 use rome_diagnostics::Applicability;
 use rome_js_factory::make;
-use rome_js_syntax::{AnyJsImportClause, AnyJsModuleItem, JsImport, JsLanguage, JsModule};
+use rome_js_syntax::{
+    AnyJsImportClause, AnyJsModuleItem, AnyJsNamedImport, AnyJsNamedImportSpecifier, JsImport,
+    JsLanguage, JsModule, JsSyntaxToken, TextRange, TriviaPieceKind, T,
+};
 use rome_rowan::{
-    syntax::SyntaxTrivia, AstNode, AstNodeExt, AstNodeList, BatchMutationExt, SyntaxTokenText,
-    SyntaxTriviaPiece,
+    syntax::SyntaxTrivia, AstNode, AstNodeExt, AstNodeList, AstSeparatedList, BatchMutationExt,
+    SyntaxTokenText, SyntaxTriviaPiece, TriviaPiece,
 };
 
 use crate::JsRuleAction;
@@ -106,10 +111,10 @@ impl Rule for OrganizeImports {
             let key = source.inner_string_text().ok()?;
             match nodes.entry(ImportKey(key)) {
                 Entry::Vacant(entry) => {
-                    entry.insert(vec![import]);
+                    entry.insert(vec![ImportNode::from(import)]);
                 }
                 Entry::Occupied(mut entry) => {
-                    entry.get_mut().push(import);
+                    entry.get_mut().push(ImportNode::from(import));
                 }
             }
         }
@@ -192,7 +197,7 @@ impl Rule for OrganizeImports {
                 .flat_map(|nodes| nodes.iter())
                 .enumerate();
 
-            for (node_index, node) in nodes_iter {
+            for (node_index, import_node) in nodes_iter {
                 // For each node in the group, pop an item from the old list
                 // iterator (ignoring `item` itself) and discard it
                 if node_index > 0 {
@@ -200,8 +205,8 @@ impl Rule for OrganizeImports {
                         .unwrap_or_else(|| panic!("mising node {item_slot} {node_index}"));
                 }
 
-                let first_token = node.import_token().ok()?;
-                let mut node = node.clone().detach();
+                let first_token = import_node.node.import_token().ok()?;
+                let mut node = import_node.build_sorted_node();
 
                 if node_index == 0 && group_first_token != first_token {
                     // If this node was not previously in the leading position
@@ -275,7 +280,7 @@ struct ImportGroup {
     first_node: JsImport,
     /// Multimap storing all the imports for each import source in the group,
     /// sorted in natural order
-    nodes: BTreeMap<ImportKey, Vec<JsImport>>,
+    nodes: BTreeMap<ImportKey, Vec<ImportNode>>,
 }
 
 impl ImportGroup {
@@ -284,11 +289,99 @@ impl ImportGroup {
         // The imports are sorted if the start of each node in the `BTreeMap`
         // (sorted in natural order) is higher or equal to the previous item in
         // the sequence
+        let mut iter = self.nodes.values().flat_map(|nodes| nodes.iter());
+
+        let import_node = match iter.next() {
+            Some(node) => node,
+            None => return true,
+        };
+
+        if !import_node.is_sorted() {
+            return false;
+        }
+
+        let mut last = import_node.node.syntax().text_range().start();
+        iter.all(|import_node| {
+            let start = import_node.node.syntax().text_range().start();
+            if start < last {
+                return false;
+            }
+
+            // Only return false if the node has been fully inspected and was
+            // found to be unsorted, but continue visiting the remaining
+            // imports if the node was sorted or contained syntax errors
+            if !import_node.is_sorted() {
+                return false;
+            }
+
+            last = start;
+            true
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ImportNode {
+    /// The original `JsImport` node this import node was created from
+    node: JsImport,
+    /// The number of separators present in the named specifiers list of this node if it has one
+    separator_count: usize,
+    /// Map storing all the named import specifiers and their associated trailing separator,
+    /// sorted in natural order
+    specifiers: BTreeMap<ImportKey, (AnyJsNamedImportSpecifier, Option<JsSyntaxToken>)>,
+}
+
+impl From<JsImport> for ImportNode {
+    fn from(node: JsImport) -> Self {
+        let import_clause = node.import_clause().ok();
+
+        let mut separator_count = 0;
+        let specifiers = import_clause.and_then(|import_clause| {
+            let import_named_clause = match import_clause {
+                AnyJsImportClause::JsImportBareClause(_)
+                | AnyJsImportClause::JsImportDefaultClause(_)
+                | AnyJsImportClause::JsImportNamespaceClause(_) => return None,
+                AnyJsImportClause::JsImportNamedClause(import_clause) => import_clause,
+            };
+
+            let named_import = import_named_clause.named_import().ok()?;
+            let named_import_specifiers = match named_import {
+                AnyJsNamedImport::JsNamespaceImportSpecifier(_) => return None,
+                AnyJsNamedImport::JsNamedImportSpecifiers(named_import_specifiers) => {
+                    named_import_specifiers
+                }
+            };
+
+            let mut result = BTreeMap::new();
+
+            for element in named_import_specifiers.specifiers().elements() {
+                let node = element.node.ok()?;
+                let key = import_specifier_name(&node)?;
+
+                let trailing_separator = element.trailing_separator.ok()?;
+                separator_count += usize::from(trailing_separator.is_some());
+
+                result.insert(ImportKey(key), (node, trailing_separator));
+            }
+
+            Some(result)
+        });
+
+        Self {
+            node,
+            separator_count,
+            specifiers: specifiers.unwrap_or_default(),
+        }
+    }
+}
+
+impl ImportNode {
+    /// Returns `true` if the named import specifiers of this import node are sorted
+    fn is_sorted(&self) -> bool {
         let mut iter = self
-            .nodes
+            .specifiers
             .values()
-            .flat_map(|nodes| nodes.iter())
-            .map(|node| node.syntax().text_range().start());
+            .map(|(node, _)| node.syntax().text_range().start());
 
         let mut last = match iter.next() {
             Some(last) => last,
@@ -296,11 +389,266 @@ impl ImportGroup {
         };
 
         iter.all(|value| {
-            let result = value >= last;
+            if value < last {
+                return false;
+            }
+
             last = value;
-            result
+            true
         })
     }
+
+    /// Build a clone of the original node this import node was created from with its import specifiers sorted
+    fn build_sorted_node(&self) -> JsImport {
+        let import = self.node.clone().detach();
+
+        let import_clause = import.import_clause();
+        let import_named_clause =
+            if let Ok(AnyJsImportClause::JsImportNamedClause(node)) = import_clause {
+                node
+            } else {
+                return import;
+            };
+
+        let named_import = import_named_clause.named_import();
+        let old_specifiers =
+            if let Ok(AnyJsNamedImport::JsNamedImportSpecifiers(node)) = named_import {
+                node
+            } else {
+                return import;
+            };
+
+        let element_count = self.specifiers.len();
+        let last_element = element_count.saturating_sub(1);
+        let separator_count = self.separator_count.max(last_element);
+        let needs_newline: Cell<Option<Option<JsSyntaxToken>>> = Cell::new(None);
+
+        let items = self
+            .specifiers
+            .values()
+            .enumerate()
+            .map(|(index, (node, sep))| {
+                let is_last = index == last_element;
+
+                let mut node = node.clone().detach();
+                let prev_token = match node.syntax().last_token() {
+                    Some(last_token) => last_token,
+                    None => return node,
+                };
+
+                if let Some(sep) = sep {
+                    if is_last && separator_count == last_element {
+                        // If this is the last item and we are removing its trailing separator,
+                        // move the trailing trivia from the separator to the node
+                        let next_token = prev_token.with_trailing_trivia(exact_chain(
+                            trivia_iter(&prev_token, TriviaPosition::Trailing),
+                            trivia_iter(sep, TriviaPosition::Trailing),
+                        ));
+
+                        node = node
+                            .replace_token_discard_trivia(prev_token, next_token)
+                            .expect("prev_token should be a child of node");
+                    }
+                } else if !is_last {
+                    // If the node has no separator and this is not the last item,
+                    // remove the trailing trivia since it will get cloned on the inserted separator
+                    let next_token = prev_token.with_trailing_trivia([]);
+                    node = node
+                        .replace_token_discard_trivia(prev_token, next_token)
+                        .expect("prev_token should be a child of node");
+                }
+
+                // Check if the last separator we emitted ended with a single-line comment
+                if let Some(newline_source) = needs_newline.take() {
+                    if let Some(first_token) = node.syntax().first_token() {
+                        if let Some(new_token) =
+                            prepend_leading_newline(&first_token, newline_source)
+                        {
+                            node = node
+                                .replace_token_discard_trivia(first_token, new_token)
+                                .expect("first_token should be a child of node");
+                        }
+                    }
+                }
+
+                node
+            });
+
+        let separators = self
+            .specifiers
+            .values()
+            .take(separator_count)
+            .map(|(node, sep)| {
+                // If this entry has an associated separator, reuse it
+                let (token, will_need_newline) = if let Some(sep) = sep {
+                    // If the last trivia piece for the separator token is a single-line comment,
+                    // signal to the items iterator it will need to prepend a newline to the leading
+                    // trivia of the next node
+                    let will_need_newline = sep
+                        .trailing_trivia()
+                        .last()
+                        .map(|piece| matches!(piece.kind(), TriviaPieceKind::SingleLineComment))
+                        .unwrap_or(false);
+
+                    (sep.clone(), will_need_newline)
+                } else {
+                    // If the node we're attaching this separator to has no trailing trivia, just create a simple comma token
+                    let last_trailing_trivia = match node.syntax().last_trailing_trivia() {
+                        Some(trivia) if !trivia.is_empty() => trivia,
+                        _ => return make::token(T![,]),
+                    };
+
+                    // Otherwise we need to clone the trailing trivia from the node to the separator
+                    // (the items iterator should have already filtered this trivia when it previously
+                    // emitted the node)
+                    let mut text = String::from(",");
+                    let mut trailing = Vec::with_capacity(last_trailing_trivia.pieces().len());
+
+                    let mut will_need_newline = false;
+                    for piece in last_trailing_trivia.pieces() {
+                        text.push_str(piece.text());
+                        trailing.push(TriviaPiece::new(piece.kind(), piece.text_len()));
+                        will_need_newline =
+                            matches!(piece.kind(), TriviaPieceKind::SingleLineComment);
+                    }
+
+                    let token = JsSyntaxToken::new_detached(T![,], &text, [], trailing);
+                    (token, will_need_newline)
+                };
+
+                // If the last trivia piece was a single-line comment, signal to the items iterator
+                // it will need to prepend a newline to the leading trivia of the next node, and provide
+                // it the token that followed this separator in the original source so the newline trivia
+                // can be cloned from there
+                let newline_source =
+                    will_need_newline.then(|| sep.as_ref().and_then(|token| token.next_token()));
+
+                needs_newline.set(newline_source);
+
+                token
+            });
+
+        let mut new_specifiers = old_specifiers
+            .clone()
+            .detach()
+            .with_specifiers(make::js_named_import_specifier_list(items, separators));
+
+        // If the separators iterator has a pending newline, prepend it to closing curly token
+        if let Some(newline_source) = needs_newline.into_inner() {
+            let new_token = new_specifiers
+                .r_curly_token()
+                .ok()
+                .and_then(|token| prepend_leading_newline(&token, newline_source));
+
+            if let Some(new_token) = new_token {
+                new_specifiers = new_specifiers.with_r_curly_token(new_token);
+            }
+        }
+
+        import
+            .replace_node_discard_trivia(old_specifiers, new_specifiers)
+            .expect("old_specifiers should be a child of import")
+    }
+}
+
+/// Return the name associated with a given named import specifier
+///
+/// Currently named import specifiers are sorted using their import name,
+/// not the local name they get imported as
+fn import_specifier_name(import_specifier: &AnyJsNamedImportSpecifier) -> Option<SyntaxTokenText> {
+    let token = match import_specifier {
+        AnyJsNamedImportSpecifier::JsNamedImportSpecifier(import_specifier) => {
+            import_specifier.name().ok()?.value().ok()?
+        }
+        AnyJsNamedImportSpecifier::JsShorthandNamedImportSpecifier(import_specifier) => {
+            import_specifier
+                .local_name()
+                .ok()?
+                .as_js_identifier_binding()?
+                .name_token()
+                .ok()?
+        }
+        AnyJsNamedImportSpecifier::JsBogusNamedImportSpecifier(_) => return None,
+    };
+
+    Some(token.token_text_trimmed())
+}
+
+/// Return a clone of `prev_token` with a newline trivia piece prepended to its
+/// leading trivia if it didn't have one already. This function will try to copy
+/// the newline trivia piece from the leading trivia of `newline_source` if its set
+fn prepend_leading_newline(
+    prev_token: &JsSyntaxToken,
+    newline_source: Option<JsSyntaxToken>,
+) -> Option<JsSyntaxToken> {
+    // Check if this node already starts with a newline,
+    // if it does we don't need to prepend anything
+    let leading_trivia = prev_token.leading_trivia();
+    let has_leading_newline = leading_trivia
+        .first()
+        .map(|piece| piece.is_newline())
+        .unwrap_or(false);
+
+    if has_leading_newline {
+        return None;
+    }
+
+    // Extract the leading newline from the `newline_source` token
+    let leading_newline = newline_source.and_then(|newline_source| {
+        let leading_trivia = newline_source.leading_trivia();
+        let leading_piece = leading_trivia.first()?;
+
+        if !leading_piece.is_newline() {
+            return None;
+        }
+
+        Some(leading_piece)
+    });
+
+    // Prepend a newline trivia piece to the node, either by copying the leading newline
+    // and whitespace from `newline_source`, or falling back to the "\n" character
+    let leading_newline = if let Some(leading_newline) = &leading_newline {
+        (leading_newline.kind(), leading_newline.text())
+    } else {
+        (TriviaPieceKind::Newline, "\n")
+    };
+
+    let piece_count = 1 + leading_trivia.pieces().len();
+    let mut iter = once(leading_newline).chain(trivia_iter(prev_token, TriviaPosition::Leading));
+
+    Some(prev_token.with_leading_trivia((0..piece_count).map(|_| iter.next().unwrap())))
+}
+
+enum TriviaPosition {
+    Leading,
+    Trailing,
+}
+
+/// Builds an iterator over the leading or trailing trivia pieces of a token
+///
+/// The items of the iterator inherit their lifetime from the token,
+/// rather than the trivia pieces themselves
+fn trivia_iter(
+    token: &JsSyntaxToken,
+    position: TriviaPosition,
+) -> impl Iterator<Item = (TriviaPieceKind, &str)> + ExactSizeIterator {
+    let token_text = token.text();
+    let token_range = token.text_range();
+
+    let trivia = match position {
+        TriviaPosition::Leading => token.leading_trivia(),
+        TriviaPosition::Trailing => token.trailing_trivia(),
+    };
+
+    trivia.pieces().map(move |piece| {
+        let piece_range = piece.text_range();
+        let range = TextRange::at(piece_range.start() - token_range.start(), piece_range.len());
+
+        let text = &token_text[range];
+        assert_eq!(text, piece.text());
+
+        (piece.kind(), text)
+    })
 }
 
 #[derive(Debug)]

--- a/crates/rome_js_analyze/tests/specs/correctness/organizeImports/namedSpecifiers.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/organizeImports/namedSpecifiers.js
@@ -1,0 +1,54 @@
+import { a1, a3, a5, a2, a4 } from 'a';
+
+import { b1 /* comment 1 */, b3 /* comment 3 */, b5 /* comment 5 */, b2 /* comment 2 */, b4 /* comment 4 */, } from 'b';
+
+import { c1, /* comment 1 */ c3, /* comment 3 */ c5, /* comment 5 */ c2, /* comment 2 */ c4, /* comment 4 */ } from 'c';
+
+import { d1 /* comment 1 */, d3 /* comment 3 */, d5 /* comment 5 */, d2 /* comment 2 */, d4 /* comment 4 */ } from 'd';
+
+import {
+    e1,
+    e3,
+    e5,
+    e2,
+    e4,
+} from 'e';
+
+import {
+    f1,
+    f3,
+    f5,
+    f2,
+    f4
+} from 'f';
+
+import {
+    g1, // comment 1
+    g3, // comment 3
+    g5, // comment 5
+    g2, // comment 2
+    g4, // comment 4
+} from 'g';
+
+import {
+    h1, // comment 1
+    h3, // comment 3
+    h5, // comment 5
+    h2, // comment 2
+    h4 // comment 4
+} from 'h';
+
+import {
+    i5, i4, i6, // comment 6
+    i2, i1, i3, // comment 3
+} from 'i';
+
+import {
+    j1, /* comment 1 */ j3 /* comment 3 */,
+    j2, // comment 2
+} from 'j';
+
+import {
+    k1, /* comment 1 */
+    k3, // comment 3
+    k2, /* comment 2 */ } from 'k';

--- a/crates/rome_js_analyze/tests/specs/correctness/organizeImports/namedSpecifiers.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/organizeImports/namedSpecifiers.js.snap
@@ -1,0 +1,146 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: namedSpecifiers.js
+---
+# Input
+```js
+import { a1, a3, a5, a2, a4 } from 'a';
+
+import { b1 /* comment 1 */, b3 /* comment 3 */, b5 /* comment 5 */, b2 /* comment 2 */, b4 /* comment 4 */, } from 'b';
+
+import { c1, /* comment 1 */ c3, /* comment 3 */ c5, /* comment 5 */ c2, /* comment 2 */ c4, /* comment 4 */ } from 'c';
+
+import { d1 /* comment 1 */, d3 /* comment 3 */, d5 /* comment 5 */, d2 /* comment 2 */, d4 /* comment 4 */ } from 'd';
+
+import {
+    e1,
+    e3,
+    e5,
+    e2,
+    e4,
+} from 'e';
+
+import {
+    f1,
+    f3,
+    f5,
+    f2,
+    f4
+} from 'f';
+
+import {
+    g1, // comment 1
+    g3, // comment 3
+    g5, // comment 5
+    g2, // comment 2
+    g4, // comment 4
+} from 'g';
+
+import {
+    h1, // comment 1
+    h3, // comment 3
+    h5, // comment 5
+    h2, // comment 2
+    h4 // comment 4
+} from 'h';
+
+import {
+    i5, i4, i6, // comment 6
+    i2, i1, i3, // comment 3
+} from 'i';
+
+import {
+    j1, /* comment 1 */ j3 /* comment 3 */,
+    j2, // comment 2
+} from 'j';
+
+import {
+    k1, /* comment 1 */
+    k3, // comment 3
+    k2, /* comment 2 */ } from 'k';
+
+```
+
+# Actions
+```diff
+@@ -1,54 +1,57 @@
+-import { a1, a3, a5, a2, a4 } from 'a';
++import { a1, a2, a3, a4, a5 } from 'a';
+ 
+-import { b1 /* comment 1 */, b3 /* comment 3 */, b5 /* comment 5 */, b2 /* comment 2 */, b4 /* comment 4 */, } from 'b';
++import { b1 /* comment 1 */, b2 /* comment 2 */, b3 /* comment 3 */, b4 /* comment 4 */, b5 /* comment 5 */, } from 'b';
+ 
+-import { c1, /* comment 1 */ c3, /* comment 3 */ c5, /* comment 5 */ c2, /* comment 2 */ c4, /* comment 4 */ } from 'c';
++import { c1, /* comment 1 */ c2, /* comment 2 */ c3, /* comment 3 */ c4, /* comment 4 */ c5, /* comment 5 */ } from 'c';
+ 
+-import { d1 /* comment 1 */, d3 /* comment 3 */, d5 /* comment 5 */, d2 /* comment 2 */, d4 /* comment 4 */ } from 'd';
++import { d1 /* comment 1 */, d2 /* comment 2 */, d3 /* comment 3 */, d4, /* comment 4 */ d5 /* comment 5 */ } from 'd';
+ 
+ import {
+     e1,
+-    e3,
+-    e5,
+     e2,
++    e3,
+     e4,
++    e5,
+ } from 'e';
+ 
+ import {
+     f1,
++    f2,
+     f3,
+-    f5,
+-    f2,
+-    f4
++    f4,
++    f5
+ } from 'f';
+ 
+ import {
+     g1, // comment 1
+-    g3, // comment 3
+-    g5, // comment 5
+     g2, // comment 2
++    g3, // comment 3
+     g4, // comment 4
++    g5, // comment 5
+ } from 'g';
+ 
+ import {
+     h1, // comment 1
++    h2, // comment 2
+     h3, // comment 3
+-    h5, // comment 5
+-    h2, // comment 2
+-    h4 // comment 4
++    h4, // comment 4
++    h5 // comment 5
+ } from 'h';
+ 
+-import {
+-    i5, i4, i6, // comment 6
+-    i2, i1, i3, // comment 3
++import {i1, 
++    i2, i3, // comment 3
++i4, 
++    i5, i6, // comment 6
+ } from 'i';
+ 
+ import {
+-    j1, /* comment 1 */ j3 /* comment 3 */,
++    j1, /* comment 1 */ 
+     j2, // comment 2
++j3 /* comment 3 */,
+ } from 'j';
+ 
+ import {
+     k1, /* comment 1 */
++    k2, /* comment 2 */ 
+     k3, // comment 3
+-    k2, /* comment 2 */ } from 'k';
++} from 'k';
+
+```
+
+

--- a/crates/rome_rowan/src/syntax/trivia.rs
+++ b/crates/rome_rowan/src/syntax/trivia.rs
@@ -618,7 +618,7 @@ impl<L: Language> SyntaxTrivia<L> {
 
         Some(SyntaxTriviaPiece {
             raw: self.raw.clone(),
-            offset: self.raw.text_range().end() - piece.length,
+            offset: self.raw.text_range().start(),
             trivia: *piece,
             _p: Default::default(),
         })


### PR DESCRIPTION
## Summary

This PR extends the `organizeImports` code action to not only sort whole import nodes, but also reorder the named import specifiers within a given node.
The implementation is made quite complex by the necessity of moving nodes along with the relevant comments while remaining syntactically correct, which means inserting or removing comma tokens and newline trivias as nodes get moved to different places.
The current solution correctly handles nodes that were formatted using the Rome Formatter, but the output may be formatted incorrectly when the formatting of the input get more complex (this is only formatting though, it should not result in any syntax errors).

I've also fixed a bug in the `SyntaxTrivia::first` method that was causing it to return a trivia piece with an incorrect source offset.

## Test Plan

I've added an additional snapshot file for the rule testing both case that are expected to work correctly, as well as more complex patterns that are not currently well supported.
