### PR TITLE
fix(rome_cli): improve the logging of panics and connection errors

### DIFF
--- a/crates/rome_cli/src/panic.rs
+++ b/crates/rome_cli/src/panic.rs
@@ -11,7 +11,7 @@ pub fn setup_panic_handler() {
 }
 
 fn panic_handler(info: &PanicInfo) {
-    // Buffer the error message to a string before printing it to stderr at once
+    // Buffer the error message to a string before printing it at once
     // to prevent it from getting mixed with other errors if multiple threads
     // panic at the same time
     let mut error = String::new();
@@ -37,5 +37,11 @@ fn panic_handler(info: &PanicInfo) {
         writeln!(error, "Message: {msg}").unwrap();
     }
 
+    // Write the panic to stderr
     eprintln!("{error}");
+
+    // Write the panic to the log file, this is done last since the `tracing`
+    // infrastructure could panic a second time and abort the process, so we
+    // want to ensure the error has at least been logged to stderr beforehand
+    tracing::error!("{error}");
 }

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -1,4 +1,5 @@
 import { spawn } from "child_process";
+import type { Readable } from "stream";
 import { connect, type Socket } from "net";
 import { promisify } from "util";
 import {
@@ -247,44 +248,52 @@ async function fileExists(path: Uri) {
 	}
 }
 
-function getSocket(
+function collectStream(stream: Readable) {
+	return new Promise<string>((resolve, reject) => {
+		let buffer = "";
+		stream.on("data", (data) => {
+			buffer += data.toString("utf-8");
+		});
+
+		stream.on("error", reject);
+		stream.on("end", () => {
+			resolve(buffer);
+		});
+	})
+}
+
+async function getSocket(
 	outputChannel: OutputChannel,
 	command: string,
 ): Promise<string> {
-	return new Promise((resolve, reject) => {
-		const process = spawn(command, ["__print_socket"], {
-			stdio: "pipe",
-		});
-
-		process.on("error", reject);
-
-		let stdout = "";
-		process.stdout.on("data", (data) => {
-			stdout += data.toString("utf-8");
-		});
-
-		let stderr = "";
-		process.stderr.on("data", (data) => {
-			stderr += data.toString("utf-8");
-		});
-
-		process.on("exit", (code) => {
-			const pipeName = stdout.trimEnd();
-
-			if (code !== 0 || pipeName.length === 0) {
-				let message = `Command "${command} __print_socket" exited with code ${code}`;
-				if (stderr.length > 0) {
-					message += `\nOutput:\n${stderr}`;
-				}
-
-				reject(new Error(message));
-				return;
-			}
-
-			outputChannel.appendLine(`Connecting to "${pipeName}" ...`);
-			resolve(pipeName);
-		});
+	const process = spawn(command, ["__print_socket"], {
+		stdio: "pipe",
 	});
+
+	const exitCode = new Promise<number>((resolve, reject) => {
+		process.on("error", reject);
+		process.on("exit", resolve);
+	});
+
+	const [stdout, stderr, code] = await Promise.all([
+		collectStream(process.stdout),
+		collectStream(process.stderr),
+		exitCode,
+	]);
+
+	const pipeName = stdout.trimEnd();
+
+	if (code !== 0 || pipeName.length === 0) {
+		let message = `Command "${command} __print_socket" exited with code ${code}`;
+		if (stderr.length > 0) {
+			message += `\nOutput:\n${stderr}`;
+		}
+
+		throw new Error(message);
+	} else {
+		outputChannel.appendLine(`Connecting to "${pipeName}" ...`);
+		return pipeName;
+	}
 }
 
 function wrapConnectionError(err: Error, path: string): Error {

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -259,7 +259,7 @@ function collectStream(stream: Readable) {
 		stream.on("end", () => {
 			resolve(buffer);
 		});
-	})
+	});
 }
 
 async function getSocket(


### PR DESCRIPTION
## Summary

Fixes #3920

This is a followup to #3952 adding additional logs to the CLI and VSCode extension. Specifically, it extends the panic hook of the CLI to print the panic message to the current tracing log file in addition to stderr. This ensures that panic messages can be retrieved in the logs when they cause a background process like the language server to crash.

In addition to this, I extended the previous changes to the VSCode extension to wrap errors thrown by the `connect` function in addition to the exceptions raised by the socket itself. I also improved the `getSocket` function by collecting the content of the stderr pipe for the CLI child process in addition to stdout, and to fail with an error if the content of stdout was empty. This error will now include the exit code of the CLI as well as the content of stderr if it was not empty.

## Test Plan

I tested these changes locally by introducing explicit panics in the `print_socket` and `run_daemon` functions to ensure that the panic is correctly getting logged to the tracing log file, and that the extension correctly prints the content of stderr if the CLI instance exits with an error.
