### PR TITLE
fix(rome_cli): Remove `eprintln`

### DIFF
--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -465,7 +465,6 @@ fn process_messages(options: ProcessMessagesOptions) {
                     }
                 } else {
                     for diag in diagnostics {
-                        eprintln!("Diagnostics {:?}", diag.severity());
                         let severity = diag.severity();
                         if severity == Severity::Error {
                             *errors += 1;


### PR DESCRIPTION


## Summary

Remove `eprintln` statement that

## Test Plan

**Before**
![grafik](https://user-images.githubusercontent.com/1203881/205312321-7a454aa5-57e2-47cf-bba7-429616751539.png)

**After**
![grafik](https://user-images.githubusercontent.com/1203881/205312406-e5f0310a-0392-43a9-9f32-ffe63d5d75a1.png)
