### PR TITLE
fix(rome_lsp): improve the pattern matching logic for ignored files

### DIFF
--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -1111,13 +1111,16 @@ fn does_not_format_ignored_directories() {
         CONFIG_FORMATTER_IGNORED_DIRECTORIES.as_bytes(),
     );
 
-    const FILES: [(&str, bool); 6] = [
+    const FILES: [(&str, bool); 9] = [
         ("test.js", true),
         ("test1.js", false),
         ("test2.js", false),
         ("test3/test.js", false),
         ("test4/test.js", true),
         ("test5/test.js", false),
+        ("test6/test.js", false),
+        ("test/test.test7.js", false),
+        ("test.test7.js", false),
     ];
 
     for (file_path, _) in FILES {

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -212,7 +212,9 @@ pub const CONFIG_FORMATTER_IGNORED_DIRECTORIES: &str = r#"{
       "./test2.js",
       "./test3/**/*",
       "/test4/**/*",
-      "test5/**/*"
+      "test5/**/*",
+      "**/test6/*.js",
+      "*.test7.js"
     ]
   }
 }

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -207,7 +207,13 @@ pub const CONFIG_FORMATTER_AND_FILES_IGNORE: &str = r#"{
 
 pub const CONFIG_FORMATTER_IGNORED_DIRECTORIES: &str = r#"{
   "formatter": {
-    "ignore": ["scripts/*"]
+    "ignore": [
+      "test1.js",
+      "./test2.js",
+      "./test3/**/*",
+      "/test4/**/*",
+      "test5/**/*"
+    ]
   }
 }
 "#;

--- a/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
@@ -12,7 +12,9 @@ expression: content
       "./test2.js",
       "./test3/**/*",
       "/test4/**/*",
-      "test5/**/*"
+      "test5/**/*",
+      "**/test6/*.js",
+      "*.test7.js"
     ]
   }
 }
@@ -24,6 +26,18 @@ expression: content
 ```js
 statement();
 
+```
+
+## `test.test7.js`
+
+```js
+  statement(  )  
+```
+
+## `test/test.test7.js`
+
+```js
+  statement(  )  
 ```
 
 ## `test1.js`
@@ -52,6 +66,12 @@ statement();
 ```
 
 ## `test5/test.js`
+
+```js
+  statement(  )  
+```
+
+## `test6/test.js`
 
 ```js
   statement(  )  

--- a/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/does_not_format_ignored_directories.snap
@@ -7,29 +7,60 @@ expression: content
 ```json
 {
   "formatter": {
-    "ignore": ["scripts/*"]
+    "ignore": [
+      "test1.js",
+      "./test2.js",
+      "./test3/**/*",
+      "/test4/**/*",
+      "test5/**/*"
+    ]
   }
 }
 
 ```
 
-## `scripts/test.js`
-
-```js
-  statement(  )  
-```
-
-## `src/test.js`
+## `test.js`
 
 ```js
 statement();
 
 ```
 
+## `test1.js`
+
+```js
+  statement(  )  
+```
+
+## `test2.js`
+
+```js
+  statement(  )  
+```
+
+## `test3/test.js`
+
+```js
+  statement(  )  
+```
+
+## `test4/test.js`
+
+```js
+statement();
+
+```
+
+## `test5/test.js`
+
+```js
+  statement(  )  
+```
+
 # Emitted Messages
 
 ```block
-Formatted 2 file(s) in <TIME>
+Formatted 3 file(s) in <TIME>
 ```
 
 

--- a/crates/rome_lsp/src/handlers/analysis.rs
+++ b/crates/rome_lsp/src/handlers/analysis.rs
@@ -32,7 +32,7 @@ pub(crate) fn code_actions(
     params: CodeActionParams,
 ) -> Result<Option<CodeActionResponse>> {
     let url = params.text_document.uri.clone();
-    let rome_path = session.file_path(&url);
+    let rome_path = session.file_path(&url)?;
 
     let unsupported_lint = &session.workspace.supports_feature(SupportsFeatureParams {
         path: rome_path,
@@ -57,7 +57,7 @@ pub(crate) fn code_actions(
     }
 
     let url = params.text_document.uri.clone();
-    let rome_path = session.file_path(&url);
+    let rome_path = session.file_path(&url)?;
     let doc = session.document(&url)?;
 
     let diagnostics = params.context.diagnostics;

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -15,7 +15,7 @@ pub(crate) fn format(
     params: DocumentFormattingParams,
 ) -> Result<Option<Vec<TextEdit>>> {
     let url = params.text_document.uri;
-    let rome_path = session.file_path(&url);
+    let rome_path = session.file_path(&url)?;
 
     let doc = session.document(&url)?;
 
@@ -56,7 +56,7 @@ pub(crate) fn format_range(
     params: DocumentRangeFormattingParams,
 ) -> Result<Option<Vec<TextEdit>>> {
     let url = params.text_document.uri;
-    let rome_path = session.file_path(&url);
+    let rome_path = session.file_path(&url)?;
     let doc = session.document(&url)?;
 
     let start_index = utils::offset(&doc.line_index, params.range.start).with_context(|| {
@@ -119,7 +119,7 @@ pub(crate) fn format_on_type(
     let url = params.text_document_position.text_document.uri;
     let position = params.text_document_position.position;
 
-    let rome_path = session.file_path(&url);
+    let rome_path = session.file_path(&url)?;
     let doc = session.document(&url)?;
 
     let offset = utils::offset(&doc.line_index, position)

--- a/crates/rome_lsp/src/handlers/rename.rs
+++ b/crates/rome_lsp/src/handlers/rename.rs
@@ -8,7 +8,7 @@ use tracing::trace;
 #[tracing::instrument(level = "debug", skip(session), err)]
 pub(crate) fn rename(session: &Session, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
     let url = params.text_document_position.text_document.uri;
-    let rome_path = session.file_path(&url);
+    let rome_path = session.file_path(&url)?;
 
     trace!("Renaming...");
 

--- a/crates/rome_lsp/src/handlers/text_document.rs
+++ b/crates/rome_lsp/src/handlers/text_document.rs
@@ -18,7 +18,7 @@ pub(crate) async fn did_open(
     let content = params.text_document.text;
     let language_hint = Language::from_language_id(&params.text_document.language_id);
 
-    let rome_path = session.file_path(&url);
+    let rome_path = session.file_path(&url)?;
     let doc = Document::new(version, &content);
 
     session.workspace.open_file(OpenFileParams {
@@ -46,7 +46,7 @@ pub(crate) async fn did_change(
     let url = params.text_document.uri;
     let version = params.text_document.version;
 
-    let rome_path = session.file_path(&url);
+    let rome_path = session.file_path(&url)?;
     let doc = session.document(&url)?;
 
     let mut content = doc.content;
@@ -93,7 +93,7 @@ pub(crate) async fn did_close(
     params: lsp_types::DidCloseTextDocumentParams,
 ) -> Result<()> {
     let url = params.text_document.uri;
-    let rome_path = session.file_path(&url);
+    let rome_path = session.file_path(&url)?;
 
     session
         .workspace

--- a/crates/rome_lsp/src/requests/syntax_tree.rs
+++ b/crates/rome_lsp/src/requests/syntax_tree.rs
@@ -15,7 +15,7 @@ pub struct SyntaxTreePayload {
 
 pub(crate) fn syntax_tree(session: &Session, url: &Url) -> Result<String> {
     info!("Showing syntax tree");
-    let rome_path = session.file_path(url);
+    let rome_path = session.file_path(url)?;
     let syntax_tree = session
         .workspace
         .get_syntax_tree(GetSyntaxTreeParams { path: rome_path })?;

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -3,6 +3,7 @@ use crate::config::CONFIGURATION_SECTION;
 use crate::documents::Document;
 use crate::url_interner::UrlInterner;
 use crate::utils;
+use anyhow::{anyhow, Result};
 use futures::stream::futures_unordered::FuturesUnordered;
 use futures::StreamExt;
 use rome_analyze::RuleCategories;
@@ -127,17 +128,33 @@ impl Session {
         self.url_interner.write().unwrap().intern(url)
     }
 
-    pub(crate) fn file_path(&self, url: &lsp_types::Url) -> RomePath {
+    pub(crate) fn file_path(&self, url: &lsp_types::Url) -> Result<RomePath> {
         let file_id = self.file_id(url.clone());
-        RomePath::new(url.path(), file_id)
+        let mut path_to_file = url
+            .to_file_path()
+            .map_err(|()| anyhow!("failed to convert {url} to a filesystem path"))?;
+
+        let relative_path = {
+            let root_uri = self.root_uri.read().unwrap();
+            root_uri.as_ref().and_then(|root_uri| {
+                let root_path = root_uri.to_file_path().ok()?;
+                path_to_file.strip_prefix(&root_path).ok()
+            })
+        };
+
+        if let Some(relative_path) = relative_path {
+            path_to_file = relative_path.into();
+        }
+
+        Ok(RomePath::new(path_to_file, file_id))
     }
 
     /// Computes diagnostics for the file matching the provided url and publishes
     /// them to the client. Called from [`handlers::text_document`] when a file's
     /// contents changes.
     #[tracing::instrument(level = "debug", skip_all, fields(url = display(&url), diagnostic_count), err)]
-    pub(crate) async fn update_diagnostics(&self, url: lsp_types::Url) -> anyhow::Result<()> {
-        let rome_path = self.file_path(&url);
+    pub(crate) async fn update_diagnostics(&self, url: lsp_types::Url) -> Result<()> {
+        let rome_path = self.file_path(&url)?;
         let doc = self.document(&url)?;
         let unsupported_lint = self.workspace.supports_feature(SupportsFeatureParams {
             feature: FeatureName::Lint,

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -48,6 +48,10 @@ use tower_lsp::lsp_types::WorkDoneProgressParams;
 use tower_lsp::LspService;
 use tower_lsp::{jsonrpc::Request, lsp_types::InitializeParams};
 
+/// Statically build an [lsp::Url] instance that points to the file at `$path`
+/// within the workspace. The filesystem path contained in the return URI is
+/// guaranteed to be a valid path for the underlying operating system, but
+/// doesn't have to refer to an existing file on the host machine.
 macro_rules! url {
     ($path:literal) => {
         if cfg!(windows) {

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -43,11 +43,20 @@ use tower_lsp::lsp_types::TextDocumentContentChangeEvent;
 use tower_lsp::lsp_types::TextDocumentIdentifier;
 use tower_lsp::lsp_types::TextDocumentItem;
 use tower_lsp::lsp_types::TextEdit;
-use tower_lsp::lsp_types::Url;
 use tower_lsp::lsp_types::VersionedTextDocumentIdentifier;
 use tower_lsp::lsp_types::WorkDoneProgressParams;
 use tower_lsp::LspService;
 use tower_lsp::{jsonrpc::Request, lsp_types::InitializeParams};
+
+macro_rules! url {
+    ($path:literal) => {
+        if cfg!(windows) {
+            lsp::Url::parse(concat!("file:///z%3A/workspace/", $path)).unwrap()
+        } else {
+            lsp::Url::parse(concat!("file:///workspace/", $path)).unwrap()
+        }
+    };
+}
 
 struct Server {
     service: Timeout<LspService<LSPServer>>,
@@ -137,7 +146,7 @@ impl Server {
                 InitializeParams {
                     process_id: None,
                     root_path: None,
-                    root_uri: None,
+                    root_uri: Some(url!("")),
                     initialization_options: None,
                     capabilities: ClientCapabilities::default(),
                     trace: None,
@@ -182,7 +191,7 @@ impl Server {
             "textDocument/didOpen",
             DidOpenTextDocumentParams {
                 text_document: TextDocumentItem {
-                    uri: Url::parse("test://workspace/document.js")?,
+                    uri: url!("document.js"),
                     language_id: String::from("javascript"),
                     version: 0,
                     text: text.to_string(),
@@ -201,7 +210,7 @@ impl Server {
             "textDocument/didChange",
             DidChangeTextDocumentParams {
                 text_document: VersionedTextDocumentIdentifier {
-                    uri: Url::parse("test://workspace/document.js")?,
+                    uri: url!("document.js"),
                     version,
                 },
                 content_changes,
@@ -215,7 +224,7 @@ impl Server {
             "textDocument/didClose",
             DidCloseTextDocumentParams {
                 text_document: TextDocumentIdentifier {
-                    uri: Url::parse("test://workspace/document.js")?,
+                    uri: url!("document.js"),
                 },
             },
         )
@@ -378,7 +387,7 @@ async fn document_lifecycle() -> Result<()> {
             "rome/get_syntax_tree",
             "get_syntax_tree",
             GetSyntaxTreeParams {
-                path: RomePath::new("/document.js", FileId::zero()),
+                path: RomePath::new("document.js", FileId::zero()),
             },
         )
         .await?
@@ -455,7 +464,7 @@ async fn document_no_extension() -> Result<()> {
             "textDocument/didOpen",
             DidOpenTextDocumentParams {
                 text_document: TextDocumentItem {
-                    uri: Url::parse("test://workspace/document")?,
+                    uri: url!("document"),
                     language_id: String::from("javascript"),
                     version: 0,
                     text: String::from("statement()"),
@@ -470,7 +479,7 @@ async fn document_no_extension() -> Result<()> {
             "formatting",
             DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: Url::parse("test://workspace/document")?,
+                    uri: url!("document"),
                 },
                 options: FormattingOptions {
                     tab_size: 4,
@@ -496,7 +505,7 @@ async fn document_no_extension() -> Result<()> {
             "textDocument/didClose",
             DidCloseTextDocumentParams {
                 text_document: TextDocumentIdentifier {
-                    uri: Url::parse("test://workspace/document")?,
+                    uri: url!("document"),
                 },
             },
         )
@@ -534,7 +543,7 @@ async fn pull_diagnostics() -> Result<()> {
         notification,
         Some(ServerNotification::PublishDiagnostics(
             PublishDiagnosticsParams {
-                uri: Url::parse("test://workspace/document.js")?,
+                uri: url!("document.js"),
                 version: Some(0),
                 diagnostics: vec![lsp::Diagnostic {
                     range: lsp::Range {
@@ -558,7 +567,7 @@ async fn pull_diagnostics() -> Result<()> {
                     ),
                     related_information: Some(vec![lsp::DiagnosticRelatedInformation {
                         location: lsp::Location {
-                            uri: lsp::Url::parse("test://workspace/document.js")?,
+                            uri: url!("document.js"),
                             range: lsp::Range {
                                 start: lsp::Position {
                                     line: 0,
@@ -630,7 +639,7 @@ async fn pull_quick_fixes() -> Result<()> {
             "pull_code_actions",
             lsp::CodeActionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Url::parse("test://workspace/document.js")?,
+                    uri: url!("document.js"),
                 },
                 range: lsp::Range {
                     start: lsp::Position {
@@ -659,7 +668,7 @@ async fn pull_quick_fixes() -> Result<()> {
 
     let mut changes = HashMap::default();
     changes.insert(
-        lsp::Url::parse("test://workspace/document.js")?,
+        url!("document.js"),
         vec![lsp::TextEdit {
             range: lsp::Range {
                 start: lsp::Position {
@@ -694,7 +703,7 @@ async fn pull_quick_fixes() -> Result<()> {
 
     let mut suppression_changes = HashMap::default();
     suppression_changes.insert(
-        lsp::Url::parse("test://workspace/document.js")?,
+        url!("document.js"),
         vec![lsp::TextEdit {
             range: lsp::Range {
                 start: lsp::Position {
@@ -762,7 +771,7 @@ async fn pull_refactors() -> Result<()> {
             "pull_code_actions",
             lsp::CodeActionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Url::parse("test://workspace/document.js")?,
+                    uri: url!("document.js"),
                 },
                 range: lsp::Range {
                     start: lsp::Position {
@@ -792,7 +801,7 @@ async fn pull_refactors() -> Result<()> {
     let mut changes = HashMap::default();
 
     changes.insert(
-        lsp::Url::parse("test://workspace/document.js")?,
+        url!("document.js"),
         vec![
             lsp::TextEdit {
                 range: lsp::Range {
@@ -873,7 +882,7 @@ async fn pull_fix_all() -> Result<()> {
             "pull_code_actions",
             lsp::CodeActionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Url::parse("test://workspace/document.js")?,
+                    uri: url!("document.js"),
                 },
                 range: lsp::Range {
                     start: lsp::Position {
@@ -907,7 +916,7 @@ async fn pull_fix_all() -> Result<()> {
     let mut changes = HashMap::default();
 
     changes.insert(
-        lsp::Url::parse("test://workspace/document.js")?,
+        url!("document.js"),
         vec![lsp::TextEdit {
             range: lsp::Range {
                 start: lsp::Position {
@@ -973,7 +982,7 @@ async fn format_with_syntax_errors() -> Result<()> {
             "formatting",
             DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: Url::parse("test://workspace/document.js")?,
+                    uri: url!("document.js"),
                 },
                 options: FormattingOptions {
                     tab_size: 4,

--- a/crates/rome_service/src/matcher/pattern.rs
+++ b/crates/rome_service/src/matcher/pattern.rs
@@ -122,17 +122,20 @@ impl Pattern {
         let mut is_recursive = false;
         let mut i = 0;
 
-        // A pattern is relative if it starts with "." followed by a separator
+        // A pattern is relative if it starts with "." followed by a separator,
+        // eg. "./test" or ".\test"
         let is_relative = matches!(chars.get(..2), Some(['.', sep]) if path::is_separator(*sep));
         if is_relative {
-            // If a pattern starts with a relative prefix, strip it from the pattern and replace it with "**"
+            // If a pattern starts with a relative prefix, strip it from the
+            // pattern and replace it with a "**" sequence
             i += 2;
             tokens.push(AnyRecursiveSequence);
         } else {
-            // A pattern is absolute if it starts with a path separator
+            // A pattern is absolute if it starts with a path separator, eg. "/home" or "\\?\C:\Users"
             let mut is_absolute = chars.first().map_or(false, |c| path::is_separator(*c));
 
-            // On windows a pattern may also be absolute if it starts with a drive letter, a colon and a separator
+            // On windows a pattern may also be absolute if it starts with a
+            // drive letter, a colon and a separator, eg. "c:/Users" or "G:\Users"
             if cfg!(windows) && !is_absolute {
                 is_absolute = matches!(chars.get(..3), Some(['a'..='z' | 'A'..='Z', ':', sep]) if path::is_separator(*sep));
             }
@@ -855,5 +858,41 @@ mod test {
     fn test_path_join() {
         let pattern = Path::new("one").join(Path::new("**/*.rs"));
         assert!(Pattern::new(pattern.to_str().unwrap()).is_ok());
+    }
+
+    #[test]
+    fn test_pattern_relative() {
+        assert!(Pattern::new("./b").unwrap().matches_path(Path::new("a/b")));
+        assert!(Pattern::new("b").unwrap().matches_path(Path::new("a/b")));
+
+        if cfg!(windows) {
+            assert!(Pattern::new(".\\b")
+                .unwrap()
+                .matches_path(Path::new("a\\b")));
+            assert!(Pattern::new("b").unwrap().matches_path(Path::new("a\\b")));
+        }
+    }
+
+    #[test]
+    fn test_pattern_absolute() {
+        assert!(Pattern::new("/a/b")
+            .unwrap()
+            .matches_path(Path::new("/a/b")));
+
+        if cfg!(windows) {
+            assert!(Pattern::new("c:/a/b")
+                .unwrap()
+                .matches_path(Path::new("c:/a/b")));
+            assert!(Pattern::new("C:\\a\\b")
+                .unwrap()
+                .matches_path(Path::new("C:\\a\\b")));
+
+            assert!(Pattern::new("\\\\?\\c:\\a\\b")
+                .unwrap()
+                .matches_path(Path::new("\\\\?\\c:\\a\\b")));
+            assert!(Pattern::new("\\\\?\\C:/a/b")
+                .unwrap()
+                .matches_path(Path::new("\\\\?\\C:/a/b")));
+        }
     }
 }

--- a/crates/rome_service/src/matcher/pattern.rs
+++ b/crates/rome_service/src/matcher/pattern.rs
@@ -125,8 +125,9 @@ impl Pattern {
         // A pattern is relative if it starts with "." followed by a separator
         let is_relative = matches!(chars.get(..2), Some(['.', sep]) if path::is_separator(*sep));
         if is_relative {
-            // If a pattern starts with a relative prefix, strip it from the pattern
+            // If a pattern starts with a relative prefix, strip it from the pattern and replace it with "**"
             i += 2;
+            tokens.push(AnyRecursiveSequence);
         } else {
             // A pattern is absolute if it starts with a path separator
             let mut is_absolute = chars.first().map_or(false, |c| path::is_separator(*c));
@@ -136,10 +137,9 @@ impl Pattern {
                 is_absolute = matches!(chars.get(..3), Some(['a'..='z' | 'A'..='Z', ':', sep]) if path::is_separator(*sep));
             }
 
-            // If a pattern is not absolute, insert a "**/" sequence in front
+            // If a pattern is not absolute, insert a "**" sequence in front
             if !is_absolute {
                 tokens.push(AnyRecursiveSequence);
-                tokens.push(Char('/'));
             }
         }
 

--- a/crates/rome_service/src/matcher/pattern.rs
+++ b/crates/rome_service/src/matcher/pattern.rs
@@ -895,4 +895,33 @@ mod test {
                 .matches_path(Path::new("\\\\?\\C:/a/b")));
         }
     }
+
+    #[test]
+    fn test_pattern_glob() {
+        assert!(Pattern::new("*.js")
+            .unwrap()
+            .matches_path(Path::new("b/c.js")));
+
+        assert!(Pattern::new("**/*.js")
+            .unwrap()
+            .matches_path(Path::new("b/c.js")));
+
+        assert!(Pattern::new("*.js")
+            .unwrap()
+            .matches_path(Path::new("/a/b/c.js")));
+
+        assert!(Pattern::new("**/*.js")
+            .unwrap()
+            .matches_path(Path::new("/a/b/c.js")));
+
+        if cfg!(windows) {
+            assert!(Pattern::new("*.js")
+                .unwrap()
+                .matches_path(Path::new("C:\\a\\b\\c.js")));
+
+            assert!(Pattern::new("**/*.js")
+                .unwrap()
+                .matches_path(Path::new("\\\\?\\C:\\a\\b\\c.js")));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3790

This PR fixes how ignore patterns are parsed and changes how paths are represented in the language server to reduce discrepancies with the CLI. For ignore patterns, the parse will now strip the `./` prefix from the input string, and prepend the pattern with a `**` group if the input string doesn't start with an absolute filesystem path. For the Language Server, the logic converting URIs into `RomePath` will now try to strip the path to the root of the workspace from the path of the file, which has the effect of making most paths relative much like they generally are on the CLI.

## Test Plan

I've update the tests for the file ignores on the CLI to check that various forms of ignore patterns are all working correctly. I also modified the LSP tests to ensure it only constructs URIs that can be turned into valid paths for the underlying OS.
