### PR TITLE
fix(ci): fix the release workflow for the JS API

### DIFF
--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -96,7 +96,9 @@ jobs:
 
       - name: Compile backends
         run: |
+          pnpm --prefix npm/js-api build:wasm-bundler
           pnpm --prefix npm/js-api build:wasm-node
+          pnpm --prefix npm/js-api build:wasm-web
           pnpm --prefix npm/backend-jsonrpc i
           pnpm --prefix npm/backend-jsonrpc run build
 

--- a/npm/js-api/package.json
+++ b/npm/js-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rometools/js-api",
-  "version": "0.2.0",
+  "version": "0.1.3",
   "description": "JavaScript APIs for the Rome package",
   "scripts": {
     "tsc": "tsc --noEmit",


### PR DESCRIPTION
## Summary

This PR fixes the `release_js_api` workflow by ensuring all the distributions of the `rome_wasm` crate (bundler, node and web) have been built before running `tsc` so the type checker can ensure all the definitions are valid and coherent.

## Test Plan

Run the release workflow for version `0.2.0` again (I've downgraded the version number in this PR to bump it again in a followup commit and trigger the release workflow again)
