### PR TITLE
fix(rome_js_syntax): Allow module syntax in `cts` files

### DIFF
--- a/crates/rome_js_syntax/src/source_type.rs
+++ b/crates/rome_js_syntax/src/source_type.rs
@@ -234,9 +234,10 @@ fn compute_source_type_from_path_or_extension(
     file_name: &str,
     extension: &str,
 ) -> Result<SourceType, SourceTypeError> {
-    let source_type = if file_name.ends_with(".d.ts") || file_name.ends_with(".d.mts") {
-        SourceType::d_ts()
-    } else if file_name.ends_with(".d.cts") {
+    let source_type = if file_name.ends_with(".d.ts")
+        || file_name.ends_with(".d.mts")
+        || file_name.ends_with(".d.cts")
+    {
         SourceType::d_ts()
     } else {
         match extension {

--- a/crates/rome_js_syntax/src/source_type.rs
+++ b/crates/rome_js_syntax/src/source_type.rs
@@ -237,13 +237,12 @@ fn compute_source_type_from_path_or_extension(
     let source_type = if file_name.ends_with(".d.ts") || file_name.ends_with(".d.mts") {
         SourceType::d_ts()
     } else if file_name.ends_with(".d.cts") {
-        SourceType::d_ts().with_module_kind(ModuleKind::Script)
+        SourceType::d_ts()
     } else {
         match extension {
             "cjs" => SourceType::js_module().with_module_kind(ModuleKind::Script),
             "js" | "mjs" | "jsx" => SourceType::jsx(),
-            "ts" | "mts" => SourceType::ts(),
-            "cts" => SourceType::ts().with_module_kind(ModuleKind::Script),
+            "ts" | "mts" | "cts" => SourceType::ts(),
             "tsx" => SourceType::tsx(),
             _ => return Err(SourceTypeError::UnknownExtension(extension.into())),
         }

--- a/crates/rome_js_syntax/src/union_ext.rs
+++ b/crates/rome_js_syntax/src/union_ext.rs
@@ -109,7 +109,7 @@ impl AnyJsClassMember {
         }
     }
 
-    /// Tests if the member has a [`JsLiteralMemberName`](rome_js_syntax::JsLiteralMemberName) of `name`.
+    /// Tests if the member has a [`JsLiteralMemberName`](crate::JsLiteralMemberName) of `name`.
     pub fn has_name(&self, name: &str) -> SyntaxResult<bool> {
         match self.name()? {
             Some(AnyJsClassMemberName::JsLiteralMemberName(literal)) => {

--- a/website/src/playground/utils.ts
+++ b/website/src/playground/utils.ts
@@ -288,7 +288,7 @@ export function isJSXFilename(filename: string): boolean {
 }
 
 export function isScriptFilename(filename: string): boolean {
-	return filename.endsWith(".cjs") || filename.endsWith(".cts");
+	return filename.endsWith(".cjs");
 }
 
 export function isModuleFilename(filename: string): boolean {
@@ -296,7 +296,8 @@ export function isModuleFilename(filename: string): boolean {
 		filename.endsWith(".mjs") ||
 		filename.endsWith(".mts") ||
 		filename.endsWith(".js") ||
-		filename.endsWith(".ts")
+		filename.endsWith(".ts") ||
+		filename.endsWith(".cts")
 	);
 }
 

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -423,11 +423,8 @@ impl FromStr for CodeBlockTest {
                 "js" | "mjs" | "jsx" => {
                     test.source_type = SourceType::jsx();
                 }
-                "ts" | "mts" => {
+                "ts" | "mts" | "cts" => {
                     test.source_type = SourceType::ts();
-                }
-                "cts" => {
-                    test.source_type = SourceType::ts().with_module_kind(ModuleKind::Script);
                 }
                 "tsx" => {
                     test.source_type = SourceType::tsx();


### PR DESCRIPTION
## Summary

Fixes #3918

## Test Plan

```bash
cargo run --bin rome -- check ../rome-test/x.cts
```

Doesn't fail where `x.cts` contains

```ts
import X from "test";
```