### PR TITLE
fix(rome_js_analyze): fix ts const assertion on noUndeclaredVariables

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
@@ -6,10 +6,8 @@ use crate::semantic_services::SemanticServices;
 use rome_analyze::context::RuleContext;
 use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
-use rome_js_syntax::{
-    JsIdentifierAssignment, JsReferenceIdentifier, JsSyntaxKind, JsxReferenceIdentifier, TextRange,
-};
-use rome_rowan::{declare_node_union, AstNode};
+use rome_js_syntax::{TextRange, TsAsExpression, TsReferenceType};
+use rome_rowan::AstNode;
 
 declare_rule! {
     /// Prevents the usage of variables that haven't been declared inside the document
@@ -28,10 +26,6 @@ declare_rule! {
     }
 }
 
-declare_node_union! {
-    pub(crate) AnyIdentifier = JsReferenceIdentifier | JsIdentifierAssignment | JsxReferenceIdentifier
-}
-
 impl Rule for NoUndeclaredVariables {
     type Query = SemanticServices;
     type State = (TextRange, String);
@@ -42,26 +36,17 @@ impl Rule for NoUndeclaredVariables {
         ctx.query()
             .all_unresolved_references()
             .filter_map(|reference| {
-                let node = reference.syntax().clone();
-                let node_parent = node.parent();
+                let identifier = reference.tree();
+                let under_as_expression = identifier
+                    .parent::<TsReferenceType>()
+                    .and_then(|ty| ty.parent::<TsAsExpression>())
+                    .is_some();
 
-                let node = AnyIdentifier::unwrap_cast(node);
-                let token = match node {
-                    AnyIdentifier::JsReferenceIdentifier(node) => node.value_token(),
-                    AnyIdentifier::JsIdentifierAssignment(node) => node.name_token(),
-                    AnyIdentifier::JsxReferenceIdentifier(node) => node.value_token(),
-                };
-
-                let token = token.ok()?;
+                let token = identifier.value_token().ok()?;
                 let text = token.text_trimmed();
 
                 // Typescript Const Assertion
-                if text == "const"
-                    && matches!(
-                        node_parent,
-                        Some(parent) if parent.kind() == JsSyntaxKind::TS_REFERENCE_TYPE
-                    )
-                {
+                if text == "const" && under_as_expression {
                     return None;
                 }
 

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables.ts
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables.ts
@@ -8,5 +8,8 @@ export type NestedContextDefault<S extends NestedContextDefault = ''> = '' | `($
 export type Whatever<S extends number> = `Hello ${S}`
 export type WhateverDefault<S extends number = 2> = `Hello ${S}`
 
+// Const assertions are valid
+const fruits = ["banana"] as const;
+
 // Invalid
 export type Invalid<S extends number> = `Hello ${T}`

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables.ts.snap
@@ -14,18 +14,21 @@ export type NestedContextDefault<S extends NestedContextDefault = ''> = '' | `($
 export type Whatever<S extends number> = `Hello ${S}`
 export type WhateverDefault<S extends number = 2> = `Hello ${S}`
 
+// Const assertions are valid
+const fruits = ["banana"] as const;
+
 // Invalid
 export type Invalid<S extends number> = `Hello ${T}`
 ```
 
 # Diagnostics
 ```
-noUndeclaredVariables.ts:12:50 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+noUndeclaredVariables.ts:15:50 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The T variable is undeclared
   
-    11 │ // Invalid
-  > 12 │ export type Invalid<S extends number> = `Hello ${T}`
+    14 │ // Invalid
+  > 15 │ export type Invalid<S extends number> = `Hello ${T}`
        │                                                  ^
   
 

--- a/crates/rome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/rome_js_semantic/src/semantic_model/reference.rs
@@ -1,3 +1,5 @@
+use rome_js_syntax::AnyReferenceIdentifier;
+
 use super::*;
 use std::sync::Arc;
 
@@ -115,6 +117,10 @@ impl UnresolvedReference {
     pub fn syntax(&self) -> &JsSyntaxNode {
         let reference = &self.data.unresolved_references[self.id];
         &self.data.node_by_range[&reference.range]
+    }
+
+    pub fn tree(&self) -> AnyReferenceIdentifier {
+        AnyReferenceIdentifier::unwrap_cast(self.syntax().clone())
     }
 
     pub fn range(&self) -> &TextRange {

--- a/crates/rome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/rome_js_semantic/src/semantic_model/reference.rs
@@ -1,4 +1,4 @@
-use rome_js_syntax::AnyReferenceIdentifier;
+use rome_js_syntax::AnyJsIdentifierUsage;
 
 use super::*;
 use std::sync::Arc;
@@ -119,8 +119,8 @@ impl UnresolvedReference {
         &self.data.node_by_range[&reference.range]
     }
 
-    pub fn tree(&self) -> AnyReferenceIdentifier {
-        AnyReferenceIdentifier::unwrap_cast(self.syntax().clone())
+    pub fn tree(&self) -> AnyJsIdentifierUsage {
+        AnyJsIdentifierUsage::unwrap_cast(self.syntax().clone())
     }
 
     pub fn range(&self) -> &TextRange {

--- a/crates/rome_js_syntax/src/identifier_ext.rs
+++ b/crates/rome_js_syntax/src/identifier_ext.rs
@@ -2,15 +2,15 @@ use crate::{JsIdentifierAssignment, JsReferenceIdentifier, JsSyntaxToken, JsxRef
 use rome_rowan::{declare_node_union, SyntaxResult};
 
 declare_node_union! {
-    pub AnyReferenceIdentifier = JsReferenceIdentifier | JsIdentifierAssignment | JsxReferenceIdentifier
+    pub AnyJsIdentifierUsage = JsReferenceIdentifier | JsIdentifierAssignment | JsxReferenceIdentifier
 }
 
-impl AnyReferenceIdentifier {
+impl AnyJsIdentifierUsage {
     pub fn value_token(&self) -> SyntaxResult<JsSyntaxToken> {
         match self {
-            AnyReferenceIdentifier::JsReferenceIdentifier(node) => node.value_token(),
-            AnyReferenceIdentifier::JsIdentifierAssignment(node) => node.name_token(),
-            AnyReferenceIdentifier::JsxReferenceIdentifier(node) => node.value_token(),
+            AnyJsIdentifierUsage::JsReferenceIdentifier(node) => node.value_token(),
+            AnyJsIdentifierUsage::JsIdentifierAssignment(node) => node.name_token(),
+            AnyJsIdentifierUsage::JsxReferenceIdentifier(node) => node.value_token(),
         }
     }
 }

--- a/crates/rome_js_syntax/src/identifier_ext.rs
+++ b/crates/rome_js_syntax/src/identifier_ext.rs
@@ -1,0 +1,16 @@
+use crate::{JsIdentifierAssignment, JsReferenceIdentifier, JsSyntaxToken, JsxReferenceIdentifier};
+use rome_rowan::{declare_node_union, SyntaxResult};
+
+declare_node_union! {
+    pub AnyReferenceIdentifier = JsReferenceIdentifier | JsIdentifierAssignment | JsxReferenceIdentifier
+}
+
+impl AnyReferenceIdentifier {
+    pub fn value_token(&self) -> SyntaxResult<JsSyntaxToken> {
+        match self {
+            AnyReferenceIdentifier::JsReferenceIdentifier(node) => node.value_token(),
+            AnyReferenceIdentifier::JsIdentifierAssignment(node) => node.name_token(),
+            AnyReferenceIdentifier::JsxReferenceIdentifier(node) => node.value_token(),
+        }
+    }
+}

--- a/crates/rome_js_syntax/src/lib.rs
+++ b/crates/rome_js_syntax/src/lib.rs
@@ -6,6 +6,7 @@
 mod generated;
 pub mod binding_ext;
 pub mod expr_ext;
+pub mod identifier_ext;
 pub mod import_ext;
 pub mod jsx_ext;
 pub mod modifier_ext;
@@ -18,6 +19,7 @@ mod union_ext;
 
 pub use self::generated::*;
 pub use expr_ext::*;
+pub use identifier_ext::*;
 pub use modifier_ext::*;
 pub use rome_rowan::{
     SyntaxNodeText, TextLen, TextRange, TextSize, TokenAtOffset, TriviaPieceKind, WalkEvent,


### PR DESCRIPTION
## Summary

Fix a problem with `noUndeclaredVariables` regarding Typescript const assertion.

## Test Plan

```
> cargo test -p rome_js_analyze -- no_undeclared_variables
```
