### PR TITLE
refactor(rome_formatter): Extract shared separated logic

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -35,6 +35,7 @@ pub mod prelude;
 #[cfg(debug_assertions)]
 pub mod printed_tokens;
 pub mod printer;
+pub mod separated;
 mod source_map;
 pub mod trivia;
 mod verbatim;

--- a/crates/rome_formatter/src/separated.rs
+++ b/crates/rome_formatter/src/separated.rs
@@ -1,0 +1,229 @@
+use crate::prelude::*;
+use crate::{write, CstFormatContext, GroupId};
+use rome_rowan::{AstNode, AstSeparatedElement, SyntaxResult, SyntaxToken};
+
+pub trait FormatSeparatedElementRule<N>
+where
+    N: AstNode,
+{
+    type Context;
+    type FormatNode<'a>: Format<Self::Context>
+    where
+        N: 'a;
+    type FormatSeparator<'a>: Format<Self::Context>
+    where
+        N: 'a;
+
+    fn format_node<'a>(&self, node: &'a N) -> Self::FormatNode<'a>;
+    fn format_separator<'a>(
+        &self,
+        separator: &'a SyntaxToken<N::Language>,
+    ) -> Self::FormatSeparator<'a>;
+}
+
+/// Formats a single element inside a separated list.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FormatSeparatedElement<N, R>
+where
+    N: AstNode,
+    R: FormatSeparatedElementRule<N>,
+{
+    element: AstSeparatedElement<N::Language, N>,
+    rule: R,
+    is_last: bool,
+    /// The separator to write if the element has no separator yet.
+    separator: &'static str,
+    options: FormatSeparatedOptions,
+}
+
+impl<N, R> FormatSeparatedElement<N, R>
+where
+    N: AstNode,
+    R: FormatSeparatedElementRule<N>,
+{
+    /// Returns the node belonging to the element.
+    pub fn node(&self) -> SyntaxResult<&N> {
+        self.element.node()
+    }
+}
+
+impl<N, R, C> Format<C> for FormatSeparatedElement<N, R>
+where
+    N: AstNode,
+    N::Language: 'static,
+    R: FormatSeparatedElementRule<N, Context = C>,
+    C: CstFormatContext<Language = N::Language>,
+{
+    fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
+        let node = self.element.node()?;
+        let separator = self.element.trailing_separator()?;
+
+        let format_node = self.rule.format_node(node);
+
+        if !self.options.nodes_grouped {
+            format_node.fmt(f)?;
+        } else {
+            group(&format_node).fmt(f)?;
+        }
+
+        // Reuse the existing trailing separator or create it if it wasn't in the
+        // input source. Only print the last trailing token if the outer group breaks
+        if let Some(separator) = separator {
+            let format_separator = self.rule.format_separator(separator);
+
+            if self.is_last {
+                match self.options.trailing_separator {
+                    TrailingSeparator::Allowed => {
+                        // Use format_replaced instead of wrapping the result of format_token
+                        // in order to remove only the token itself when the group doesn't break
+                        // but still print its associated trivia unconditionally
+                        format_only_if_breaks(separator, &format_separator)
+                            .with_group_id(self.options.group_id)
+                            .fmt(f)?;
+                    }
+                    TrailingSeparator::Mandatory => {
+                        write!(f, [format_separator])?;
+                    }
+                    TrailingSeparator::Disallowed => {
+                        // A trailing separator was present where it wasn't allowed, opt out of formatting
+                        return Err(FormatError::SyntaxError);
+                    }
+                    TrailingSeparator::Omit => {
+                        write!(f, [format_removed(separator)])?;
+                    }
+                }
+            } else {
+                write!(f, [format_separator])?;
+            }
+        } else if self.is_last {
+            match self.options.trailing_separator {
+                TrailingSeparator::Allowed => {
+                    write!(
+                        f,
+                        [if_group_breaks(&text(self.separator))
+                            .with_group_id(self.options.group_id)]
+                    )?;
+                }
+                TrailingSeparator::Mandatory => {
+                    text(self.separator).fmt(f)?;
+                }
+                TrailingSeparator::Omit | TrailingSeparator::Disallowed => { /* no op */ }
+            }
+        } else {
+            unreachable!(
+                "This is a syntax error, separator must be present between every two elements"
+            );
+        };
+
+        Ok(())
+    }
+}
+
+/// Iterator for formatting separated elements. Prints the separator between each element and
+/// inserts a trailing separator if necessary
+pub struct FormatSeparatedIter<I, Node, Rule>
+where
+    Node: AstNode,
+{
+    next: Option<AstSeparatedElement<Node::Language, Node>>,
+    rule: Rule,
+    inner: I,
+    separator: &'static str,
+    options: FormatSeparatedOptions,
+}
+
+impl<I, Node, Rule> FormatSeparatedIter<I, Node, Rule>
+where
+    Node: AstNode,
+{
+    pub fn new(inner: I, separator: &'static str, rule: Rule) -> Self {
+        Self {
+            inner,
+            rule,
+            separator,
+            next: None,
+            options: FormatSeparatedOptions::default(),
+        }
+    }
+
+    /// Wraps every node inside of a group
+    pub fn nodes_grouped(mut self) -> Self {
+        self.options.nodes_grouped = true;
+        self
+    }
+
+    pub fn with_trailing_separator(mut self, separator: TrailingSeparator) -> Self {
+        self.options.trailing_separator = separator;
+        self
+    }
+
+    #[allow(unused)]
+    pub fn with_group_id(mut self, group_id: Option<GroupId>) -> Self {
+        self.options.group_id = group_id;
+        self
+    }
+}
+
+impl<I, Node, Rule> Iterator for FormatSeparatedIter<I, Node, Rule>
+where
+    Node: AstNode,
+    I: Iterator<Item = AstSeparatedElement<Node::Language, Node>>,
+    Rule: FormatSeparatedElementRule<Node> + Clone,
+{
+    type Item = FormatSeparatedElement<Node, Rule>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let element = self.next.take().or_else(|| self.inner.next())?;
+
+        self.next = self.inner.next();
+        let is_last = self.next.is_none();
+
+        Some(FormatSeparatedElement {
+            element,
+            rule: self.rule.clone(),
+            is_last,
+            separator: self.separator,
+            options: self.options,
+        })
+    }
+}
+
+impl<I, Node, Rule> std::iter::FusedIterator for FormatSeparatedIter<I, Node, Rule>
+where
+    Node: AstNode,
+    I: Iterator<Item = AstSeparatedElement<Node::Language, Node>> + std::iter::FusedIterator,
+    Rule: FormatSeparatedElementRule<Node> + Clone,
+{
+}
+
+impl<I, Node, Rule> std::iter::ExactSizeIterator for FormatSeparatedIter<I, Node, Rule>
+where
+    Node: AstNode,
+    I: Iterator<Item = AstSeparatedElement<Node::Language, Node>> + ExactSizeIterator,
+    Rule: FormatSeparatedElementRule<Node> + Clone,
+{
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+pub enum TrailingSeparator {
+    /// A trailing separator is allowed and preferred
+    #[default]
+    Allowed,
+
+    /// A trailing separator is not allowed
+    Disallowed,
+
+    /// A trailing separator is mandatory for the syntax to be correct
+    Mandatory,
+
+    /// A trailing separator might be present, but the consumer
+    /// decides to remove it
+    Omit,
+}
+
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+pub struct FormatSeparatedOptions {
+    trailing_separator: TrailingSeparator,
+    group_id: Option<GroupId>,
+    nodes_grouped: bool,
+}

--- a/crates/rome_js_formatter/src/prelude.rs
+++ b/crates/rome_js_formatter/src/prelude.rs
@@ -6,6 +6,7 @@ pub(crate) use crate::{
     FormattedIterExt, JsFormatContext, JsFormatter,
 };
 pub use rome_formatter::prelude::*;
+pub use rome_formatter::separated::TrailingSeparator;
 pub use rome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
 
-pub use crate::separated::{FormatAstSeparatedListExtension, TrailingSeparator};
+pub(crate) use crate::separated::FormatAstSeparatedListExtension;

--- a/crates/rome_js_formatter/src/separated.rs
+++ b/crates/rome_js_formatter/src/separated.rs
@@ -1,171 +1,40 @@
 use crate::prelude::*;
-use crate::AsFormat;
-use rome_formatter::{write, GroupId};
-use rome_js_syntax::JsLanguage;
-use rome_rowan::{
-    AstNode, AstSeparatedElement, AstSeparatedList, AstSeparatedListElementsIterator, Language,
-    SyntaxResult,
-};
-use std::iter::FusedIterator;
+use crate::{AsFormat, FormatJsSyntaxToken};
+use rome_formatter::separated::{FormatSeparatedElementRule, FormatSeparatedIter};
+use rome_formatter::FormatRefWithRule;
+use rome_js_syntax::{JsLanguage, JsSyntaxToken};
+use rome_rowan::{AstNode, AstSeparatedList, AstSeparatedListElementsIterator};
+use std::marker::PhantomData;
 
-/// Formats a single element inside of a separated list.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FormatSeparatedElement<L: Language, N> {
-    element: AstSeparatedElement<L, N>,
-    is_last: bool,
-    /// The separator to write if the element has no separator yet.
-    separator: &'static str,
-    options: FormatSeparatedOptions,
-}
-
-impl<L: Language, N: AstNode<Language = L>> FormatSeparatedElement<L, N> {
-    /// Returns the node belonging to the element.
-    pub fn node(&self) -> SyntaxResult<&N> {
-        self.element.node()
-    }
-}
-
-impl<N> Format<JsFormatContext> for FormatSeparatedElement<JsLanguage, N>
+#[derive(Clone)]
+pub(crate) struct JsFormatSeparatedElementRule<N>
 where
-    N: AstNode<Language = JsLanguage> + AsFormat<JsFormatContext>,
+    N: AstNode<Language = JsLanguage>,
 {
-    fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
-        let node = self.element.node()?;
-        let separator = self.element.trailing_separator()?;
-
-        if !self.options.nodes_grouped {
-            node.format().fmt(f)?;
-        } else {
-            group(&node.format()).fmt(f)?;
-        }
-
-        // Reuse the existing trailing separator or create it if it wasn't in the
-        // input source. Only print the last trailing token if the outer group breaks
-        if let Some(separator) = separator {
-            if self.is_last {
-                match self.options.trailing_separator {
-                    TrailingSeparator::Allowed => {
-                        // Use format_replaced instead of wrapping the result of format_token
-                        // in order to remove only the token itself when the group doesn't break
-                        // but still print its associated trivia unconditionally
-                        format_only_if_breaks(separator, &separator.format())
-                            .with_group_id(self.options.group_id)
-                            .fmt(f)?;
-                    }
-                    TrailingSeparator::Mandatory => {
-                        write!(f, [separator.format()])?;
-                    }
-                    TrailingSeparator::Disallowed => {
-                        // A trailing separator was present where it wasn't allowed, opt out of formatting
-                        return Err(FormatError::SyntaxError);
-                    }
-                    TrailingSeparator::Omit => {
-                        write!(f, [format_removed(separator)])?;
-                    }
-                }
-            } else {
-                write!(f, [separator.format()])?;
-            }
-        } else if self.is_last {
-            match self.options.trailing_separator {
-                TrailingSeparator::Allowed => {
-                    write!(
-                        f,
-                        [if_group_breaks(&text(self.separator))
-                            .with_group_id(self.options.group_id)]
-                    )?;
-                }
-                TrailingSeparator::Mandatory => {
-                    text(self.separator).fmt(f)?;
-                }
-                TrailingSeparator::Omit | TrailingSeparator::Disallowed => { /* no op */ }
-            }
-        } else {
-            unreachable!(
-                "This is a syntax error, separator must be present between every two elements"
-            );
-        };
-
-        Ok(())
-    }
+    node: PhantomData<N>,
 }
 
-/// Iterator for formatting separated elements. Prints the separator between each element and
-/// inserts a trailing separator if necessary
-pub struct FormatSeparatedIter<I, Language, Node>
+impl<N> FormatSeparatedElementRule<N> for JsFormatSeparatedElementRule<N>
 where
-    Language: rome_rowan::Language,
+    N: AstNode<Language = JsLanguage> + AsFormat<JsFormatContext> + 'static,
 {
-    next: Option<AstSeparatedElement<Language, Node>>,
-    inner: I,
-    separator: &'static str,
-    options: FormatSeparatedOptions,
-}
+    type Context = JsFormatContext;
+    type FormatNode<'a> = N::Format<'a>;
+    type FormatSeparator<'a> = FormatRefWithRule<'a, JsSyntaxToken, FormatJsSyntaxToken>;
 
-impl<I, L, Node> FormatSeparatedIter<I, L, Node>
-where
-    L: Language,
-{
-    fn new(inner: I, separator: &'static str) -> Self {
-        Self {
-            inner,
-            separator,
-            next: None,
-            options: FormatSeparatedOptions::default(),
-        }
+    fn format_node<'a>(&self, node: &'a N) -> Self::FormatNode<'a> {
+        node.format()
     }
 
-    /// Wraps every node inside of a group
-    pub fn nodes_grouped(mut self) -> Self {
-        self.options.nodes_grouped = true;
-        self
+    fn format_separator<'a>(&self, separator: &'a JsSyntaxToken) -> Self::FormatSeparator<'a> {
+        separator.format()
     }
-
-    pub fn with_trailing_separator(mut self, separator: TrailingSeparator) -> Self {
-        self.options.trailing_separator = separator;
-        self
-    }
-
-    #[allow(unused)]
-    pub fn with_group_id(mut self, group_id: Option<GroupId>) -> Self {
-        self.options.group_id = group_id;
-        self
-    }
-}
-
-impl<I, N> Iterator for FormatSeparatedIter<I, JsLanguage, N>
-where
-    I: Iterator<Item = AstSeparatedElement<JsLanguage, N>>,
-{
-    type Item = FormatSeparatedElement<JsLanguage, N>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let element = self.next.take().or_else(|| self.inner.next())?;
-
-        self.next = self.inner.next();
-        let is_last = self.next.is_none();
-
-        Some(FormatSeparatedElement {
-            element,
-            is_last,
-            separator: self.separator,
-            options: self.options,
-        })
-    }
-}
-
-impl<I, N> FusedIterator for FormatSeparatedIter<I, JsLanguage, N> where
-    I: Iterator<Item = AstSeparatedElement<JsLanguage, N>> + FusedIterator
-{
-}
-
-impl<I, N> ExactSizeIterator for FormatSeparatedIter<I, JsLanguage, N> where
-    I: Iterator<Item = AstSeparatedElement<JsLanguage, N>> + ExactSizeIterator
-{
 }
 
 /// AST Separated list formatting extension methods
-pub trait FormatAstSeparatedListExtension: AstSeparatedList<Language = JsLanguage> {
+pub(crate) trait FormatAstSeparatedListExtension:
+    AstSeparatedList<Language = JsLanguage>
+{
     /// Prints a separated list of nodes
     ///
     /// Trailing separators will be reused from the original list or
@@ -177,35 +46,15 @@ pub trait FormatAstSeparatedListExtension: AstSeparatedList<Language = JsLanguag
         separator: &'static str,
     ) -> FormatSeparatedIter<
         AstSeparatedListElementsIterator<JsLanguage, Self::Node>,
-        JsLanguage,
         Self::Node,
+        JsFormatSeparatedElementRule<Self::Node>,
     > {
-        FormatSeparatedIter::new(self.elements(), separator)
+        FormatSeparatedIter::new(
+            self.elements(),
+            separator,
+            JsFormatSeparatedElementRule { node: PhantomData },
+        )
     }
 }
 
 impl<T> FormatAstSeparatedListExtension for T where T: AstSeparatedList<Language = JsLanguage> {}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
-pub enum TrailingSeparator {
-    /// A trailing separator is allowed and preferred
-    #[default]
-    Allowed,
-
-    /// A trailing separator is not allowed
-    Disallowed,
-
-    /// A trailing separator is mandatory for the syntax to be correct
-    Mandatory,
-
-    /// A trailing separator might be present, but the consumer
-    /// decides to remove it
-    Omit,
-}
-
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
-pub struct FormatSeparatedOptions {
-    trailing_separator: TrailingSeparator,
-    group_id: Option<GroupId>,
-    nodes_grouped: bool,
-}

--- a/crates/rome_js_formatter/src/separated.rs
+++ b/crates/rome_js_formatter/src/separated.rs
@@ -31,6 +31,12 @@ where
     }
 }
 
+type JsFormatSeparatedIter<Node> = FormatSeparatedIter<
+    AstSeparatedListElementsIterator<JsLanguage, Node>,
+    Node,
+    JsFormatSeparatedElementRule<Node>,
+>;
+
 /// AST Separated list formatting extension methods
 pub(crate) trait FormatAstSeparatedListExtension:
     AstSeparatedList<Language = JsLanguage>
@@ -41,15 +47,8 @@ pub(crate) trait FormatAstSeparatedListExtension:
     /// created by calling the `separator_factory` function.
     /// The last trailing separator in the list will only be printed
     /// if the outer group breaks.
-    fn format_separated(
-        &self,
-        separator: &'static str,
-    ) -> FormatSeparatedIter<
-        AstSeparatedListElementsIterator<JsLanguage, Self::Node>,
-        Self::Node,
-        JsFormatSeparatedElementRule<Self::Node>,
-    > {
-        FormatSeparatedIter::new(
+    fn format_separated(&self, separator: &'static str) -> JsFormatSeparatedIter<Self::Node> {
+        JsFormatSeparatedIter::new(
             self.elements(),
             separator,
             JsFormatSeparatedElementRule { node: PhantomData },

--- a/crates/rome_json_formatter/src/separated.rs
+++ b/crates/rome_json_formatter/src/separated.rs
@@ -9,11 +9,11 @@ use rome_rowan::{AstNode, AstSeparatedList, AstSeparatedListElementsIterator};
 use std::marker::PhantomData;
 
 #[derive(Clone)]
-pub(crate) struct FormatJsonSeparatedElementRule<N> {
+pub(crate) struct JsonFormatSeparatedElementRule<N> {
     node: PhantomData<N>,
 }
 
-impl<N> FormatSeparatedElementRule<N> for FormatJsonSeparatedElementRule<N>
+impl<N> FormatSeparatedElementRule<N> for JsonFormatSeparatedElementRule<N>
 where
     N: AstNode<Language = JsonLanguage> + AsFormat<JsonFormatContext> + 'static,
 {
@@ -30,6 +30,12 @@ where
     }
 }
 
+type JsonFormatSeparatedIter<Node> = FormatSeparatedIter<
+    AstSeparatedListElementsIterator<JsonLanguage, Node>,
+    Node,
+    JsonFormatSeparatedElementRule<Node>,
+>;
+
 /// AST Separated list formatting extension methods
 pub(crate) trait FormatAstSeparatedListExtension:
     AstSeparatedList<Language = JsonLanguage>
@@ -40,18 +46,11 @@ pub(crate) trait FormatAstSeparatedListExtension:
     /// created by calling the `separator_factory` function.
     /// The last trailing separator in the list will only be printed
     /// if the outer group breaks.
-    fn format_separated(
-        &self,
-        separator: &'static str,
-    ) -> FormatSeparatedIter<
-        AstSeparatedListElementsIterator<JsonLanguage, Self::Node>,
-        Self::Node,
-        FormatJsonSeparatedElementRule<Self::Node>,
-    > {
-        FormatSeparatedIter::new(
+    fn format_separated(&self, separator: &'static str) -> JsonFormatSeparatedIter<Self::Node> {
+        JsonFormatSeparatedIter::new(
             self.elements(),
             separator,
-            FormatJsonSeparatedElementRule { node: PhantomData },
+            JsonFormatSeparatedElementRule { node: PhantomData },
         )
         .with_trailing_separator(TrailingSeparator::Disallowed)
     }

--- a/crates/rome_json_formatter/src/separated.rs
+++ b/crates/rome_json_formatter/src/separated.rs
@@ -1,137 +1,39 @@
 use crate::prelude::*;
-use crate::AsFormat;
-use rome_formatter::{write, GroupId};
-use rome_json_syntax::JsonLanguage;
-use rome_rowan::{
-    AstNode, AstSeparatedElement, AstSeparatedList, AstSeparatedListElementsIterator, Language,
-    SyntaxResult,
+use crate::FormatJsonSyntaxToken;
+use rome_formatter::separated::{
+    FormatSeparatedElementRule, FormatSeparatedIter, TrailingSeparator,
 };
-use std::iter::FusedIterator;
+use rome_formatter::FormatRefWithRule;
+use rome_json_syntax::{JsonLanguage, JsonSyntaxToken};
+use rome_rowan::{AstNode, AstSeparatedList, AstSeparatedListElementsIterator};
+use std::marker::PhantomData;
 
-/// Formats a single element inside of a separated list.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FormatSeparatedElement<L: Language, N> {
-    element: AstSeparatedElement<L, N>,
-    is_last: bool,
-    /// The separator to write if the element has no separator yet.
-    separator: &'static str,
-    options: FormatSeparatedOptions,
+#[derive(Clone)]
+pub(crate) struct FormatJsonSeparatedElementRule<N> {
+    node: PhantomData<N>,
 }
 
-impl<L: Language, N: AstNode<Language = L>> FormatSeparatedElement<L, N> {
-    /// Returns the node belonging to the element.
-    #[allow(unused)]
-    pub fn node(&self) -> SyntaxResult<&N> {
-        self.element.node()
-    }
-}
-
-impl<N> Format<JsonFormatContext> for FormatSeparatedElement<JsonLanguage, N>
+impl<N> FormatSeparatedElementRule<N> for FormatJsonSeparatedElementRule<N>
 where
-    N: AstNode<Language = JsonLanguage> + AsFormat<JsonFormatContext>,
+    N: AstNode<Language = JsonLanguage> + AsFormat<JsonFormatContext> + 'static,
 {
-    fn fmt(&self, f: &mut Formatter<JsonFormatContext>) -> FormatResult<()> {
-        let node = self.element.node()?;
-        let separator = self.element.trailing_separator()?;
+    type Context = JsonFormatContext;
+    type FormatNode<'a> = N::Format<'a>;
+    type FormatSeparator<'a> = FormatRefWithRule<'a, JsonSyntaxToken, FormatJsonSyntaxToken>;
 
-        if !self.options.nodes_grouped {
-            node.format().fmt(f)?;
-        } else {
-            group(&node.format()).fmt(f)?;
-        }
-
-        // Reuse the existing trailing separator or create it if it wasn't in the
-        // input source. Only print the last trailing token if the outer group breaks
-        if let Some(separator) = separator {
-            if self.is_last {
-                return Err(FormatError::SyntaxError);
-            } else {
-                write!(f, [separator.format()])?;
-            }
-        } else if self.is_last {
-            /* no op */
-        } else {
-            unreachable!(
-                "This is a syntax error, separator must be present between every two elements"
-            );
-        };
-
-        Ok(())
-    }
-}
-
-/// Iterator for formatting separated elements. Prints the separator between each element and
-/// inserts a trailing separator if necessary
-pub struct FormatSeparatedIter<I, Language, Node>
-where
-    Language: rome_rowan::Language,
-{
-    next: Option<AstSeparatedElement<Language, Node>>,
-    inner: I,
-    separator: &'static str,
-    options: FormatSeparatedOptions,
-}
-
-impl<I, L, Node> FormatSeparatedIter<I, L, Node>
-where
-    L: Language,
-{
-    fn new(inner: I, separator: &'static str) -> Self {
-        Self {
-            inner,
-            separator,
-            next: None,
-            options: FormatSeparatedOptions::default(),
-        }
+    fn format_node<'a>(&self, node: &'a N) -> Self::FormatNode<'a> {
+        node.format()
     }
 
-    /// Wraps every node inside of a group
-    #[allow(unused)]
-    pub fn nodes_grouped(mut self) -> Self {
-        self.options.nodes_grouped = true;
-        self
+    fn format_separator<'a>(&self, separator: &'a JsonSyntaxToken) -> Self::FormatSeparator<'a> {
+        separator.format()
     }
-
-    #[allow(unused)]
-    pub fn with_group_id(mut self, group_id: Option<GroupId>) -> Self {
-        self.options.group_id = group_id;
-        self
-    }
-}
-
-impl<I, N> Iterator for FormatSeparatedIter<I, JsonLanguage, N>
-where
-    I: Iterator<Item = AstSeparatedElement<JsonLanguage, N>>,
-{
-    type Item = FormatSeparatedElement<JsonLanguage, N>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let element = self.next.take().or_else(|| self.inner.next())?;
-
-        self.next = self.inner.next();
-        let is_last = self.next.is_none();
-
-        Some(FormatSeparatedElement {
-            element,
-            is_last,
-            separator: self.separator,
-            options: self.options,
-        })
-    }
-}
-
-impl<I, N> FusedIterator for FormatSeparatedIter<I, JsonLanguage, N> where
-    I: Iterator<Item = AstSeparatedElement<JsonLanguage, N>> + FusedIterator
-{
-}
-
-impl<I, N> ExactSizeIterator for FormatSeparatedIter<I, JsonLanguage, N> where
-    I: Iterator<Item = AstSeparatedElement<JsonLanguage, N>> + ExactSizeIterator
-{
 }
 
 /// AST Separated list formatting extension methods
-pub trait FormatAstSeparatedListExtension: AstSeparatedList<Language = JsonLanguage> {
+pub(crate) trait FormatAstSeparatedListExtension:
+    AstSeparatedList<Language = JsonLanguage>
+{
     /// Prints a separated list of nodes
     ///
     /// Trailing separators will be reused from the original list or
@@ -143,17 +45,16 @@ pub trait FormatAstSeparatedListExtension: AstSeparatedList<Language = JsonLangu
         separator: &'static str,
     ) -> FormatSeparatedIter<
         AstSeparatedListElementsIterator<JsonLanguage, Self::Node>,
-        JsonLanguage,
         Self::Node,
+        FormatJsonSeparatedElementRule<Self::Node>,
     > {
-        FormatSeparatedIter::new(self.elements(), separator)
+        FormatSeparatedIter::new(
+            self.elements(),
+            separator,
+            FormatJsonSeparatedElementRule { node: PhantomData },
+        )
+        .with_trailing_separator(TrailingSeparator::Disallowed)
     }
 }
 
 impl<T> FormatAstSeparatedListExtension for T where T: AstSeparatedList<Language = JsonLanguage> {}
-
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
-pub struct FormatSeparatedOptions {
-    group_id: Option<GroupId>,
-    nodes_grouped: bool,
-}


### PR DESCRIPTION
## Summary

This PR extracts the `separated()` helper for formatting separated lists into `rome_formatter` so that it can be re-used between the different language implementations. 

It's a bit awkward because the `AsFormat` and `IntoFormat` aren't available in the `rome_formatter` crate. That's why the iterator extension trait must still be duplicated between implementations. 

## Test Plan

`cargo test`

## Documentation
- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
