### PR TITLE
feat(rome_cli): Add JS runtime and package manager information to `rage`

### DIFF
--- a/crates/rome_cli/src/commands/rage.rs
+++ b/crates/rome_cli/src/commands/rage.rs
@@ -30,6 +30,9 @@ pub(crate) fn rage(mut session: CliSession) -> Result<(), Termination> {
     {EnvVarOs("ROME_LOG_DIR")}
     {EnvVarOs("NO_COLOR")}
     {EnvVarOs("TERM")}
+    {EnvVarOs("JS_RUNTIME_VERSION")}
+    {EnvVarOs("JS_RUNTIME_NAME")}
+    {EnvVarOs("NODE_PACKAGE_MANAGER")}
 
     {RageConfiguration(&session.app.fs)}
     {WorkspaceRage(session.app.workspace.deref())}

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/rage_ok.snap
@@ -17,6 +17,9 @@ Environment:
   ROME_LOG_DIR:         **PLACEHOLDER**
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
+  JS_RUNTIME_VERSION:   unset
+  JS_RUNTIME_NAME:      unset
+  NODE_PACKAGE_MANAGER: unset
 
 Rome Configuration:
   Status:               unset

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_configuration.snap
@@ -27,6 +27,9 @@ Environment:
   ROME_LOG_DIR:         **PLACEHOLDER**
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
+  JS_RUNTIME_VERSION:   unset
+  JS_RUNTIME_NAME:      unset
+  NODE_PACKAGE_MANAGER: unset
 
 Rome Configuration:
   Status:               loaded

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_malformed_configuration.snap
@@ -27,6 +27,9 @@ Environment:
   ROME_LOG_DIR:         **PLACEHOLDER**
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
+  JS_RUNTIME_VERSION:   unset
+  JS_RUNTIME_NAME:      unset
+  NODE_PACKAGE_MANAGER: unset
 
 Rome Configuration:
   Status:               Failed to load

--- a/crates/rome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_rage/with_server_logs.snap
@@ -17,6 +17,9 @@ Environment:
   ROME_LOG_DIR:         **PLACEHOLDER**
   NO_COLOR:             **PLACEHOLDER**
   TERM:                 **PLACEHOLDER**
+  JS_RUNTIME_VERSION:   unset
+  JS_RUNTIME_NAME:      unset
+  NODE_PACKAGE_MANAGER: unset
 
 Rome Configuration:
   Status:               unset

--- a/npm/rome/bin/rome
+++ b/npm/rome/bin/rome
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { platform, arch } = process;
+const { platform, arch, env, version, release } = process;
 
 const PLATFORMS = {
 	win32: {
@@ -21,7 +21,16 @@ if (binPath) {
 	const result = require("child_process").spawnSync(
 		require.resolve(binPath),
 		process.argv.slice(2),
-		{ shell: false, stdio: "inherit" },
+		{
+			shell: false,
+			stdio: "inherit",
+			env: {
+				...env,
+				JS_RUNTIME_VERSION: version,
+				JS_RUNTIME_NAME: release.name,
+				NODE_PACKAGE_MANAGER: detectPackageManager(),
+			},
+		},
 	);
 
 	if (result.error) {
@@ -36,4 +45,23 @@ if (binPath) {
 			"and follow the instructions there to build the CLI for your platform.",
 	);
 	process.exitCode = 1;
+}
+
+/**
+ * NPM, Yarn, and other package manager set the `npm_config_user_agent`. It has the following format:
+ *
+ * ```
+ * "npm/8.3.0 node/v16.13.2 win32 x64 workspaces/false
+ * ```
+ *
+ * @returns The package manager string (`npm/8.3.0`) or null if the user agent string isn't set.
+ */
+function detectPackageManager() {
+	const userAgent = env.npm_config_user_agent;
+
+	if (userAgent == null) {
+		return null;
+	}
+
+	return userAgent.split(" ")[0];
 }


### PR DESCRIPTION
## Summary

This PR extends the `rome rage` command to include the name and version of the JavaScript runtime that executed the `rome` wrapper script as well as the name and version of the package manager:

## Test Plan

```
❯ npx rome rage
CLI:
  Version:              0.0.0
  Color support:        true

Platform:
  CPU Architecture:     x86_64
  OS:                   windows

Environment:
  ROME_LOG_DIR:         unset
  NO_COLOR:             unset
  TERM:                 unset
  JS_RUNTIME_VERSION:   "v16.13.2"
  JS_RUNTIME_NAME:      "node"
  NODE_PACKAGE_MANAGER: "npm/8.3.0"

 ❯ yarn rome rage
 yarn run v1.22.19
 $ C:\Users\Micha\git\rome-test\node_modules\.bin\rome rage
 CLI:
   Version:              0.0.0
   Color support:        true

 Platform:
   CPU Architecture:     x86_64
   OS:                   windows

 Environment:
   ROME_LOG_DIR:         unset
   NO_COLOR:             unset
   TERM:                 unset
   JS_RUNTIME_VERSION:   "v16.13.2"
   JS_RUNTIME_NAME:      "node"
   NODE_PACKAGE_MANAGER: "yarn/1.22.19"

❯ pnpm rome rage
CLI:
  Version:              0.0.0
  Color support:        true

Platform:
  CPU Architecture:     x86_64
  OS:                   windows

Environment:
  ROME_LOG_DIR:         unset
  NO_COLOR:             unset
  TERM:                 unset
  JS_RUNTIME_VERSION:   "v16.13.2"
  JS_RUNTIME_NAME:      "node"
  NODE_PACKAGE_MANAGER: "pnpm/7.13.6"
```
