### PR TITLE
fix(rome_js_analyze): fix useConst suggestion when some bindings cannot live inside const

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_const.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_const.rs
@@ -150,7 +150,10 @@ impl ConstBindings {
             declaration,
             VariableDeclaration::JsForVariableDeclaration(..)
         );
+        let mut bindings = 0;
         declaration.for_each_binding(|binding, declarator| {
+            bindings += 1;
+
             let has_initializer = declarator.initializer().is_some();
             let fix =
                 check_binding_can_be_const(&binding, in_for_in_or_of_loop, has_initializer, model);
@@ -163,7 +166,9 @@ impl ConstBindings {
                 None => state.can_fix = false,
             }
         });
-        if state.can_be_const.is_empty() {
+
+        // Only flag if all bindings can be const
+        if state.can_be_const.len() != bindings {
             None
         } else {
             Some(state)

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_const.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_const.rs
@@ -42,17 +42,17 @@ declare_rule! {
     /// }
     /// ```
     ///
-    /// ```js,expect_diagnostic
-    /// let a = 1, b = 2;
-    /// b = 3;
-    /// ```
-    ///
     /// ## Valid
     ///
     /// ```js
     /// let a = 2;
     /// a = 3;
     /// console.log(a);
+    /// ```
+    /// 
+    /// ```js
+    /// let a = 1, b = 2;
+    /// b = 3;
     /// ```
     pub(crate) UseConst {
         version: "11.0.0",

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_const.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_const.rs
@@ -49,7 +49,7 @@ declare_rule! {
     /// a = 3;
     /// console.log(a);
     /// ```
-    /// 
+    ///
     /// ```js
     /// let a = 1, b = 2;
     /// b = 3;

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -261,7 +261,10 @@ fn check_code_action(
     assert_eq!(new_tree.to_string(), output);
 
     if has_bogus_nodes_or_empty_slots(&new_tree) {
-        panic!("modified tree has bogus nodes or empty slots:\n{new_tree:#?}")
+        panic!(
+            "modified tree has bogus nodes or empty slots:\n{new_tree:#?} \n\n {}",
+            new_tree
+        )
     }
 
     // Checks the returned tree contains no missing children node

--- a/crates/rome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidVariables.ts
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidVariables.ts
@@ -12,3 +12,5 @@ const [i] = [1];
 
 var [{ j }] = [{ j: 1 }]
 var { k: [l] } = { k: [1] } 
+
+let m, n;

--- a/crates/rome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidVariables.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidVariables.ts.snap
@@ -19,6 +19,8 @@ const [i] = [1];
 var [{ j }] = [{ j: 1 }]
 var { k: [l] } = { k: [1] } 
 
+let m, n;
+
 ```
 
 # Diagnostics
@@ -247,6 +249,7 @@ invalidVariables.ts:14:11 lint/correctness/noUnusedVariables  FIXABLE  ━━━
   > 14 │ var { k: [l] } = { k: [1] }·
        │           ^
     15 │ 
+    16 │ let m, n;
   
   i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
   
@@ -257,6 +260,55 @@ invalidVariables.ts:14:11 lint/correctness/noUnusedVariables  FIXABLE  ━━━
     14    │ - var·{·k:·[l]·}·=·{·k:·[1]·}·
        14 │ + var·{·k:·[_l]·}·=·{·k:·[1]·}·
     15 15 │   
+    16 16 │   let m, n;
+  
+
+```
+
+```
+invalidVariables.ts:16:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable is unused.
+  
+    14 │ var { k: [l] } = { k: [1] }·
+    15 │ 
+  > 16 │ let m, n;
+       │     ^
+    17 │ 
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+  i Suggested fix: If this is intentional, prepend m with an underscore.
+  
+    14 14 │   var { k: [l] } = { k: [1] }·
+    15 15 │   
+    16    │ - let·m,·n;
+       16 │ + let·_m,·n;
+    17 17 │   
+  
+
+```
+
+```
+invalidVariables.ts:16:8 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable is unused.
+  
+    14 │ var { k: [l] } = { k: [1] }·
+    15 │ 
+  > 16 │ let m, n;
+       │        ^
+    17 │ 
+  
+  i Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
+  
+  i Suggested fix: If this is intentional, prepend n with an underscore.
+  
+    14 14 │   var { k: [l] } = { k: [1] }·
+    15 15 │   
+    16    │ - let·m,·n;
+       16 │ + let·m,·_n;
+    17 17 │   
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/correctness/noUnusedVariables/validVariables.tsx
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnusedVariables/validVariables.tsx
@@ -9,3 +9,7 @@ console.log(a, b, c);
 let value;
 function Button() {}
 console.log(<Button att={value}/>);
+
+// object assignment pattern
+let d, e; 
+({d, e} = {d: 1, e: 2});

--- a/crates/rome_js_analyze/tests/specs/correctness/noUnusedVariables/validVariables.tsx.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUnusedVariables/validVariables.tsx.snap
@@ -1,0 +1,25 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: validVariables.tsx
+---
+# Input
+```js
+/* should not generate diagnostics */
+
+var a = 1;
+let b = 1;
+const c = 1;
+console.log(a, b, c);
+
+// being used inside JSX
+let value;
+function Button() {}
+console.log(<Button att={value}/>);
+
+// object assignment pattern
+let d, e; 
+({d, e} = {d: 1, e: 2});
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noVar/invalidScript.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noVar/invalidScript.jsonc.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 73
 expression: invalidScript.jsonc
 ---
 # Input
@@ -88,7 +87,7 @@ var [x = -1, y] = [1,2]; y = 0;
 
 # Diagnostics
 ```
-invalidScript.jsonc:1:1 lint/nursery/noVar  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidScript.jsonc:1:1 lint/nursery/noVar ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use let or const instead of var.
   
@@ -98,11 +97,6 @@ invalidScript.jsonc:1:1 lint/nursery/noVar  FIXABLE  ━━━━━━━━━
   i A variable declared with var in the global scope pollutes the global object.
   
   i See MDN web docs for more details.
-  
-  i Suggested fix: Use 'let' instead.
-  
-  - var·[x·=·-1,·y]·=·[1,2];·y·=·0;
-  + let·[x·=·-1,·y]·=·[1,2];·y·=·0;
   
 
 ```
@@ -114,7 +108,7 @@ var {a: x = -1, b: y} = {a:1,b:2}; y = 0;
 
 # Diagnostics
 ```
-invalidScript.jsonc:1:1 lint/nursery/noVar  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidScript.jsonc:1:1 lint/nursery/noVar ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use let or const instead of var.
   
@@ -124,11 +118,6 @@ invalidScript.jsonc:1:1 lint/nursery/noVar  FIXABLE  ━━━━━━━━━
   i A variable declared with var in the global scope pollutes the global object.
   
   i See MDN web docs for more details.
-  
-  i Suggested fix: Use 'let' instead.
-  
-  - var·{a:·x·=·-1,·b:·y}·=·{a:1,b:2};·y·=·0;
-  + let·{a:·x·=·-1,·b:·y}·=·{a:1,b:2};·y·=·0;
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/nursery/useConst/invalid.jsonc
+++ b/crates/rome_js_analyze/tests/specs/nursery/useConst/invalid.jsonc
@@ -2,14 +2,10 @@
 	"let x = 1; foo(x);",
 	"for (let i in [1,2,3]) { foo(i); }",
 	"for (let x of [1,2,3]) { foo(x); }",
-	"let [x = -1, y] = [1,2]; y = 0;",
-	"let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
 	"(function() { let x = 1; foo(x); })();",
 	"(function() { for (let i in [1,2,3]) { foo(i); } })();",
 	"(function() { for (let x of [1,2,3]) { foo(x); } })();",
-	"(function() { let [x = -1, y] = [1,2]; y = 0; })();",
 	"let f = (function() { let g = x; })(); f = 1;",
-	"(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
 	"let x = 0; { let x = 1; foo(x); } x = 0;",
 	"for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }",
 	"for (let i in [1,2,3]) { let x = 1; foo(x); }",
@@ -18,20 +14,13 @@
 	"let x; x = 0;",
 	"switch (a) { case 0: let x; x = 0; }",
 	"(function() { let x; x = 1; })();",
-	"let {a = 0, b} = obj; b = 0; foo(a, b);",
-	"let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;",
 	"let {a: {b, c}} = {a: {b: 1, c: 2}}",
-	"let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
 	"let {a = 0, b} = obj; foo(a, b);",
 	"let [a] = [1]",
 	"let {a} = obj",
 	"let a, b; ({a = 0, b} = obj); foo(a, b);",
-	"let {a = 0, b} = obj, c = a; b = a;",
-	"let {a = 0, b} = obj, c = a; b = a;",
 
 	// https://github.com/eslint/eslint/issues/8187
-	"let { name, ...otherStuff } = obj; otherStuff = {};",
-	"let { name, ...otherStuff } = obj; otherStuff = {};",
 	"let x; function foo() { bar(x); } x = 0;",
 
 	// https://github.com/eslint/eslint/issues/5837
@@ -48,17 +37,12 @@
 	"let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();",
 	"let predicate; [, {foo:returnType, ...predicate} ] = foo();",
 	"let x = 'x', y = 'y';",
-	"let x = 'x', y = 'y'; x = 1",
+
 	"let x = 1, y = 'y'; let z = 1;",
 	"let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;",
 	"let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }",
 	"let someFunc = () => { let a = 1, b = 2; foo(a, b) }",
-
-	// https://github.com/eslint/eslint/issues/11699
-	"let {a, b} = c, d;",
-	"let {a, b, c} = {}, e, f;",
-	"function a() { let foo = 0, bar = 1; foo = 1; } function b() { let foo = 0, bar = 2; foo = 2; }",
-
+	
 	// https://github.com/eslint/eslint/issues/13899
 	"/*eslint no-undef-init:error*/ let foo = undefined;",
 	"let a = 1; class C { static { a; } }",
@@ -74,8 +58,9 @@
 	"class C { static { let a; a = 0; console.log(a); } }",
 
 	// https://github.com/eslint/eslint/issues/16266
-	"let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, list, obj, total);",
 	"let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);",
-	"let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);",
-	"let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);"
+	"let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);",
+
+	"class C { static { () => a; let a = 1; } };",
+	"let x; function foo() { bar(x); } x = 0;"
 ]

--- a/crates/rome_js_analyze/tests/specs/nursery/useConst/invalid.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useConst/invalid.jsonc.snap
@@ -85,50 +85,6 @@ invalid.jsonc:1:6 lint/nursery/useConst  FIXABLE  ━━━━━━━━━━
 
 # Input
 ```js
-let [x = -1, y] = [1,2]; y = 0;
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let [x = -1, y] = [1,2]; y = 0;
-      │ ^^^
-  
-  i 'x' is never re-assigned.
-  
-  > 1 │ let [x = -1, y] = [1,2]; y = 0;
-      │      ^
-  
-
-```
-
-# Input
-```js
-let {a: x = -1, b: y} = {a:1,b:2}; y = 0;
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let {a: x = -1, b: y} = {a:1,b:2}; y = 0;
-      │ ^^^
-  
-  i 'x' is never re-assigned.
-  
-  > 1 │ let {a: x = -1, b: y} = {a:1,b:2}; y = 0;
-      │         ^
-  
-
-```
-
-# Input
-```js
 (function() { let x = 1; foo(x); })();
 ```
 
@@ -210,28 +166,6 @@ invalid.jsonc:1:20 lint/nursery/useConst  FIXABLE  ━━━━━━━━━�
 
 # Input
 ```js
-(function() { let [x = -1, y] = [1,2]; y = 0; })();
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:15 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ (function() { let [x = -1, y] = [1,2]; y = 0; })();
-      │               ^^^
-  
-  i 'x' is never re-assigned.
-  
-  > 1 │ (function() { let [x = -1, y] = [1,2]; y = 0; })();
-      │                    ^
-  
-
-```
-
-# Input
-```js
 let f = (function() { let g = x; })(); f = 1;
 ```
 
@@ -253,28 +187,6 @@ invalid.jsonc:1:23 lint/nursery/useConst  FIXABLE  ━━━━━━━━━�
   
   - let·f·=·(function()·{·let·g·=·x;·})();·f·=·1;
   + let·f·=·(function()·{·const·g·=·x;·})();·f·=·1;
-  
-
-```
-
-# Input
-```js
-(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:15 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ (function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();
-      │               ^^^
-  
-  i 'x' is never re-assigned.
-  
-  > 1 │ (function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();
-      │                       ^
   
 
 ```
@@ -493,50 +405,6 @@ invalid.jsonc:1:15 lint/nursery/useConst ━━━━━━━━━━━━━
 
 # Input
 ```js
-let {a = 0, b} = obj; b = 0; foo(a, b);
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let {a = 0, b} = obj; b = 0; foo(a, b);
-      │ ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ let {a = 0, b} = obj; b = 0; foo(a, b);
-      │      ^
-  
-
-```
-
-# Input
-```js
-let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;
-      │ ^^^
-  
-  i 'c' is never re-assigned.
-  
-  > 1 │ let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;
-      │             ^
-  
-
-```
-
-# Input
-```js
 let {a: {b, c}} = {a: {b: 1, c: 2}}
 ```
 
@@ -563,28 +431,6 @@ invalid.jsonc:1:1 lint/nursery/useConst  FIXABLE  ━━━━━━━━━━
   
   - let·{a:·{b,·c}}·=·{a:·{b:·1,·c:·2}}
   + const·{a:·{b,·c}}·=·{a:·{b:·1,·c:·2}}
-  
-
-```
-
-# Input
-```js
-let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);
-      │ ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);
-      │     ^
   
 
 ```
@@ -698,104 +544,6 @@ invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━�
   
   > 1 │ let a, b; ({a = 0, b} = obj); foo(a, b);
       │        ^
-  
-
-```
-
-# Input
-```js
-let {a = 0, b} = obj, c = a; b = a;
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares some variables which are never re-assigned.
-  
-  > 1 │ let {a = 0, b} = obj, c = a; b = a;
-      │ ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ let {a = 0, b} = obj, c = a; b = a;
-      │      ^
-  
-  i 'c' is never re-assigned.
-  
-  > 1 │ let {a = 0, b} = obj, c = a; b = a;
-      │                       ^
-  
-
-```
-
-# Input
-```js
-let {a = 0, b} = obj, c = a; b = a;
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares some variables which are never re-assigned.
-  
-  > 1 │ let {a = 0, b} = obj, c = a; b = a;
-      │ ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ let {a = 0, b} = obj, c = a; b = a;
-      │      ^
-  
-  i 'c' is never re-assigned.
-  
-  > 1 │ let {a = 0, b} = obj, c = a; b = a;
-      │                       ^
-  
-
-```
-
-# Input
-```js
-let { name, ...otherStuff } = obj; otherStuff = {};
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
-      │ ^^^
-  
-  i 'name' is never re-assigned.
-  
-  > 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
-      │       ^^^^
-  
-
-```
-
-# Input
-```js
-let { name, ...otherStuff } = obj; otherStuff = {};
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
-      │ ^^^
-  
-  i 'name' is never re-assigned.
-  
-  > 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
-      │       ^^^^
   
 
 ```
@@ -1067,28 +815,6 @@ invalid.jsonc:1:1 lint/nursery/useConst  FIXABLE  ━━━━━━━━━━
 
 # Input
 ```js
-let x = 'x', y = 'y'; x = 1
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let x = 'x', y = 'y'; x = 1
-      │ ^^^
-  
-  i 'y' is never re-assigned.
-  
-  > 1 │ let x = 'x', y = 'y'; x = 1
-      │              ^
-  
-
-```
-
-# Input
-```js
 let x = 1, y = 'y'; let z = 1;
 ```
 
@@ -1173,27 +899,6 @@ invalid.jsonc:1:1 lint/nursery/useConst  FIXABLE  ━━━━━━━━━━
   
   - let·{·a,·b,·c}·=·obj;·let·{·x,·y,·z}·=·anotherObj;·x·=·2;
   + const·{·a,·b,·c}·=·obj;·let·{·x,·y,·z}·=·anotherObj;·x·=·2;
-  
-
-```
-
-```
-invalid.jsonc:1:23 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares some variables which are never re-assigned.
-  
-  > 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
-      │                       ^^^
-  
-  i 'y' is never re-assigned.
-  
-  > 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
-      │                                ^
-  
-  i 'z' is never re-assigned.
-  
-  > 1 │ let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;
-      │                                   ^
   
 
 ```
@@ -1305,103 +1010,6 @@ invalid.jsonc:1:24 lint/nursery/useConst  FIXABLE  ━━━━━━━━━�
   
   - let·someFunc·=·()·=>·{·let·a·=·1,·b·=·2;·foo(a,·b)·}
   + let·someFunc·=·()·=>·{·const·a·=·1,·b·=·2;·foo(a,·b)·}
-  
-
-```
-
-# Input
-```js
-let {a, b} = c, d;
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares some variables which are never re-assigned.
-  
-  > 1 │ let {a, b} = c, d;
-      │ ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ let {a, b} = c, d;
-      │      ^
-  
-  i 'b' is never re-assigned.
-  
-  > 1 │ let {a, b} = c, d;
-      │         ^
-  
-
-```
-
-# Input
-```js
-let {a, b, c} = {}, e, f;
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares some variables which are never re-assigned.
-  
-  > 1 │ let {a, b, c} = {}, e, f;
-      │ ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ let {a, b, c} = {}, e, f;
-      │      ^
-  
-  i 'b' is never re-assigned.
-  
-  > 1 │ let {a, b, c} = {}, e, f;
-      │         ^
-  
-  i 'c' is never re-assigned.
-  
-  > 1 │ let {a, b, c} = {}, e, f;
-      │            ^
-  
-
-```
-
-# Input
-```js
-function a() { let foo = 0, bar = 1; foo = 1; } function b() { let foo = 0, bar = 2; foo = 2; }
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:16 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ function a() { let foo = 0, bar = 1; foo = 1; } function b() { let foo = 0, bar = 2; foo = 2; }
-      │                ^^^
-  
-  i 'bar' is never re-assigned.
-  
-  > 1 │ function a() { let foo = 0, bar = 1; foo = 1; } function b() { let foo = 0, bar = 2; foo = 2; }
-      │                             ^^^
-  
-
-```
-
-```
-invalid.jsonc:1:64 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ function a() { let foo = 0, bar = 1; foo = 1; } function b() { let foo = 0, bar = 2; foo = 2; }
-      │                                                                ^^^
-  
-  i 'bar' is never re-assigned.
-  
-  > 1 │ function a() { let foo = 0, bar = 1; foo = 1; } function b() { let foo = 0, bar = 2; foo = 2; }
-      │                                                                             ^^^
   
 
 ```
@@ -1733,38 +1341,6 @@ invalid.jsonc:1:20 lint/nursery/useConst ━━━━━━━━━━━━━
 
 # Input
 ```js
-let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, list, obj, total);
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares some variables which are never re-assigned.
-  
-  > 1 │ let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, list, obj, total);
-      │ ^^^
-  
-  i 'itemId' is never re-assigned.
-  
-  > 1 │ let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, list, obj, total);
-      │       ^^^^^^
-  
-  i 'list' is never re-assigned.
-  
-  > 1 │ let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, list, obj, total);
-      │               ^^^^
-  
-  i 'obj' is never re-assigned.
-  
-  > 1 │ let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, list, obj, total);
-      │                            ^^^
-  
-
-```
-
-# Input
-```js
 let { itemId, list } = {}, obj = []; console.log(itemId, list, obj);
 ```
 
@@ -1802,33 +1378,6 @@ invalid.jsonc:1:1 lint/nursery/useConst  FIXABLE  ━━━━━━━━━━
 
 # Input
 ```js
-let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);
-```
-
-# Diagnostics
-```
-invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares some variables which are never re-assigned.
-  
-  > 1 │ let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);
-      │ ^^^
-  
-  i 'itemId' is never re-assigned.
-  
-  > 1 │ let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);
-      │       ^^^^^^
-  
-  i 'list' is never re-assigned.
-  
-  > 1 │ let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);
-      │               ^^^^
-  
-
-```
-
-# Input
-```js
 let [ itemId, list ] = [], obj = []; console.log(itemId, list, obj);
 ```
 
@@ -1860,6 +1409,55 @@ invalid.jsonc:1:1 lint/nursery/useConst  FIXABLE  ━━━━━━━━━━
   
   - let·[·itemId,·list·]·=·[],·obj·=·[];·console.log(itemId,·list,·obj);
   + const·[·itemId,·list·]·=·[],·obj·=·[];·console.log(itemId,·list,·obj);
+  
+
+```
+
+# Input
+```js
+class C { static { () => a; let a = 1; } };
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:29 lint/nursery/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This 'let' declares a variable which is never re-assigned.
+  
+  > 1 │ class C { static { () => a; let a = 1; } };
+      │                             ^^^
+  
+  i 'a' is never re-assigned.
+  
+  > 1 │ class C { static { () => a; let a = 1; } };
+      │                                 ^
+  
+  i Suggested fix: Use 'const' instead.
+  
+  - class·C·{·static·{·()·=>·a;·let·a·=·1;·}·};
+  + class·C·{·static·{·()·=>·a;·const·a·=·1;·}·};
+  
+
+```
+
+# Input
+```js
+let x; function foo() { bar(x); } x = 0;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This 'let' declares a variable which is never re-assigned.
+  
+  > 1 │ let x; function foo() { bar(x); } x = 0;
+      │ ^^^
+  
+  i 'x' is never re-assigned.
+  
+  > 1 │ let x; function foo() { bar(x); } x = 0;
+      │     ^
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/nursery/useConst/valid.jsonc
+++ b/crates/rome_js_analyze/tests/specs/nursery/useConst/valid.jsonc
@@ -30,7 +30,6 @@
 	"let a; function foo() { bar(++a); }",
 	"{ let id; function foo() { if (typeof id !== 'undefined') { return; } id = setInterval(() => {}, 250); } foo()",
 	"/*exported a*/ let a; function init() { a = foo(); }",
-	"/*exported a*/ let a = 1",
 	"let a; if (true) a = 0; foo(a);",
 	"(function (a) { let b; ({ a, b } = obj); })();",
 	"(function (a) { let b; ([ a, b ] = obj); })();",
@@ -53,11 +52,11 @@
 
 	// https://github.com/eslint/eslint/issues/8187
 	"let { name, ...otherStuff } = obj; otherStuff = {};",
-	"let { name, ...otherStuff } = obj; otherStuff = {};",
 
 	// https://github.com/eslint/eslint/issues/8308
 	"let predicate; [typeNode.returnType, predicate] = foo();",
 	"let predicate; [typeNode.returnType, ...predicate] = foo();",
+	
 	// intentionally testing empty slot in destructuring assignment
 	"let predicate; [typeNode.returnType,, predicate] = foo();",
 	"let predicate; [typeNode.returnType=5, predicate] = foo();",
@@ -68,9 +67,6 @@
 	"let predicate; [, {foo:typeNode.returnType, predicate}] = foo();",
 	"let predicate; [, {foo:typeNode.returnType, ...predicate}] = foo();",
 	"let a; const b = {}; ({ a, c: b.c } = func());",
-
-	// ignoreReadBeforeAssign
-	"let x; function foo() { bar(x); } x = 0;",
 
 	// https://github.com/eslint/eslint/issues/10520
 	"const x = [1,2]; let y; [,y] = x; y = 0;",
@@ -84,6 +80,23 @@
 	"class C { static { let a, b; if (foo) { ({ a, b } = foo); } } }",
 	"class C { static { let a, b; if (foo) ({ a, b } = foo); } }",
 	"class C { static { a++; } foo() { a++ } } let a = 1; ",
-	"class C { static { () => a; let a = 1; } };",
-	"let b; { let e; ({ a: { b, e } } = foo()); }"
+	"let b; { let e; ({ a: { b, e } } = foo()); }",
+	"let [x = -1, y] = [1,2]; y = 0;",
+	"let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
+	"(function() { let [x = -1, y] = [1,2]; y = 0; })();",
+	"(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
+	"let {a = 0, b} = obj; b = 0; foo(a, b);",
+	"let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;",
+	"let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
+	"let {a = 0, b} = obj, c = a; b = a;",
+	"let x = 'x', y = 'y'; x = 1",
+
+	// https://github.com/eslint/eslint/issues/11699
+	"let {a, b} = c, d;",
+	"let {a, b, c} = {}, e, f;",
+	"function a() { let foo = 0, bar = 1; foo = 1; } function b() { let foo = 0, bar = 2; foo = 2; }",
+
+	// https://github.com/eslint/eslint/issues/16266
+	"let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, list, obj, total);",
+	"let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);"
 ]

--- a/crates/rome_js_analyze/tests/specs/nursery/useConst/valid.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useConst/valid.jsonc.snap
@@ -159,33 +159,6 @@ let a; function foo() { bar(++a); }
 
 # Input
 ```js
-/*exported a*/ let a = 1
-```
-
-# Diagnostics
-```
-valid.jsonc:1:16 lint/nursery/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ /*exported a*/ let a = 1
-      │                ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ /*exported a*/ let a = 1
-      │                    ^
-  
-  i Suggested fix: Use 'const' instead.
-  
-  - /*exported·a*/·let·a·=·1
-  + /*exported·a*/·const·a·=·1
-  
-
-```
-
-# Input
-```js
 let a; if (true) a = 0; foo(a);
 ```
 
@@ -249,87 +222,14 @@ let x; for (x of array) { x; }
 let {a, b} = obj; b = 0;
 ```
 
-# Diagnostics
-```
-valid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let {a, b} = obj; b = 0;
-      │ ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ let {a, b} = obj; b = 0;
-      │      ^
-  
-
-```
-
 # Input
 ```js
 let a, b; ({a, b} = obj); b++;
 ```
 
-# Diagnostics
-```
-valid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let a, b; ({a, b} = obj); b++;
-      │ ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ let a, b; ({a, b} = obj); b++;
-      │     ^
-  
-
-```
-
 # Input
 ```js
 let { name, ...otherStuff } = obj; otherStuff = {};
-```
-
-# Diagnostics
-```
-valid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
-      │ ^^^
-  
-  i 'name' is never re-assigned.
-  
-  > 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
-      │       ^^^^
-  
-
-```
-
-# Input
-```js
-let { name, ...otherStuff } = obj; otherStuff = {};
-```
-
-# Diagnostics
-```
-valid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
-      │ ^^^
-  
-  i 'name' is never re-assigned.
-  
-  > 1 │ let { name, ...otherStuff } = obj; otherStuff = {};
-      │       ^^^^
-  
-
 ```
 
 # Input
@@ -389,28 +289,6 @@ let a; const b = {}; ({ a, c: b.c } = func());
 
 # Input
 ```js
-let x; function foo() { bar(x); } x = 0;
-```
-
-# Diagnostics
-```
-valid.jsonc:1:1 lint/nursery/useConst ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ let x; function foo() { bar(x); } x = 0;
-      │ ^^^
-  
-  i 'x' is never re-assigned.
-  
-  > 1 │ let x; function foo() { bar(x); } x = 0;
-      │     ^
-  
-
-```
-
-# Input
-```js
 const x = [1,2]; let y; [,y] = x; y = 0;
 ```
 
@@ -461,34 +339,77 @@ class C { static { a++; } foo() { a++ } } let a = 1;
 
 # Input
 ```js
-class C { static { () => a; let a = 1; } };
-```
-
-# Diagnostics
-```
-valid.jsonc:1:29 lint/nursery/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This 'let' declares a variable which is never re-assigned.
-  
-  > 1 │ class C { static { () => a; let a = 1; } };
-      │                             ^^^
-  
-  i 'a' is never re-assigned.
-  
-  > 1 │ class C { static { () => a; let a = 1; } };
-      │                                 ^
-  
-  i Suggested fix: Use 'const' instead.
-  
-  - class·C·{·static·{·()·=>·a;·let·a·=·1;·}·};
-  + class·C·{·static·{·()·=>·a;·const·a·=·1;·}·};
-  
-
+let b; { let e; ({ a: { b, e } } = foo()); }
 ```
 
 # Input
 ```js
-let b; { let e; ({ a: { b, e } } = foo()); }
+let [x = -1, y] = [1,2]; y = 0;
+```
+
+# Input
+```js
+let {a: x = -1, b: y} = {a:1,b:2}; y = 0;
+```
+
+# Input
+```js
+(function() { let [x = -1, y] = [1,2]; y = 0; })();
+```
+
+# Input
+```js
+(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();
+```
+
+# Input
+```js
+let {a = 0, b} = obj; b = 0; foo(a, b);
+```
+
+# Input
+```js
+let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;
+```
+
+# Input
+```js
+let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);
+```
+
+# Input
+```js
+let {a = 0, b} = obj, c = a; b = a;
+```
+
+# Input
+```js
+let x = 'x', y = 'y'; x = 1
+```
+
+# Input
+```js
+let {a, b} = c, d;
+```
+
+# Input
+```js
+let {a, b, c} = {}, e, f;
+```
+
+# Input
+```js
+function a() { let foo = 0, bar = 1; foo = 1; } function b() { let foo = 0, bar = 2; foo = 2; }
+```
+
+# Input
+```js
+let { itemId, list } = {}, obj = [], total = 0; total = 9; console.log(itemId, list, obj, total);
+```
+
+# Input
+```js
+let [ itemId, list ] = [], total = 0; total = 9; console.log(itemId, list, total);
 ```
 
 

--- a/crates/rome_js_analyze/tests/specs/nursery/useConst/validPartial.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/useConst/validPartial.js
@@ -1,0 +1,3 @@
+let {a, b} = v;
+a++;
+console.log(a);

--- a/crates/rome_js_analyze/tests/specs/nursery/useConst/validPartial.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useConst/validPartial.js.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: validPartial.js
+---
+# Input
+```js
+let {a, b} = v;
+a++;
+console.log(a);
+```
+
+

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -125,6 +125,8 @@ assert_semantics! {
 }
 f(1);"#,
     ok_reference_write_expression, "let a/*#A*/ = 1; let b = a/*WRITE A*/ = 2;",
+    ok_reference_write_object_assignment_pattern,
+        "let a/*#A*/, b/*#B*/; ({a/*WRITE A*/, b/*WRITE B*/} = obj);",
 }
 
 // Write Hoisting
@@ -213,7 +215,6 @@ assert_semantics! {
 }
 
 // Classes
-
 assert_semantics! {
     ok_class_reference,
         "class A/*#A*/ {} new A/*READ A*/();",
@@ -222,6 +223,8 @@ assert_semantics! {
     //https://github.com/rome/tools/issues/3779
     ok_class_expression_2,
         "const A/*#A1*/ = print(class A/*#A2*/ {}); console.log(A/*READ A1*/);",
+    ok_class_static_init,
+        "class C { static { () => a/*READ A*/; let a/*#A*/ = 1; } };",
 }
 
 // Typescript types

--- a/crates/rome_js_syntax/src/binding_ext.rs
+++ b/crates/rome_js_syntax/src/binding_ext.rs
@@ -7,7 +7,7 @@ use crate::{
     JsImportDefaultClause, JsImportNamespaceClause, JsMethodClassMember, JsMethodObjectMember,
     JsNamedImportSpecifier, JsNamespaceImportSpecifier, JsParameterList, JsParameters,
     JsRestParameter, JsSetterClassMember, JsSetterObjectMember, JsShorthandNamedImportSpecifier,
-    JsSyntaxKind, JsSyntaxNode, JsVariableDeclarator, TsCallSignatureTypeMember,
+    JsSyntaxKind, JsSyntaxNode, JsSyntaxToken, JsVariableDeclarator, TsCallSignatureTypeMember,
     TsConstructSignatureTypeMember, TsConstructorSignatureClassMember, TsConstructorType,
     TsDeclareFunctionDeclaration, TsDeclareFunctionExportDefaultDeclaration, TsEnumDeclaration,
     TsFunctionType, TsIdentifierBinding, TsImportEqualsDeclaration, TsIndexSignatureClassMember,
@@ -15,7 +15,7 @@ use crate::{
     TsMethodSignatureTypeMember, TsModuleDeclaration, TsPropertyParameter,
     TsSetterSignatureClassMember, TsSetterSignatureTypeMember, TsTypeAliasDeclaration,
 };
-use rome_rowan::{declare_node_union, AstNode};
+use rome_rowan::{declare_node_union, AstNode, SyntaxResult};
 
 declare_node_union! {
     pub AnyJsBindingDeclaration =
@@ -118,6 +118,13 @@ fn is_under_object_pattern_binding(node: &JsSyntaxNode) -> Option<bool> {
 }
 
 impl AnyJsIdentifierBinding {
+    pub fn name_token(&self) -> SyntaxResult<JsSyntaxToken> {
+        match self {
+            AnyJsIdentifierBinding::JsIdentifierBinding(binding) => binding.name_token(),
+            AnyJsIdentifierBinding::TsIdentifierBinding(binding) => binding.name_token(),
+        }
+    }
+
     pub fn declaration(&self) -> Option<AnyJsBindingDeclaration> {
         let node = match self {
             AnyJsIdentifierBinding::JsIdentifierBinding(binding) => &binding.syntax,
@@ -136,6 +143,17 @@ impl AnyJsIdentifierBinding {
 
     pub fn is_under_object_pattern_binding(&self) -> Option<bool> {
         is_under_object_pattern_binding(self.syntax())
+    }
+
+    pub fn with_name_token(self, name_token: JsSyntaxToken) -> AnyJsIdentifierBinding {
+        match self {
+            AnyJsIdentifierBinding::JsIdentifierBinding(binding) => {
+                AnyJsIdentifierBinding::JsIdentifierBinding(binding.with_name_token(name_token))
+            }
+            AnyJsIdentifierBinding::TsIdentifierBinding(binding) => {
+                AnyJsIdentifierBinding::TsIdentifierBinding(binding.with_name_token(name_token))
+            }
+        }
     }
 }
 

--- a/website/src/pages/lint/rules/useConst.md
+++ b/website/src/pages/lint/rules/useConst.md
@@ -144,34 +144,16 @@ let a = 3;
   
 </code></pre>
 
-```jsx
-let a = 1, b = 2;
-b = 3;
-```
-
-<pre class="language-text"><code class="language-text">nursery/useConst.js:1:1 <a href="https://docs.rome.tools/lint/rules/useConst">lint/nursery/useConst</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This 'let' declares a variable which is never re-assigned.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>let a = 1, b = 2;
-   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>b = 3;
-    <strong>3 │ </strong>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">'a' is never re-assigned.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>let a = 1, b = 2;
-   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>b = 3;
-    <strong>3 │ </strong>
-  
-</code></pre>
-
 ## Valid
 
 ```jsx
 let a = 2;
 a = 3;
 console.log(a);
+```
+
+```jsx
+let a = 1, b = 2;
+b = 3;
 ```
 


### PR DESCRIPTION
## Summary

Fixes: https://github.com/rome/tools/issues/4006

The real fix is at: `crates/rome_js_analyze/src/semantic_analyzers/nursery/use_const.rs`
All the other changes were using some of the examples to better test semantic model and batch mutation with the cases of `useConst`.

I also moved a lot of cases from valid to invalid and vice-versa.
The older version of `crates/rome_js_analyze/tests/specs/nursery/useConst/valid.jsonc.snap` incorrectly had some diagnostics. I also fixed that.

## Test Plan

```
> cargo test -p rome_js_analyze -- use_const
```
