### PR TITLE
fix(rome_js_analyze): use exhaustive deps considering external const as stable

### DIFF
--- a/crates/rome_js_analyze/src/react/hooks.rs
+++ b/crates/rome_js_analyze/src/react/hooks.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use rome_js_semantic::{Capture, ClosureExtensions, SemanticModel};
 use rome_js_syntax::{
-    AnyJsExpression, JsArrayBindingPattern, JsArrayBindingPatternElementList, JsCallExpression,
-    JsIdentifierBinding, JsVariableDeclarator, TextRange,
+    binding_ext::AnyJsIdentifierBinding, AnyJsExpression, JsArrayBindingPattern,
+    JsArrayBindingPatternElementList, JsCallExpression, JsVariableDeclarator, TextRange,
 };
 use rome_rowan::AstNode;
 use serde::{Deserialize, Serialize};
@@ -138,11 +138,11 @@ impl StableReactHookConfiguration {
 /// }, [name]);
 /// ```
 pub fn is_binding_react_stable(
-    binding: &JsIdentifierBinding,
+    binding: &AnyJsIdentifierBinding,
     stable_config: &HashSet<StableReactHookConfiguration>,
 ) -> bool {
     fn array_binding_declarator_index(
-        binding: &JsIdentifierBinding,
+        binding: &AnyJsIdentifierBinding,
     ) -> Option<(JsVariableDeclarator, Option<usize>)> {
         let index = binding.syntax().index() / 2;
         let declarator = binding
@@ -153,7 +153,7 @@ pub fn is_binding_react_stable(
     }
 
     fn assignment_declarator(
-        binding: &JsIdentifierBinding,
+        binding: &AnyJsIdentifierBinding,
     ) -> Option<(JsVariableDeclarator, Option<usize>)> {
         let declarator = binding.parent::<JsVariableDeclarator>()?;
         Some((declarator, None))
@@ -191,7 +191,6 @@ mod test {
     use super::*;
     use rome_diagnostics::FileId;
     use rome_js_syntax::SourceType;
-    use rome_rowan::SyntaxNodeCast;
 
     #[test]
     pub fn ok_react_stable_captures() {
@@ -206,7 +205,7 @@ mod test {
             .filter(|x| x.text_trimmed() == "ref")
             .last()
             .unwrap();
-        let set_name = node.cast::<JsIdentifierBinding>().unwrap();
+        let set_name = AnyJsIdentifierBinding::cast(node).unwrap();
 
         let config = HashSet::from_iter([
             StableReactHookConfiguration::new("useRef", None),

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
@@ -258,19 +258,19 @@ fn capture_needs_to_be_in_the_dependency_list(
         | AnyJsBindingDeclaration::TsImportEqualsDeclaration(_) => {
             unreachable!()
         }
-
     }
 }
 
 // Find the function that is calling the hook
 fn function_of_hook_call(call: &JsCallExpression) -> Option<JsSyntaxNode> {
-    call.syntax()
-        .ancestors()
-        .find(|x| matches!(x.kind(), 
+    call.syntax().ancestors().find(|x| {
+        matches!(
+            x.kind(),
             JsSyntaxKind::JS_FUNCTION_DECLARATION
-            | JsSyntaxKind::JS_FUNCTION_EXPRESSION
-            | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION
-        ))
+                | JsSyntaxKind::JS_FUNCTION_EXPRESSION
+                | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION
+        )
+    })
 }
 
 impl Rule for UseExhaustiveDependencies {

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
@@ -4,9 +4,10 @@ use rome_analyze::{
     context::RuleContext, declare_rule, DeserializableRuleOptions, Rule, RuleDiagnostic,
 };
 use rome_console::markup;
+use rome_js_semantic::{Capture, SemanticModel};
 use rome_js_syntax::{
-    JsCallExpression, JsIdentifierBinding, JsStaticMemberExpression, JsSyntaxKind, JsSyntaxNode,
-    JsVariableDeclaration, JsVariableDeclarator, TextRange, TsIdentifierBinding,
+    binding_ext::AnyJsBindingDeclaration, JsCallExpression, JsStaticMemberExpression, JsSyntaxKind,
+    JsSyntaxNode, JsVariableDeclaration, TextRange,
 };
 use rome_rowan::{AstNode, SyntaxNodeCast};
 use serde::{Deserialize, Serialize};
@@ -20,56 +21,70 @@ declare_rule! {
     /// ### Invalid
     ///
     /// ```js,expect_diagnostic
-    /// let a = 1;
-    /// useEffect(() => {
-    ///     console.log(a);
-    /// })
+    /// function f() {
+    ///     let a = 1;
+    ///     useEffect(() => {
+    ///         console.log(a);
+    ///     });
+    /// }
     /// ```
     ///
     /// ```js,expect_diagnostic
-    /// let b = 1;
-    /// useEffect(() => {
-    /// }, [b])
+    /// function f() {
+    ///     let b = 1;
+    ///     useEffect(() => {
+    ///     }, [b]);
+    /// }
     /// ```
     ///
     /// ```js,expect_diagnostic
-    /// const [name, setName] = useState();
-    /// useEffect(() => {
-    ///     console.log(name);
-    ///     setName("");
-    /// }, [name, setName])
+    /// function f() {
+    ///     const [name, setName] = useState();
+    ///     useEffect(() => {
+    ///         console.log(name);
+    ///         setName("");
+    ///     }, [name, setName]);
+    /// }
     /// ```
     ///
     /// ```js,expect_diagnostic
-    /// let a = 1;
-    /// const b = a + 1;
-    /// useEffect(() => {
-    ///     console.log(b);
-    /// })
+    /// function f() {
+    ///     let a = 1;
+    ///     const b = a + 1;
+    ///     useEffect(() => {
+    ///         console.log(b);
+    ///     });
+    /// }
     /// ```
     ///
     /// ## Valid
     ///
     /// ```js
-    /// let a = 1;
-    /// useEffect(() => {
-    ///     console.log(a);
-    /// }, [a]);
+    /// function f() {
+    ///     let a = 1;
+    ///     useEffect(() => {
+    ///         console.log(a);
+    ///     }, [a]);
+    /// }
     /// ```
     ///
     /// ```js
-    /// const a = 1;
-    /// useEffect(() => {
-    ///     console.log(a);
-    /// });
+    /// function f() {
+    ///     const a = 1;
+    ///     useEffect(() => {
+    ///         console.log(a);
+    ///     });
+    /// }
     /// ```
     ///
     /// ```js
-    /// const [name, setName] = useState();
-    /// useEffect(() => {
-    ///     console.log(name);
-    ///     setName("");
-    /// }, [name])
+    /// function f() {
+    ///     const [name, setName] = useState();
+    ///     useEffect(() => {
+    ///         console.log(name);
+    ///         setName("");
+    ///     }, [name]);
+    /// }
     /// ```
     ///
     pub(crate) UseExhaustiveDependencies {
@@ -167,6 +182,80 @@ fn get_whole_static_member_expression(
     root.cast()
 }
 
+// Test if a capture needs to be in the dependency list
+// of a react hook call
+fn capture_needs_to_be_in_the_dependency_list(
+    capture: Capture,
+    component_function_range: &TextRange,
+    model: &SemanticModel,
+    options: &ReactExtensiveDependenciesOptions,
+) -> Option<Capture> {
+    let binding = capture.binding();
+
+    // Ignore if imported
+    if binding.is_imported() {
+        return None;
+    }
+
+    match binding.tree().declaration()? {
+        // These declarations are always stable
+        AnyJsBindingDeclaration::JsFunctionDeclaration(_)
+        | AnyJsBindingDeclaration::JsClassDeclaration(_)
+        | AnyJsBindingDeclaration::TsEnumDeclaration(_)
+        | AnyJsBindingDeclaration::TsTypeAliasDeclaration(_)
+        | AnyJsBindingDeclaration::TsInterfaceDeclaration(_)
+        | AnyJsBindingDeclaration::TsModuleDeclaration(_) => None,
+
+        // Variable declarators are stable if ...
+        AnyJsBindingDeclaration::JsVariableDeclarator(declarator) => {
+            let declaration = declarator
+                .syntax()
+                .ancestors()
+                .filter_map(JsVariableDeclaration::cast)
+                .next()?;
+            let declaration_range = declaration.syntax().text_range();
+
+            if declaration.is_const() {
+                // ... they are `const` and declared outside of the component function
+                let _ = component_function_range.intersect(declaration_range)?;
+
+                // ... they are `const` and their initializer is constant
+                let initializer = declarator.initializer()?;
+                let expr = initializer.expression().ok()?;
+                if model.is_constant(&expr) {
+                    return None;
+                }
+            }
+
+            // ... they are assign to stable returns of another React function
+            let not_stable = !is_binding_react_stable(&binding.tree(), &options.stable_config);
+            not_stable.then_some(capture)
+        }
+
+        // all others need to be in the dependency list
+        AnyJsBindingDeclaration::JsFormalParameter(_)
+        | AnyJsBindingDeclaration::JsRestParameter(_)
+        | AnyJsBindingDeclaration::JsBogusParameter(_)
+        | AnyJsBindingDeclaration::TsIndexSignatureParameter(_)
+        | AnyJsBindingDeclaration::TsPropertyParameter(_)
+        | AnyJsBindingDeclaration::JsFunctionExpression(_)
+        | AnyJsBindingDeclaration::TsDeclareFunctionDeclaration(_)
+        | AnyJsBindingDeclaration::JsClassExpression(_)
+        | AnyJsBindingDeclaration::JsImportDefaultClause(_)
+        | AnyJsBindingDeclaration::JsImportNamespaceClause(_)
+        | AnyJsBindingDeclaration::JsShorthandNamedImportSpecifier(_)
+        | AnyJsBindingDeclaration::JsNamedImportSpecifier(_)
+        | AnyJsBindingDeclaration::JsBogusNamedImportSpecifier(_)
+        | AnyJsBindingDeclaration::JsDefaultImportSpecifier(_)
+        | AnyJsBindingDeclaration::JsNamespaceImportSpecifier(_)
+        | AnyJsBindingDeclaration::TsImportEqualsDeclaration(_)
+        | AnyJsBindingDeclaration::JsClassExportDefaultDeclaration(_)
+        | AnyJsBindingDeclaration::JsFunctionExportDefaultDeclaration(_)
+        | AnyJsBindingDeclaration::TsDeclareFunctionExportDefaultDeclaration(_)
+        | AnyJsBindingDeclaration::JsCatchDeclaration(_) => Some(capture),
+    }
+}
+
 impl Rule for UseExhaustiveDependencies {
     type Query = Semantic<JsCallExpression>;
     type State = Fix;
@@ -178,63 +267,29 @@ impl Rule for UseExhaustiveDependencies {
 
         let mut signals = vec![];
 
-        let node = ctx.query();
-        if let Some(result) = react_hook_with_dependency(node, &options.hooks_config) {
+        let call = ctx.query();
+        if let Some(result) = react_hook_with_dependency(call, &options.hooks_config) {
             let model = ctx.model();
+
+            let Some(component_function) = call
+                .syntax()
+                .ancestors()
+                .find(|x| matches!(x.kind(), JsSyntaxKind::JS_FUNCTION_DECLARATION))
+            else {
+                return vec![]
+            };
+
+            let component_function_range = component_function.text_range();
 
             let captures: Vec<_> = result
                 .all_captures(model)
-                .into_iter()
                 .filter_map(|capture| {
-                    let binding = capture.binding();
-                    let binding_syntax = binding.syntax();
-                    let node = binding_syntax.parent()?;
-                    use JsSyntaxKind::*;
-                    match node.kind() {
-                        JS_FUNCTION_DECLARATION
-                        | JS_CLASS_DECLARATION
-                        | TS_ENUM_DECLARATION
-                        | TS_TYPE_ALIAS_DECLARATION
-                        | TS_DECLARE_FUNCTION_DECLARATION => None,
-                        _ => {
-                            // Ignore if imported
-                            if let Some(true) = binding_syntax
-                                .clone()
-                                .cast::<JsIdentifierBinding>()
-                                .map(|node| model.is_imported(&node))
-                                .or_else(|| {
-                                    Some(model.is_imported(&node.cast::<TsIdentifierBinding>()?))
-                                })
-                            {
-                                None
-                            } else {
-                                let binding =
-                                    binding.syntax().clone().cast::<JsIdentifierBinding>()?;
-
-                                // Ignore if constant
-                                if let Some(declarator) = binding.parent::<JsVariableDeclarator>() {
-                                    let declaration = declarator
-                                        .syntax()
-                                        .ancestors()
-                                        .filter_map(JsVariableDeclaration::cast)
-                                        .next()?;
-
-                                    if declaration.is_const() {
-                                        let initializer = declarator.initializer()?;
-                                        let expr = initializer.expression().ok()?;
-                                        if model.is_constant(&expr) {
-                                            return None;
-                                        }
-                                    }
-                                }
-
-                                // Ignore if stable
-                                let not_stable =
-                                    !is_binding_react_stable(&binding, &options.stable_config);
-                                not_stable.then_some(capture)
-                            }
-                        }
-                    }
+                    capture_needs_to_be_in_the_dependency_list(
+                        capture,
+                        &component_function_range,
+                        model,
+                        options,
+                    )
                 })
                 .map(|capture| {
                     let path = get_whole_static_member_expression(capture.node());

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/missingDependenciesInvalid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/missingDependenciesInvalid.js
@@ -1,4 +1,4 @@
-function MyComponent() {
+function MyComponent1() {
     let a = 1;
     const b = a + 1;
     useEffect(() => {
@@ -64,9 +64,21 @@ function MyComponent5() {
 
 // Capturing an object property
 
-function MyComponent1() {
+function MyComponent6() {
   let someObj = getObj();
   useEffect(() => {
       console.log(someObj.name)
   });
 }
+
+const MyComponent7 = React.memo(function ({ a }) {
+  useEffect(() => {
+      console.log(a);
+  });
+});
+
+const MyComponent8 = React.memo(({ a }) => {
+  useEffect(() => {
+      console.log(a);
+  });
+});

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/missingDependenciesInvalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/missingDependenciesInvalid.js.snap
@@ -4,7 +4,7 @@ expression: missingDependenciesInvalid.js
 ---
 # Input
 ```js
-function MyComponent() {
+function MyComponent1() {
     let a = 1;
     const b = a + 1;
     useEffect(() => {
@@ -70,12 +70,24 @@ function MyComponent5() {
 
 // Capturing an object property
 
-function MyComponent1() {
+function MyComponent6() {
   let someObj = getObj();
   useEffect(() => {
       console.log(someObj.name)
   });
 }
+
+const MyComponent7 = React.memo(function ({ a }) {
+  useEffect(() => {
+      console.log(a);
+  });
+});
+
+const MyComponent8 = React.memo(({ a }) => {
+  useEffect(() => {
+      console.log(a);
+  });
+});
 
 ```
 
@@ -477,7 +489,7 @@ missingDependenciesInvalid.js:69:3 lint/nursery/useExhaustiveDependencies ━━
 
   ! This hook do not specify all of its dependencies.
   
-    67 │ function MyComponent1() {
+    67 │ function MyComponent6() {
     68 │   let someObj = getObj();
   > 69 │   useEffect(() => {
        │   ^^^^^^^^^
@@ -492,6 +504,52 @@ missingDependenciesInvalid.js:69:3 lint/nursery/useExhaustiveDependencies ━━
        │                   ^^^^^^^^^^^^
     71 │   });
     72 │ }
+  
+
+```
+
+```
+missingDependenciesInvalid.js:75:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook do not specify all of its dependencies.
+  
+    74 │ const MyComponent7 = React.memo(function ({ a }) {
+  > 75 │   useEffect(() => {
+       │   ^^^^^^^^^
+    76 │       console.log(a);
+    77 │   });
+  
+  i This dependency is not specified in the hook dependency list.
+  
+    74 │ const MyComponent7 = React.memo(function ({ a }) {
+    75 │   useEffect(() => {
+  > 76 │       console.log(a);
+       │                   ^
+    77 │   });
+    78 │ });
+  
+
+```
+
+```
+missingDependenciesInvalid.js:81:3 lint/nursery/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook do not specify all of its dependencies.
+  
+    80 │ const MyComponent8 = React.memo(({ a }) => {
+  > 81 │   useEffect(() => {
+       │   ^^^^^^^^^
+    82 │       console.log(a);
+    83 │   });
+  
+  i This dependency is not specified in the hook dependency list.
+  
+    80 │ const MyComponent8 = React.memo(({ a }) => {
+    81 │   useEffect(() => {
+  > 82 │       console.log(a);
+       │                   ^
+    83 │   });
+    84 │ });
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js
@@ -1,3 +1,5 @@
+/* should not generate diagnostics */
+
 import doSomething from 'a';
 
 // No captures
@@ -28,7 +30,6 @@ function MyComponent3() {
 }
 
 // interaction with other react hooks
-
 function MyComponent4() {
     const [name, setName] = useState(0);
     const ref = useRef();
@@ -63,7 +64,6 @@ function MyComponent4() {
 }
 
 // all hooks with dependencies
-
 function MyComponent5() {
     let a = 1;
     useEffect(() => console.log(a), [a]);
@@ -75,7 +75,6 @@ function MyComponent5() {
 }
 
 // inner closures
-
 function MyComponent5() {
     let a = 1;
     useEffect(() => {
@@ -84,8 +83,7 @@ function MyComponent5() {
     }, [a]);
 }
 
-// from import 
-
+// from import
 function MyComponent6() {
     useEffect(() => {
         doSomething();
@@ -101,10 +99,18 @@ function MyComponent7() {
     }, [someObj.name, someObj.age]);
 }
 
-// Specified dependency cover captures 
-
+// Specified dependency cover captures
 function MyComponent8({ a }) {
     useEffect(() => {
       console.log(a.b);
     }, [a]);
-  }
+}
+
+// Capturing const outside of component
+// https://github.com/rome/tools/issues/3727
+const outside = f();
+function MyComponent9() {
+    useEffect(() => {
+      console.log(outside);
+    });
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js
@@ -114,3 +114,16 @@ function MyComponent9() {
       console.log(outside);
     });
 }
+
+// Memoized Components
+const MyComponent10 = React.memo(function () {
+    useEffect(() => {
+        console.log(outside);
+    });
+});
+
+const MyComponent11 = React.memo(() => {
+    useEffect(() => {
+        console.log(outside);
+    });
+});

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js.snap
@@ -120,6 +120,20 @@ function MyComponent9() {
       console.log(outside);
     });
 }
+
+// Memoized Components
+const MyComponent10 = React.memo(function () {
+    useEffect(() => {
+        console.log(outside);
+    });
+});
+
+const MyComponent11 = React.memo(() => {
+    useEffect(() => {
+        console.log(outside);
+    });
+});
+
 ```
 
 

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.js.snap
@@ -4,6 +4,8 @@ expression: valid.js
 ---
 # Input
 ```js
+/* should not generate diagnostics */
+
 import doSomething from 'a';
 
 // No captures
@@ -34,7 +36,6 @@ function MyComponent3() {
 }
 
 // interaction with other react hooks
-
 function MyComponent4() {
     const [name, setName] = useState(0);
     const ref = useRef();
@@ -69,7 +70,6 @@ function MyComponent4() {
 }
 
 // all hooks with dependencies
-
 function MyComponent5() {
     let a = 1;
     useEffect(() => console.log(a), [a]);
@@ -81,7 +81,6 @@ function MyComponent5() {
 }
 
 // inner closures
-
 function MyComponent5() {
     let a = 1;
     useEffect(() => {
@@ -90,8 +89,7 @@ function MyComponent5() {
     }, [a]);
 }
 
-// from import 
-
+// from import
 function MyComponent6() {
     useEffect(() => {
         doSomething();
@@ -107,13 +105,21 @@ function MyComponent7() {
     }, [someObj.name, someObj.age]);
 }
 
-// Specified dependency cover captures 
-
+// Specified dependency cover captures
 function MyComponent8({ a }) {
     useEffect(() => {
       console.log(a.b);
     }, [a]);
-  }
+}
+
+// Capturing const outside of component
+// https://github.com/rome/tools/issues/3727
+const outside = f();
+function MyComponent9() {
+    useEffect(() => {
+      console.log(outside);
+    });
+}
 ```
 
 

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.ts
@@ -1,6 +1,8 @@
+/* should not generate diagnostics */
+
+import useEffect from 'react';
 
 // capturing declarations
-function overloaded(): number;
 function overloaded(s: string): string;
 function overloaded(s?: string) {
   return s;
@@ -8,20 +10,22 @@ function overloaded(s?: string) {
 
 enum A { B = 1 }
 abstract class C { static D = 1 }
-class D {}
-
-export type E = D;
+class D {
+    constructor() {
+        
+    }
+}
 
 declare module M {
-    function m1();
+    function f();
 }
 
 function MyComponent() {
     useEffect(() => {
-        overloaded();
+        overloaded("");
         console.log(A.B);
         console.log(C.D);
-        console.log(new E());
-        console.log(m1());
+        console.log(new D());
+        console.log(M.f());
     }, []);
 }

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/valid.ts.snap
@@ -4,9 +4,11 @@ expression: valid.ts
 ---
 # Input
 ```js
+/* should not generate diagnostics */
+
+import useEffect from 'react';
 
 // capturing declarations
-function overloaded(): number;
 function overloaded(s: string): string;
 function overloaded(s?: string) {
   return s;
@@ -14,21 +16,23 @@ function overloaded(s?: string) {
 
 enum A { B = 1 }
 abstract class C { static D = 1 }
-class D {}
-
-export type E = D;
+class D {
+    constructor() {
+        
+    }
+}
 
 declare module M {
-    function m1();
+    function f();
 }
 
 function MyComponent() {
     useEffect(() => {
-        overloaded();
+        overloaded("");
         console.log(A.B);
         console.log(C.D);
-        console.log(new E());
-        console.log(m1());
+        console.log(new D());
+        console.log(M.f());
     }, []);
 }
 ```

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -269,7 +269,6 @@ impl SemanticEventExtractor {
             ),
 
             JS_FUNCTION_DECLARATION
-            | TS_DECLARE_FUNCTION_DECLARATION
             | JS_FUNCTION_EXPRESSION
             | JS_ARROW_FUNCTION_EXPRESSION
             | JS_CONSTRUCTOR_CLASS_MEMBER
@@ -291,10 +290,12 @@ impl SemanticEventExtractor {
             | JS_CLASS_EXPORT_DEFAULT_DECLARATION
             | JS_CLASS_EXPRESSION
             | JS_FUNCTION_BODY
+            | TS_MODULE_DECLARATION
             | TS_INTERFACE_DECLARATION
             | TS_ENUM_DECLARATION
             | TS_TYPE_ALIAS_DECLARATION
-            | TS_FUNCTION_TYPE => {
+            | TS_FUNCTION_TYPE
+            | TS_DECLARE_FUNCTION_DECLARATION => {
                 self.push_scope(
                     node.text_range(),
                     ScopeHoisting::DontHoistDeclarationsToParent,
@@ -536,7 +537,6 @@ impl SemanticEventExtractor {
         match node.kind() {
             JS_MODULE | JS_SCRIPT => self.pop_scope(node.text_range()),
             JS_FUNCTION_DECLARATION
-            | TS_DECLARE_FUNCTION_DECLARATION
             | JS_FUNCTION_EXPORT_DEFAULT_DECLARATION
             | JS_FUNCTION_EXPRESSION
             | JS_ARROW_FUNCTION_EXPRESSION
@@ -551,16 +551,18 @@ impl SemanticEventExtractor {
             | JS_GETTER_OBJECT_MEMBER
             | JS_SETTER_OBJECT_MEMBER
             | JS_FUNCTION_BODY
-            | TS_INTERFACE_DECLARATION
-            | TS_ENUM_DECLARATION
-            | TS_TYPE_ALIAS_DECLARATION
-            | TS_FUNCTION_TYPE
             | JS_BLOCK_STATEMENT
             | JS_FOR_STATEMENT
             | JS_FOR_OF_STATEMENT
             | JS_FOR_IN_STATEMENT
             | JS_SWITCH_STATEMENT
-            | JS_CATCH_CLAUSE => {
+            | JS_CATCH_CLAUSE
+            | TS_DECLARE_FUNCTION_DECLARATION
+            | TS_FUNCTION_TYPE
+            | TS_INTERFACE_DECLARATION
+            | TS_ENUM_DECLARATION
+            | TS_TYPE_ALIAS_DECLARATION
+            | TS_MODULE_DECLARATION => {
                 self.pop_scope(node.text_range());
             }
             _ => {}

--- a/crates/rome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/rome_js_semantic/src/semantic_model/binding.rs
@@ -65,10 +65,18 @@ impl Binding {
         }
     }
 
-    /// Returns the syntax node associated with the binding.
+    /// Returns the syntax node associated with this binding.
     pub fn syntax(&self) -> &JsSyntaxNode {
         let binding = self.data.binding(self.index);
         &self.data.node_by_range[&binding.range]
+    }
+
+    /// Returns the typed AST node associated with this binding.
+    pub fn tree(&self) -> AnyJsIdentifierBinding {
+        let node = self.syntax();
+        let binding = AnyJsIdentifierBinding::cast_ref(node);
+        debug_assert!(binding.is_some());
+        binding.unwrap()
     }
 
     /// Returns an iterator to all references of this binding.
@@ -107,6 +115,10 @@ impl Binding {
                 index: reference.index,
             });
         std::iter::successors(first, Reference::find_next_write)
+    }
+
+    pub fn is_imported(&self) -> bool {
+        super::is_imported(self.syntax())
     }
 }
 

--- a/crates/rome_js_semantic/src/semantic_model/import.rs
+++ b/crates/rome_js_semantic/src/semantic_model/import.rs
@@ -5,6 +5,11 @@ use rome_js_syntax::{
 };
 use rome_rowan::AstNode;
 
+pub(crate) fn is_imported(node: &JsSyntaxNode) -> bool {
+    node.ancestors()
+        .any(|x| matches!(x.kind(), JsSyntaxKind::JS_IMPORT))
+}
+
 /// Marker trait that groups all "AstNode" that can be imported or
 /// exported
 pub trait CanBeImportedExported: AstNode<Language = JsLanguage> {
@@ -22,9 +27,7 @@ impl CanBeImportedExported for JsIdentifierBinding {
     }
 
     fn is_imported(&self, _: &SemanticModel) -> Self::Result {
-        self.syntax()
-            .ancestors()
-            .any(|x| matches!(x.kind(), JsSyntaxKind::JS_IMPORT))
+        is_imported(self.syntax())
     }
 }
 
@@ -37,9 +40,7 @@ impl CanBeImportedExported for TsIdentifierBinding {
     }
 
     fn is_imported(&self, _: &SemanticModel) -> Self::Result {
-        self.syntax()
-            .ancestors()
-            .any(|x| matches!(x.kind(), JsSyntaxKind::JS_IMPORT))
+        is_imported(self.syntax())
     }
 }
 
@@ -52,9 +53,7 @@ impl CanBeImportedExported for AnyJsIdentifierBinding {
     }
 
     fn is_imported(&self, _: &SemanticModel) -> Self::Result {
-        self.syntax()
-            .ancestors()
-            .any(|x| matches!(x.kind(), JsSyntaxKind::JS_IMPORT))
+        is_imported(self.syntax())
     }
 }
 
@@ -67,11 +66,8 @@ impl<T: HasDeclarationAstNode> CanBeImportedExported for T {
     }
 
     fn is_imported(&self, model: &SemanticModel) -> Self::Result {
-        Some(
-            self.binding(model)?
-                .syntax()
-                .ancestors()
-                .any(|x| matches!(x.kind(), JsSyntaxKind::JS_IMPORT)),
-        )
+        let binding = self.binding(model)?;
+        let node = binding.syntax();
+        Some(is_imported(node))
     }
 }

--- a/crates/rome_js_semantic/src/tests/functions.rs
+++ b/crates/rome_js_semantic/src/tests/functions.rs
@@ -1,5 +1,7 @@
 use crate::assert_semantics;
 
+// functions
+
 assert_semantics! {
     ok_function_declaration, "function f/*#F*/ () {}",
     ok_function_call, "function f/*#F*/ () {} f/*READ F*/();",
@@ -21,4 +23,14 @@ assert_semantics! {
             g/*READ G*/()
           }
         f()",
+}
+
+// modules
+
+assert_semantics! {
+    ok_function_inside_module,
+      "declare module M {
+        function f/*#F*/();
+      }
+      console.log(f/*?*/());",
 }

--- a/crates/rome_js_semantic/src/tests/scopes.rs
+++ b/crates/rome_js_semantic/src/tests/scopes.rs
@@ -53,6 +53,11 @@ assert_semantics! {
     ",
 }
 
+// modules
+assert_semantics! {
+    ok_scope_module, "module/*START M*/ M {}/*END M*/;",
+}
+
 // Others
 assert_semantics! {
     ok_scope_global, "/*START GLOBAL*//*END GLOBAL*/",

--- a/website/src/pages/lint/rules/useExhaustiveDependencies.md
+++ b/website/src/pages/lint/rules/useExhaustiveDependencies.md
@@ -12,138 +12,157 @@ Enforce all dependencies are correctly specified.
 ### Invalid
 
 ```jsx
-let a = 1;
-useEffect(() => {
-    console.log(a);
-})
+function f() {
+    let a = 1;
+    useEffect(() => {
+        console.log(a);
+    });
+}
 ```
 
-<pre class="language-text"><code class="language-text">nursery/useExhaustiveDependencies.js:2:1 <a href="https://docs.rome.tools/lint/rules/useExhaustiveDependencies">lint/nursery/useExhaustiveDependencies</a> ━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">nursery/useExhaustiveDependencies.js:3:5 <a href="https://docs.rome.tools/lint/rules/useExhaustiveDependencies">lint/nursery/useExhaustiveDependencies</a> ━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook do not specify all of its dependencies.</span>
   
-    <strong>1 │ </strong>let a = 1;
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>useEffect(() =&gt; {
-   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>3 │ </strong>    console.log(a);
-    <strong>4 │ </strong>})
+    <strong>1 │ </strong>function f() {
+    <strong>2 │ </strong>    let a = 1;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    useEffect(() =&gt; {
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>        console.log(a);
+    <strong>5 │ </strong>    });
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">This dependency is not specified in the hook dependency list.</span>
   
-    <strong>1 │ </strong>let a = 1;
-    <strong>2 │ </strong>useEffect(() =&gt; {
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    console.log(a);
-   <strong>   │ </strong>                <strong><span style="color: Tomato;">^</span></strong>
-    <strong>4 │ </strong>})
-    <strong>5 │ </strong>
+    <strong>2 │ </strong>    let a = 1;
+    <strong>3 │ </strong>    useEffect(() =&gt; {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>        console.log(a);
+   <strong>   │ </strong>                    <strong><span style="color: Tomato;">^</span></strong>
+    <strong>5 │ </strong>    });
+    <strong>6 │ </strong>}
   
 </code></pre>
 
 ```jsx
-let b = 1;
-useEffect(() => {
-}, [b])
+function f() {
+    let b = 1;
+    useEffect(() => {
+    }, [b]);
+}
 ```
 
-<pre class="language-text"><code class="language-text">nursery/useExhaustiveDependencies.js:2:1 <a href="https://docs.rome.tools/lint/rules/useExhaustiveDependencies">lint/nursery/useExhaustiveDependencies</a> ━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">nursery/useExhaustiveDependencies.js:3:5 <a href="https://docs.rome.tools/lint/rules/useExhaustiveDependencies">lint/nursery/useExhaustiveDependencies</a> ━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook specifies more dependencies than necessary.</span>
   
-    <strong>1 │ </strong>let b = 1;
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>useEffect(() =&gt; {
-   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>3 │ </strong>}, [b])
-    <strong>4 │ </strong>
+    <strong>1 │ </strong>function f() {
+    <strong>2 │ </strong>    let b = 1;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    useEffect(() =&gt; {
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>    }, [b]);
+    <strong>5 │ </strong>}
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">This dependency can be removed from the list.</span>
   
-    <strong>1 │ </strong>let b = 1;
-    <strong>2 │ </strong>useEffect(() =&gt; {
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>}, [b])
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
-    <strong>4 │ </strong>
-  
-</code></pre>
-
-```jsx
-const [name, setName] = useState();
-useEffect(() => {
-    console.log(name);
-    setName("");
-}, [name, setName])
-```
-
-<pre class="language-text"><code class="language-text">nursery/useExhaustiveDependencies.js:2:1 <a href="https://docs.rome.tools/lint/rules/useExhaustiveDependencies">lint/nursery/useExhaustiveDependencies</a> ━━━━━━━━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook specifies more dependencies than necessary.</span>
-  
-    <strong>1 │ </strong>const [name, setName] = useState();
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>useEffect(() =&gt; {
-   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>3 │ </strong>    console.log(name);
-    <strong>4 │ </strong>    setName(&quot;&quot;);
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">This dependency can be removed from the list.</span>
-  
-    <strong>3 │ </strong>    console.log(name);
-    <strong>4 │ </strong>    setName(&quot;&quot;);
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>}, [name, setName])
-   <strong>   │ </strong>          <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>    let b = 1;
+    <strong>3 │ </strong>    useEffect(() =&gt; {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    }, [b]);
+   <strong>   │ </strong>        <strong><span style="color: Tomato;">^</span></strong>
+    <strong>5 │ </strong>}
     <strong>6 │ </strong>
   
 </code></pre>
 
 ```jsx
-let a = 1;
-const b = a + 1;
-useEffect(() => {
-    console.log(b);
-})
+function f() {
+    const [name, setName] = useState();
+    useEffect(() => {
+        console.log(name);
+        setName("");
+    }, [name, setName]);
+}
 ```
 
-<pre class="language-text"><code class="language-text">nursery/useExhaustiveDependencies.js:3:1 <a href="https://docs.rome.tools/lint/rules/useExhaustiveDependencies">lint/nursery/useExhaustiveDependencies</a> ━━━━━━━━━━━━━━━━━━━━
+<pre class="language-text"><code class="language-text">nursery/useExhaustiveDependencies.js:3:5 <a href="https://docs.rome.tools/lint/rules/useExhaustiveDependencies">lint/nursery/useExhaustiveDependencies</a> ━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook specifies more dependencies than necessary.</span>
+  
+    <strong>1 │ </strong>function f() {
+    <strong>2 │ </strong>    const [name, setName] = useState();
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    useEffect(() =&gt; {
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>        console.log(name);
+    <strong>5 │ </strong>        setName(&quot;&quot;);
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">This dependency can be removed from the list.</span>
+  
+    <strong>4 │ </strong>        console.log(name);
+    <strong>5 │ </strong>        setName(&quot;&quot;);
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>6 │ </strong>    }, [name, setName]);
+   <strong>   │ </strong>              <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>7 │ </strong>}
+    <strong>8 │ </strong>
+  
+</code></pre>
+
+```jsx
+function f() {
+    let a = 1;
+    const b = a + 1;
+    useEffect(() => {
+        console.log(b);
+    });
+}
+```
+
+<pre class="language-text"><code class="language-text">nursery/useExhaustiveDependencies.js:4:5 <a href="https://docs.rome.tools/lint/rules/useExhaustiveDependencies">lint/nursery/useExhaustiveDependencies</a> ━━━━━━━━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook do not specify all of its dependencies.</span>
   
-    <strong>1 │ </strong>let a = 1;
-    <strong>2 │ </strong>const b = a + 1;
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>useEffect(() =&gt; {
-   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>4 │ </strong>    console.log(b);
-    <strong>5 │ </strong>})
+    <strong>2 │ </strong>    let a = 1;
+    <strong>3 │ </strong>    const b = a + 1;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    useEffect(() =&gt; {
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>5 │ </strong>        console.log(b);
+    <strong>6 │ </strong>    });
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">This dependency is not specified in the hook dependency list.</span>
   
-    <strong>2 │ </strong>const b = a + 1;
-    <strong>3 │ </strong>useEffect(() =&gt; {
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    console.log(b);
-   <strong>   │ </strong>                <strong><span style="color: Tomato;">^</span></strong>
-    <strong>5 │ </strong>})
-    <strong>6 │ </strong>
+    <strong>3 │ </strong>    const b = a + 1;
+    <strong>4 │ </strong>    useEffect(() =&gt; {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>5 │ </strong>        console.log(b);
+   <strong>   │ </strong>                    <strong><span style="color: Tomato;">^</span></strong>
+    <strong>6 │ </strong>    });
+    <strong>7 │ </strong>}
   
 </code></pre>
 
 ## Valid
 
 ```jsx
-let a = 1;
-useEffect(() => {
-    console.log(a);
-}, [a]);
+function f() {
+    let a = 1;
+    useEffect(() => {
+        console.log(a);
+    }, [a]);
+}
 ```
 
 ```jsx
-const a = 1;
-useEffect(() => {
-    console.log(a);
-});
+function f() {
+    const a = 1;
+    useEffect(() => {
+        console.log(a);
+    });
+}
 ```
 
 ```jsx
-const [name, setName] = useState();
-useEffect(() => {
-    console.log(name);
-    setName("");
-}, [name])
+function f() {
+    const [name, setName] = useState();
+    useEffect(() => {
+        console.log(name);
+        setName("");
+    }, [name]);
+}
 ```
 

--- a/website/src/pages/lint/rules/useExhaustiveDependencies.md
+++ b/website/src/pages/lint/rules/useExhaustiveDependencies.md
@@ -12,7 +12,7 @@ Enforce all dependencies are correctly specified.
 ### Invalid
 
 ```jsx
-function f() {
+function component() {
     let a = 1;
     useEffect(() => {
         console.log(a);
@@ -24,7 +24,7 @@ function f() {
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook do not specify all of its dependencies.</span>
   
-    <strong>1 │ </strong>function f() {
+    <strong>1 │ </strong>function component() {
     <strong>2 │ </strong>    let a = 1;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    useEffect(() =&gt; {
    <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
@@ -43,7 +43,7 @@ function f() {
 </code></pre>
 
 ```jsx
-function f() {
+function component() {
     let b = 1;
     useEffect(() => {
     }, [b]);
@@ -54,7 +54,7 @@ function f() {
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook specifies more dependencies than necessary.</span>
   
-    <strong>1 │ </strong>function f() {
+    <strong>1 │ </strong>function component() {
     <strong>2 │ </strong>    let b = 1;
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    useEffect(() =&gt; {
    <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
@@ -73,7 +73,7 @@ function f() {
 </code></pre>
 
 ```jsx
-function f() {
+function component() {
     const [name, setName] = useState();
     useEffect(() => {
         console.log(name);
@@ -86,7 +86,7 @@ function f() {
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This hook specifies more dependencies than necessary.</span>
   
-    <strong>1 │ </strong>function f() {
+    <strong>1 │ </strong>function component() {
     <strong>2 │ </strong>    const [name, setName] = useState();
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>    useEffect(() =&gt; {
    <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
@@ -105,7 +105,7 @@ function f() {
 </code></pre>
 
 ```jsx
-function f() {
+function component() {
     let a = 1;
     const b = a + 1;
     useEffect(() => {
@@ -139,7 +139,7 @@ function f() {
 ## Valid
 
 ```jsx
-function f() {
+function component() {
     let a = 1;
     useEffect(() => {
         console.log(a);
@@ -148,7 +148,7 @@ function f() {
 ```
 
 ```jsx
-function f() {
+function component() {
     const a = 1;
     useEffect(() => {
         console.log(a);
@@ -157,7 +157,7 @@ function f() {
 ```
 
 ```jsx
-function f() {
+function component() {
     const [name, setName] = useState();
     useEffect(() => {
         console.log(name);


### PR DESCRIPTION
## Summary

This PR closes https://github.com/rome/tools/issues/3727.
The main issue is that before we only considered `const` as stable if the initializer is constant. The specific example was calling a function, which we assume is never constant.

Now, all `const` declarator outside of component are considered as stable.

I also did a small refactor of the code using the new `Binding` and `.declarator()`.

This is done on top of https://github.com/rome/tools/pull/3860 and will wait for it before rebasing.

## Test Plan

```
> cargo test -p rome_js_analyze -- use_exhaustive_dependencies
```
