### PR TITLE
fix(rome_js_analyzer): correctly delegate unresolved references to its parent scope

### DIFF
--- a/crates/rome_js_analyze/tests/specs/style/noArguments.cjs
+++ b/crates/rome_js_analyze/tests/specs/style/noArguments.cjs
@@ -1,5 +1,9 @@
 function f() {
     console.log(arguments);
+
+    for(let i = 0;i < arguments.length; ++i) {
+        console.log(arguments[i]);
+    }
 }
 
 function f() {

--- a/crates/rome_js_analyze/tests/specs/style/noArguments.cjs.snap
+++ b/crates/rome_js_analyze/tests/specs/style/noArguments.cjs.snap
@@ -6,6 +6,10 @@ expression: noArguments.cjs
 ```js
 function f() {
     console.log(arguments);
+
+    for(let i = 0;i < arguments.length; ++i) {
+        console.log(arguments[i]);
+    }
 }
 
 function f() {
@@ -23,8 +27,41 @@ noArguments.cjs:2:17 lint/style/noArguments ━━━━━━━━━━━━
     1 │ function f() {
   > 2 │     console.log(arguments);
       │                 ^^^^^^^^^
-    3 │ }
-    4 │ 
+    3 │ 
+    4 │     for(let i = 0;i < arguments.length; ++i) {
+  
+  i arguments does not have Array.prototype methods and can be inconvenient to use.
+  
+
+```
+
+```
+noArguments.cjs:4:23 lint/style/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use the rest parameters instead of arguments.
+  
+    2 │     console.log(arguments);
+    3 │ 
+  > 4 │     for(let i = 0;i < arguments.length; ++i) {
+      │                       ^^^^^^^^^
+    5 │         console.log(arguments[i]);
+    6 │     }
+  
+  i arguments does not have Array.prototype methods and can be inconvenient to use.
+  
+
+```
+
+```
+noArguments.cjs:5:21 lint/style/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use the rest parameters instead of arguments.
+  
+    4 │     for(let i = 0;i < arguments.length; ++i) {
+  > 5 │         console.log(arguments[i]);
+      │                     ^^^^^^^^^
+    6 │     }
+    7 │ }
   
   i arguments does not have Array.prototype methods and can be inconvenient to use.
   

--- a/crates/rome_js_analyze/tests/suppression/correctness/noUndeclaredVariables.ts.snap
+++ b/crates/rome_js_analyze/tests/suppression/correctness/noUndeclaredVariables.ts.snap
@@ -14,6 +14,27 @@ export type Invalid<S extends number> = `
 
 # Diagnostics
 ```
+noUndeclaredVariables.ts:1:50 lint/correctness/noUndeclaredVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  ! The T variable is undeclared
+  
+  > 1 │ export type Invalid<S extends number> = `Hello ${T}`
+      │                                                  ^
+    2 │ 
+    3 │ export type Invalid<S extends number> = `
+  
+  i Safe fix: Suppress rule lint/correctness/noUndeclaredVariables
+  
+    1   │ - export·type·Invalid<S·extends·number>·=·`Hello·${T}`
+      1 │ + export·type·Invalid<S·extends·number>·=·`Hello·${//·rome-ignore·lint/correctness/noUndeclaredVariables:·<explanation>
+      2 │ + T}`
+    2 3 │   
+    3 4 │   export type Invalid<S extends number> = `
+  
+
+```
+
+```
 noUndeclaredVariables.ts:5:7 lint/correctness/noUndeclaredVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   ! The T variable is undeclared

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -606,7 +606,7 @@ impl SemanticEventExtractor {
 
         if let Some(scope) = self.scopes.pop() {
             // Match references and declarations
-            for (name, references) in scope.references {
+            for (name, mut references) in scope.references {
                 // If we know the declaration of these reference push the correct events...
                 if let Some(declaration_at) = self.bindings.get(&name) {
                     for reference in references {
@@ -647,7 +647,8 @@ impl SemanticEventExtractor {
                     }
                 } else if let Some(parent) = self.scopes.last_mut() {
                     // ... if not, promote these references to the parent scope ...
-                    parent.references.insert(name, references);
+                    let parent_references = parent.references.entry(name).or_default();
+                    parent_references.append(&mut references);
                 } else {
                     // ... or raise UnresolvedReference if this is the global scope.
                     for reference in references {

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -194,8 +194,16 @@ assert_semantics! {
 }
 
 assert_semantics! {
-    ok_unmatched_reference, r#"a/*?*/"#,
-    ok_function_expression_read,"let f/*#F*/ = function g/*#G*/(){}; g/*?*/();",
+    ok_unresolved_reference, r#"a/*?*/"#,
+    ok_unresolved_function_expression_read,"let f/*#F*/ = function g/*#G*/(){}; g/*?*/();",
+    ok_unresolved_reference_arguments,
+        r#"function f() {
+            console.log(arguments/*?*/);
+        
+            for(let i = 0;i < arguments/*?*/.length; ++i) {
+                console.log(arguments/*?*/[i]);
+            }
+        }"#,
 }
 
 // Exports


### PR DESCRIPTION
## Summary

Fixes https://github.com/rome/tools/issues/4003

## Test Plan

```
> cargo test -p rome_js_analyze -- no_arguments
```
