### PR TITLE
feat(rome_service): internal errors as diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,13 +258,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -842,15 +842,14 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.18.2"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a9aec10c9a062ef0454fd49ebaefa59239f836d1b30891d9cc2289978dd970"
+checksum = "261bf85ed492cd1c47c9ba675e48649682a9d2d2e77f515c5386d7726fb0ba76"
 dependencies = [
  "console",
  "globset",
+ "lazy_static",
  "linked-hash-map",
- "once_cell",
- "serde",
  "similar",
  "walkdir",
  "yaml-rust",
@@ -1639,6 +1638,8 @@ dependencies = [
  "countme",
  "drop_bomb",
  "indexmap",
+ "insta",
+ "rome_console",
  "rome_diagnostics",
  "rome_js_parser",
  "rome_js_syntax",
@@ -1725,6 +1726,7 @@ dependencies = [
  "cfg-if",
  "countme",
  "iai",
+ "insta",
  "quickcheck",
  "quickcheck_macros",
  "rome_diagnostics",
@@ -1920,6 +1922,7 @@ version = "0.0.0"
 dependencies = [
  "dashmap",
  "indexmap",
+ "insta",
  "rome_analyze",
  "rome_console",
  "rome_diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ dashmap = "5.4.0"
 rustc-hash = "1.1.0"
 countme = "3.0.1"
 tokio = { version = "1.15.0" }
+insta = "1.21.2"

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -47,5 +47,5 @@ mimalloc = "0.1.29"
 tikv-jemallocator = "0.5.0"
 
 [dev-dependencies]
-insta = "1.18.2"
+insta = { workspace = true }
 tokio = { workspace = true, features = ["io-util"] }

--- a/crates/rome_diagnostics/src/lib.rs
+++ b/crates/rome_diagnostics/src/lib.rs
@@ -67,3 +67,33 @@ impl DiagnosticTag {
 }
 
 pub const MAXIMUM_DISPLAYABLE_DIAGNOSTICS: u16 = 200;
+
+#[cfg(debug_assertions)]
+use rome_console::fmt::{Formatter, Termcolor};
+#[cfg(debug_assertions)]
+use rome_console::markup;
+#[cfg(debug_assertions)]
+use std::fmt::Write;
+
+/// Utility function for testing purpose. The function will print an [Error]
+/// to a string, which is then returned by the function.
+#[cfg(debug_assertions)]
+pub fn print_diagnostic_to_string(diagnostic: Error) -> String {
+    let mut buffer = termcolor::Buffer::no_color();
+
+    Formatter::new(&mut Termcolor(&mut buffer))
+        .write_markup(markup! {
+            {PrintDiagnostic::verbose(&diagnostic)}
+        })
+        .expect("failed to emit diagnostic");
+
+    let mut content = String::new();
+    writeln!(
+        content,
+        "{}",
+        std::str::from_utf8(buffer.as_slice()).expect("non utf8 in error buffer")
+    )
+    .unwrap();
+
+    content
+}

--- a/crates/rome_diagnostics/src/lib.rs
+++ b/crates/rome_diagnostics/src/lib.rs
@@ -37,6 +37,9 @@ pub use crate::error::{Error, Result};
 pub use crate::location::{
     FileId, FilePath, LineIndex, LineIndexBuf, Location, Resource, SourceCode,
 };
+use rome_console::fmt::{Formatter, Termcolor};
+use rome_console::markup;
+use std::fmt::Write;
 
 pub mod prelude {
     //! Anonymously re-exports all the traits declared by this module, this is
@@ -68,16 +71,8 @@ impl DiagnosticTag {
 
 pub const MAXIMUM_DISPLAYABLE_DIAGNOSTICS: u16 = 200;
 
-#[cfg(debug_assertions)]
-use rome_console::fmt::{Formatter, Termcolor};
-#[cfg(debug_assertions)]
-use rome_console::markup;
-#[cfg(debug_assertions)]
-use std::fmt::Write;
-
 /// Utility function for testing purpose. The function will print an [Error]
 /// to a string, which is then returned by the function.
-#[cfg(debug_assertions)]
 pub fn print_diagnostic_to_string(diagnostic: Error) -> String {
     let mut buffer = termcolor::Buffer::no_color();
 

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -144,6 +144,8 @@ define_dategories! {
     "suppressions/unused",
     "suppressions/deprecatedSyntax",
 
+    "configuration",
+
     // Used in tests and examples
     "args/fileNotFound",
     "flags/invalid",

--- a/crates/rome_formatter/Cargo.toml
+++ b/crates/rome_formatter/Cargo.toml
@@ -19,11 +19,13 @@ countme = { workspace = true }
 drop_bomb = "0.1.5"
 indexmap = { workspace = true }
 unicode-width = "0.1.9"
+rome_diagnostics = { path = "../rome_diagnostics" }
+rome_console = { path = "../rome_console" }
 
 [dev-dependencies]
 rome_js_parser = { path = "../rome_js_parser"}
 rome_js_syntax = { path = "../rome_js_syntax" }
-rome_diagnostics = { path = "../rome_diagnostics" }
+insta = { workspace = true }
 
 [features]
 serde = ["dep:serde", "schemars", "rome_rowan/serde"]

--- a/crates/rome_formatter/src/diagnostics.rs
+++ b/crates/rome_formatter/src/diagnostics.rs
@@ -18,10 +18,10 @@ pub enum FormatError {
     InvalidDocument(InvalidDocumentError),
 
     /// Formatting failed because some content encountered a situation where a layout
-    /// choice by an enclosing [`Format`] resulted in a poor layout for a child [`Format`].
+    /// choice by an enclosing [crate::Format] resulted in a poor layout for a child [crate::Format].
     ///
-    /// It's up to an enclosing [`Format`] to handle the error and pick another layout.
-    /// This error should not be raised if there's no outer [`Format`] handling the poor layout error,
+    /// It's up to an enclosing [crate::Format] to handle the error and pick another layout.
+    /// This error should not be raised if there's no outer [crate::Format] handling the poor layout error,
     /// avoiding that formatting of the whole document fails.
     PoorLayout,
 }
@@ -257,7 +257,7 @@ mod test {
     #[test]
     fn invalid_document() {
         snap_diagnostic(
-            "poor_layout",
+            "invalid_document",
             FormatError::InvalidDocument(InvalidDocumentError::ExpectedStart {
                 expected_start: TagKind::Align,
                 actual: ActualStart::Start(TagKind::ConditionalContent),

--- a/crates/rome_formatter/src/diagnostics.rs
+++ b/crates/rome_formatter/src/diagnostics.rs
@@ -1,0 +1,280 @@
+use crate::prelude::TagKind;
+use rome_diagnostics::{category, Category, Diagnostic, DiagnosticTags, Location, Severity};
+use rome_rowan::{SyntaxError, TextRange};
+use std::error::Error;
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Series of errors encountered during formatting
+pub enum FormatError {
+    /// In case a node can't be formatted because it either misses a require child element or
+    /// a child is present that should not (e.g. a trailing comma after a rest element).
+    SyntaxError,
+    /// In case range formatting failed because the provided range was larger
+    /// than the formatted syntax tree
+    RangeError { input: TextRange, tree: TextRange },
+
+    /// In case printing the document failed because it has an invalid structure.
+    InvalidDocument(InvalidDocumentError),
+
+    /// Formatting failed because some content encountered a situation where a layout
+    /// choice by an enclosing [`Format`] resulted in a poor layout for a child [`Format`].
+    ///
+    /// It's up to an enclosing [`Format`] to handle the error and pick another layout.
+    /// This error should not be raised if there's no outer [`Format`] handling the poor layout error,
+    /// avoiding that formatting of the whole document fails.
+    PoorLayout,
+}
+
+impl std::fmt::Display for FormatError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FormatError::SyntaxError => fmt.write_str("syntax error"),
+            FormatError::RangeError { input, tree } => std::write!(
+                fmt,
+                "formatting range {input:?} is larger than syntax tree {tree:?}"
+            ),
+            FormatError::InvalidDocument(error) => std::write!(fmt, "Invalid document: {error}\n\n This is an internal Rome error. Please report if necessary."),
+            FormatError::PoorLayout => {
+                std::write!(fmt, "Poor layout: The formatter wasn't able to pick a good layout for your document. This is an internal Rome error. Please report if necessary.")
+            }
+        }
+    }
+}
+
+impl Error for FormatError {}
+
+impl From<SyntaxError> for FormatError {
+    fn from(error: SyntaxError) -> Self {
+        FormatError::from(&error)
+    }
+}
+
+impl From<&SyntaxError> for FormatError {
+    fn from(syntax_error: &SyntaxError) -> Self {
+        match syntax_error {
+            SyntaxError::MissingRequiredChild => FormatError::SyntaxError,
+        }
+    }
+}
+
+impl From<PrintError> for FormatError {
+    fn from(error: PrintError) -> Self {
+        FormatError::from(&error)
+    }
+}
+
+impl From<&PrintError> for FormatError {
+    fn from(error: &PrintError) -> Self {
+        match error {
+            PrintError::InvalidDocument(reason) => FormatError::InvalidDocument(*reason),
+        }
+    }
+}
+
+impl Diagnostic for FormatError {
+    fn location(&self) -> Location<'_> {
+        Location::builder().build()
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Error
+    }
+
+    fn tags(&self) -> DiagnosticTags {
+        match self {
+            FormatError::SyntaxError => DiagnosticTags::empty(),
+            FormatError::RangeError { .. } => DiagnosticTags::empty(),
+            FormatError::InvalidDocument(_) => DiagnosticTags::INTERNAL,
+            FormatError::PoorLayout => DiagnosticTags::INTERNAL,
+        }
+    }
+
+    fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, fmt)
+    }
+
+    fn category(&self) -> Option<&'static Category> {
+        Some(category!("format"))
+    }
+
+    fn message(
+        &self,
+        fmt: &mut rome_diagnostics::console::fmt::Formatter<'_>,
+    ) -> std::io::Result<()> {
+        match self {
+            FormatError::SyntaxError => fmt.write_str("Syntax error."),
+            FormatError::RangeError { input, tree } => std::write!(
+                fmt,
+                "Formatting range {input:?} is larger than syntax tree {tree:?}"
+            ),
+            FormatError::InvalidDocument(error) => std::write!(fmt, "Invalid document: {error}"),
+            FormatError::PoorLayout => {
+                std::write!(fmt, "Poor layout: The formatter wasn't able to pick a good layout for your document.")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum InvalidDocumentError {
+    /// Mismatching start/end kinds
+    ///
+    /// ```plain
+    /// StartIndent
+    /// ...
+    /// EndGroup
+    /// ```
+    StartEndTagMismatch {
+        start_kind: TagKind,
+        end_kind: TagKind,
+    },
+
+    /// End tag without a corresponding start tag.
+    ///
+    /// ```plain
+    /// Text
+    /// EndGroup
+    /// ```
+    StartTagMissing { kind: TagKind },
+
+    /// Expected a specific start tag but instead is:
+    /// * at the end of the document
+    /// * at another start tag
+    /// * at an end tag
+    ExpectedStart {
+        expected_start: TagKind,
+        actual: ActualStart,
+    },
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ActualStart {
+    /// The actual element is not a tag.
+    Content,
+
+    /// The actual element was a start tag of another kind.
+    Start(TagKind),
+
+    /// The actual element is an end tag instead of a start tag.
+    End(TagKind),
+
+    /// Reached the end of the document
+    EndOfDocument,
+}
+
+impl std::fmt::Display for InvalidDocumentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvalidDocumentError::StartEndTagMismatch {
+                start_kind,
+                end_kind,
+            } => {
+                std::write!(
+                    f,
+                    "Expected end tag of kind {start_kind:?} but found {end_kind:?}."
+                )
+            }
+            InvalidDocumentError::StartTagMissing { kind } => {
+                std::write!(f, "End tag of kind {kind:?} without matching start tag.")
+            }
+            InvalidDocumentError::ExpectedStart {
+                expected_start,
+                actual,
+            } => {
+                match actual {
+                    ActualStart::EndOfDocument => {
+                        std::write!(f, "Expected start tag of kind {expected_start:?} but at the end of document.")
+                    }
+                    ActualStart::Start(start) => {
+                        std::write!(f, "Expected start tag of kind {expected_start:?} but found start tag of kind {start:?}.")
+                    }
+                    ActualStart::End(end) => {
+                        std::write!(f, "Expected start tag of kind {expected_start:?} but found end tag of kind {end:?}.")
+                    }
+                    ActualStart::Content => {
+                        std::write!(f, "Expected start tag of kind {expected_start:?} but found non-tag element.")
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum PrintError {
+    InvalidDocument(InvalidDocumentError),
+}
+
+impl Error for PrintError {}
+
+impl std::fmt::Display for PrintError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrintError::InvalidDocument(inner) => {
+                std::write!(f, "Invalid document: {inner}")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::diagnostics::{ActualStart, InvalidDocumentError};
+    use crate::prelude::{FormatError, TagKind};
+    use rome_diagnostics::{print_diagnostic_to_string, DiagnosticExt, Error};
+    use rome_js_syntax::TextRange;
+
+    fn snap_diagnostic(test_name: &str, diagnostic: Error) {
+        let content = print_diagnostic_to_string(diagnostic);
+
+        insta::with_settings!({
+            prepend_module_to_snapshot => false,
+        }, {
+            insta::assert_snapshot!(test_name, content);
+
+        });
+    }
+
+    #[test]
+    fn formatter_syntax_error() {
+        snap_diagnostic(
+            "formatter_syntax_error",
+            FormatError::SyntaxError.with_file_path("example.js"),
+        )
+    }
+
+    #[test]
+    fn poor_layout() {
+        snap_diagnostic(
+            "poor_layout",
+            FormatError::PoorLayout.with_file_path("example.js"),
+        )
+    }
+
+    #[test]
+    fn invalid_document() {
+        snap_diagnostic(
+            "poor_layout",
+            FormatError::InvalidDocument(InvalidDocumentError::ExpectedStart {
+                expected_start: TagKind::Align,
+                actual: ActualStart::Start(TagKind::ConditionalContent),
+            })
+            .with_file_path("example.js"),
+        )
+    }
+
+    #[test]
+    fn range_error() {
+        snap_diagnostic(
+            "range_error",
+            FormatError::RangeError {
+                input: TextRange::new(7.into(), 10.into()),
+                tree: TextRange::new(0.into(), 5.into()),
+            }
+            .with_file_path("example.js"),
+        )
+    }
+}

--- a/crates/rome_formatter/src/prelude.rs
+++ b/crates/rome_formatter/src/prelude.rs
@@ -8,12 +8,12 @@ pub use crate::trivia::{
     format_replaced, format_trailing_comments, format_trimmed_token,
 };
 
-pub use crate::verbatim::{format_bogus_node, format_suppressed_node, format_verbatim_node};
-
+pub use crate::diagnostics::FormatError;
 pub use crate::format_element::document::Document;
 pub use crate::format_element::tag::{LabelId, Tag, TagKind};
+pub use crate::verbatim::{format_bogus_node, format_suppressed_node, format_verbatim_node};
 
 pub use crate::{
     best_fitting, dbg_write, format, format_args, write, Buffer as _, BufferExtensions, Format,
-    Format as _, FormatError, FormatResult, FormatRule, FormatWithRule as _, SimpleFormatContext,
+    Format as _, FormatResult, FormatRule, FormatWithRule as _, SimpleFormatContext,
 };

--- a/crates/rome_formatter/src/snapshots/formatter_syntax_error.snap
+++ b/crates/rome_formatter/src/snapshots/formatter_syntax_error.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_formatter/src/diagnostics.rs
+expression: content
+---
+example.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Syntax error.
+  
+
+

--- a/crates/rome_formatter/src/snapshots/invalid_document.snap
+++ b/crates/rome_formatter/src/snapshots/invalid_document.snap
@@ -4,7 +4,7 @@ expression: content
 ---
 example.js format  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Poor layout: The formatter wasn't able to pick a good layout for your document.
+  × Invalid document: Expected start tag of kind Align but found start tag of kind ConditionalContent.
   
   ! This diagnostic was derived from an internal Rome error. Potential bug, please report it if necessary.
   

--- a/crates/rome_formatter/src/snapshots/poor_layout.snap
+++ b/crates/rome_formatter/src/snapshots/poor_layout.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rome_formatter/src/diagnostics.rs
+expression: content
+---
+example.js format  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Poor layout: The formatter wasn't able to pick a good layout for your document.
+  
+  ! This diagnostic was derived from an internal Rome error. Potential bug, please report it if necessary.
+  
+
+
+if necessary.
+  
+
+

--- a/crates/rome_formatter/src/snapshots/range_error.snap
+++ b/crates/rome_formatter/src/snapshots/range_error.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_formatter/src/diagnostics.rs
+expression: content
+---
+example.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatting range 7..10 is larger than syntax tree 0..5
+  
+
+

--- a/crates/rome_formatter_test/Cargo.toml
+++ b/crates/rome_formatter_test/Cargo.toml
@@ -20,6 +20,6 @@ rome_fs = { path = "../rome_fs" }
 rome_service = { path = "../rome_service" }
 similar = "2.1.0"
 similar-asserts = "1.2.0"
-insta = { version="1.18.2", features = ["glob"] }
+insta = { workspace = true, features = ["glob"] }
 
 [dev-dependencies]

--- a/crates/rome_formatter_test/src/snapshot_builder.rs
+++ b/crates/rome_formatter_test/src/snapshot_builder.rs
@@ -207,7 +207,7 @@ impl<'a> SnapshotBuilder<'a> {
             prepend_module_to_snapshot => false,
             snapshot_path => self.input_file.parent().unwrap(),
             omit_expression => true,
-            info => &info
+            raw_info => &info.test_file.into()
         }, {
             insta::assert_snapshot!(file_name, self.snapshot);
         });

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -27,7 +27,7 @@ natord = "1.0.9"
 tests_macros = { path = "../tests_macros" }
 rome_text_edit = { path = "../rome_text_edit" }
 rome_js_parser = { path = "../rome_js_parser", features = ["tests"] }
-insta = { version = "1.18.2", features = ["glob"] }
+insta = { workspace = true, features = ["glob"] }
 countme = { workspace = true, features = ["enable"] }
 similar = "2.1.0"
 json_comments = "0.2.1"

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -10,7 +10,7 @@ use rome_analyze::{
     Phases, RuleAction, RuleRegistry, ServiceBag, SuppressionKind, SyntaxVisitor,
 };
 use rome_aria::{AriaProperties, AriaRoles};
-use rome_diagnostics::{category, FileId};
+use rome_diagnostics::{category, Diagnostic, FileId};
 use rome_js_syntax::suppression::SuppressionDiagnostic;
 use rome_js_syntax::{suppression::parse_suppression_comment, JsLanguage};
 use serde::{Deserialize, Serialize};
@@ -431,8 +431,31 @@ pub enum RuleError {
     },
 }
 
+impl Diagnostic for RuleError {}
+
 impl std::fmt::Display for RuleError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RuleError::ReplacedRootWithNonRootError {
+                rule_name: Some((group, rule)),
+            } => {
+                std::write!(
+                    fmt,
+                    "the rule '{group}/{rule}' replaced the root of the file with a non-root node."
+                )
+            }
+            RuleError::ReplacedRootWithNonRootError { rule_name: None } => {
+                std::write!(
+                    fmt,
+                    "a code action replaced the root of the file with a non-root node."
+                )
+            }
+        }
+    }
+}
+
+impl rome_console::fmt::Display for RuleError {
+    fn fmt(&self, fmt: &mut rome_console::fmt::Formatter) -> std::io::Result<()> {
         match self {
             RuleError::ReplacedRootWithNonRootError {
                 rule_name: Some((group, rule)),

--- a/crates/rome_js_analyze/src/utils/rename.rs
+++ b/crates/rome_js_analyze/src/utils/rename.rs
@@ -1,10 +1,14 @@
+use rome_console::fmt::Formatter;
+use rome_console::markup;
+use rome_diagnostics::{Diagnostic, Location, Severity};
 use rome_js_semantic::{ReferencesExtensions, SemanticModel};
 use rome_js_syntax::{
     binding_ext::AnyJsIdentifierBinding, JsIdentifierAssignment, JsIdentifierBinding, JsLanguage,
-    JsReferenceIdentifier, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
+    JsReferenceIdentifier, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken, TextRange,
 };
 use rome_rowan::{AstNode, BatchMutation, SyntaxNodeCast, TriviaPiece};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 pub trait RenamableNode {
     fn binding(&self, model: &SemanticModel) -> Option<JsSyntaxNode>;
@@ -57,33 +61,89 @@ impl RenamableNode for AnyJsRenamableDeclaration {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub enum RenameError {
-    CannotFindDeclaration,
+    CannotFindDeclaration(String),
     CannotBeRenamed {
         original_name: String,
+        original_range: TextRange,
         new_name: String,
     },
+}
+
+impl std::fmt::Display for RenameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RenameError::CannotBeRenamed {
+                original_name,
+                new_name,
+                ..
+            } => {
+                write!(
+                    f,
+                    "encountered an error while renaming the symbol \"{}\" to \"{}\"",
+                    original_name, new_name
+                )
+            }
+            RenameError::CannotFindDeclaration(_) => {
+                write!(
+                    f,
+                    "encountered an error finding a declaration at the specified position"
+                )
+            }
+        }
+    }
+}
+
+impl Diagnostic for RenameError {
+    fn severity(&self) -> Severity {
+        Severity::Error
+    }
+
+    fn message(&self, fmt: &mut Formatter<'_>) -> std::io::Result<()> {
+        match self {
+            RenameError::CannotFindDeclaration(node) => {
+                fmt.write_markup(
+                    markup! { "Can't find the declaration. Found node "{{node}} }
+                )
+            }
+            RenameError::CannotBeRenamed { original_name, new_name, .. } => {
+                fmt.write_markup(
+                    markup! { "Can't rename from "<Emphasis>{{original_name}}</Emphasis>" to "<Emphasis>{{new_name}}</Emphasis>"" }
+                )
+            }
+        }
+    }
+
+    fn location(&self) -> Location<'_> {
+        let location = Location::builder();
+        if let RenameError::CannotBeRenamed { original_range, .. } = self {
+            location.span(original_range).build()
+        } else {
+            location.build()
+        }
+    }
 }
 
 impl TryFrom<JsSyntaxNode> for AnyJsRenamableDeclaration {
     type Error = RenameError;
 
     fn try_from(node: JsSyntaxNode) -> Result<Self, Self::Error> {
+        let node_name = node.text_trimmed().to_string();
         match node.kind() {
             JsSyntaxKind::JS_IDENTIFIER_BINDING => node
                 .cast::<JsIdentifierBinding>()
                 .map(AnyJsRenamableDeclaration::JsIdentifierBinding)
-                .ok_or(Self::Error::CannotFindDeclaration),
+                .ok_or(Self::Error::CannotFindDeclaration(node_name)),
             JsSyntaxKind::JS_REFERENCE_IDENTIFIER => node
                 .cast::<JsReferenceIdentifier>()
                 .map(AnyJsRenamableDeclaration::JsReferenceIdentifier)
-                .ok_or(Self::Error::CannotFindDeclaration),
+                .ok_or(Self::Error::CannotFindDeclaration(node_name)),
             JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT => node
                 .cast::<JsIdentifierAssignment>()
                 .map(AnyJsRenamableDeclaration::JsIdentifierAssignment)
-                .ok_or(Self::Error::CannotFindDeclaration),
-            _ => Err(Self::Error::CannotFindDeclaration),
+                .ok_or(Self::Error::CannotFindDeclaration(node_name)),
+            _ => Err(Self::Error::CannotFindDeclaration(node_name)),
         }
     }
 }
@@ -251,7 +311,10 @@ impl RenameSymbolExtensions for BatchMutation<JsLanguage> {
 
 #[cfg(test)]
 mod tests {
+    use crate::utils::rename::RenameError;
     use crate::{assert_rename_nok, assert_rename_ok};
+    use rome_diagnostics::{print_diagnostic_to_string, DiagnosticExt, Error};
+    use rome_js_syntax::TextRange;
 
     assert_rename_ok! {
         ok_rename_declaration,
@@ -289,5 +352,39 @@ mod tests {
         nok_rename_write_reference, "let a; if (true) { let b; a = 1 }",
         nok_rename_read_reference_parent_scope_conflict, "function f() { let b; if(true) { console.log(a); } } var a;",
         nok_rename_function_conflict, "function a() {} function b() {}",
+    }
+
+    fn snap_diagnostic(test_name: &str, diagnostic: Error) {
+        let content = print_diagnostic_to_string(diagnostic);
+
+        insta::with_settings!({
+            prepend_module_to_snapshot => false,
+        }, {
+            insta::assert_snapshot!(test_name, content);
+
+        });
+    }
+
+    #[test]
+    fn cannot_find_declaration() {
+        snap_diagnostic(
+            "cannot_find_declaration",
+            RenameError::CannotFindDeclaration("async".to_string()).with_file_path("example.js"),
+        )
+    }
+
+    #[test]
+    fn cannot_be_renamed() {
+        let source_code = "async function f() {}";
+        snap_diagnostic(
+            "cannot_be_renamed",
+            RenameError::CannotBeRenamed {
+                original_name: "async".to_string(),
+                original_range: TextRange::new(0.into(), 5.into()),
+                new_name: "await".to_string(),
+            }
+            .with_file_path("example.js")
+            .with_file_source_code(source_code),
+        )
     }
 }

--- a/crates/rome_js_analyze/src/utils/snapshots/cannot_be_renamed.snap
+++ b/crates/rome_js_analyze/src/utils/snapshots/cannot_be_renamed.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rome_js_analyze/src/utils/rename.rs
+expression: content
+---
+example.js:1:1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Can't rename from async to await
+  
+  > 1 │ async function f() {}
+      │ ^^^^^
+  
+
+

--- a/crates/rome_js_analyze/src/utils/snapshots/cannot_find_declaration.snap
+++ b/crates/rome_js_analyze/src/utils/snapshots/cannot_find_declaration.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_js_analyze/src/utils/rename.rs
+expression: content
+---
+example.js ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Can't find the declaration. Found node async
+  
+
+

--- a/crates/rome_js_formatter/Cargo.toml
+++ b/crates/rome_js_formatter/Cargo.toml
@@ -30,6 +30,7 @@ rome_js_factory = { path = "../rome_js_factory" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tests_macros = { path = "../tests_macros" }
+insta = { workspace = true, features = ["glob"] }
 rome_diagnostics = { path = "../rome_diagnostics" }
 countme = { workspace = true, features = ["enable"] }
 quickcheck = "1.0.3"

--- a/crates/rome_js_syntax/src/union_ext.rs
+++ b/crates/rome_js_syntax/src/union_ext.rs
@@ -109,7 +109,7 @@ impl AnyJsClassMember {
         }
     }
 
-    /// Tests if the member has a [`JsLiteralMemberName`](rome_js_syntax::JsLiteralMemberName) of `name`.
+    /// Tests if the member has a [`JsLiteralMemberName`](crate::JsLiteralMemberName) of `name`.
     pub fn has_name(&self, name: &str) -> SyntaxResult<bool> {
         match self.name()? {
             Some(AnyJsClassMemberName::JsLiteralMemberName(literal)) => {

--- a/crates/rome_json_formatter/Cargo.toml
+++ b/crates/rome_json_formatter/Cargo.toml
@@ -22,6 +22,6 @@ rome_json_factory = { path = "../rome_json_factory" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tests_macros = { path = "../tests_macros" }
-insta = { version="1.18.2", features = ["glob"] }
+insta = { workspace = true, features = ["glob"] }
 rome_diagnostics = { path = "../rome_diagnostics" }
 countme = { workspace = true, features = ["enable"] }

--- a/crates/rome_json_parser/Cargo.toml
+++ b/crates/rome_json_parser/Cargo.toml
@@ -21,5 +21,5 @@ tracing = { workspace = true }
 tests_macros = { path = "../tests_macros" }
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-insta = { version="1.18.2" }
+insta = { workspace = true }
 

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -36,3 +36,6 @@ tracing = { workspace = true, features = ["attributes"] }
 
 [features]
 schemars = ["dep:schemars", "rome_formatter/serde", "rome_js_factory", "rome_text_edit/schemars"]
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/crates/rome_service/src/configuration/diagnostics.rs
+++ b/crates/rome_service/src/configuration/diagnostics.rs
@@ -1,0 +1,214 @@
+use rome_diagnostics::{category, Category, Diagnostic, LineIndexBuf, Location, Severity};
+use rome_rowan::{TextRange, TextSize};
+use std::fmt::{Debug, Display, Formatter};
+
+/// Series of errors that can be thrown while computing the configuration
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum ConfigurationError {
+    /// Thrown when the program can't serialize the configuration, while saving it
+    SerializationError,
+
+    /// Thrown when trying to **create** a new configuration file, but it exists already
+    ConfigAlreadyExists,
+
+    /// Error thrown when de-serialising the configuration from file, the issues can be many:
+    /// - syntax error
+    /// - incorrect fields
+    /// - incorrect values
+    DeserializationError {
+        message: String,
+        text_range: Option<TextRange>,
+        input: String,
+    },
+
+    /// Thrown when an unknown rule is found
+    UnknownRule(String),
+
+    /// Thrown when the pattern inside the `ignore` field errors
+    InvalidIgnorePattern(String, String),
+}
+
+impl Debug for ConfigurationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigurationError::SerializationError => std::fmt::Display::fmt(self, f),
+            ConfigurationError::DeserializationError { .. } => std::fmt::Display::fmt(self, f),
+            ConfigurationError::ConfigAlreadyExists => std::fmt::Display::fmt(self, f),
+            ConfigurationError::UnknownRule(_) => std::fmt::Display::fmt(self, f),
+            ConfigurationError::InvalidIgnorePattern(_, _) => std::fmt::Display::fmt(self, f),
+        }
+    }
+}
+
+impl Display for ConfigurationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigurationError::SerializationError => {
+                write!(
+                    f,
+                    "Couldn't save the configuration on disk, probably because of some error inside the content of the file"
+                )
+            }
+            ConfigurationError::DeserializationError { message, .. } => {
+                write!(
+                    f,
+                    "Rome couldn't load the configuration file, here's why: \n{}",
+                    message
+                )
+            }
+            ConfigurationError::ConfigAlreadyExists => {
+                write!(f, "It seems that a configuration file already exists")
+            }
+
+            ConfigurationError::UnknownRule(rule) => {
+                write!(f, "invalid rule name `{rule}`")
+            }
+            ConfigurationError::InvalidIgnorePattern(pattern, reason) => {
+                write!(f, "Couldn't parse the pattern {pattern}, reason: {reason}")
+            }
+        }
+    }
+}
+
+impl Diagnostic for ConfigurationError {
+    fn category(&self) -> Option<&'static Category> {
+        Some(category!("configuration"))
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Error
+    }
+
+    fn description(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, fmt)
+    }
+
+    fn message(&self, f: &mut rome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        match self {
+            ConfigurationError::SerializationError => {
+                write!(
+                    f,
+                    "Couldn't save the configuration on disk, probably because of some error inside the content of the file"
+                )
+            }
+            ConfigurationError::DeserializationError { message, .. } => {
+                write!(
+                    f,
+                    "Rome couldn't load the configuration file, here's why: \n{}",
+                    message
+                )
+            }
+            ConfigurationError::ConfigAlreadyExists => {
+                write!(f, "It seems that a configuration file already exists")
+            }
+
+            ConfigurationError::UnknownRule(rule) => {
+                write!(f, "Invalid rule name `{rule}`")
+            }
+            ConfigurationError::InvalidIgnorePattern(pattern, reason) => {
+                write!(f, "Couldn't parse the pattern {pattern}, reason: {reason}")
+            }
+        }
+    }
+
+    fn location(&self) -> Location<'_> {
+        if let Self::DeserializationError { text_range, .. } = self {
+            Location::builder().span(text_range).build()
+        } else {
+            Location::builder().build()
+        }
+    }
+}
+
+pub(crate) fn from_serde_error_to_range(
+    error: &serde_json::Error,
+    input: &str,
+) -> Option<TextRange> {
+    let line_starts = LineIndexBuf::from_source_text(input);
+    let line = error.line();
+    line.checked_sub(1).and_then(|line_index| {
+        let line_start = line_starts.get(line_index)?;
+        let column_index = error.column().checked_sub(1)?;
+        let column_offset = TextSize::try_from(column_index).ok()?;
+
+        let span_start = line_start + column_offset;
+        Some(TextRange::at(span_start, TextSize::from(0)))
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use crate::configuration::diagnostics::{from_serde_error_to_range, ConfigurationError};
+    use crate::{Configuration, MatchOptions, Matcher};
+    use rome_diagnostics::{print_diagnostic_to_string, DiagnosticExt, Error};
+
+    fn snap_diagnostic(test_name: &str, diagnostic: Error) {
+        let content = print_diagnostic_to_string(diagnostic);
+
+        insta::with_settings!({
+            prepend_module_to_snapshot => false,
+        }, {
+            insta::assert_snapshot!(test_name, content);
+
+        });
+    }
+
+    #[test]
+    fn unknown_rule() {
+        snap_diagnostic(
+            "unknown_rule",
+            ConfigurationError::UnknownRule("foo_bar".to_string()).with_file_path("rome.json"),
+        )
+    }
+
+    #[test]
+    fn config_already_exists() {
+        snap_diagnostic(
+            "config_already_exists",
+            ConfigurationError::ConfigAlreadyExists.with_file_path("rome.json"),
+        )
+    }
+
+    #[test]
+    fn incorrect_pattern() {
+        let mut matcher = Matcher::new(MatchOptions {
+            case_sensitive: true,
+            require_literal_leading_dot: false,
+            require_literal_separator: false,
+        });
+
+        let pattern = "*******";
+        if let Err(error) = matcher.add_pattern(pattern) {
+            snap_diagnostic(
+                "incorrect_pattern",
+                ConfigurationError::InvalidIgnorePattern(
+                    pattern.to_string(),
+                    error.msg.to_string(),
+                )
+                .with_file_path("rome.json"),
+            )
+        } else {
+            panic!("Tha pattern should fail")
+        }
+    }
+
+    #[test]
+    fn deserialization_error() {
+        let content = "{ \n\n\"formatter\" }";
+        let result = serde_json::from_str::<Configuration>(content);
+        if let Err(error) = result {
+            snap_diagnostic(
+                "deserialization_error",
+                ConfigurationError::DeserializationError {
+                    text_range: from_serde_error_to_range(&error, content),
+                    input: content.to_string(),
+                    message: error.to_string(),
+                }
+                .with_file_path("rome.json")
+                .with_file_source_code(content),
+            )
+        } else {
+            panic!("The JSON should be incorrect")
+        }
+    }
+}

--- a/crates/rome_service/src/configuration/snapshots/config_already_exists.snap
+++ b/crates/rome_service/src/configuration/snapshots/config_already_exists.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/configuration/diagnostics.rs
+expression: content
+---
+rome.json configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × It seems that a configuration file already exists
+  
+
+

--- a/crates/rome_service/src/configuration/snapshots/deserialization_error.snap
+++ b/crates/rome_service/src/configuration/snapshots/deserialization_error.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rome_service/src/configuration/diagnostics.rs
+expression: content
+---
+rome.json:3:13 configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Rome couldn't load the configuration file, here's why: 
+    expected `:` at line 3 column 13
+  
+    1 │ {·
+    2 │ 
+  > 3 │ "formatter" }
+      │             
+  
+
+

--- a/crates/rome_service/src/configuration/snapshots/incorrect_pattern.snap
+++ b/crates/rome_service/src/configuration/snapshots/incorrect_pattern.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/configuration/diagnostics.rs
+expression: content
+---
+rome.json configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Couldn't parse the pattern *******, reason: wildcards are either regular `*` or recursive `**`
+  
+
+

--- a/crates/rome_service/src/configuration/snapshots/unknown_rule.snap
+++ b/crates/rome_service/src/configuration/snapshots/unknown_rule.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/configuration/diagnostics.rs
+expression: content
+---
+rome.json configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Invalid rule name `foo_bar`
+  
+
+

--- a/crates/rome_service/src/diagnostics.rs
+++ b/crates/rome_service/src/diagnostics.rs
@@ -1,0 +1,547 @@
+use crate::file_handlers::Language;
+use crate::ConfigurationError;
+use rome_console::fmt::Bytes;
+use rome_console::markup;
+use rome_diagnostics::{category, Category, Diagnostic, DiagnosticTags, Location, Severity};
+use rome_formatter::FormatError;
+use rome_fs::RomePath;
+use rome_js_analyze::utils::rename::RenameError;
+use rome_js_analyze::RuleError;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::ffi::OsStr;
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize)]
+/// Generic errors thrown during rome operations
+pub enum RomeError {
+    /// The project contains uncommitted changes
+    DirtyWorkspace,
+    /// The file does not exist in the [Workspace]
+    NotFound,
+    /// A file is not supported. It contains the language and path of the file
+    /// Use this error if Rome is trying to process a file that Rome can't understand
+    SourceFileNotSupported(Language, RomePath),
+    /// The formatter encountered an error while formatting the file
+    FormatError(FormatError),
+    /// The file could not be formatted since it has syntax errors and `format_with_errors` is disabled
+    FormatWithErrorsDisabled,
+    /// The file could not be analyzed because a rule caused an error.
+    RuleError(RuleError),
+    /// Thrown when Rome can't read a generic directory
+    CantReadDirectory(String),
+    /// Thrown when Rome can't read a generic file
+    CantReadFile(String),
+    /// Error thrown when validating the configuration. Once deserialized, further checks have to be done.
+    Configuration(ConfigurationError),
+    /// Error thrown when Rome cannot rename a symbol.
+    RenameError(RenameError),
+    /// Error emitted by the underlying transport layer for a remote Workspace
+    TransportError(TransportError),
+    /// Emitted when the file is ignored and should not be processed
+    FileIgnored(String),
+    /// Emitted when a file could not be parsed because it's larger than the size limite
+    FileTooLarge {
+        path: PathBuf,
+        size: usize,
+        limit: usize,
+    },
+}
+
+impl Diagnostic for RomeError {
+    fn category(&self) -> Option<&'static Category> {
+        match self {
+            RomeError::DirtyWorkspace => Some(category!("internalError/fs")),
+            RomeError::NotFound => Some(category!("internalError/fs")),
+            RomeError::SourceFileNotSupported(_, _) => Some(category!("internalError/fs")),
+            RomeError::FormatError(err) => err.category(),
+            RomeError::FormatWithErrorsDisabled => Some(category!("parse")),
+            RomeError::RuleError(error) => error.category(),
+            RomeError::CantReadDirectory(_) => Some(category!("internalError/fs")),
+            RomeError::CantReadFile(_) => Some(category!("internalError/fs")),
+            RomeError::Configuration(error) => error.category(),
+            RomeError::RenameError(error) => error.category(),
+            RomeError::TransportError(error) => error.category(),
+            RomeError::FileIgnored(_) => Some(category!("internalError/fs")),
+            RomeError::FileTooLarge { .. } => Some(category!("internalError/fs")),
+        }
+    }
+
+    fn description(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RomeError::SourceFileNotSupported(language, path) => {
+                if *language != Language::Unknown {
+                    write!(
+                        f,
+                        "Rome doesn't support this feature for the language {language:?}"
+                    )
+                } else if let Some(ext) = path.extension().and_then(OsStr::to_str) {
+                    write!(
+                        f,
+                        "Rome could not determine the language for the file extension {ext:?}"
+                    )
+                } else {
+                    write!(
+                f,
+                "Rome could not determine the language for the file {path:?} because it doesn't have a clear extension"
+                )
+                }
+            }
+            RomeError::NotFound => {
+                write!(f, "the file does not exist in the workspace")
+            }
+            RomeError::FormatError(cause) => {
+                write!(
+                    f,
+                    "the formatter encountered an error while formatting the file: {}",
+                    cause
+                )
+            }
+            RomeError::FormatWithErrorsDisabled => {
+                write!(f, "the file could not be formatted since it has syntax errors and `format_with_errors` is disabled")
+            }
+            RomeError::CantReadDirectory(path) => {
+                write!(
+                f,
+                "Rome couldn't read the following directory, maybe for permissions reasons or it doesn't exists: {}",
+                path
+                )
+            }
+            RomeError::CantReadFile(path) => {
+                write!(
+                f,
+                "Rome couldn't read the following file, maybe for permissions reasons or it doesn't exists: {}",
+                path
+                )
+            }
+
+            RomeError::Configuration(error) => fmt::Display::fmt(error, f),
+            RomeError::DirtyWorkspace => {
+                write!(f, "Uncommitted changes in repository")
+            }
+            RomeError::RenameError(error) => fmt::Display::fmt(error, f),
+            RomeError::RuleError(cause) => {
+                write!(
+                    f,
+                    "the linter encountered an error while analyzing the file: {cause}",
+                )
+            }
+
+            RomeError::TransportError(err) => {
+                write!(f, "{err}",)
+            }
+            RomeError::FileIgnored(path) => {
+                write!(f, "The file {} was ignored", path)
+            }
+            RomeError::FileTooLarge { path, size, limit } => {
+                write!(f, "Size of {} is {} which exceeds configured maximum of {} for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.", path.display(), Bytes(*size), Bytes(*limit))
+            }
+        }
+    }
+
+    fn message(&self, f: &mut rome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        match self {
+            RomeError::DirtyWorkspace => {
+                f.write_markup(markup! { "Uncommitted changes in repository" })
+            }
+            RomeError::NotFound => {
+                f.write_markup(markup! { "The file does not exist in the workspace." })
+            }
+            RomeError::SourceFileNotSupported(language, path) => {
+                if *language != Language::Unknown {
+                    f.write_markup(
+                        markup! { "Rome doesn't support this feature for the language "{{language}}"" }
+                    )
+                } else if let Some(ext) = path.extension().and_then(OsStr::to_str) {
+                    f.write_markup(markup! {
+                        "Rome could not determine the language for the file extension "{{ext}}""
+                    })
+                } else {
+                    let path = format!("{}", path.display());
+                    f.write_markup(
+                        markup!{
+                            "Rome could not determine the language for the file "{{path}}" because it doesn't have a clear extension"
+                        }
+                    )
+                }
+            }
+            RomeError::FormatError(err) => err.message(f),
+            RomeError::FormatWithErrorsDisabled => f.write_markup(
+                markup!{  "The file could not be formatted since it has syntax errors and "<Emphasis>"formatWithErrors"</Emphasis>" is disabled" }
+            ),
+            RomeError::RuleError(error) => error.message(f),
+            RomeError::CantReadDirectory(path) => {
+                f.write_markup(
+                    markup!{
+                        "Rome couldn't read the following directory, maybe for permissions reasons or it doesn't exists: "{{path}}
+
+                    }
+                )
+            }
+            RomeError::CantReadFile(path) => {
+                f.write_markup(
+                    markup!{
+                        "Rome couldn't read the following file, maybe for permissions reasons or it doesn't exists: "{{path}}
+
+                    }
+                )
+            },
+            RomeError::Configuration(error) => error.message(f),
+            RomeError::RenameError(error) => error.message(f),
+            RomeError::TransportError(error) => error.message(f),
+            RomeError::FileIgnored(path) => {
+                write!(f, "The file {} was ignored", path)
+            },
+            RomeError::FileTooLarge { path, size, limit } => {
+                let path = format!("{}", path.display());
+                f.write_markup(
+                    markup!{
+            "Size of "{{path}}" is "{{Bytes(*size)}}" which exceeds configured maximum of "{{Bytes(*limit)}}" for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't."
+                    }
+                )
+            },
+        }
+    }
+
+    fn severity(&self) -> Severity {
+        match self {
+            RomeError::DirtyWorkspace => Severity::Error,
+            RomeError::NotFound => Severity::Error,
+            RomeError::SourceFileNotSupported(_, _) => Severity::Error,
+            RomeError::FormatError(err) => err.severity(),
+            RomeError::FormatWithErrorsDisabled => Severity::Error,
+            RomeError::RuleError(error) => error.severity(),
+            RomeError::CantReadDirectory(_) => Severity::Error,
+            RomeError::CantReadFile(_) => Severity::Error,
+            RomeError::Configuration(error) => error.severity(),
+            RomeError::RenameError(error) => error.severity(),
+            RomeError::TransportError(error) => error.severity(),
+            RomeError::FileIgnored(_) => Severity::Error,
+            RomeError::FileTooLarge { .. } => Severity::Error,
+        }
+    }
+
+    fn tags(&self) -> DiagnosticTags {
+        match self {
+            RomeError::DirtyWorkspace => DiagnosticTags::empty(),
+            RomeError::NotFound => DiagnosticTags::INTERNAL,
+            RomeError::SourceFileNotSupported(_, _) => DiagnosticTags::empty(),
+            RomeError::FormatError(err) => err.tags(),
+            RomeError::FormatWithErrorsDisabled => DiagnosticTags::empty(),
+            RomeError::RuleError(error) => error.tags(),
+            RomeError::CantReadDirectory(_) => DiagnosticTags::empty(),
+            RomeError::CantReadFile(_) => DiagnosticTags::empty(),
+            RomeError::Configuration(error) => error.tags(),
+            RomeError::RenameError(error) => error.tags(),
+            RomeError::TransportError(error) => error.tags(),
+            RomeError::FileIgnored(_) => DiagnosticTags::empty(),
+            RomeError::FileTooLarge { .. } => DiagnosticTags::empty(),
+        }
+    }
+
+    fn location(&self) -> Location<'_> {
+        match self {
+            RomeError::DirtyWorkspace => Location::builder().build(),
+            RomeError::NotFound => Location::builder().build(),
+            RomeError::SourceFileNotSupported(_, _) => Location::builder().build(),
+            RomeError::FormatError(err) => err.location(),
+            RomeError::FormatWithErrorsDisabled => Location::builder().build(),
+            RomeError::RuleError(error) => error.location(),
+            RomeError::CantReadDirectory(_) => Location::builder().build(),
+            RomeError::CantReadFile(_) => Location::builder().build(),
+            RomeError::Configuration(error) => error.location(),
+            RomeError::RenameError(error) => error.location(),
+            RomeError::TransportError(error) => error.location(),
+            RomeError::FileIgnored(path) => Location::builder().resource(path).build(),
+            RomeError::FileTooLarge { .. } => Location::builder().build(),
+        }
+    }
+
+    fn source(&self) -> Option<&dyn Diagnostic> {
+        match self {
+            RomeError::DirtyWorkspace => None,
+            RomeError::NotFound => None,
+            RomeError::SourceFileNotSupported(_, _) => None,
+            RomeError::FormatError(error) => Diagnostic::source(error),
+            RomeError::FormatWithErrorsDisabled => None,
+            RomeError::RuleError(error) => Diagnostic::source(error),
+            RomeError::CantReadDirectory(_) => None,
+            RomeError::CantReadFile(_) => None,
+            RomeError::Configuration(error) => Diagnostic::source(error),
+            RomeError::RenameError(error) => Diagnostic::source(error),
+            RomeError::TransportError(error) => Diagnostic::source(error),
+            RomeError::FileIgnored(_) => None,
+            RomeError::FileTooLarge { .. } => None,
+        }
+    }
+}
+
+impl Debug for RomeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl Display for RomeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            RomeError::SourceFileNotSupported(language, path) => {
+                if *language != Language::Unknown {
+                    write!(
+                        f,
+                        "Rome doesn't support this feature for the language {language:?}"
+                    )
+                } else if let Some(ext) = path.extension().and_then(OsStr::to_str) {
+                    write!(
+                        f,
+                        "Rome could not determine the language for the file extension {ext:?}"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Rome could not determine the language for the file {path:?} because it doesn't have a clear extension"
+                    )
+                }
+            }
+            RomeError::NotFound => {
+                write!(f, "the file does not exist in the workspace")
+            }
+            RomeError::FormatError(cause) => {
+                write!(
+                    f,
+                    "the formatter encountered an error while formatting the file: {}",
+                    cause
+                )
+            }
+            RomeError::FormatWithErrorsDisabled => {
+                write!(f, "the file could not be formatted since it has syntax errors and `format_with_errors` is disabled")
+            }
+            RomeError::CantReadDirectory(path) => {
+                write!(
+                    f,
+                    "Rome couldn't read the following directory, maybe for permissions reasons or it doesn't exists: {}",
+                    path
+                )
+            }
+            RomeError::CantReadFile(path) => {
+                write!(
+                    f,
+                    "Rome couldn't read the following file, maybe for permissions reasons or it doesn't exists: {}",
+                    path
+                )
+            }
+
+            RomeError::Configuration(error) => fmt::Display::fmt(error, f),
+            RomeError::DirtyWorkspace => {
+                write!(f, "Uncommitted changes in repository")
+            }
+            RomeError::RenameError(error) => fmt::Display::fmt(error, f),
+            RomeError::RuleError(cause) => {
+                write!(
+                    f,
+                    "the linter encountered an error while analyzing the file: {cause}",
+                )
+            }
+
+            RomeError::TransportError(err) => {
+                write!(f, "{err}",)
+            }
+            RomeError::FileIgnored(path) => {
+                write!(f, "The file {} was ignored", path)
+            }
+            RomeError::FileTooLarge { path, size, limit } => {
+                write!(f, "Size of {} is {} which exceeds configured maximum of {} for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.", path.display(), Bytes(*size), Bytes(*limit))
+            }
+        }
+    }
+}
+
+impl Error for RomeError {}
+
+impl From<FormatError> for RomeError {
+    fn from(err: FormatError) -> Self {
+        Self::FormatError(err)
+    }
+}
+
+impl From<TransportError> for RomeError {
+    fn from(err: TransportError) -> Self {
+        Self::TransportError(err)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+/// Error emitted by the underlying transport layer for a remote Workspace
+pub enum TransportError {
+    /// Error emitted by the transport layer if the connection was lost due to an I/O error
+    ChannelClosed,
+    /// Error emitted by the transport layer if a request timed out
+    Timeout,
+    /// Error caused by a serialization or deserialization issue
+    SerdeError(String),
+    /// Generic error type for RPC errors that can't be deserialized into RomeError
+    RPCError(String),
+}
+
+impl Error for TransportError {}
+
+impl Display for TransportError {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        match self {
+            TransportError::SerdeError(err) => write!(fmt, "serialization error: {err}"),
+            TransportError::ChannelClosed => fmt.write_str(
+                "a request to the remote workspace failed because the connection was interrupted",
+            ),
+            TransportError::Timeout => {
+                fmt.write_str("the request to the remote workspace timed out")
+            }
+            TransportError::RPCError(err) => fmt.write_str(err),
+        }
+    }
+}
+
+impl Diagnostic for TransportError {
+    fn category(&self) -> Option<&'static Category> {
+        Some(category!("internalError/io"))
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Error
+    }
+
+    fn message(&self, fmt: &mut rome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        match self {
+            TransportError::SerdeError(err) => write!(fmt, "serialization error: {err}"),
+            TransportError::ChannelClosed => fmt.write_str(
+                "a request to the remote workspace failed because the connection was interrupted",
+            ),
+            TransportError::Timeout => {
+                fmt.write_str("the request to the remote workspace timed out")
+            }
+            TransportError::RPCError(err) => fmt.write_str(err),
+        }
+    }
+    fn tags(&self) -> DiagnosticTags {
+        DiagnosticTags::INTERNAL
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::file_handlers::Language;
+    use crate::{RomeError, TransportError};
+    use rome_diagnostics::{print_diagnostic_to_string, DiagnosticExt, Error, FileId};
+    use rome_fs::RomePath;
+    use std::path::PathBuf;
+
+    fn snap_diagnostic(test_name: &str, diagnostic: Error) {
+        let content = print_diagnostic_to_string(diagnostic);
+
+        insta::with_settings!({
+            prepend_module_to_snapshot => false,
+        }, {
+            insta::assert_snapshot!(test_name, content);
+
+        });
+    }
+
+    #[test]
+    fn dirty_workspace() {
+        snap_diagnostic("dirty_workspace", RomeError::DirtyWorkspace.into())
+    }
+
+    #[test]
+    fn file_ignored() {
+        snap_diagnostic(
+            "file_ignored",
+            RomeError::FileIgnored("example.js".to_string())
+                .with_file_path("example.js")
+                .into(),
+        )
+    }
+
+    #[test]
+    fn cant_read_directory() {
+        snap_diagnostic(
+            "cant_read_directory",
+            RomeError::CantReadDirectory("example/".to_string())
+                .with_file_path("example.js")
+                .into(),
+        )
+    }
+
+    #[test]
+    fn cant_read_file() {
+        snap_diagnostic(
+            "cant_read_file",
+            RomeError::CantReadFile("example.js".to_string())
+                .with_file_path("example.js")
+                .into(),
+        )
+    }
+
+    #[test]
+    fn not_found() {
+        snap_diagnostic(
+            "not_found",
+            RomeError::NotFound.with_file_path("not_found.js"),
+        )
+    }
+
+    #[test]
+    fn source_file_not_supported() {
+        snap_diagnostic(
+            "source_file_not_supported",
+            RomeError::SourceFileNotSupported(
+                Language::Unknown,
+                RomePath::new("not_supported.toml", FileId::zero()),
+            )
+            .with_file_path("not_supported.toml"),
+        )
+    }
+
+    #[test]
+    fn file_too_large() {
+        snap_diagnostic(
+            "file_too_large",
+            RomeError::FileTooLarge {
+                path: PathBuf::from("example.js"),
+                limit: 100,
+                size: 500,
+            }
+            .with_file_path("example.js"),
+        )
+    }
+
+    #[test]
+    fn transport_channel_closed() {
+        snap_diagnostic(
+            "transport_channel_closed",
+            TransportError::ChannelClosed.into(),
+        )
+    }
+
+    #[test]
+    fn transport_timeout() {
+        snap_diagnostic("transport_timeout", TransportError::Timeout.into())
+    }
+
+    #[test]
+    fn transport_rpc_error() {
+        snap_diagnostic(
+            "transport_rpc_error",
+            TransportError::RPCError("Some generic error".to_string()).into(),
+        )
+    }
+
+    #[test]
+    fn transport_serde_error() {
+        snap_diagnostic(
+            "transport_serde_error",
+            TransportError::SerdeError("Some serialization/deserialization error".to_string())
+                .into(),
+        )
+    }
+}

--- a/crates/rome_service/src/diagnostics.rs
+++ b/crates/rome_service/src/diagnostics.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 pub enum RomeError {
     /// The project contains uncommitted changes
     DirtyWorkspace,
-    /// The file does not exist in the [Workspace]
+    /// The file does not exist in the [crate::Workspace]
     NotFound,
     /// A file is not supported. It contains the language and path of the file
     /// Use this error if Rome is trying to process a file that Rome can't understand

--- a/crates/rome_service/src/diagnostics.rs
+++ b/crates/rome_service/src/diagnostics.rs
@@ -456,9 +456,7 @@ mod test {
     fn file_ignored() {
         snap_diagnostic(
             "file_ignored",
-            RomeError::FileIgnored("example.js".to_string())
-                .with_file_path("example.js")
-                .into(),
+            RomeError::FileIgnored("example.js".to_string()).with_file_path("example.js"),
         )
     }
 
@@ -466,9 +464,7 @@ mod test {
     fn cant_read_directory() {
         snap_diagnostic(
             "cant_read_directory",
-            RomeError::CantReadDirectory("example/".to_string())
-                .with_file_path("example.js")
-                .into(),
+            RomeError::CantReadDirectory("example/".to_string()).with_file_path("example.js"),
         )
     }
 
@@ -476,9 +472,7 @@ mod test {
     fn cant_read_file() {
         snap_diagnostic(
             "cant_read_file",
-            RomeError::CantReadFile("example.js".to_string())
-                .with_file_path("example.js")
-                .into(),
+            RomeError::CantReadFile("example.js".to_string()).with_file_path("example.js"),
         )
     }
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -520,6 +520,7 @@ fn rename(
         .and_then(|token| token.parent())
     {
         let original_name = node.text_trimmed();
+        let range = node.text_range();
         match node.try_into() {
             Ok(node) => {
                 let mut batch = root.begin();
@@ -527,6 +528,7 @@ fn rename(
                 if !result {
                     Err(RomeError::RenameError(RenameError::CannotBeRenamed {
                         original_name: original_name.to_string(),
+                        original_range: range,
                         new_name,
                     }))
                 } else {
@@ -537,7 +539,9 @@ fn rename(
             Err(err) => Err(RomeError::RenameError(err)),
         }
     } else {
-        Err(RomeError::RenameError(RenameError::CannotFindDeclaration))
+        Err(RomeError::RenameError(RenameError::CannotFindDeclaration(
+            new_name,
+        )))
     }
 }
 

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 pub use javascript::JsFormatterSettings;
 use rome_analyze::AnalysisFilter;
+use rome_console::fmt::Formatter;
+use rome_console::markup;
 use rome_formatter::Printed;
 use rome_fs::RomePath;
 use rome_js_syntax::{TextRange, TextSize};
@@ -97,6 +99,19 @@ impl Language {
     }
 }
 
+impl rome_console::fmt::Display for Language {
+    fn fmt(&self, fmt: &mut Formatter) -> std::io::Result<()> {
+        match self {
+            Language::JavaScript => fmt.write_markup(markup! { "JavaScript" }),
+            Language::JavaScriptReact => fmt.write_markup(markup! { "JSX" }),
+            Language::TypeScript => fmt.write_markup(markup! { "TypeScript" }),
+            Language::TypeScriptReact => fmt.write_markup(markup! { "TSX" }),
+            Language::Json => fmt.write_markup(markup! { "JSON" }),
+            Language::Unknown => fmt.write_markup(markup! { "Unknown" }),
+        }
+    }
+}
+
 // TODO: The Css variant is unused at the moment
 #[allow(dead_code)]
 pub(crate) enum Mime {
@@ -113,6 +128,17 @@ impl std::fmt::Display for Mime {
             Mime::Json => write!(f, "application/json"),
             Mime::Javascript => write!(f, "application/javascript"),
             Mime::Text => write!(f, "text/plain"),
+        }
+    }
+}
+
+impl rome_console::fmt::Display for Mime {
+    fn fmt(&self, f: &mut rome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        match self {
+            Mime::Css => f.write_markup(markup! { "text/css"}),
+            Mime::Json => f.write_markup(markup! { "application/json"}),
+            Mime::Javascript => f.write_markup(markup! { "application/javascript"}),
+            Mime::Text => f.write_markup(markup! { "text/plain"}),
         }
     }
 }

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -133,13 +133,8 @@ impl std::fmt::Display for Mime {
 }
 
 impl rome_console::fmt::Display for Mime {
-    fn fmt(&self, f: &mut rome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
-        match self {
-            Mime::Css => f.write_markup(markup! { "text/css"}),
-            Mime::Json => f.write_markup(markup! { "application/json"}),
-            Mime::Javascript => f.write_markup(markup! { "application/javascript"}),
-            Mime::Text => f.write_markup(markup! { "text/plain"}),
-        }
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::io::Result<()> {
+        write!(f, "{self}")
     }
 }
 

--- a/crates/rome_service/src/lib.rs
+++ b/crates/rome_service/src/lib.rs
@@ -1,23 +1,15 @@
-use rome_console::fmt::Bytes;
 use rome_console::{Console, EnvConsole};
-use rome_formatter::FormatError;
-use rome_fs::{FileSystem, OsFileSystem, RomePath};
-use rome_js_analyze::utils::rename::RenameError;
-use rome_js_analyze::RuleError;
+use rome_fs::{FileSystem, OsFileSystem};
 use serde::{Deserialize, Serialize};
-use std::error::Error;
-use std::ffi::OsStr;
-use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::{Deref, DerefMut};
-use std::path::PathBuf;
 
 pub mod configuration;
 mod file_handlers;
+pub mod matcher;
 pub mod settings;
 pub mod workspace;
 
-pub mod matcher;
-
+mod diagnostics;
 #[cfg(feature = "schemars")]
 pub mod workspace_types;
 
@@ -27,11 +19,11 @@ pub use crate::configuration::{
 pub use crate::matcher::{MatchOptions, Matcher, Pattern};
 
 pub use crate::file_handlers::JsFormatterSettings;
-use crate::file_handlers::Language;
 pub use crate::workspace::Workspace;
 
 /// Exports only for this crate
 pub(crate) use crate::configuration::{deserialize_set_of_strings, serialize_set_of_strings};
+pub use crate::diagnostics::{RomeError, TransportError};
 
 pub const VERSION: &str = match option_env!("ROME_VERSION") {
     Some(version) => version,
@@ -47,183 +39,6 @@ pub struct App<'app> {
     /// A reference to the internal console, where its buffer will be used to write messages and
     /// errors
     pub console: DynRef<'app, dyn Console>,
-}
-
-#[derive(Serialize, Deserialize)]
-/// Generic errors thrown during rome operations
-pub enum RomeError {
-    /// The project contains uncommitted changes
-    DirtyWorkspace,
-    /// The file does not exist in the [Workspace]
-    NotFound,
-    /// A file is not supported. It contains the language and path of the file
-    /// Use this error if Rome is trying to process a file that Rome can't understand
-    SourceFileNotSupported(Language, RomePath),
-    /// The formatter encountered an error while formatting the file
-    FormatError(FormatError),
-    /// The file could not be formatted since it has syntax errors and `format_with_errors` is disabled
-    FormatWithErrorsDisabled,
-    /// The file could not be analyzed because a rule caused an error.
-    RuleError(RuleError),
-    /// Thrown when Rome can't read a generic directory
-    CantReadDirectory(PathBuf),
-    /// Thrown when Rome can't read a generic file
-    CantReadFile(PathBuf),
-    /// Error thrown when validating the configuration. Once deserialized, further checks have to be done.
-    Configuration(ConfigurationError),
-    /// Error thrown when Rome cannot rename a symbol.
-    RenameError(RenameError),
-    /// Error emitted by the underlying transport layer for a remote Workspace
-    TransportError(TransportError),
-    /// Emitted when the file is ignored and should not be processed
-    FileIgnored(PathBuf),
-    /// Emitted when a file could not be parsed because it's larger than the size limite
-    FileTooLarge {
-        path: PathBuf,
-        size: usize,
-        limit: usize,
-    },
-}
-
-impl Debug for RomeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl Display for RomeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            RomeError::SourceFileNotSupported(language, path) => {
-                if *language != Language::Unknown {
-                    write!(
-                        f,
-                        "Rome doesn't support this feature for the language {language:?}"
-                    )
-                } else if let Some(ext) = path.extension().and_then(OsStr::to_str) {
-                    write!(
-                        f,
-                        "Rome could not determine the language for the file extension {ext:?}"
-                    )
-                } else {
-                    write!(
-                        f,
-                        "Rome could not determine the language for the file {path:?} because it doesn't have a clear extension"
-                    )
-                }
-            }
-            RomeError::NotFound => {
-                write!(f, "the file does not exist in the workspace")
-            }
-            RomeError::FormatError(cause) => {
-                write!(
-                    f,
-                    "the formatter encountered an error while formatting the file: {}",
-                    cause
-                )
-            }
-            RomeError::FormatWithErrorsDisabled => {
-                write!(f, "the file could not be formatted since it has syntax errors and `format_with_errors` is disabled")
-            }
-            RomeError::CantReadDirectory(path) => {
-                write!(
-                    f,
-                    "Rome couldn't read the following directory, maybe for permissions reasons or it doesn't exists: {}",
-                    path.display()
-                )
-            }
-            RomeError::CantReadFile(path) => {
-                write!(
-                    f,
-                    "Rome couldn't read the following file, maybe for permissions reasons or it doesn't exists: {}",
-                    path.display()
-                )
-            }
-
-            RomeError::Configuration(error) => fmt::Display::fmt(error, f),
-            RomeError::DirtyWorkspace => {
-                write!(f, "Uncommitted changes in repository")
-            }
-            RomeError::RenameError(error) => match error {
-                RenameError::CannotBeRenamed {
-                    original_name,
-                    new_name,
-                } => {
-                    write!(
-                        f,
-                        "encountered an error while renaming the symbol \"{}\" to \"{}\"",
-                        original_name, new_name
-                    )
-                }
-                RenameError::CannotFindDeclaration => {
-                    write!(
-                        f,
-                        "encountered an error finding a declaration at the specified position"
-                    )
-                }
-            },
-            RomeError::RuleError(cause) => {
-                write!(
-                    f,
-                    "the linter encountered an error while analyzing the file: {cause}",
-                )
-            }
-
-            RomeError::TransportError(err) => {
-                write!(f, "{err}",)
-            }
-            RomeError::FileIgnored(path) => {
-                write!(f, "The file {} was ignored", path.display())
-            }
-            RomeError::FileTooLarge { path, size, limit } => {
-                write!(f, "Size of {} is {} which exceeds configured maximum of {} for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.", path.display(), Bytes(*size), Bytes(*limit))
-            }
-        }
-    }
-}
-
-impl Error for RomeError {}
-
-impl From<FormatError> for RomeError {
-    fn from(err: FormatError) -> Self {
-        Self::FormatError(err)
-    }
-}
-
-impl From<TransportError> for RomeError {
-    fn from(err: TransportError) -> Self {
-        Self::TransportError(err)
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-/// Error emitted by the underlying transport layer for a remote Workspace
-pub enum TransportError {
-    /// Error emitted by the transport layer if the connection was lost due to an I/O error
-    ChannelClosed,
-    /// Error emitted by the transport layer if a request timed out
-    Timeout,
-    /// Error caused by a serialization or deserialization issue
-    SerdeError(String),
-    /// Generic error type for RPC errors that can't be deserialized into RomeError
-    RPCError(String),
-}
-
-impl Error for TransportError {}
-
-impl Display for TransportError {
-    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        match self {
-            TransportError::SerdeError(err) => write!(fmt, "serialization error: {err}"),
-            TransportError::ChannelClosed => fmt.write_str(
-                "a request to the remote workspace failed because the connection was interrupted",
-            ),
-            TransportError::Timeout => {
-                fmt.write_str("the request to the remote workspace timed out")
-            }
-            TransportError::RPCError(err) => fmt.write_str(err),
-        }
-    }
 }
 
 impl Default for App<'static> {

--- a/crates/rome_service/src/snapshots/cant_read_directory.snap
+++ b/crates/rome_service/src/snapshots/cant_read_directory.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+example.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Rome couldn't read the following directory, maybe for permissions reasons or it doesn't exists: example/
+  
+
+

--- a/crates/rome_service/src/snapshots/cant_read_directory.snap
+++ b/crates/rome_service/src/snapshots/cant_read_directory.snap
@@ -2,7 +2,7 @@
 source: crates/rome_service/src/diagnostics.rs
 expression: content
 ---
-example.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+example/ internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Rome couldn't read the following directory, maybe for permissions reasons or it doesn't exists: example/
   

--- a/crates/rome_service/src/snapshots/cant_read_file.snap
+++ b/crates/rome_service/src/snapshots/cant_read_file.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+example.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Rome couldn't read the following file, maybe for permissions reasons or it doesn't exists: example.js
+  
+
+

--- a/crates/rome_service/src/snapshots/dirty_workspace.snap
+++ b/crates/rome_service/src/snapshots/dirty_workspace.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Uncommitted changes in repository
+  
+
+

--- a/crates/rome_service/src/snapshots/file_ignored.snap
+++ b/crates/rome_service/src/snapshots/file_ignored.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+example.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file example.js was ignored
+  
+
+

--- a/crates/rome_service/src/snapshots/file_too_large.snap
+++ b/crates/rome_service/src/snapshots/file_too_large.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+example.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Size of example.js is 500 B which exceeds configured maximum of 100 B for this project. The file size limit exists to prevent us inadvertently slowing down and loading large files that we shouldn't.
+  
+
+

--- a/crates/rome_service/src/snapshots/formatter_syntax_error.snap
+++ b/crates/rome_service/src/snapshots/formatter_syntax_error.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+example.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × the formatter encountered an error while formatting the file: Syntax error.
+  
+
+

--- a/crates/rome_service/src/snapshots/not_found.snap
+++ b/crates/rome_service/src/snapshots/not_found.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+not_found.js internalError/fs  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file does not exist in the workspace.
+  
+  ! This diagnostic was derived from an internal Rome error. Potential bug, please report it if necessary.
+  
+
+

--- a/crates/rome_service/src/snapshots/source_file_not_supported.snap
+++ b/crates/rome_service/src/snapshots/source_file_not_supported.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+not_supported.toml internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Rome could not determine the language for the file extension toml
+  
+
+

--- a/crates/rome_service/src/snapshots/transport_channel_closed.snap
+++ b/crates/rome_service/src/snapshots/transport_channel_closed.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+internalError/io  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × a request to the remote workspace failed because the connection was interrupted
+  
+  ! This diagnostic was derived from an internal Rome error. Potential bug, please report it if necessary.
+  
+
+

--- a/crates/rome_service/src/snapshots/transport_rpc_error.snap
+++ b/crates/rome_service/src/snapshots/transport_rpc_error.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+internalError/io  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some generic error
+  
+  ! This diagnostic was derived from an internal Rome error. Potential bug, please report it if necessary.
+  
+
+

--- a/crates/rome_service/src/snapshots/transport_serde_error.snap
+++ b/crates/rome_service/src/snapshots/transport_serde_error.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+internalError/io  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × serialization error: Some serialization/deserialization error
+  
+  ! This diagnostic was derived from an internal Rome error. Potential bug, please report it if necessary.
+  
+
+

--- a/crates/rome_service/src/snapshots/transport_timeout.snap
+++ b/crates/rome_service/src/snapshots/transport_timeout.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rome_service/src/diagnostics.rs
+expression: content
+---
+internalError/io  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × the request to the remote workspace timed out
+  
+  ! This diagnostic was derived from an internal Rome error. Potential bug, please report it if necessary.
+  
+
+

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -116,7 +116,10 @@ impl WorkspaceServer {
         };
 
         if ignored {
-            return Err(RomeError::FileIgnored(rome_path.to_path_buf()));
+            return Err(RomeError::FileIgnored(format!(
+                "{}",
+                rome_path.to_path_buf().display()
+            )));
         }
 
         match self.syntax.entry(rome_path) {

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -763,6 +763,7 @@ export type Category =
 	| "suppressions/unknownRule"
 	| "suppressions/unused"
 	| "suppressions/deprecatedSyntax"
+	| "configuration"
 	| "args/fileNotFound"
 	| "flags/invalid"
 	| "semanticTests";


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR implements the trait `Diagnostic` to the enum `RomeError`. This change **doesn't change** the current logic of how the errors are printed to the console.

List of the changes:
- the various errors defined in the multiple crates have been moved inside a generic file called `diagnostics.rs`, and it seems a generic pattern we are adopting across the code base
- `insta` has been moved into the workspace, so we have one single version across the code base
- some errors have been slightly changed, for example, the `ConfigurationError`, so more and better information can be printed using the `Diagnostic` trait
- the messages inside the `message()` and `description()` functions are a copy-paste from the `Display` trait, and I intend to keep them this way. We can review the messaging once the transition is completed and we print these diagnostics in the CLI
- various errors have now snapshot tests, to show people how they **_will_ look like** once the transition is finished (not in this PR) 

**These changes are safe and can be merged whenever**.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I created new snapshots to show the look and file of the changes.
The current tests of the CLI should stay the same.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
