### PR TITLE
feat(rome_js_analyzer): implement rule noRedeclaration, no-redeclare

### DIFF
--- a/crates/rome_analyze/src/context.rs
+++ b/crates/rome_analyze/src/context.rs
@@ -56,7 +56,7 @@ where
     /// use rome_analyze::{declare_rule, Rule, RuleCategory, RuleMeta, RuleMetadata};
     /// use rome_analyze::context::RuleContext;
     /// use serde::Deserialize;
-    /// declare_rule! {    
+    /// declare_rule! {
     ///     /// Some doc
     ///     pub(crate) Name {
     ///         version: "0.0.0",

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -108,6 +108,7 @@ define_dategories! {
     "lint/nursery/noSvgWithoutTitle": "https://docs.rome.tools/lint/rules/noSvgWithoutTitle",
     "lint/nursery/noUselessCatch": "https://docs.rome.tools/lint/rules/noUselessCatch",
     // Insert new nursery rule here
+    "lint/nursery/noRedeclaration": "https://docs.rome.tools/lint/rules/noRedeclaration",
 
     // performance
     "lint/performance/noDelete": "https://docs.rome.tools/lint/rules/noDelete",

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery.rs
@@ -2,6 +2,7 @@
 
 use rome_analyze::declare_group;
 mod no_class_assign;
+mod no_redeclaration;
 mod no_restricted_globals;
 mod no_var;
 mod use_camel_case;
@@ -9,4 +10,4 @@ mod use_const;
 mod use_exhaustive_dependencies;
 mod use_hook_at_top_level;
 mod use_iframe_title;
-declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_class_assign :: NoClassAssign , self :: no_restricted_globals :: NoRestrictedGlobals , self :: no_var :: NoVar , self :: use_camel_case :: UseCamelCase , self :: use_const :: UseConst , self :: use_exhaustive_dependencies :: UseExhaustiveDependencies , self :: use_hook_at_top_level :: UseHookAtTopLevel , self :: use_iframe_title :: UseIframeTitle ,] } }
+declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_class_assign :: NoClassAssign , self :: no_redeclaration :: NoRedeclaration , self :: no_restricted_globals :: NoRestrictedGlobals , self :: no_var :: NoVar , self :: use_camel_case :: UseCamelCase , self :: use_const :: UseConst , self :: use_exhaustive_dependencies :: UseExhaustiveDependencies , self :: use_hook_at_top_level :: UseHookAtTopLevel , self :: use_iframe_title :: UseIframeTitle ,] } }

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_redeclaration.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_redeclaration.rs
@@ -1,0 +1,106 @@
+use std::{collections::HashMap, hash::Hash, vec::IntoIter};
+
+use rome_console::markup;
+use rome_js_semantic::{Binding, Scope};
+
+use crate::semantic_services::Semantic;
+use rome_analyze::{context::RuleContext, Rule, RuleDiagnostic};
+use rome_js_syntax::{JsModule, JsScript, TextRange};
+
+use rome_analyze::declare_rule;
+use rome_rowan::{declare_node_union, AstNode};
+
+declare_rule! {
+    /// Eliminate variables that have multiple declarations in the same scope.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// var a = 3;
+    /// var a = 10;
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// class C {
+    ///     static {
+    ///         var c = 3;
+    ///         var c = 10;
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// var a = 3;
+    /// a = 10;
+    /// ```
+    ///
+    pub(crate) NoRedeclaration {
+        version: "12.0.0",
+        name: "noRedeclaration",
+        recommended: true,
+    }
+}
+
+declare_node_union! {
+    pub(crate) AnyJsBlock =  JsScript | JsModule
+}
+
+type Duplicates = HashMap<String, Vec<Binding>>;
+
+type Redeclaration = (String, TextRange, Binding);
+
+impl Rule for NoRedeclaration {
+    type Query = Semantic<AnyJsBlock>;
+    type State = Redeclaration;
+    type Signals = IntoIter<Redeclaration>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let mut redeclarations = Vec::default();
+        for scope in ctx.model().scopes() {
+            check_redeclarations_in_single_scope(&scope, &mut redeclarations);
+        }
+        redeclarations.into_iter()
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let (name, text_range, binding) = state;
+        let diag = RuleDiagnostic::new(
+            rule_category!(),
+            binding.syntax().text_trimmed_range(),
+            markup! {
+               "Shouldn't redeclare '"{ name }"'. Consider to delete it or rename it"
+            },
+        )
+        .detail(
+            text_range,
+            markup! {
+               "'"{ name }"' is defined here."
+            },
+        );
+        Some(diag)
+    }
+}
+
+fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<Redeclaration>) {
+    let mut duplicates = Duplicates::default();
+    let bindings = scope.bindings();
+    for binding in bindings {
+        let name = binding.tree().text();
+        duplicates.entry(name).or_default().push(binding)
+    }
+
+    // only keep the actual redeclarations
+    duplicates.retain(|_, list| list.len() > 1);
+
+    for (name, list) in duplicates {
+        let first_binding_range = list[0].syntax().text_trimmed_range();
+        list.into_iter()
+            .skip(1) // skip the first binding
+            .for_each(|binding| redeclarations.push((name.clone(), first_binding_range, binding)))
+    }
+}

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_const.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_const.rs
@@ -265,7 +265,7 @@ impl VariableDeclaration {
 /// Visit [JsIdentifierBinding] in the given [JsAnyBindingPattern].
 ///
 /// Traversal stops if the given function returns true.
-fn with_binding_pat_identifiers(
+pub(crate) fn with_binding_pat_identifiers(
     pat: AnyJsBindingPattern,
     f: &mut impl FnMut(JsIdentifierBinding) -> bool,
 ) -> bool {

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.jsonc
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.jsonc
@@ -1,0 +1,28 @@
+[
+	"var a = 3; var a = 10;",
+	"var c; { var a; var a;} ",
+
+	// in non-strict mode, function a is hoisted
+	"var a; { function a(){} }",
+
+	"switch(foo) { case a: var b = 3;\ncase b: var b = 4}",
+	"var a = 3; var a = 10;",
+	"var a = {}; var a = [];",
+	"var a; function a() {}",
+	"function a() {} function a() {}",
+	"var a = function() { }; var a = function() { }",
+	"var a = function() { }; var a = new Date();",
+	"var a = 3; var a = 10; var a = 15;",
+	"var a; var a;",
+	"export var a; var a;",
+	"class C { static { var a; var a; } }",
+	"class C { static { var a; { var a; } } }",
+	"class C { static { { var a; } var a; } }",
+	"class C { static { { var a; } { var a; } } }",
+	"var a; var {a = 0, b: Object = 0} = {};",
+	"var a; var {a = 0, b: globalThis = 0} = {};",
+	"function f() { var a; var a; }",
+	"function f() { var a; if (test) { var a; } }",
+	"for (var a, a;;);",
+	"for (;;){ var a, a,;}"
+]

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.jsonc.snap
@@ -1,0 +1,530 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid.jsonc
+---
+# Input
+```js
+var a = 3; var a = 10;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:16 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a = 3; var a = 10;
+      │                ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a = 3; var a = 10;
+      │     ^
+  
+
+```
+
+# Input
+```js
+var c; { var a; var a;} 
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:21 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var c; { var a; var a;}·
+      │                     ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var c; { var a; var a;}·
+      │              ^
+  
+
+```
+
+# Input
+```js
+var a; { function a(){} }
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:19 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a; { function a(){} }
+      │                   ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a; { function a(){} }
+      │     ^
+  
+
+```
+
+# Input
+```js
+switch(foo) { case a: var b = 3;
+case b: var b = 4}
+```
+
+# Diagnostics
+```
+invalid.jsonc:2:13 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'b'. Consider to delete it or rename it
+  
+    1 │ switch(foo) { case a: var b = 3;
+  > 2 │ case b: var b = 4}
+      │             ^
+  
+  i 'b' is defined here.
+  
+  > 1 │ switch(foo) { case a: var b = 3;
+      │                           ^
+    2 │ case b: var b = 4}
+  
+
+```
+
+# Input
+```js
+var a = 3; var a = 10;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:16 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a = 3; var a = 10;
+      │                ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a = 3; var a = 10;
+      │     ^
+  
+
+```
+
+# Input
+```js
+var a = {}; var a = [];
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:17 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a = {}; var a = [];
+      │                 ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a = {}; var a = [];
+      │     ^
+  
+
+```
+
+# Input
+```js
+var a; function a() {}
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:17 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a; function a() {}
+      │                 ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a; function a() {}
+      │     ^
+  
+
+```
+
+# Input
+```js
+function a() {} function a() {}
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:26 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ function a() {} function a() {}
+      │                          ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ function a() {} function a() {}
+      │          ^
+  
+
+```
+
+# Input
+```js
+var a = function() { }; var a = function() { }
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:29 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a = function() { }; var a = function() { }
+      │                             ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a = function() { }; var a = function() { }
+      │     ^
+  
+
+```
+
+# Input
+```js
+var a = function() { }; var a = new Date();
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:29 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a = function() { }; var a = new Date();
+      │                             ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a = function() { }; var a = new Date();
+      │     ^
+  
+
+```
+
+# Input
+```js
+var a = 3; var a = 10; var a = 15;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:16 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a = 3; var a = 10; var a = 15;
+      │                ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a = 3; var a = 10; var a = 15;
+      │     ^
+  
+
+```
+
+```
+invalid.jsonc:1:28 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a = 3; var a = 10; var a = 15;
+      │                            ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a = 3; var a = 10; var a = 15;
+      │     ^
+  
+
+```
+
+# Input
+```js
+var a; var a;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:12 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a; var a;
+      │            ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a; var a;
+      │     ^
+  
+
+```
+
+# Input
+```js
+export var a; var a;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:19 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ export var a; var a;
+      │                   ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ export var a; var a;
+      │            ^
+  
+
+```
+
+# Input
+```js
+class C { static { var a; var a; } }
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:31 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ class C { static { var a; var a; } }
+      │                               ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ class C { static { var a; var a; } }
+      │                        ^
+  
+
+```
+
+# Input
+```js
+class C { static { var a; { var a; } } }
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:33 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ class C { static { var a; { var a; } } }
+      │                                 ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ class C { static { var a; { var a; } } }
+      │                        ^
+  
+
+```
+
+# Input
+```js
+class C { static { { var a; } var a; } }
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:35 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ class C { static { { var a; } var a; } }
+      │                                   ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ class C { static { { var a; } var a; } }
+      │                          ^
+  
+
+```
+
+# Input
+```js
+class C { static { { var a; } { var a; } } }
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:37 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ class C { static { { var a; } { var a; } } }
+      │                                     ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ class C { static { { var a; } { var a; } } }
+      │                          ^
+  
+
+```
+
+# Input
+```js
+var a; var {a = 0, b: Object = 0} = {};
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:13 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a; var {a = 0, b: Object = 0} = {};
+      │             ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a; var {a = 0, b: Object = 0} = {};
+      │     ^
+  
+
+```
+
+# Input
+```js
+var a; var {a = 0, b: globalThis = 0} = {};
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:13 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ var a; var {a = 0, b: globalThis = 0} = {};
+      │             ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ var a; var {a = 0, b: globalThis = 0} = {};
+      │     ^
+  
+
+```
+
+# Input
+```js
+function f() { var a; var a; }
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:27 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ function f() { var a; var a; }
+      │                           ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ function f() { var a; var a; }
+      │                    ^
+  
+
+```
+
+# Input
+```js
+function f() { var a; if (test) { var a; } }
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:39 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ function f() { var a; if (test) { var a; } }
+      │                                       ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ function f() { var a; if (test) { var a; } }
+      │                    ^
+  
+
+```
+
+# Input
+```js
+for (var a, a;;);
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:13 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ for (var a, a;;);
+      │             ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ for (var a, a;;);
+      │          ^
+  
+
+```
+
+# Input
+```js
+for (;;){ var a, a,;}
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:18 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+  > 1 │ for (;;){ var a, a,;}
+      │                  ^
+  
+  i 'a' is defined here.
+  
+  > 1 │ for (;;){ var a, a,;}
+      │               ^
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.ts
@@ -1,0 +1,6 @@
+class C {
+	static {
+		var a;
+		var a;
+	}
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.ts.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```js
+class C {
+	static {
+		var a;
+		var a;
+	}
+}
+
+```
+
+# Diagnostics
+```
+invalid.ts:4:7 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'a'. Consider to delete it or rename it
+  
+    2 │ 	static {
+    3 │ 		var a;
+  > 4 │ 		var a;
+      │ 		    ^
+    5 │ 	}
+    6 │ }
+  
+  i 'a' is defined here.
+  
+    1 │ class C {
+    2 │ 	static {
+  > 3 │ 		var a;
+      │ 		    ^
+    4 │ 		var a;
+    5 │ 	}
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid.jsonc
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid.jsonc
@@ -1,0 +1,14 @@
+[
+	"var a = 3; var b = function() { var a = 10; };",
+	"var a = 3; a = 10;",
+	"if (true) {\n    let b = 2;\n} else {    \nlet b = 3;\n}",
+	"var a; class C { static { var a; } }",
+	"class C { static { var a; } } var a; ",
+	"function a(){} class C { static { var a; } }",
+	"var a; class C { static { function a(){} } }",
+	"class C { static { var a; } static { var a; } }",
+	"class C { static { function a(){} } static { function a(){} } }",
+	"class C { static { var a; { let a; } } }",
+	"class C { static { let a; { let a; } } }",
+	"class C { static { { let a; } { let a; } } }"
+]

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid.jsonc.snap
@@ -1,0 +1,69 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid.jsonc
+---
+# Input
+```js
+var a = 3; var b = function() { var a = 10; };
+```
+
+# Input
+```js
+var a = 3; a = 10;
+```
+
+# Input
+```js
+if (true) {
+    let b = 2;
+} else {    
+let b = 3;
+}
+```
+
+# Input
+```js
+var a; class C { static { var a; } }
+```
+
+# Input
+```js
+class C { static { var a; } } var a; 
+```
+
+# Input
+```js
+function a(){} class C { static { var a; } }
+```
+
+# Input
+```js
+var a; class C { static { function a(){} } }
+```
+
+# Input
+```js
+class C { static { var a; } static { var a; } }
+```
+
+# Input
+```js
+class C { static { function a(){} } static { function a(){} } }
+```
+
+# Input
+```js
+class C { static { var a; { let a; } } }
+```
+
+# Input
+```js
+class C { static { let a; { let a; } } }
+```
+
+# Input
+```js
+class C { static { { let a; } { let a; } } }
+```
+
+

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -1014,6 +1014,9 @@ pub struct Nursery {
     #[doc = "Disallow direct use of Object.prototype builtins."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_prototype_builtins: Option<RuleConfiguration>,
+    #[doc = "Eliminate variables that have multiple declarations in the same scope."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_redeclaration: Option<RuleConfiguration>,
     #[doc = "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\"."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_redundant_alt: Option<RuleConfiguration>,
@@ -1125,7 +1128,7 @@ pub struct Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 63] = [
+    pub(crate) const GROUP_RULES: [&'static str; 64] = [
         "noAccessKey",
         "noAssignInExpressions",
         "noBannedTypes",
@@ -1153,6 +1156,7 @@ impl Nursery {
         "noParameterProperties",
         "noPrecisionLoss",
         "noPrototypeBuiltins",
+        "noRedeclaration",
         "noRedundantAlt",
         "noRedundantUseStrict",
         "noRestrictedGlobals",
@@ -1190,7 +1194,7 @@ impl Nursery {
         "useValidLang",
         "useYield",
     ];
-    const RECOMMENDED_RULES: [&'static str; 52] = [
+    const RECOMMENDED_RULES: [&'static str; 53] = [
         "noAssignInExpressions",
         "noBannedTypes",
         "noClassAssign",
@@ -1213,6 +1217,7 @@ impl Nursery {
         "noInnerDeclarations",
         "noInvalidConstructorSuper",
         "noNoninteractiveElementToInteractiveRole",
+        "noRedeclaration",
         "noRedundantAlt",
         "noSelfAssignment",
         "noSelfCompare",
@@ -1244,7 +1249,7 @@ impl Nursery {
         "useValidLang",
         "useYield",
     ];
-    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 52] = [
+    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 53] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
@@ -1268,7 +1273,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
@@ -1284,19 +1289,20 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[57]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[58]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[59]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[60]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[61]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[62]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[63]),
     ];
     pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -1436,184 +1442,189 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.no_redundant_alt.as_ref() {
+        if let Some(rule) = self.no_redeclaration.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.no_redundant_use_strict.as_ref() {
+        if let Some(rule) = self.no_redundant_alt.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.no_restricted_globals.as_ref() {
+        if let Some(rule) = self.no_redundant_use_strict.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.no_self_assignment.as_ref() {
+        if let Some(rule) = self.no_restricted_globals.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.no_self_compare.as_ref() {
+        if let Some(rule) = self.no_self_assignment.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.no_setter_return.as_ref() {
+        if let Some(rule) = self.no_self_compare.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.no_string_case_mismatch.as_ref() {
+        if let Some(rule) = self.no_setter_return.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.no_svg_without_title.as_ref() {
+        if let Some(rule) = self.no_string_case_mismatch.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.no_switch_declarations.as_ref() {
+        if let Some(rule) = self.no_svg_without_title.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.no_unreachable_super.as_ref() {
+        if let Some(rule) = self.no_switch_declarations.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-        if let Some(rule) = self.no_unsafe_finally.as_ref() {
+        if let Some(rule) = self.no_unreachable_super.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
+        if let Some(rule) = self.no_unsafe_finally.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-        if let Some(rule) = self.no_unused_labels.as_ref() {
+        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-        if let Some(rule) = self.no_useless_catch.as_ref() {
+        if let Some(rule) = self.no_unused_labels.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-        if let Some(rule) = self.no_useless_rename.as_ref() {
+        if let Some(rule) = self.no_useless_catch.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.no_useless_switch_case.as_ref() {
+        if let Some(rule) = self.no_useless_rename.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.no_var.as_ref() {
+        if let Some(rule) = self.no_useless_switch_case.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.no_void_type_return.as_ref() {
+        if let Some(rule) = self.no_var.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.no_with.as_ref() {
+        if let Some(rule) = self.no_void_type_return.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+        if let Some(rule) = self.no_with.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_camel_case.as_ref() {
+        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_const.as_ref() {
+        if let Some(rule) = self.use_camel_case.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
             }
         }
-        if let Some(rule) = self.use_default_parameter_last.as_ref() {
+        if let Some(rule) = self.use_const.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
-        if let Some(rule) = self.use_default_switch_clause_last.as_ref() {
+        if let Some(rule) = self.use_default_parameter_last.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
             }
         }
-        if let Some(rule) = self.use_enum_initializers.as_ref() {
+        if let Some(rule) = self.use_default_switch_clause_last.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+        if let Some(rule) = self.use_enum_initializers.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]));
             }
         }
-        if let Some(rule) = self.use_exponentiation_operator.as_ref() {
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_exponentiation_operator.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]));
             }
         }
-        if let Some(rule) = self.use_iframe_title.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]));
             }
         }
-        if let Some(rule) = self.use_is_nan.as_ref() {
+        if let Some(rule) = self.use_iframe_title.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[57]));
             }
         }
-        if let Some(rule) = self.use_media_caption.as_ref() {
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[58]));
             }
         }
-        if let Some(rule) = self.use_numeric_literals.as_ref() {
+        if let Some(rule) = self.use_media_caption.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[59]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_props.as_ref() {
+        if let Some(rule) = self.use_numeric_literals.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[60]));
             }
         }
-        if let Some(rule) = self.use_valid_lang.as_ref() {
+        if let Some(rule) = self.use_valid_aria_props.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[61]));
             }
         }
-        if let Some(rule) = self.use_yield.as_ref() {
+        if let Some(rule) = self.use_valid_lang.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[62]));
+            }
+        }
+        if let Some(rule) = self.use_yield.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[63]));
             }
         }
         index_set
@@ -1755,184 +1766,189 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.no_redundant_alt.as_ref() {
+        if let Some(rule) = self.no_redeclaration.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.no_redundant_use_strict.as_ref() {
+        if let Some(rule) = self.no_redundant_alt.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.no_restricted_globals.as_ref() {
+        if let Some(rule) = self.no_redundant_use_strict.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.no_self_assignment.as_ref() {
+        if let Some(rule) = self.no_restricted_globals.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.no_self_compare.as_ref() {
+        if let Some(rule) = self.no_self_assignment.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.no_setter_return.as_ref() {
+        if let Some(rule) = self.no_self_compare.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.no_string_case_mismatch.as_ref() {
+        if let Some(rule) = self.no_setter_return.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.no_svg_without_title.as_ref() {
+        if let Some(rule) = self.no_string_case_mismatch.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.no_switch_declarations.as_ref() {
+        if let Some(rule) = self.no_svg_without_title.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.no_unreachable_super.as_ref() {
+        if let Some(rule) = self.no_switch_declarations.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-        if let Some(rule) = self.no_unsafe_finally.as_ref() {
+        if let Some(rule) = self.no_unreachable_super.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
+        if let Some(rule) = self.no_unsafe_finally.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-        if let Some(rule) = self.no_unused_labels.as_ref() {
+        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-        if let Some(rule) = self.no_useless_catch.as_ref() {
+        if let Some(rule) = self.no_unused_labels.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-        if let Some(rule) = self.no_useless_rename.as_ref() {
+        if let Some(rule) = self.no_useless_catch.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.no_useless_switch_case.as_ref() {
+        if let Some(rule) = self.no_useless_rename.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.no_var.as_ref() {
+        if let Some(rule) = self.no_useless_switch_case.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.no_void_type_return.as_ref() {
+        if let Some(rule) = self.no_var.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.no_with.as_ref() {
+        if let Some(rule) = self.no_void_type_return.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+        if let Some(rule) = self.no_with.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_camel_case.as_ref() {
+        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_const.as_ref() {
+        if let Some(rule) = self.use_camel_case.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
             }
         }
-        if let Some(rule) = self.use_default_parameter_last.as_ref() {
+        if let Some(rule) = self.use_const.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
-        if let Some(rule) = self.use_default_switch_clause_last.as_ref() {
+        if let Some(rule) = self.use_default_parameter_last.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
             }
         }
-        if let Some(rule) = self.use_enum_initializers.as_ref() {
+        if let Some(rule) = self.use_default_switch_clause_last.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+        if let Some(rule) = self.use_enum_initializers.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]));
             }
         }
-        if let Some(rule) = self.use_exponentiation_operator.as_ref() {
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_exponentiation_operator.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]));
             }
         }
-        if let Some(rule) = self.use_iframe_title.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]));
             }
         }
-        if let Some(rule) = self.use_is_nan.as_ref() {
+        if let Some(rule) = self.use_iframe_title.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[57]));
             }
         }
-        if let Some(rule) = self.use_media_caption.as_ref() {
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[58]));
             }
         }
-        if let Some(rule) = self.use_numeric_literals.as_ref() {
+        if let Some(rule) = self.use_media_caption.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[59]));
             }
         }
-        if let Some(rule) = self.use_valid_aria_props.as_ref() {
+        if let Some(rule) = self.use_numeric_literals.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[60]));
             }
         }
-        if let Some(rule) = self.use_valid_lang.as_ref() {
+        if let Some(rule) = self.use_valid_aria_props.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[61]));
             }
         }
-        if let Some(rule) = self.use_yield.as_ref() {
+        if let Some(rule) = self.use_valid_lang.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[62]));
+            }
+        }
+        if let Some(rule) = self.use_yield.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[63]));
             }
         }
         index_set
@@ -1943,7 +1959,7 @@ impl Nursery {
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
     }
-    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 52] {
+    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 53] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
     pub(crate) fn get_rule_configuration(&self, rule_name: &str) -> Option<&RuleConfiguration> {
@@ -1977,6 +1993,7 @@ impl Nursery {
             "noParameterProperties" => self.no_parameter_properties.as_ref(),
             "noPrecisionLoss" => self.no_precision_loss.as_ref(),
             "noPrototypeBuiltins" => self.no_prototype_builtins.as_ref(),
+            "noRedeclaration" => self.no_redeclaration.as_ref(),
             "noRedundantAlt" => self.no_redundant_alt.as_ref(),
             "noRedundantUseStrict" => self.no_redundant_use_strict.as_ref(),
             "noRestrictedGlobals" => self.no_restricted_globals.as_ref(),

--- a/crates/rome_service/src/configuration/parse/json/rules.rs
+++ b/crates/rome_service/src/configuration/parse/json/rules.rs
@@ -730,6 +730,7 @@ impl VisitNode<JsonLanguage> for Nursery {
                 "noParameterProperties",
                 "noPrecisionLoss",
                 "noPrototypeBuiltins",
+                "noRedeclaration",
                 "noRedundantAlt",
                 "noRedundantUseStrict",
                 "noRestrictedGlobals",
@@ -1260,6 +1261,24 @@ impl VisitNode<JsonLanguage> for Nursery {
                     let mut configuration = RuleConfiguration::default();
                     self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
                     self.no_prototype_builtins = Some(configuration);
+                }
+                _ => {
+                    diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
+                        "object or string",
+                        value.range(),
+                    ));
+                }
+            },
+            "noRedeclaration" => match value {
+                AnyJsonValue::JsonStringValue(_) => {
+                    let mut configuration = RuleConfiguration::default();
+                    self.map_to_known_string(&value, name_text, &mut configuration, diagnostics)?;
+                    self.no_redeclaration = Some(configuration);
+                }
+                AnyJsonValue::JsonObjectValue(_) => {
+                    let mut configuration = RuleConfiguration::default();
+                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
+                    self.no_redeclaration = Some(configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -592,6 +592,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noRedeclaration": {
+					"description": "Eliminate variables that have multiple declarations in the same scope.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noRedundantAlt": {
 					"description": "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\".",
 					"anyOf": [

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -405,6 +405,10 @@ export interface Nursery {
 	 */
 	noPrototypeBuiltins?: RuleConfiguration;
 	/**
+	 * Eliminate variables that have multiple declarations in the same scope.
+	 */
+	noRedeclaration?: RuleConfiguration;
+	/**
 	 * Enforce img alt prop does not contain the word "image", "picture", or "photo".
 	 */
 	noRedundantAlt?: RuleConfiguration;
@@ -886,6 +890,7 @@ export type Category =
 	| "lint/nursery/noPrototypeBuiltins"
 	| "lint/nursery/noSvgWithoutTitle"
 	| "lint/nursery/noUselessCatch"
+	| "lint/nursery/noRedeclaration"
 	| "lint/performance/noDelete"
 	| "lint/security/noDangerouslySetInnerHtml"
 	| "lint/security/noDangerouslySetInnerHtmlWithChildren"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -592,6 +592,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noRedeclaration": {
+					"description": "Eliminate variables that have multiple declarations in the same scope.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noRedundantAlt": {
 					"description": "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\".",
 					"anyOf": [

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -648,6 +648,12 @@ Disallow literal numbers that lose precision
 Disallow direct use of <code>Object.prototype</code> builtins.
 </section>
 <section class="rule">
+<h3 data-toc-exclude id="noRedeclaration">
+	<a href="/lint/rules/noRedeclaration">noRedeclaration</a>
+</h3>
+Eliminate variables that have multiple declarations in the same scope.
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noRedundantAlt">
 	<a href="/lint/rules/noRedundantAlt">noRedundantAlt</a>
 </h3>

--- a/website/src/pages/lint/rules/noRedeclaration.md
+++ b/website/src/pages/lint/rules/noRedeclaration.md
@@ -1,0 +1,78 @@
+---
+title: Lint Rule noRedeclaration
+parent: lint/rules/index
+---
+
+# noRedeclaration (since v12.0.0)
+
+Eliminate variables that have multiple declarations in the same scope.
+
+## Examples
+
+### Invalid
+
+```jsx
+var a = 3;
+var a = 10;
+```
+
+<pre class="language-text"><code class="language-text">nursery/noRedeclaration.js:2:5 <a href="https://docs.rome.tools/lint/rules/noRedeclaration">lint/nursery/noRedeclaration</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Shouldn't redeclare 'a'. Consider to delete it or rename it</span>
+  
+    <strong>1 │ </strong>var a = 3;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>var a = 10;
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">'a' is defined here.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>var a = 3;
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>var a = 10;
+    <strong>3 │ </strong>
+  
+</code></pre>
+
+```jsx
+class C {
+    static {
+        var c = 3;
+        var c = 10;
+    }
+}
+```
+
+<pre class="language-text"><code class="language-text">nursery/noRedeclaration.js:4:13 <a href="https://docs.rome.tools/lint/rules/noRedeclaration">lint/nursery/noRedeclaration</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Shouldn't redeclare 'c'. Consider to delete it or rename it</span>
+  
+    <strong>2 │ </strong>    static {
+    <strong>3 │ </strong>        var c = 3;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>        var c = 10;
+   <strong>   │ </strong>            <strong><span style="color: Tomato;">^</span></strong>
+    <strong>5 │ </strong>    }
+    <strong>6 │ </strong>}
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">'c' is defined here.</span>
+  
+    <strong>1 │ </strong>class C {
+    <strong>2 │ </strong>    static {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>        var c = 3;
+   <strong>   │ </strong>            <strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>        var c = 10;
+    <strong>5 │ </strong>    }
+  
+</code></pre>
+
+### Valid
+
+```jsx
+var a = 3;
+a = 10;
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
implement noRedeclaration https://eslint.org/docs/latest/rules/no-redeclare. Fixes https://github.com/rome/tools/issues/3990

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
have run 
1. `just codegen`
2. ` just test-lintrule no_redeclaration`
3. `just documentation`
4. `just check-ready`

```bash
running 2 tests
test specs::nursery::no_redeclaration::valid_jsonc ... ok
test specs::nursery::no_redeclaration::invalid_jsonc ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 249 filtered out; finished in 0.10s
```

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

<!--

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation

-->

## Caveats
+ Not handle the redeclaration of global variables and function parameters
