### PR TITLE
feat(rome_js_analyzer): partial implementation for rule `noNoninteractiveElementToInteractiveRole`

### DIFF
--- a/crates/rome_analyze/CONTRIBUTING.md
+++ b/crates/rome_analyze/CONTRIBUTING.md
@@ -47,49 +47,27 @@ the CI will fail.
 
 Let's say we want to create a new rule called `useAwesomeTricks`, which uses the semantic model.
 
-1. create a new file under `semantic_analyzers/nursery` called `use_awesome_tricks`;
-2. run the cargo alias `cargo codegen analyzer`, this command will update the file called `nursery.rs`
-inside the `semantic_analyzers` folder
-3. from there, use the [`declare_rule`](#declare_rule) macro to create a new type
-   ```rust,ignore
-   use rome_analyze::declare_rule;
+1. run the command
+	```shell
+	> just new-lintrule crates/rome_js_analyze/src/analyzers/nursery myRuleName
+	```
+	Rules go in different folders, and the folder depend on the type of query system your rule
+	will use:
+   - `type Query = Ast<>` -> `analyzers/` folder
+   - `type Query = Semantic<>` -> `semantic_analyzers/` folder
+   - `type Query = SemanticServices` -> `semantic_analyzers/` folder
+   - `type Query = Aria<>` -> `aria_analyzers` folder
+   - `type Query = ControlFlowGraph` -> `analyzers/` folder
 
-   declare_rule! {
-     /// Promotes the use of awesome tricks
-     ///
-     /// ## Examples
-     ///
-     /// ### Invalid
-     ///
-     pub(crate) UseAwesomeTricks {
-         version: "0.10.0",
-         name: "useAwesomeTricks",
-         recommended: false,
-        }
-    }
-   ```
-4. Then you need to use the `Rule` trait to implement the rule on this new created struct
-   ```rust,ignore
-   use rome_analyze::{Rule, RuleCategory};
-   use rome_js_syntax::JsAnyExpression;
-   use rome_analyze::context::RuleContext;
-
-   impl Rule for UseAwesomeTricks {
-        type Query = Semantic<JsAnyExpression>;
-        type State = String;
-        type Signals = Option<Self::State>;
-        type Options = ();
-
-        fn run(ctx: &RuleContext<Self>) -> Self::Signals {}
-   }
-   ```
-5. the `Query` needs to have the `Semantic` type, because we want to have access to the semantic model.
+	The core team will help you out if you don't get the folder right. Using the incorrect folder
+	won't break any code.
+2. the `Query` needs to have the `Semantic` type, because we want to have access to the semantic model.
 `Query` tells the engine on which AST node we want to trigger the rule.
-6. The `State` type doesn't have to be used, so it can be considered optional, but it has
+3. The `State` type doesn't have to be used, so it can be considered optional, but it has
 be defined as `type State = ()`
-7. The `run` function must be implemented. This function is called every time the analyzer
+4. The `run` function must be implemented. This function is called every time the analyzer
 finds a match for the query specified by the rule, and may return zero or more "signals".
-8. Implement the optional `diagnostic` function, to tell the user where's the error and why:
+5. Implement the optional `diagnostic` function, to tell the user where's the error and why:
     ```rust,ignore
     impl Rule for UseAwesomeTricks {
         // .. code
@@ -102,7 +80,7 @@ finds a match for the query specified by the rule, and may return zero or more "
 
     You will have to manually update the file `rome_diagnostics_categories/src/categories.rs` and add a new category
     for the new rule you're about to create.
-9. Implement the optional `action` function, if we are able to provide automatic code fix to the rule:
+6. Implement the optional `action` function, if we are able to provide automatic code fix to the rule:
     ```rust,ignore
     impl Rule for UseAwesomeTricks {
         // .. code

--- a/crates/rome_aria/src/macros.rs
+++ b/crates/rome_aria/src/macros.rs
@@ -23,6 +23,46 @@ macro_rules! define_role {
             }
         }
     };
+    ( $( #[doc = $doc:literal] )+ $id:ident {
+        PROPS: $p_value:expr,
+        ROLES: $r_value:expr,
+        CONCEPTS: $c_value:expr,
+    }) => {
+        $( #[doc = $doc] )*
+        #[derive(Debug)]
+        struct $id;
+
+        impl $id {
+            const PROPS: &[(&'static str, bool)] = &$p_value;
+            const ROLES: &[&'static str] = &$r_value;
+            const CONCEPTS: &'static [(&'static str, &'static [(&'static str, &'static str)])] =
+                $c_value;
+        }
+
+        impl $crate::AriaRoleDefinition for $id {
+            fn properties<'a>(&self) -> std::slice::Iter<'a, (&str, bool)> {
+                $id::PROPS.iter()
+            }
+
+            fn roles<'a>(&self) -> std::slice::Iter<'a, &str> {
+                $id::ROLES.iter()
+            }
+        }
+
+        impl AriaRoleDefinitionWithConcepts for $id {
+            fn concepts_by_element_name<'a>(
+                &self,
+                element_name: &str,
+            ) -> ElementsAndAttributes<'a> {
+                for (concept_name, _attributes) in Self::CONCEPTS {
+                    if *concept_name == element_name {
+                        return Some(Self::CONCEPTS.iter());
+                    }
+                }
+                None
+            }
+        }
+    };
 }
 
 #[macro_export]

--- a/crates/rome_aria/src/macros.rs
+++ b/crates/rome_aria/src/macros.rs
@@ -40,11 +40,11 @@ macro_rules! define_role {
         }
 
         impl $crate::AriaRoleDefinition for $id {
-            fn properties<'a>(&self) -> std::slice::Iter<'a, (&str, bool)> {
+            fn properties(&self) -> std::slice::Iter<(&str, bool)> {
                 $id::PROPS.iter()
             }
 
-            fn roles<'a>(&self) -> std::slice::Iter<'a, &str> {
+            fn roles(&self) -> std::slice::Iter<&str> {
                 $id::ROLES.iter()
             }
         }

--- a/crates/rome_aria/src/roles.rs
+++ b/crates/rome_aria/src/roles.rs
@@ -698,10 +698,8 @@ impl<'a> AriaRoles {
                 _ => return false,
             };
             if let Some(mut concepts) = role.concepts_by_element_name(element_name) {
-                if concepts.any(|(name, _)| *name == element_name) {
-                    if !role.is_interactive() {
-                        return true;
-                    }
+                if concepts.any(|(name, _)| *name == element_name) && !role.is_interactive() {
+                    return true;
                 }
             }
         }

--- a/crates/rome_aria/src/roles.rs
+++ b/crates/rome_aria/src/roles.rs
@@ -55,6 +55,11 @@ pub trait AriaRoleDefinition: Debug {
         }
         false
     }
+
+    /// Whether the current role is interactive
+    fn is_interactive(&self) -> bool {
+        self.roles().any(|role| *role == "widget")
+    }
 }
 
 define_role! {
@@ -62,13 +67,16 @@ define_role! {
     ButtonRole {
         PROPS: [("aria-expanded", false), ("aria-expanded", false)],
         ROLES: ["roletype", "widget", "command"],
+        CONCEPTS: &[("button", &[]), ("input", &[("type", "button")])],
     }
 }
+
 define_role! {
     /// https://www.w3.org/TR/wai-aria-1.1/#checkbox
     CheckboxRole {
         PROPS: [("aria-checked", true), ("aria-readonly", false)],
         ROLES: ["switch", "menuitemcheckbox", "widget"],
+        CONCEPTS: &[("input", &[("type", "checkbox")])],
     }
 }
 define_role! {
@@ -76,6 +84,7 @@ define_role! {
     RadioRole {
         PROPS: [("aria-checked", true), ("aria-readonly", false)],
         ROLES: ["menuitemradio", "widget"],
+        CONCEPTS: &[("input", &[("type", "radio")])],
     }
 }
 define_role! {
@@ -91,6 +100,7 @@ define_role! {
     OptionRole {
         PROPS: [("aria-selected", true)],
         ROLES: ["treeitem", "widget"],
+        CONCEPTS: &[("option", &[])],
     }
 }
 
@@ -99,6 +109,7 @@ define_role! {
     ComboBoxRole {
         PROPS: [("aria-controls", true), ("aria-expanded", true)],
         ROLES: ["select", "widget"],
+        CONCEPTS: &[("select", &[])],
     }
 }
 define_role! {
@@ -106,6 +117,7 @@ define_role! {
     HeadingRole {
         PROPS:  [("aria-level", true)],
         ROLES:  ["sectionhead"],
+        CONCEPTS: &[("h1", &[]), ("h2", &[]), ("h3", &[]), ("h4", &[]), ("h5", &[]), ("h6", &[])],
     }
 }
 define_role! {
@@ -117,6 +129,7 @@ define_role! {
             ("aria-valuenow", true),
         ],
         ROLES: ["composite", "input", "range", "widget"],
+        CONCEPTS: &[("hr", &[])],
     }
 }
 define_role! {
@@ -139,6 +152,7 @@ define_role! {
             ("aria-valuenow", true),
         ],
         ROLES: ["structure", "widget"],
+        CONCEPTS: &[("hr", &[])],
     }
 }
 
@@ -161,6 +175,7 @@ define_role! {
     ArticleRole {
         PROPS: [],
         ROLES: ["document"],
+        CONCEPTS: &[("article", &[])],
     }
 }
 
@@ -169,6 +184,7 @@ define_role! {
     DialogRole {
         PROPS: [("aria-label", false), ("aria-labelledby", false)],
         ROLES: ["window"],
+        CONCEPTS: &[("dialog", &[])],
     }
 }
 
@@ -177,6 +193,7 @@ define_role! {
     AlertRole {
         PROPS: [],
         ROLES: ["section"],
+        CONCEPTS: &[("alert", &[])],
     }
 }
 define_role! {
@@ -184,6 +201,7 @@ define_role! {
     AlertDialogRole {
         PROPS: [],
         ROLES: ["structure"],
+        CONCEPTS: &[("alert", &[])],
     }
 }
 define_role! {
@@ -212,6 +230,7 @@ define_role! {
             ("aria-rowspan", false),
         ],
         ROLES: ["section"],
+        CONCEPTS: &[("td", &[])],
     }
 }
 
@@ -220,6 +239,7 @@ define_role! {
     ColumnHeaderRole {
         PROPS: [("aria-sort", false)],
         ROLES: ["cell", "gridcell", "sectionhead"],
+        CONCEPTS: &[("th", &[("scope", "col")])],
     }
 }
 
@@ -228,6 +248,7 @@ define_role! {
     DefinitionRole {
         PROPS: [("aria-labelledby", false)],
         ROLES: ["section"],
+        CONCEPTS: &[("dd", &[]), ("dfn", &[])],
     }
 }
 
@@ -244,6 +265,7 @@ define_role! {
     FigureRole {
         PROPS: [("aria-label", false), ("aria-labelledby", false)],
         ROLES: ["section"],
+        CONCEPTS: &[("figure", &[])],
     }
 }
 
@@ -252,6 +274,7 @@ define_role! {
     FormRole {
         PROPS: [("aria-label", false), ("aria-labelledby", false)],
         ROLES: ["section"],
+        CONCEPTS: &[("form", &[])],
     }
 }
 
@@ -260,6 +283,7 @@ define_role! {
     GridRole {
         PROPS: [("aria-level", false), ("aria-multiselectable", false), ("aria-readonly", false)],
         ROLES: ["composite", "table"],
+        CONCEPTS: &[("table", &[])],
     }
 }
 
@@ -268,6 +292,7 @@ define_role! {
     GridCellRole {
         PROPS: [("aria-readonly", false), ("aria-required", false), ("aria-selected", false)],
         ROLES: ["cell", "widget"],
+        CONCEPTS: &[("td", &[])],
     }
 }
 
@@ -276,6 +301,7 @@ define_role! {
     GroupRole {
         PROPS: [("aria-activedescendant", false)],
         ROLES: ["row", "select", "toolbar"],
+        CONCEPTS: &[("fieldset", &[])],
     }
 }
 
@@ -284,6 +310,7 @@ define_role! {
     ImgRole {
         PROPS: [("aria-activedescendant", false)],
         ROLES: ["section"],
+        CONCEPTS: &[("img", &[])],
     }
 }
 
@@ -292,6 +319,7 @@ define_role! {
     LinkRole {
         PROPS: [("aria-expanded", false)],
         ROLES: ["command"],
+        CONCEPTS: &[("a", &[]), ("link", &[])],
     }
 }
 
@@ -300,6 +328,7 @@ define_role! {
     ListRole {
         PROPS: [],
         ROLES: ["section"],
+        CONCEPTS: &[("ol", &[]), ("ul", &[])],
     }
 }
 
@@ -308,6 +337,7 @@ define_role! {
     ListBoxRole {
         PROPS: [],
         ROLES: ["select"],
+        CONCEPTS: &[("select", &[])],
     }
 }
 
@@ -316,6 +346,7 @@ define_role! {
     ListItemRole {
         PROPS: [],
         ROLES: ["section"],
+        CONCEPTS: &[("li", &[])],
     }
 }
 
@@ -372,6 +403,7 @@ define_role! {
     NavigationRole {
         PROPS: [],
         ROLES: ["landmark"],
+        CONCEPTS: &[("nav", &[])],
     }
 }
 
@@ -395,6 +427,7 @@ define_role! {
     RowRole {
         PROPS: [("aria-colindex", false), ("aria-level", false), ("aria-rowindex", false), ("aria-selected", false)],
         ROLES: ["group", "widget"],
+        CONCEPTS: &[("tr", &[])],
     }
 }
 
@@ -403,6 +436,7 @@ define_role! {
     RowGroupRole {
         PROPS: [],
         ROLES: ["structure"],
+        CONCEPTS: &[("tbody", &[]), ("tfoot", &[]), ("thead", &[])],
     }
 }
 
@@ -411,6 +445,7 @@ define_role! {
     RowHeaderRole {
         PROPS: [("aria-sort", false)],
         ROLES: ["cell", "gridcell", "sectionhead"],
+        CONCEPTS: &[("th", &[("scope", "row")])],
     }
 }
 
@@ -426,6 +461,7 @@ define_role! {
             ("aria-required", false),
         ],
         ROLES: ["textbox"],
+        CONCEPTS: &[("input", &[("type", "search")])],
     }
 }
 
@@ -442,6 +478,7 @@ define_role! {
     TableRole {
         PROPS: [("aria-colcount", false), ("aria-rowcount", false)],
         ROLES: ["section"],
+        CONCEPTS: &[("table", &[])],
     }
 }
 
@@ -458,6 +495,7 @@ define_role! {
     TermRole {
         PROPS: [],
         ROLES: ["section"],
+        CONCEPTS: &[("dt", &[])],
     }
 }
 
@@ -473,6 +511,7 @@ define_role! {
             ("aria-required", false),
         ],
         ROLES: ["input"],
+        CONCEPTS: &[("textarea", &[]), ("input", &[("type", "search")])],
     }
 }
 
@@ -492,7 +531,43 @@ define_role! {
     }
 }
 
-impl AriaRoles {
+impl<'a> AriaRoles {
+    /// These are roles that will contain "concepts".
+    pub(crate) const ROLE_WITH_CONCEPTS: &'a [&'a str] = &[
+        "checkbox",
+        "radio",
+        "option",
+        "combobox",
+        "heading",
+        "separator",
+        "button",
+        "article",
+        "dialog",
+        "alert",
+        "alertdialog",
+        "cell",
+        "columnheader",
+        "definition",
+        "figure",
+        "form",
+        "grid",
+        "gridcell",
+        "group",
+        "img",
+        "link",
+        "list",
+        "listbox",
+        "listitem",
+        "navigation",
+        "row",
+        "rowgroup",
+        "rowheader",
+        "searchbox",
+        "table",
+        "term",
+        "textbox",
+    ];
+
     /// It returns the metadata of a role, if it exits.
     ///
     /// ## Examples
@@ -565,8 +640,92 @@ impl AriaRoles {
         };
         Some(result)
     }
+
+    /// Given a role, it return whether this role is interactive
+    pub fn is_role_interactive(&self, role: &str) -> bool {
+        let role = self.get_role(role);
+        if let Some(role) = role {
+            role.is_interactive()
+        } else {
+            false
+        }
+    }
+
+    /// Given the name of element, the function tell whether it's interactive
+    pub fn is_element_interactive(&self, element_name: &str) -> bool {
+        for element in Self::ROLE_WITH_CONCEPTS {
+            let role = match *element {
+                "checkbox" => &CheckboxRole as &dyn AriaRoleDefinitionWithConcepts,
+                "radio" => &RadioRole as &dyn AriaRoleDefinitionWithConcepts,
+                "option" => &OptionRole as &dyn AriaRoleDefinitionWithConcepts,
+                "combobox" => &ComboBoxRole as &dyn AriaRoleDefinitionWithConcepts,
+                "heading" => &HeadingRole as &dyn AriaRoleDefinitionWithConcepts,
+                "separator" => &SeparatorRole as &dyn AriaRoleDefinitionWithConcepts,
+                "button" => &ButtonRole as &dyn AriaRoleDefinitionWithConcepts,
+                "article" => &ArticleRole as &dyn AriaRoleDefinitionWithConcepts,
+                "dialog" => &DialogRole as &dyn AriaRoleDefinitionWithConcepts,
+                "alert" => &AlertRole as &dyn AriaRoleDefinitionWithConcepts,
+                "alertdialog" => &AlertDialogRole as &dyn AriaRoleDefinitionWithConcepts,
+                "cell" => &CellRole as &dyn AriaRoleDefinitionWithConcepts,
+                "columnheader" => &ColumnHeaderRole as &dyn AriaRoleDefinitionWithConcepts,
+                "definition" => &DefinitionRole as &dyn AriaRoleDefinitionWithConcepts,
+                "figure" => &FigureRole as &dyn AriaRoleDefinitionWithConcepts,
+                "form" => &FormRole as &dyn AriaRoleDefinitionWithConcepts,
+                "grid" => &GridRole as &dyn AriaRoleDefinitionWithConcepts,
+                "gridcell" => &GridCellRole as &dyn AriaRoleDefinitionWithConcepts,
+                "group" => &GroupRole as &dyn AriaRoleDefinitionWithConcepts,
+                "img" => &ImgRole as &dyn AriaRoleDefinitionWithConcepts,
+                "link" => &LinkRole as &dyn AriaRoleDefinitionWithConcepts,
+                "list" => &ListRole as &dyn AriaRoleDefinitionWithConcepts,
+                "listbox" => &ListBoxRole as &dyn AriaRoleDefinitionWithConcepts,
+                "listitem" => &ListItemRole as &dyn AriaRoleDefinitionWithConcepts,
+                "navigation" => &NavigationRole as &dyn AriaRoleDefinitionWithConcepts,
+                "row" => &RowRole as &dyn AriaRoleDefinitionWithConcepts,
+                "rowgroup" => &RowGroupRole as &dyn AriaRoleDefinitionWithConcepts,
+                "rowheader" => &RowHeaderRole as &dyn AriaRoleDefinitionWithConcepts,
+                "searchbox" => &SearchboxRole as &dyn AriaRoleDefinitionWithConcepts,
+                "table" => &TableRole as &dyn AriaRoleDefinitionWithConcepts,
+                "term" => &TermRole as &dyn AriaRoleDefinitionWithConcepts,
+                "textbox" => &TextboxRole as &dyn AriaRoleDefinitionWithConcepts,
+                _ => return false,
+            };
+            if let Some(mut concepts) = role.concepts_by_element_name(element_name) {
+                if concepts.any(|(name, _)| *name == element_name) {
+                    return role.is_interactive();
+                }
+            }
+        }
+
+        true
+    }
+}
+
+type ElementsAndAttributes<'a> = Option<Iter<'a, (&'a str, &'a [(&'a str, &'a str)])>>;
+
+pub trait AriaRoleDefinitionWithConcepts: AriaRoleDefinition {
+    fn concepts_by_element_name<'a>(&self, _element_name: &str) -> ElementsAndAttributes<'a> {
+        None
+    }
 }
 
 /// Convenient type to retrieve metadata regarding ARIA roles
 #[derive(Debug, Default)]
 pub struct AriaRoles;
+
+#[cfg(test)]
+mod test {
+    use crate::AriaRoles;
+
+    #[test]
+    fn should_be_interactive() {
+        let aria_roles = AriaRoles {};
+
+        assert!(aria_roles.is_element_interactive("input"));
+        assert!(aria_roles.is_element_interactive("option"));
+        assert!(aria_roles.is_element_interactive("select"));
+        assert!(aria_roles.is_element_interactive("button"));
+        assert!(aria_roles.is_element_interactive("td"));
+        assert!(aria_roles.is_element_interactive("tr"));
+        assert!(aria_roles.is_element_interactive("hr"));
+    }
+}

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -86,6 +86,7 @@ define_dategories! {
     "lint/nursery/useMediaCaption": "https://docs.rome.tools/lint/rules/useMediaCaption",
     "lint/nursery/useIframeTitle": "https://docs.rome.tools/lint/rules/useIframeTitle",
     "lint/nursery/useNumericLiterals": "https://docs.rome.tools/lint/rules/useNumericLiterals",
+    "lint/nursery/noNoninteractiveElementToInteractiveRole": "https://docs.rome.tools/lint/rules/noNoninteractiveElementToInteractiveRole",
     "lint/nursery/useValidForDirection": "https://docs.rome.tools/lint/rules/useValidForDirection",
     "lint/nursery/useHookAtTopLevel": "https://docs.rome.tools/lint/rules/useHookAtTopLevel",
     // Insert new nursery rule here

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery.rs
@@ -1,8 +1,9 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 use rome_analyze::declare_group;
+mod no_noninteractive_element_to_interactive_role;
 mod use_aria_prop_types;
 mod use_aria_props_for_role;
 mod use_valid_aria_props;
 mod use_valid_lang;
-declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: use_aria_prop_types :: UseAriaPropTypes , self :: use_aria_props_for_role :: UseAriaPropsForRole , self :: use_valid_aria_props :: UseValidAriaProps , self :: use_valid_lang :: UseValidLang ,] } }
+declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole , self :: use_aria_prop_types :: UseAriaPropTypes , self :: use_aria_props_for_role :: UseAriaPropsForRole , self :: use_valid_aria_props :: UseValidAriaProps , self :: use_valid_lang :: UseValidLang ,] } }

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_element_to_interactive_role.rs
@@ -74,16 +74,22 @@ impl Rule for NoNoninteractiveElementToInteractiveRole {
                         AnyJsExpression::AnyJsLiteralExpression(
                             AnyJsLiteralExpression::JsStringLiteralExpression(string),
                         ) => string.inner_string_text().ok(),
-                        AnyJsExpression::JsTemplateExpression(template) => template
-                            .elements()
-                            .iter()
-                            .next()
-                            .and_then(|chunk| {
-                                chunk
-                                    .as_js_template_chunk_element()
-                                    .and_then(|t| t.template_chunk_token().ok())
-                            })
-                            .map(|t| t.token_text_trimmed()),
+                        AnyJsExpression::JsTemplateExpression(template) => {
+                            if template.elements().len() == 1 {
+                                template
+                                    .elements()
+                                    .iter()
+                                    .next()
+                                    .and_then(|chunk| {
+                                        chunk
+                                            .as_js_template_chunk_element()
+                                            .and_then(|t| t.template_chunk_token().ok())
+                                    })
+                                    .map(|t| t.token_text_trimmed())
+                            } else {
+                                None
+                            }
+                        }
                         _ => None,
                     }
                 }

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_element_to_interactive_role.rs
@@ -91,7 +91,7 @@ impl Rule for NoNoninteractiveElementToInteractiveRole {
                 _ => None,
             }?;
             let element_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
-            if !aria_roles.is_element_interactive(element_name.text_trimmed())
+            if aria_roles.is_not_interactive_element(element_name.text_trimmed())
                 && aria_roles.is_role_interactive(role_attribute_value.text())
             {
                 return Some(RuleState {

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_element_to_interactive_role.rs
@@ -1,0 +1,120 @@
+use crate::aria_services::Aria;
+use rome_analyze::context::RuleContext;
+use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
+use rome_console::markup;
+use rome_js_syntax::jsx_ext::AnyJsxElement;
+use rome_js_syntax::{AnyJsExpression, AnyJsLiteralExpression, AnyJsxAttributeValue};
+use rome_rowan::{AstNode, AstNodeList, TextRange};
+declare_rule! {
+    /// Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.
+    ///
+    /// Non-interactive HTML elements indicate _content_ and _containers_ in the user interface.
+    /// Non-interactive elements include `<main>`, `<area>`, `<h1>` (,`<h2>`, etc), `<img>`, `<li>`, `<ul>` and `<ol>`.
+    ///
+    /// Interactive HTML elements indicate _controls_ in the user interface.
+    /// Interactive elements include `<a href>`, `<button>`, `<input>`, `<select>`, `<textarea>`.
+    ///
+    /// [WAI-ARIA roles](https://www.w3.org/TR/wai-aria-1.1/#usage_intro) should not be used to convert a non-interactive element to an interactive element.
+    /// Interactive ARIA roles include `button`, `link`, `checkbox`, `menuitem`, `menuitemcheckbox`, `menuitemradio`, `option`, `radio`, `searchbox`, `switch` and `textbox`.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <h1 role="button">Some text</h1>
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    ///
+    /// ```jsx
+    /// <span role="button">Some text</span>
+    /// ```
+    ///
+    /// ## Accessibility guidelines
+    ///
+    /// - [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+    ///
+    /// ### Resources
+    ///
+    /// - [WAI-ARIA roles](https://www.w3.org/TR/wai-aria-1.1/#usage_intro)
+    /// - [WAI-ARIA Authoring Practices Guide - Design Patterns and Widgets](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_ex)
+    /// - [Fundamental Keyboard Navigation Conventions](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav)
+    /// - [Mozilla Developer Network - ARIA Techniques](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Keyboard_and_focus)
+    ///
+    pub(crate) NoNoninteractiveElementToInteractiveRole {
+        version: "12.0.0",
+        name: "noNoninteractiveElementToInteractiveRole",
+        recommended: true,
+    }
+}
+
+pub(crate) struct RuleState {
+    attribute_range: TextRange,
+    element_name: String,
+}
+
+impl Rule for NoNoninteractiveElementToInteractiveRole {
+    type Query = Aria<AnyJsxElement>;
+    type State = RuleState;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        let aria_roles = ctx.aria_roles();
+        if node.is_element() {
+            let role_attribute = node.find_attribute_by_name("role")?;
+            let role_attribute_value = role_attribute.initializer()?.value().ok()?;
+            let role_attribute_value = match role_attribute_value {
+                AnyJsxAttributeValue::JsxString(string) => string.inner_string_text().ok(),
+                AnyJsxAttributeValue::JsxExpressionAttributeValue(expression) => {
+                    match expression.expression().ok()? {
+                        AnyJsExpression::AnyJsLiteralExpression(
+                            AnyJsLiteralExpression::JsStringLiteralExpression(string),
+                        ) => string.inner_string_text().ok(),
+                        AnyJsExpression::JsTemplateExpression(template) => template
+                            .elements()
+                            .iter()
+                            .next()
+                            .and_then(|chunk| {
+                                chunk
+                                    .as_js_template_chunk_element()
+                                    .and_then(|t| t.template_chunk_token().ok())
+                            })
+                            .map(|t| t.token_text_trimmed()),
+                        _ => None,
+                    }
+                }
+
+                _ => None,
+            }?;
+            let element_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
+            if !aria_roles.is_element_interactive(element_name.text_trimmed())
+                && aria_roles.is_role_interactive(role_attribute_value.text())
+            {
+                return Some(RuleState {
+                    attribute_range: role_attribute.range(),
+                    element_name: element_name.text_trimmed().to_string(),
+                });
+            }
+        }
+
+        None
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        Some(RuleDiagnostic::new(
+            rule_category!(),
+            state.attribute_range,
+            markup! {
+                "The HTML element "<Emphasis>{{&state.element_name}}</Emphasis>" is non-interactive and should not have an interactive role."
+            },
+        ).note(
+            markup!{
+                "Replace "<Emphasis>{{&state.element_name}}</Emphasis>" with a div or a span."
+            }
+        ))
+    }
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/invalid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/invalid.jsx
@@ -1,0 +1,7 @@
+var a = <h1 role="checkbox"></h1>;
+var a = <h1 role="radio"></h1>;
+var a = <h1 role="button"></h1>;
+var a = <h1 role="combobox"></h1>;
+var a = <h1 role="scrollbar"></h1>;
+var a = <h1 role={"scrollbar"}></h1>;
+var a = <h1 role={`scrollbar`}></h1>;

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/invalid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/invalid.jsx
@@ -5,3 +5,4 @@ var a = <h1 role="combobox"></h1>;
 var a = <h1 role="scrollbar"></h1>;
 var a = <h1 role={"scrollbar"}></h1>;
 var a = <h1 role={`scrollbar`}></h1>;
+	var a = <ol role="menuitem" />;

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/invalid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/invalid.jsx.snap
@@ -1,0 +1,133 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid.jsx
+---
+# Input
+```js
+var a = <h1 role="checkbox"></h1>;
+var a = <h1 role="radio"></h1>;
+var a = <h1 role="button"></h1>;
+var a = <h1 role="combobox"></h1>;
+var a = <h1 role="scrollbar"></h1>;
+var a = <h1 role={"scrollbar"}></h1>;
+var a = <h1 role={`scrollbar`}></h1>;
+
+```
+
+# Diagnostics
+```
+invalid.jsx:1:13 lint/nursery/noNoninteractiveElementToInteractiveRole ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element h1 is non-interactive and should not have an interactive role.
+  
+  > 1 │ var a = <h1 role="checkbox"></h1>;
+      │             ^^^^^^^^^^^^^^^
+    2 │ var a = <h1 role="radio"></h1>;
+    3 │ var a = <h1 role="button"></h1>;
+  
+  i Replace h1 with a div or a span.
+  
+
+```
+
+```
+invalid.jsx:2:13 lint/nursery/noNoninteractiveElementToInteractiveRole ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element h1 is non-interactive and should not have an interactive role.
+  
+    1 │ var a = <h1 role="checkbox"></h1>;
+  > 2 │ var a = <h1 role="radio"></h1>;
+      │             ^^^^^^^^^^^^
+    3 │ var a = <h1 role="button"></h1>;
+    4 │ var a = <h1 role="combobox"></h1>;
+  
+  i Replace h1 with a div or a span.
+  
+
+```
+
+```
+invalid.jsx:3:13 lint/nursery/noNoninteractiveElementToInteractiveRole ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element h1 is non-interactive and should not have an interactive role.
+  
+    1 │ var a = <h1 role="checkbox"></h1>;
+    2 │ var a = <h1 role="radio"></h1>;
+  > 3 │ var a = <h1 role="button"></h1>;
+      │             ^^^^^^^^^^^^^
+    4 │ var a = <h1 role="combobox"></h1>;
+    5 │ var a = <h1 role="scrollbar"></h1>;
+  
+  i Replace h1 with a div or a span.
+  
+
+```
+
+```
+invalid.jsx:4:13 lint/nursery/noNoninteractiveElementToInteractiveRole ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element h1 is non-interactive and should not have an interactive role.
+  
+    2 │ var a = <h1 role="radio"></h1>;
+    3 │ var a = <h1 role="button"></h1>;
+  > 4 │ var a = <h1 role="combobox"></h1>;
+      │             ^^^^^^^^^^^^^^^
+    5 │ var a = <h1 role="scrollbar"></h1>;
+    6 │ var a = <h1 role={"scrollbar"}></h1>;
+  
+  i Replace h1 with a div or a span.
+  
+
+```
+
+```
+invalid.jsx:5:13 lint/nursery/noNoninteractiveElementToInteractiveRole ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element h1 is non-interactive and should not have an interactive role.
+  
+    3 │ var a = <h1 role="button"></h1>;
+    4 │ var a = <h1 role="combobox"></h1>;
+  > 5 │ var a = <h1 role="scrollbar"></h1>;
+      │             ^^^^^^^^^^^^^^^^
+    6 │ var a = <h1 role={"scrollbar"}></h1>;
+    7 │ var a = <h1 role={`scrollbar`}></h1>;
+  
+  i Replace h1 with a div or a span.
+  
+
+```
+
+```
+invalid.jsx:6:13 lint/nursery/noNoninteractiveElementToInteractiveRole ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element h1 is non-interactive and should not have an interactive role.
+  
+    4 │ var a = <h1 role="combobox"></h1>;
+    5 │ var a = <h1 role="scrollbar"></h1>;
+  > 6 │ var a = <h1 role={"scrollbar"}></h1>;
+      │             ^^^^^^^^^^^^^^^^^^
+    7 │ var a = <h1 role={`scrollbar`}></h1>;
+    8 │ 
+  
+  i Replace h1 with a div or a span.
+  
+
+```
+
+```
+invalid.jsx:7:13 lint/nursery/noNoninteractiveElementToInteractiveRole ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element h1 is non-interactive and should not have an interactive role.
+  
+    5 │ var a = <h1 role="scrollbar"></h1>;
+    6 │ var a = <h1 role={"scrollbar"}></h1>;
+  > 7 │ var a = <h1 role={`scrollbar`}></h1>;
+      │             ^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i Replace h1 with a div or a span.
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/invalid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/invalid.jsx.snap
@@ -11,6 +11,7 @@ var a = <h1 role="combobox"></h1>;
 var a = <h1 role="scrollbar"></h1>;
 var a = <h1 role={"scrollbar"}></h1>;
 var a = <h1 role={`scrollbar`}></h1>;
+	var a = <ol role="menuitem" />;
 
 ```
 
@@ -107,7 +108,7 @@ invalid.jsx:6:13 lint/nursery/noNoninteractiveElementToInteractiveRole ━━━
   > 6 │ var a = <h1 role={"scrollbar"}></h1>;
       │             ^^^^^^^^^^^^^^^^^^
     7 │ var a = <h1 role={`scrollbar`}></h1>;
-    8 │ 
+    8 │ 	var a = <ol role="menuitem" />;
   
   i Replace h1 with a div or a span.
   
@@ -123,7 +124,8 @@ invalid.jsx:7:13 lint/nursery/noNoninteractiveElementToInteractiveRole ━━━
     6 │ var a = <h1 role={"scrollbar"}></h1>;
   > 7 │ var a = <h1 role={`scrollbar`}></h1>;
       │             ^^^^^^^^^^^^^^^^^^
-    8 │ 
+    8 │ 	var a = <ol role="menuitem" />;
+    9 │ 
   
   i Replace h1 with a div or a span.
   

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/valid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/valid.jsx
@@ -1,0 +1,1 @@
+let a = <span role="button"></span>;

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/valid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/valid.jsx
@@ -1,1 +1,2 @@
 let a = <span role="button"></span>;
+let a = <span role={`scroll${a}bar`}></span>;

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/valid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/valid.jsx.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid.jsx
+---
+# Input
+```js
+let a = <span role="button"></span>;
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/valid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveElementToInteractiveRole/valid.jsx.snap
@@ -5,6 +5,7 @@ expression: valid.jsx
 # Input
 ```js
 let a = <span role="button"></span>;
+let a = <span role={`scroll${a}bar`}></span>;
 
 ```
 

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -184,7 +184,9 @@ impl Rules {
             None
         }
     }
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     #[doc = r" It returns a tuple of filters. The first element of the tuple are the enabled rules,"]
     #[doc = r" while the second element are the disabled rules."]
     #[doc = r""]
@@ -419,7 +421,9 @@ impl A11y {
         RuleFilter::Rule("a11y", Self::CATEGORY_RULES[7]),
         RuleFilter::Rule("a11y", Self::CATEGORY_RULES[8]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -439,7 +443,9 @@ impl A11y {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -525,7 +531,9 @@ impl Complexity {
         RuleFilter::Rule("complexity", Self::CATEGORY_RULES[4]),
         RuleFilter::Rule("complexity", Self::CATEGORY_RULES[5]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -545,7 +553,9 @@ impl Complexity {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -654,7 +664,9 @@ impl Correctness {
         RuleFilter::Rule("correctness", Self::CATEGORY_RULES[9]),
         RuleFilter::Rule("correctness", Self::CATEGORY_RULES[10]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -674,7 +686,9 @@ impl Correctness {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -937,7 +951,9 @@ impl Nursery {
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[41]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[42]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -957,7 +973,9 @@ impl Nursery {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -1015,7 +1033,9 @@ impl Performance {
     const RECOMMENDED_RULES: [&'static str; 1] = ["noDelete"];
     const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 1] =
         [RuleFilter::Rule("performance", Self::CATEGORY_RULES[0])];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -1035,7 +1055,9 @@ impl Performance {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -1103,7 +1125,9 @@ impl Security {
         RuleFilter::Rule("security", Self::CATEGORY_RULES[0]),
         RuleFilter::Rule("security", Self::CATEGORY_RULES[1]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -1123,7 +1147,9 @@ impl Security {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -1232,7 +1258,9 @@ impl Style {
         RuleFilter::Rule("style", Self::CATEGORY_RULES[11]),
         RuleFilter::Rule("style", Self::CATEGORY_RULES[12]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -1252,7 +1280,9 @@ impl Style {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -1390,7 +1420,9 @@ impl Suspicious {
         RuleFilter::Rule("suspicious", Self::CATEGORY_RULES[14]),
         RuleFilter::Rule("suspicious", Self::CATEGORY_RULES[15]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -1410,7 +1442,9 @@ impl Suspicious {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::CATEGORY_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -184,9 +184,7 @@ impl Rules {
             None
         }
     }
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     #[doc = r" It returns a tuple of filters. The first element of the tuple are the enabled rules,"]
     #[doc = r" while the second element are the disabled rules."]
     #[doc = r""]
@@ -421,9 +419,7 @@ impl A11y {
         RuleFilter::Rule("a11y", Self::CATEGORY_RULES[7]),
         RuleFilter::Rule("a11y", Self::CATEGORY_RULES[8]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -443,9 +439,7 @@ impl A11y {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::CATEGORY_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -531,9 +525,7 @@ impl Complexity {
         RuleFilter::Rule("complexity", Self::CATEGORY_RULES[4]),
         RuleFilter::Rule("complexity", Self::CATEGORY_RULES[5]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -553,9 +545,7 @@ impl Complexity {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::CATEGORY_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -664,9 +654,7 @@ impl Correctness {
         RuleFilter::Rule("correctness", Self::CATEGORY_RULES[9]),
         RuleFilter::Rule("correctness", Self::CATEGORY_RULES[10]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -686,9 +674,7 @@ impl Correctness {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::CATEGORY_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -769,6 +755,8 @@ struct NurserySchema {
     no_invalid_constructor_super: Option<RuleConfiguration>,
     #[doc = "Disallow non-null assertions using the ! postfix operator."]
     no_non_null_assertion: Option<RuleConfiguration>,
+    #[doc = "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements."]
+    no_noninteractive_element_to_interactive_role: Option<RuleConfiguration>,
     #[doc = "Disallow literal numbers that lose precision"]
     no_precision_loss: Option<RuleConfiguration>,
     #[doc = "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\"."]
@@ -830,7 +818,7 @@ struct NurserySchema {
 }
 impl Nursery {
     const CATEGORY_NAME: &'static str = "nursery";
-    pub(crate) const CATEGORY_RULES: [&'static str; 43] = [
+    pub(crate) const CATEGORY_RULES: [&'static str; 46] = [
         "noAccessKey",
         "noAssignInExpressions",
         "noBannedTypes",
@@ -847,6 +835,7 @@ impl Nursery {
         "noHeaderScope",
         "noInvalidConstructorSuper",
         "noNonNullAssertion",
+        "noNoninteractiveElementToInteractiveRole",
         "noPrecisionLoss",
         "noRedundantAlt",
         "noRedundantUseStrict",
@@ -877,7 +866,7 @@ impl Nursery {
         "useValidAriaProps",
         "useValidLang",
     ];
-    const RECOMMENDED_RULES: [&'static str; 34] = [
+    const RECOMMENDED_RULES: [&'static str; 37] = [
         "noAssignInExpressions",
         "noBannedTypes",
         "noClassAssign",
@@ -892,6 +881,7 @@ impl Nursery {
         "noExtraSemicolons",
         "noHeaderScope",
         "noInvalidConstructorSuper",
+        "noNoninteractiveElementToInteractiveRole",
         "noRedundantAlt",
         "noSelfCompare",
         "noSetterReturn",
@@ -915,7 +905,7 @@ impl Nursery {
         "useValidAriaProps",
         "useValidLang",
     ];
-    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 34] = [
+    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 37] = [
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[1]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[2]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[3]),
@@ -930,8 +920,8 @@ impl Nursery {
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[12]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[13]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[14]),
-        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[17]),
-        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[20]),
+        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[16]),
+        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[18]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[21]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[22]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[23]),
@@ -940,20 +930,21 @@ impl Nursery {
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[26]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[27]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[28]),
-        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[30]),
-        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[32]),
+        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[29]),
+        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[31]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[33]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[34]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[35]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[36]),
-        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[39]),
+        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[37]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[40]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[41]),
         RuleFilter::Rule("nursery", Self::CATEGORY_RULES[42]),
+        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[43]),
+        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[44]),
+        RuleFilter::Rule("nursery", Self::CATEGORY_RULES[45]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -973,14 +964,12 @@ impl Nursery {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::CATEGORY_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
     }
-    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 34] {
+    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 37] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
 }
@@ -1033,9 +1022,7 @@ impl Performance {
     const RECOMMENDED_RULES: [&'static str; 1] = ["noDelete"];
     const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 1] =
         [RuleFilter::Rule("performance", Self::CATEGORY_RULES[0])];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -1055,9 +1042,7 @@ impl Performance {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::CATEGORY_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -1125,9 +1110,7 @@ impl Security {
         RuleFilter::Rule("security", Self::CATEGORY_RULES[0]),
         RuleFilter::Rule("security", Self::CATEGORY_RULES[1]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -1147,9 +1130,7 @@ impl Security {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::CATEGORY_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -1258,9 +1239,7 @@ impl Style {
         RuleFilter::Rule("style", Self::CATEGORY_RULES[11]),
         RuleFilter::Rule("style", Self::CATEGORY_RULES[12]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -1280,9 +1259,7 @@ impl Style {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::CATEGORY_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -1420,9 +1397,7 @@ impl Suspicious {
         RuleFilter::Rule("suspicious", Self::CATEGORY_RULES[14]),
         RuleFilter::Rule("suspicious", Self::CATEGORY_RULES[15]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         IndexSet::from_iter(self.rules.iter().filter_map(|(key, conf)| {
             if conf.is_enabled() {
@@ -1442,9 +1417,7 @@ impl Suspicious {
         }))
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::CATEGORY_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::CATEGORY_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -754,6 +754,7 @@
           ]
         },
         "noNoninteractiveElementToInteractiveRole": {
+          "description": "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.",
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -753,6 +753,16 @@
             }
           ]
         },
+        "noNoninteractiveElementToInteractiveRole": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "noPrecisionLoss": {
           "description": "Disallow literal numbers that lose precision",
           "anyOf": [

--- a/justfile
+++ b/justfile
@@ -8,10 +8,11 @@ codegen:
   cargo codegen-bindings
 
 codegen-linter:
-	  cargo codegen-configuration
-    cargo codegen-schema
-    cargo codegen-bindings
-    cargo lintdoc
+  cargo codegen analyzer
+  cargo codegen-configuration
+  cargo codegen-schema
+  cargo codegen-bindings
+  cargo lintdoc
 
 documentation:
   cargo lintdoc

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -350,6 +350,10 @@ export interface Nursery {
 	 */
 	noNonNullAssertion?: RuleConfiguration;
 	/**
+	 * Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.
+	 */
+	noNoninteractiveElementToInteractiveRole?: RuleConfiguration;
+	/**
 	 * Disallow literal numbers that lose precision
 	 */
 	noPrecisionLoss?: RuleConfiguration;
@@ -782,6 +786,7 @@ export type Category =
 	| "lint/nursery/useMediaCaption"
 	| "lint/nursery/useIframeTitle"
 	| "lint/nursery/useNumericLiterals"
+	| "lint/nursery/noNoninteractiveElementToInteractiveRole"
 	| "lint/nursery/useValidForDirection"
 	| "lint/nursery/useHookAtTopLevel"
 	| "lint/performance/noDelete"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -754,6 +754,7 @@
           ]
         },
         "noNoninteractiveElementToInteractiveRole": {
+          "description": "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.",
           "anyOf": [
             {
               "$ref": "#/definitions/RuleConfiguration"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -753,6 +753,16 @@
             }
           ]
         },
+        "noNoninteractiveElementToInteractiveRole": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "noPrecisionLoss": {
           "description": "Disallow literal numbers that lose precision",
           "anyOf": [

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -574,6 +574,12 @@ It also checks whether a call <code>super()</code> is missing from classes that 
 Disallow non-null assertions using the <code>!</code> postfix operator.
 </section>
 <section class="rule">
+<h3 data-toc-exclude id="noNoninteractiveElementToInteractiveRole">
+	<a href="/lint/rules/noNoninteractiveElementToInteractiveRole">noNoninteractiveElementToInteractiveRole</a>
+</h3>
+Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noPrecisionLoss">
 	<a href="/lint/rules/noPrecisionLoss">noPrecisionLoss</a>
 </h3>

--- a/website/src/pages/lint/rules/noNoninteractiveElementToInteractiveRole.md
+++ b/website/src/pages/lint/rules/noNoninteractiveElementToInteractiveRole.md
@@ -1,0 +1,55 @@
+---
+title: Lint Rule noNoninteractiveElementToInteractiveRole
+parent: lint/rules/index
+---
+
+# noNoninteractiveElementToInteractiveRole (since v12.0.0)
+
+Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.
+
+Non-interactive HTML elements indicate _content_ and _containers_ in the user interface.
+Non-interactive elements include `<main>`, `<area>`, `<h1>` (,`<h2>`, etc), `<img>`, `<li>`, `<ul>` and `<ol>`.
+
+Interactive HTML elements indicate _controls_ in the user interface.
+Interactive elements include `<a href>`, `<button>`, `<input>`, `<select>`, `<textarea>`.
+
+[WAI-ARIA roles](https://www.w3.org/TR/wai-aria-1.1/#usage_intro) should not be used to convert a non-interactive element to an interactive element.
+Interactive ARIA roles include `button`, `link`, `checkbox`, `menuitem`, `menuitemcheckbox`, `menuitemradio`, `option`, `radio`, `searchbox`, `switch` and `textbox`.
+
+## Examples
+
+### Invalid
+
+```jsx
+<h1 role="button">Some text</h1>
+```
+
+<pre class="language-text"><code class="language-text">nursery/noNoninteractiveElementToInteractiveRole.js:1:5 <a href="https://docs.rome.tools/lint/rules/noNoninteractiveElementToInteractiveRole">lint/nursery/noNoninteractiveElementToInteractiveRole</a> ━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">The HTML element </span><span style="color: Tomato;"><strong>h1</strong></span><span style="color: Tomato;"> is non-interactive and should not have an interactive role.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;h1 role=&quot;button&quot;&gt;Some text&lt;/h1&gt;
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>h1</strong></span><span style="color: rgb(38, 148, 255);"> with a div or a span.</span>
+  
+</code></pre>
+
+### Valid
+
+```jsx
+<span role="button">Some text</span>
+```
+
+## Accessibility guidelines
+
+- [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+
+### Resources
+
+- [WAI-ARIA roles](https://www.w3.org/TR/wai-aria-1.1/#usage_intro)
+- [WAI-ARIA Authoring Practices Guide - Design Patterns and Widgets](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_ex)
+- [Fundamental Keyboard Navigation Conventions](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav)
+- [Mozilla Developer Network - ARIA Techniques](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Keyboard_and_focus)
+

--- a/website/src/playground/Playground.tsx
+++ b/website/src/playground/Playground.tsx
@@ -47,7 +47,6 @@ export default function PlaygroundLoader({
 	const romeOutput = file.rome;
 	const prettierOutput = file.prettier;
 
-	// rome-ignore lint/nursery/useExhaustiveDependencies: dynamic dependencies
 	const codeMirrorExtensions = useMemo(() => {
 		if (isJSONFilename(playgroundState.currentFile)) {
 			return [json()];
@@ -65,14 +64,12 @@ export default function PlaygroundLoader({
 
 	const astPanelCodeMirrorRef = useRef<null | ReactCodeMirrorRef>(null);
 
-	// rome-ignore lint/nursery/useExhaustiveDependencies: dynamic dependencies
 	useEffect(() => {
 		if (clipboardStatus !== "normal") {
 			setClipboardStatus("normal");
 		}
 	}, [romeOutput.formatter.ir]);
 
-	// rome-ignore lint/nursery/useExhaustiveDependencies: dynamic dependencies
 	const onUpdate = useCallback((viewUpdate: ViewUpdate) => {
 		const cursorPosition = viewUpdate.state.selection.ranges[0]?.from ?? 0;
 		setPlaygroundState((state) =>
@@ -127,7 +124,6 @@ export default function PlaygroundLoader({
 		});
 	}, [romeOutput.syntax.ast]);
 
-	// rome-ignore lint/nursery/useExhaustiveDependencies: dynamic dependencies
 	const onChange = useCallback((value: string) => {
 		setPlaygroundState((state) => ({
 			...state,

--- a/website/src/playground/components/Tabs.tsx
+++ b/website/src/playground/components/Tabs.tsx
@@ -45,6 +45,7 @@ export default function Tabs({
 								"react-tabs__tab",
 								isSelected && "react-tabs__tab--selected",
 							)}
+							// rome-ignore lint/nursery/noNoninteractiveElementToInteractiveRole: false positive?
 							role="tab"
 							aria-selected={isSelected}
 							aria-disabled={isSelected}

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -44,7 +44,7 @@ declare_rule! {{
     /// ```
     ///
     pub(crate) {rule_name_upper_camel} {{
-        version: "12.0.0",
+        version: "next",
         name: "{rule_name_lower_camel}",
         recommended: false,
     }}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Start implementing #3816 
Closes https://github.com/rome/tools/issues/3950

In order to implement this rule, new metadata were necessary. This metadata describes **some** of the existing roles, by adding the "concepts". 

Concepts are information that tells us how an HTML can be mapped via ARIA roles, for example:

```html
<button>Hit me</button>
```

Can be mapped with ARIA roles like this:

```html
<input type="button">Hit me</input>
<span role="button">Hit me</span>
```

This kind of information will be needed for another rule.

Not only that, though. These metadata are also useful to identify whether some HTML elements are non-interactive and if some ARIA roles are interactive.

- ARIA roles are interactive if they have `"widget"` in their list of roles
- HTML elements are deemed **non-interactive** if they belong to some ARIA role, and if that role is **NOT** interactive. The rest of the HTML elements can be seen as interactive.

For example, `h1` is NOT interactive because there's a role called `"heading"` that contains it, and this role is not interactive - it doesn't contain `"widget"`

The implementation of the rule still lacks some logic that I need to figure out, so the rule is still under heavy development.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added some test cases to make sure the rule works, but I plan to add more test cases once the implementation of the rule is correct.
The old rule had a bug, which I fixed in this version of the rule.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
