### PR TITLE
feat(rome_js_analyze): Improve generated suppression text

### DIFF
--- a/crates/rome_js_analyze/src/suppression_action.rs
+++ b/crates/rome_js_analyze/src/suppression_action.rs
@@ -61,7 +61,7 @@ pub(crate) fn apply_suppression_comment(payload: SuppressionCommentEmitterPayloa
                 let jsx_comment = jsx_expression_child(
                     token(T!['{']).with_trailing_trivia([(
                         TriviaPieceKind::SingleLineComment,
-                        format!("/* {}: suppressed */", suppression_text).as_str(),
+                        format!("/* {}: <explanation> */", suppression_text).as_str(),
                     )]),
                     token(T!['}']),
                 )
@@ -99,7 +99,7 @@ pub(crate) fn apply_suppression_comment(payload: SuppressionCommentEmitterPayloa
                         (TriviaPieceKind::Newline, "\n"),
                         (
                             TriviaPieceKind::SingleLineComment,
-                            format!("// {}: suppressed ", suppression_text).as_str(),
+                            format!("// {}: <explanation>", suppression_text).as_str(),
                         ),
                         (TriviaPieceKind::Newline, "\n"),
                     ])
@@ -107,7 +107,7 @@ pub(crate) fn apply_suppression_comment(payload: SuppressionCommentEmitterPayloa
                     new_token = new_token.with_leading_trivia([
                         (
                             TriviaPieceKind::SingleLineComment,
-                            format!("// {}: suppressed ", suppression_text).as_str(),
+                            format!("// {}: <explanation>", suppression_text).as_str(),
                         ),
                         (TriviaPieceKind::Newline, "\n"),
                     ])
@@ -122,7 +122,7 @@ pub(crate) fn apply_suppression_comment(payload: SuppressionCommentEmitterPayloa
                         (TriviaPieceKind::Newline, "\n"),
                         (
                             TriviaPieceKind::SingleLineComment,
-                            format!("// {}: suppressed ", suppression_text).as_str(),
+                            format!("// {}: <explanation>", suppression_text).as_str(),
                         ),
                         (TriviaPieceKind::Newline, "\n"),
                     ])
@@ -131,7 +131,7 @@ pub(crate) fn apply_suppression_comment(payload: SuppressionCommentEmitterPayloa
                         (TriviaPieceKind::Newline, "\n"),
                         (
                             TriviaPieceKind::SingleLineComment,
-                            format!("// {}: suppressed ", suppression_text).as_str(),
+                            format!("// {}: <explanation>", suppression_text).as_str(),
                         ),
                         (TriviaPieceKind::Newline, "\n"),
                     ])
@@ -140,7 +140,7 @@ pub(crate) fn apply_suppression_comment(payload: SuppressionCommentEmitterPayloa
                 new_token = new_token.with_trailing_trivia([
                     (
                         TriviaPieceKind::SingleLineComment,
-                        format!("// {}: suppressed ", suppression_text).as_str(),
+                        format!("// {}: <explanation>", suppression_text).as_str(),
                     ),
                     (TriviaPieceKind::Newline, "\n"),
                 ])
@@ -148,7 +148,7 @@ pub(crate) fn apply_suppression_comment(payload: SuppressionCommentEmitterPayloa
                 new_token = new_token.with_leading_trivia([
                     (
                         TriviaPieceKind::SingleLineComment,
-                        format!("// {}: suppressed ", suppression_text).as_str(),
+                        format!("// {}: <explanation>", suppression_text).as_str(),
                     ),
                     (TriviaPieceKind::Newline, "\n"),
                 ])

--- a/crates/rome_js_analyze/tests/suppression/a11y/useKeyWithClickEvents.jsx.snap
+++ b/crates/rome_js_analyze/tests/suppression/a11y/useKeyWithClickEvents.jsx.snap
@@ -37,7 +37,7 @@ useKeyWithClickEvents.jsx:1:1 lint/a11y/useKeyWithClickEvents  FIXABLE  ━━�
   
   i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents
   
-       1 │ + //·rome-ignore·lint/a11y/useKeyWithClickEvents:·suppressed·
+       1 │ + //·rome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
     1  2 │   <div
     2  3 │       className="SomeManyClasses"
   

--- a/crates/rome_js_analyze/tests/suppression/correctness/noArrayIndexKey.jsx.snap
+++ b/crates/rome_js_analyze/tests/suppression/correctness/noArrayIndexKey.jsx.snap
@@ -70,7 +70,7 @@ noArrayIndexKey.jsx:4:22 lint/correctness/noArrayIndexKey  FIXABLE  ━━━━
      2  2 │   
      3  3 │   something.forEach((Element, index) => {
      4    │ - ····return·<div·key={index}>foo</div>;
-        4 │ + ····//·rome-ignore·lint/correctness/noArrayIndexKey:·suppressed·
+        4 │ + ····//·rome-ignore·lint/correctness/noArrayIndexKey:·<explanation>
         5 │ + return··<div·key={index}>foo</div>;
      5  6 │   });
      6  7 │   
@@ -107,7 +107,7 @@ noArrayIndexKey.jsx:7:49 lint/correctness/noArrayIndexKey  FIXABLE  ━━━━
   
      5  5 │   });
      6  6 │   
-        7 │ + //·rome-ignore·lint/correctness/noArrayIndexKey:·suppressed·
+        7 │ + //·rome-ignore·lint/correctness/noArrayIndexKey:·<explanation>
      7  8 │   something.forEach((Element, index) => <div key={index}>foo</div>);
      8  9 │   
   
@@ -144,7 +144,7 @@ noArrayIndexKey.jsx:11:23 lint/correctness/noArrayIndexKey  FIXABLE  ━━━�
      9  9 │   something.forEach((Element, index) => {
     10 10 │       return <List>
     11    │ - ············<div·key={index}>foo</div>
-       11 │ + ············{/*·rome-ignore·lint/correctness/noArrayIndexKey:·suppressed·*/}
+       11 │ + ············{/*·rome-ignore·lint/correctness/noArrayIndexKey:·<explanation>·*/}
        12 │ + ············<div·key={index}>foo</div>
     12 13 │       </List>;
     13 14 │   });
@@ -182,7 +182,7 @@ noArrayIndexKey.jsx:17:20 lint/correctness/noArrayIndexKey  FIXABLE  ━━━�
     15 15 │   something.forEach((Element, index) => {
     16 16 │       return <List
     17    │ - ········><div·key={index}>foo</div>
-       17 │ + ········//·rome-ignore·lint/correctness/noArrayIndexKey:·suppressed·
+       17 │ + ········//·rome-ignore·lint/correctness/noArrayIndexKey:·<explanation>
        18 │ + ><div·key={index}>foo</div>
     18 19 │       </List>;
     19 20 │   });
@@ -220,7 +220,7 @@ noArrayIndexKey.jsx:25:19 lint/correctness/noArrayIndexKey  FIXABLE  ━━━�
     23 23 │           "a b\
     24 24 │           cd"
     25    │ - ········<div·key={index}>foo</div>
-       25 │ + ········{/*·rome-ignore·lint/correctness/noArrayIndexKey:·suppressed·*/}
+       25 │ + ········{/*·rome-ignore·lint/correctness/noArrayIndexKey:·<explanation>·*/}
        26 │ + ········<div·key={index}>foo</div>
     26 27 │       </List>;
     27 28 │   });
@@ -258,7 +258,7 @@ noArrayIndexKey.jsx:32:22 lint/correctness/noArrayIndexKey  FIXABLE  ━━━�
     30 30 │       return <List>
     31 31 │           "a b\
     32    │ - ········cd"<div·key={index}>foo</div>
-       32 │ + ········cd"{/*·rome-ignore·lint/correctness/noArrayIndexKey:·suppressed·*/}
+       32 │ + ········cd"{/*·rome-ignore·lint/correctness/noArrayIndexKey:·<explanation>·*/}
        33 │ + ········<div·key={index}>foo</div>
     33 34 │       </List>;
     34 35 │   });

--- a/crates/rome_js_analyze/tests/suppression/correctness/noDoubleEquals/noDoubleEquals.js.snap
+++ b/crates/rome_js_analyze/tests/suppression/correctness/noDoubleEquals/noDoubleEquals.js.snap
@@ -56,7 +56,7 @@ noDoubleEquals.js:3:5 lint/correctness/noDoubleEquals  FIXABLE  ━━━━━�
      1  1 │   const foo = `
      2  2 │   text
      3    │ - ${a·==·b}
-        3 │ + ${//·rome-ignore·lint/correctness/noDoubleEquals:·suppressed·
+        3 │ + ${//·rome-ignore·lint/correctness/noDoubleEquals:·<explanation>
         4 │ + a··==·b}
      4  5 │   `;
      5  6 │   
@@ -90,7 +90,7 @@ noDoubleEquals.js:7:3 lint/correctness/noDoubleEquals  FIXABLE  ━━━━━�
      5  5 │   
      6  6 │   // existing comment
      7    │ - a·==·b;
-        7 │ + //·rome-ignore·lint/correctness/noDoubleEquals:·suppressed·
+        7 │ + //·rome-ignore·lint/correctness/noDoubleEquals:·<explanation>
         8 │ + a··==·b;
      8  9 │   
      9 10 │   if (a == b) {
@@ -126,7 +126,7 @@ noDoubleEquals.js:9:7 lint/correctness/noDoubleEquals  FIXABLE  ━━━━━�
      7  7 │   a == b;
      8  8 │   
      9    │ - if·(a·==·b)·{
-        9 │ + //·rome-ignore·lint/correctness/noDoubleEquals:·suppressed·
+        9 │ + //·rome-ignore·lint/correctness/noDoubleEquals:·<explanation>
        10 │ + if··(a·==·b)·{
     10 11 │       false;
     11 12 │   }
@@ -160,7 +160,7 @@ noDoubleEquals.js:14:11 lint/correctness/noDoubleEquals  FIXABLE  ━━━━�
     12 12 │   
     13 13 │   if (/** some weird comment
     14    │ - ····**/·a·==·b)·{
-       14 │ + ····**/·//·rome-ignore·lint/correctness/noDoubleEquals:·suppressed·
+       14 │ + ····**/·//·rome-ignore·lint/correctness/noDoubleEquals:·<explanation>
        15 │ + a·==·b)·{
     15 16 │   
     16 17 │       }
@@ -194,7 +194,7 @@ noDoubleEquals.js:19:34 lint/correctness/noDoubleEquals  FIXABLE  ━━━━�
     17 17 │   
     18 18 │   let a = `Output of "rome rage":
     19    │ - ··formatter·enabled:·${formatter·==·true}
-       19 │ + ··formatter·enabled:·${//·rome-ignore·lint/correctness/noDoubleEquals:·suppressed·
+       19 │ + ··formatter·enabled:·${//·rome-ignore·lint/correctness/noDoubleEquals:·<explanation>
        20 │ + formatter··==·true}
     20 21 │     linter: ${linter}
     21 22 │   `;

--- a/crates/rome_js_analyze/tests/suppression/correctness/noDoubleEquals/noDoubleEquals.jsx.snap
+++ b/crates/rome_js_analyze/tests/suppression/correctness/noDoubleEquals/noDoubleEquals.jsx.snap
@@ -42,7 +42,7 @@ noDoubleEquals.jsx:3:51 lint/correctness/noDoubleEquals  FIXABLE  ━━━━�
     1 1 │   let a = <button
     2 2 │       className="SomeManyClasses"
     3   │ - ····onClick={(event)·=>·console.log(event.ctrlKey·==·true)}
-      3 │ + ····//·rome-ignore·lint/correctness/noDoubleEquals:·suppressed·
+      3 │ + ····//·rome-ignore·lint/correctness/noDoubleEquals:·<explanation>
       4 │ + onClick={(event)·=>·console.log(event.ctrlKey·==·true)}
     4 5 │       style="color: red"
     5 6 │   >

--- a/crates/rome_js_analyze/tests/suppression/correctness/noUndeclaredVariables.ts.snap
+++ b/crates/rome_js_analyze/tests/suppression/correctness/noUndeclaredVariables.ts.snap
@@ -29,7 +29,7 @@ noUndeclaredVariables.ts:5:7 lint/correctness/noUndeclaredVariables  FIXABLE  �
     3 3 │   export type Invalid<S extends number> = `
     4 4 │       Hello
     5   │ - ····${T}
-      5 │ + ····${//·rome-ignore·lint/correctness/noUndeclaredVariables:·suppressed·
+      5 │ + ····${//·rome-ignore·lint/correctness/noUndeclaredVariables:·<explanation>
       6 │ + T}
     6 7 │   `
   

--- a/crates/rome_js_analyze/tests/suppression/correctness/noUnusedVariables/simple.js.snap
+++ b/crates/rome_js_analyze/tests/suppression/correctness/noUnusedVariables/simple.js.snap
@@ -21,7 +21,7 @@ simple.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━
   i Safe fix: Suppress rule lint/correctness/noUnusedVariables
   
     1   │ - let·c·=·!a·||·!b;
-      1 │ + //·rome-ignore·lint/correctness/noUnusedVariables:·suppressed·
+      1 │ + //·rome-ignore·lint/correctness/noUnusedVariables:·<explanation>
       2 │ + let··c·=·!a·||·!b;
   
 

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -707,7 +707,7 @@ async fn pull_quick_fixes() -> Result<()> {
                 },
             },
             new_text: String::from(
-                "// rome-ignore lint/correctness/noCompareNegZero: suppressed \n",
+                "// rome-ignore lint/correctness/noCompareNegZero: <explanation>\n",
             ),
         }],
     );


### PR DESCRIPTION
The suppression code action used to insert a suppression comment with the *reason* `suppressed`. The issue with `suppressed` is that users might think that this is the exact syntax necessary for suppression comments rather than it being a placeholder for the reason why the rule is suppressed.

This PR changes the inserted suppression:

```
//·rome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>

```

which hopefully makes it clear to users that they should replace `<explanation>` with a reason.

A more involved solution could select the `<explanation>` after adding the suppression comment.

## Test Plan

See updated snapshots
