### PR TITLE
chore(codegen): fix codegen for new lint rule

### DIFF
--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -78,6 +78,7 @@ define_dategories! {
     "lint/nursery/useNumericLiterals": "https://docs.rome.tools/lint/rules/useNumericLiterals",
     "lint/nursery/useValidForDirection": "https://docs.rome.tools/lint/rules/useValidForDirection",
     "lint/nursery/useHookAtTopLevel": "https://docs.rome.tools/lint/rules/useHookAtTopLevel",
+    // Insert new nursery rule here
 
     // performance
     "lint/performance/noDelete": "https://docs.rome.tools/lint/rules/noDelete",

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -15,7 +15,7 @@ pub fn generate_new_lintrule(path: &str, rule_name: &str) {
     let rule_name_snake = rule_name.to_snake();
     let rule_name_lower_camel = rule_name_snake.to_camel_lowercase();
 
-    // Generate rule code 
+    // Generate rule code
     let code = format!(
         r#"use crate::semantic_services::Semantic;
 use rome_analyze::{{
@@ -102,12 +102,17 @@ impl Rule for {rule_name_upper_camel} {{
     let tests_path = format!("crates/rome_js_analyze/tests/specs/nursery/{rule_name_lower_camel}");
     let _ = std::fs::create_dir_all(tests_path);
 
-    let test_file = format!("crates/rome_js_analyze/tests/specs/nursery/{rule_name_lower_camel}/valid.js");
+    let test_file =
+        format!("crates/rome_js_analyze/tests/specs/nursery/{rule_name_lower_camel}/valid.js");
     if std::fs::File::open(&test_file).is_err() {
-        let _ = std::fs::write(test_file, "/* should not generate diagnostics */\n\n var a = 1;");
+        let _ = std::fs::write(
+            test_file,
+            "/* should not generate diagnostics */\n\n var a = 1;",
+        );
     }
-    
-    let test_file = format!("crates/rome_js_analyze/tests/specs/nursery/{rule_name_lower_camel}/invalid.js");
+
+    let test_file =
+        format!("crates/rome_js_analyze/tests/specs/nursery/{rule_name_lower_camel}/invalid.js");
     if std::fs::File::open(&test_file).is_err() {
         let _ = std::fs::write(test_file, "\n\n var a = 1;\na = 2;\n a = 3;");
     }

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -14,49 +14,69 @@ pub fn generate_new_lintrule(path: &str, rule_name: &str) {
     let rule_name_upper_camel = rule_name.to_camel();
     let rule_name_snake = rule_name.to_snake();
     let rule_name_lower_camel = rule_name_snake.to_camel_lowercase();
+
+    // Generate rule code 
     let code = format!(
-        r#"use rome_analyze::{{
-context::RuleContext, declare_rule, Rule, RuleDiagnostic,
+        r#"use crate::semantic_services::Semantic;
+use rome_analyze::{{
+    context::RuleContext, declare_rule, Rule, RuleDiagnostic,
 }};
-use crate::semantic_services::Semantic;
-use rome_js_syntax::JsCallExpression;
+use rome_console::markup;
+use rome_js_semantic::{{Reference, ReferencesExtensions}};
+use rome_js_syntax::JsIdentifierBinding;
 
 declare_rule! {{
-/// Put your description here
-///
-/// ## Examples
-///
-/// ### Invalid
-///
-/// ```js,expect_diagnostic
-/// ```
-///
-/// ## Valid
-///
-/// ```js
-/// ```
-///
-pub(crate) {rule_name_upper_camel} {{
-version: "12.0.0",
-name: "{rule_name_lower_camel}",
-recommended: false,
-}}
+    /// Put your description here
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// var a = 1;
+    /// a = 2;
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```js
+    /// var a = 1;
+    /// ```
+    ///
+    pub(crate) {rule_name_upper_camel} {{
+        version: "12.0.0",
+        name: "{rule_name_lower_camel}",
+        recommended: false,
+    }}
 }}
 
 impl Rule for {rule_name_upper_camel} {{
-type Query = Semantic<JsCallExpression>;
-type State = ();
-type Signals = Vec<Self::State>;
-type Options = ();
+    type Query = Semantic<JsIdentifierBinding>;
+    type State = Reference;
+    type Signals = Vec<Self::State>;
+    type Options = ();
+    
+    fn run(ctx: &RuleContext<Self>) -> Vec<Self::State> {{
+        let binding = ctx.query();
+        let model = ctx.model();
 
-fn run(_: &RuleContext<Self>) -> Vec<Self::State> {{
-let mut signals = vec![];
-signals
-}}
-
-fn diagnostic(_: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {{
-None
-}}
+        binding.all_references(model).collect()
+    }}
+    
+    fn diagnostic(_: &RuleContext<Self>, reference: &Self::State) -> Option<RuleDiagnostic> {{
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                reference.syntax().text_trimmed_range(),
+                markup! {{
+                    "Variable is read here"
+                }},
+            )
+            .note(markup! {{
+                "This note will give you more information"
+            }}),
+        )
+    }}
 }}
 "#
     );
@@ -65,18 +85,30 @@ None
 
     let categories_path = "crates/rome_diagnostics_categories/src/categories.rs";
     let categories = std::fs::read_to_string(categories_path).unwrap();
-    let insertion_point = r#"
-    
-    ;
 
-    // General categories"#;
-    debug_assert!(categories.contains(insertion_point));
-    let categories = categories.replace(insertion_point, &format!(r#"
-    "lint/nursery/{rule_name_lower_camel}": "https://docs.rome.tools/lint/rules/{rule_name_lower_camel}",
-    
-    ;
+    if !categories.contains(&rule_name_lower_camel) {
+        let insertion_point = r#"    // Insert new nursery rule here"#;
+        debug_assert!(categories.contains(insertion_point));
 
-    // General categories"#));
-    debug_assert!(categories.contains(&rule_name_lower_camel));
-    std::fs::write(categories_path, categories).unwrap();
+        let categories = categories.replace(insertion_point, &format!(
+        r#"lint/nursery/{rule_name_lower_camel}": "https://docs.rome.tools/lint/rules/{rule_name_lower_camel}",
+{insertion_point}"#));
+        debug_assert!(categories.contains(&rule_name_lower_camel));
+
+        std::fs::write(categories_path, categories).unwrap();
+    }
+
+    // Generate test code
+    let tests_path = format!("crates/rome_js_analyze/tests/specs/nursery/{rule_name_lower_camel}");
+    let _ = std::fs::create_dir_all(tests_path);
+
+    let test_file = format!("crates/rome_js_analyze/tests/specs/nursery/{rule_name_lower_camel}/valid.js");
+    if std::fs::File::open(&test_file).is_err() {
+        let _ = std::fs::write(test_file, "/* should not generate diagnostics */\n\n var a = 1;");
+    }
+    
+    let test_file = format!("crates/rome_js_analyze/tests/specs/nursery/{rule_name_lower_camel}/invalid.js");
+    if std::fs::File::open(&test_file).is_err() {
+        let _ = std::fs::write(test_file, "\n\n var a = 1;\na = 2;\n a = 3;");
+    }
 }


### PR DESCRIPTION
## Summary

This PR fixes codegen for new lint rules.

## Test Plan

```
> just new-lintrule /crates/rome_js_analyze/src/semantic_analyzers/nursery SomeRule
```

## Documentation

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
