### PR TITLE
refactor(rome_lsp): refactor the initialization and configuration loading logic

### DIFF
--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -42,6 +42,8 @@ pub(crate) struct Session {
 
     /// The LSP client for this session.
     pub(crate) client: tower_lsp::Client,
+
+    /// The parameters provided by the client in the "initialize" request
     initialize_params: OnceCell<InitializeParams>,
 
     /// the configuration of the LSP
@@ -58,6 +60,7 @@ pub(crate) struct Session {
     pub(crate) cancellation: Arc<Notify>,
 }
 
+/// The parameters provided by the client in the "initialize" request
 struct InitializeParams {
     /// The capabilities provided by the client as part of [`lsp_types::InitializeParams`]
     client_capabilities: lsp_types::ClientCapabilities,
@@ -282,7 +285,7 @@ impl Session {
         let client_configurations = match self.client.configuration(vec![item]).await {
             Ok(client_configurations) => client_configurations,
             Err(err) => {
-                error!("Cannot read configuration from the client: {err}");
+                error!("Couldn't read configuration from the client: {err}");
                 return;
             }
         };
@@ -294,7 +297,7 @@ impl Session {
 
             let mut config = self.config.write().unwrap();
             if let Err(err) = config.set_workspace_settings(client_configuration) {
-                error!("Cannot set client configuration: {}", err);
+                error!("Couldn't set client configuration: {}", err);
             }
         } else {
             info!("Client did not return any configuration");

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -9,19 +9,19 @@ use rome_analyze::RuleCategories;
 use rome_console::markup;
 use rome_diagnostics::location::FileId;
 use rome_fs::{FileSystem, OsFileSystem, RomePath};
-use rome_service::configuration::Configuration;
 use rome_service::workspace::{FeatureName, PullDiagnosticsParams, SupportsFeatureParams};
 use rome_service::workspace::{RageEntry, RageParams, RageResult, UpdateSettingsParams};
 use rome_service::{load_config, Workspace};
 use rome_service::{DynRef, RomeError};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::RwLock;
-use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
+use tokio::sync::OnceCell;
 use tower_lsp::lsp_types;
 use tower_lsp::lsp_types::Url;
-use tracing::{error, info, trace};
+use tracing::{error, info};
 
 pub(crate) struct ClientInformation {
     /// The name of the client
@@ -42,10 +42,7 @@ pub(crate) struct Session {
 
     /// The LSP client for this session.
     pub(crate) client: tower_lsp::Client,
-    /// The capabilities provided by the client as part of [`lsp_types::InitializeParams`]
-    pub(crate) client_capabilities: RwLock<Option<lsp_types::ClientCapabilities>>,
-
-    pub(crate) client_information: Mutex<Option<ClientInformation>>,
+    initialize_params: OnceCell<InitializeParams>,
 
     /// the configuration of the LSP
     pub(crate) config: RwLock<Config>,
@@ -55,15 +52,17 @@ pub(crate) struct Session {
     /// File system to read files inside the workspace
     pub(crate) fs: DynRef<'static, dyn FileSystem>,
 
-    /// The configuration coming from `rome.json` file
-    pub(crate) configuration: RwLock<Option<Configuration>>,
-
-    pub(crate) root_uri: RwLock<Option<Url>>,
-
     documents: RwLock<HashMap<lsp_types::Url, Document>>,
     url_interner: RwLock<UrlInterner>,
 
     pub(crate) cancellation: Arc<Notify>,
+}
+
+struct InitializeParams {
+    /// The capabilities provided by the client as part of [`lsp_types::InitializeParams`]
+    client_capabilities: lsp_types::ClientCapabilities,
+    client_information: Option<ClientInformation>,
+    root_uri: Option<Url>,
 }
 
 pub(crate) type SessionHandle = Arc<Session>;
@@ -75,25 +74,37 @@ impl Session {
         workspace: Arc<dyn Workspace>,
         cancellation: Arc<Notify>,
     ) -> Self {
-        let client_capabilities = RwLock::new(Default::default());
         let documents = Default::default();
         let url_interner = Default::default();
         let config = RwLock::new(Config::new());
-        let configuration = RwLock::new(None);
-        let root_uri = RwLock::new(None);
         Self {
             key,
             client,
-            client_information: Default::default(),
-            client_capabilities,
+            initialize_params: OnceCell::default(),
             workspace,
             documents,
             url_interner,
             config,
             fs: DynRef::Owned(Box::new(OsFileSystem)),
-            configuration,
-            root_uri,
             cancellation,
+        }
+    }
+
+    /// Initialize this session instance with the incoming initialization parameters from the client
+    pub(crate) fn initialize(
+        &self,
+        client_capabilities: lsp_types::ClientCapabilities,
+        client_information: Option<ClientInformation>,
+        root_uri: Option<Url>,
+    ) {
+        let result = self.initialize_params.set(InitializeParams {
+            client_capabilities,
+            client_information,
+            root_uri,
+        });
+
+        if let Err(err) = result {
+            error!("Failed to initialize session: {err}");
         }
     }
 
@@ -204,95 +215,89 @@ impl Session {
 
     /// True if the client supports dynamic registration of "workspace/didChangeConfiguration" requests
     pub(crate) fn can_register_did_change_configuration(&self) -> bool {
-        self.client_capabilities
-            .read()
-            .unwrap()
-            .as_ref()
-            .and_then(|c| c.workspace.as_ref())
+        self.initialize_params
+            .get()
+            .and_then(|c| c.client_capabilities.workspace.as_ref())
             .and_then(|c| c.did_change_configuration)
             .and_then(|c| c.dynamic_registration)
             == Some(true)
     }
 
+    /// Returns the base path of the workspace on the filesystem if it has one
     pub(crate) fn base_path(&self) -> Option<PathBuf> {
-        let root_uri = self.root_uri.read().unwrap();
-        root_uri.as_ref().and_then(|root_uri| match root_uri.to_file_path() {
+        let initialize_params = self.initialize_params.get()?;
+
+        let root_uri = initialize_params.root_uri.as_ref()?;
+        match root_uri.to_file_path() {
             Ok(base_path) => Some(base_path),
             Err(()) => {
-                error!("The Workspace root URI {root_uri:?} could not be parsed as a filesystem path");
+                error!(
+                    "The Workspace root URI {root_uri:?} could not be parsed as a filesystem path"
+                );
                 None
             }
-        })
+        }
     }
 
-    /// This function attempts to read the configuration from the root URI
-    pub(crate) async fn update_configuration(&self) {
+    /// Returns a reference to the client informations for this session
+    pub(crate) fn client_information(&self) -> Option<&ClientInformation> {
+        self.initialize_params.get()?.client_information.as_ref()
+    }
+
+    /// This function attempts to read the `rome.json` configuration file from
+    /// the root URI and update the workspace settings accordingly
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn load_workspace_settings(&self) {
         let base_path = self.base_path();
 
         match load_config(&self.fs, base_path) {
             Ok(Some(configuration)) => {
-                info!("Configuration found, and it is valid!");
-                self.configuration.write().unwrap().replace(configuration);
+                info!("Loaded workspace settings: {configuration:#?}");
+
+                let result = self
+                    .workspace
+                    .update_settings(UpdateSettingsParams { configuration });
+
+                if let Err(error) = result {
+                    error!("Failed to set workspace settings: {}", error)
+                }
+            }
+            Ok(None) => {
+                // Ignore, load_config already logs an error in this case
             }
             Err(err) => {
-                error!("Couldn't load the configuration file, reason:\n {}", err);
+                error!("Couldn't load the workspace settings, reason:\n {}", err);
             }
-            _ => {}
-        };
+        }
     }
 
     /// Requests "workspace/configuration" from client and updates Session config
-    pub(crate) async fn fetch_client_configuration(&self) {
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn load_client_configuration(&self) {
         let item = lsp_types::ConfigurationItem {
             scope_uri: None,
             section: Some(String::from(CONFIGURATION_SECTION)),
         };
-        let items = vec![item];
-        let client_configurations = self.client.configuration(items).await;
 
-        if let Ok(client_configurations) = client_configurations {
-            client_configurations
-                .into_iter()
-                .next()
-                .and_then(|client_configuration| {
-                    let mut config = self.config.write().unwrap();
-
-                    config
-                        .set_workspace_settings(client_configuration)
-                        .map_err(|err| {
-                            error!("Cannot set workspace settings: {}", err);
-                        })
-                        .ok()?;
-                    self.update_workspace_settings();
-
-                    Some(())
-                });
-        } else {
-            trace!("Cannot read configuration from the client");
-        }
-    }
-
-    /// If updates the [Workspace] settings with the new configuration that was
-    /// read from file.
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub(crate) fn update_workspace_settings(&self) {
-        let mut configuration = self.configuration.write().unwrap();
-
-        // This operation is intended, we want to consume the configuration because once it's read
-        // from the LSP, it's not needed anymore
-        if let Some(configuration) = configuration.take() {
-            trace!(
-                "The LSP will now use the following configuration: \n {:?}",
-                &configuration
-            );
-
-            let result = self
-                .workspace
-                .update_settings(UpdateSettingsParams { configuration });
-
-            if let Err(error) = result {
-                error!("{:?}", &error)
+        let client_configurations = match self.client.configuration(vec![item]).await {
+            Ok(client_configurations) => client_configurations,
+            Err(err) => {
+                error!("Cannot read configuration from the client: {err}");
+                return;
             }
+        };
+
+        let client_configuration = client_configurations.into_iter().next();
+
+        if let Some(client_configuration) = client_configuration {
+            info!("Loaded client configuration: {client_configuration:#?}");
+
+            let mut config = self.config.write().unwrap();
+            if let Err(err) = config.set_workspace_settings(client_configuration) {
+                error!("Cannot set client configuration: {}", err);
+            }
+        } else {
+            info!("Client did not return any configuration");
         }
     }
 


### PR DESCRIPTION
## Summary

This PR refactors the initialization and configuration loading logic of the language server Session to limit the use of `Mutex` and `RwLock`:
- The `client_capabilities`, `client_information` and `root_uri` fields are only written to when the session is initialized, with all following access being read-only. I've moved these fields to a new `InitializeParams` struct stored in a `OnceCell` container (I'm using the implementation from `tokio` to avoid having to pull in another crate until `std::sync::OnceLock` is stabilized) that should provide a similar "write-once read-many" synchronization primitive at a lower performance and memory cost than `Mutex` or `RwLock`.
- The workspace configuration used to be loaded in `update_configuration` but applied to the workspace in `update_workspace_settings`, requiring it to be stored in an `RwLock` in the meantime. I've separated the logic for loading the configuration into `load_workspace_settings` (load the `rome.json` file and apply it to the workspace) and `load_client_configuration` (load the editor configuration and store it in the session config) to eliminate the need for an intermediate storage.

In addition to these changes, I also added or modified some of the tracing logs related to initialization and configuration loading to help us debug potential issues using the output of `rome rage`

## Test Plan

This is intended as an internal change only, it should not modify the observable behavior of the language server. In particular the `rome_lsp` test suite should continue to pass, as well as the `rome_cli` tests that make use of the daemon service infrastructure.
