### PR TITLE
refactor(rome_analyze): refactor how Visitors, Queryables and QueryMatches are related

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "rome_console",
- "rome_control_flow",
  "rome_diagnostics",
  "rome_rowan",
  "rustc-hash",

--- a/crates/rome_analyze/CONTRIBUTING.md
+++ b/crates/rome_analyze/CONTRIBUTING.md
@@ -387,6 +387,98 @@ If this the rule can retrieve its option with
 let options = ctx.options();
 ```
 
+#### Custom Visitors
+
+Some lint rules may need to deeply inspect the child nodes of a query match
+before deciding on whether they should emit a signal or not. These rules can be
+inefficient to implement using the query system, as they will lead to redundant
+traversal passes being executed over the same syntax tree. To make this more
+efficient, you can implement a custom `Queryable` type and and associated
+`Visitor` to emit it as part of the analyzer's main traversal pass. As an
+example, here's how this could be done to implement the `useYield` rule:
+
+```rust,ignore
+// First, create a visitor struct that holds a stack of function syntax nodes and booleans
+#[derive(Default)]
+struct MissingYieldVisitor {
+    stack: Vec<(AnyFunctionLike, bool)>,
+}
+
+// Implement the `Visitor` trait for this struct
+impl Visitor for MissingYieldVisitor {
+    fn visit(
+        &mut self,
+        event: &WalkEvent<SyntaxNode<Self::Language>>,
+        ctx: VisitorContext<Self::Language>,
+    ) {
+        match event {
+            WalkEvent::Enter(node) => {
+                // When the visitor enters a function node, push a new entry on the stack
+                if let Some(node) = AnyFunctionLike::cast_ref(node) {
+                    self.stack.push((node, false));
+                }
+                
+                if let Some((_, has_yield)) = self.stack.last_mut() {
+                    // When the visitor enters a `yield` expression, set the
+                    // `has_yield` flag for the top entry on the stack to `true`
+                    if JsYieldExpression::can_cast(node.kind()) {
+                        *has_yield = true;
+                    }
+                }
+            }
+            WalkEvent::Leave(node) => {
+                // When the visitor exits a function, if it matches the node of the top-most
+                // entry of the stack and the `has_yield` flag is `false`, emit a query match
+                if let Some(exit_node) = AnyFunctionLike::cast_ref(node) {
+                    if let Some((enter_node, has_yield)) = self.stack.pop() {
+                        assert_eq!(enter_node, exit_node);
+                        if !has_yield {
+                            ctx.match_query(MissingYield(enter_node));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Declare a query match struct type containing a JavaScript function node
+struct MissingYield(AnyFunctionLike);
+
+// Implement the `Queryable` trait for this type
+impl Queryable for MissingYield {
+    // `Input` is the type that `ctx.match_query()` is called with in the visitor
+    type Input = Self;
+    // `Output` if the type that `ctx.query()` will return in the rule
+    type Output = AnyFunctionLike;
+    
+    fn build_visitor(
+        analyzer: &mut impl AddVisitor<Self::Language>,
+        _: &<Self::Language as Language>::Root,
+    ) {
+        // Register our custom visitor to run in the `Syntax` phase
+        analyzer.add_visitor(Phases::Syntax, MissingYieldVisitor::default());
+    }
+
+    // Extract the output object from the input type
+    fn unwrap_match(services: &ServiceBag, query: &Self::Input) -> Self::Output {
+        query.0.clone()
+    }
+}
+
+impl Rule for UseYield {
+    // Declare the custom `MissingYield` queryable as the rule's query
+    type Query = MissingYield;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        // Read the function's root node from the queryable output
+        let query: &AnyFunctionLike = ctx.query();
+
+        // ...
+    }
+}
+```
+
 # Using Just
 
 It is also possible to do all the steps above using our `Just` automation. For example, we can create

--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 
 [dependencies]
 rome_rowan = { path = "../rome_rowan" }
-rome_control_flow = { path = "../rome_control_flow" }
 rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 bitflags = "1.3.2"

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -107,6 +107,7 @@ where
         }
     }
 
+    /// Registers a [Visitor] to be executed as part of a given `phase` of the analyzer run
     pub fn add_visitor(
         &mut self,
         phase: Phases,

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::diagnostics::AnalyzerDiagnostic;
 use crate::diagnostics::SuppressionDiagnostic;
 pub use crate::matcher::{InspectMatcher, MatchQueryParams, QueryMatcher, RuleKey, SignalEntry};
 pub use crate::options::{AnalyzerConfiguration, AnalyzerOptions, AnalyzerRules};
-pub use crate::query::{AddVisitor, Ast, QueryKey, QueryMatch, Queryable};
+pub use crate::query::{AddVisitor, QueryKey, QueryMatch, Queryable};
 pub use crate::registry::{
     LanguageRoot, MetadataRegistry, Phase, Phases, RegistryRuleMetadata, RegistryVisitor,
     RuleRegistry, RuleRegistryBuilder, RuleSuppressions,
@@ -40,7 +40,7 @@ pub use crate::rule::{
 pub use crate::services::{FromServices, MissingServicesDiagnostic, ServiceBag};
 use crate::signals::DiagnosticSignal;
 pub use crate::signals::{AnalyzerAction, AnalyzerSignal};
-pub use crate::syntax::SyntaxVisitor;
+pub use crate::syntax::{Ast, SyntaxVisitor};
 pub use crate::visitor::{NodeVisitor, Visitor, VisitorContext, VisitorFinishContext};
 pub use rule::DeserializableRuleOptions;
 

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::diagnostics::AnalyzerDiagnostic;
 use crate::diagnostics::SuppressionDiagnostic;
 pub use crate::matcher::{InspectMatcher, MatchQueryParams, QueryMatcher, RuleKey, SignalEntry};
 pub use crate::options::{AnalyzerConfiguration, AnalyzerOptions, AnalyzerRules};
-pub use crate::query::{Ast, QueryKey, QueryMatch, Queryable};
+pub use crate::query::{AddVisitor, Ast, QueryKey, QueryMatch, Queryable};
 pub use crate::registry::{
     LanguageRoot, MetadataRegistry, Phase, Phases, RegistryRuleMetadata, RegistryVisitor,
     RuleRegistry, RuleRegistryBuilder, RuleSuppressions,
@@ -107,14 +107,12 @@ where
         }
     }
 
-    pub fn add_visitor<V>(&mut self, phase: Phases, visitor: V)
-    where
-        V: Visitor<Language = L> + 'analyzer,
-    {
-        self.phases
-            .entry(phase)
-            .or_default()
-            .push(Box::new(visitor));
+    pub fn add_visitor(
+        &mut self,
+        phase: Phases,
+        visitor: Box<dyn Visitor<Language = L> + 'analyzer>,
+    ) {
+        self.phases.entry(phase).or_default().push(visitor);
     }
 
     pub fn run(self, mut ctx: AnalyzerContext<L>) -> Option<Break> {

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -338,7 +338,7 @@ mod tests {
             &mut emit_signal,
         );
 
-        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
+        analyzer.add_visitor(Phases::Syntax, Box::new(SyntaxVisitor::default()));
 
         let ctx: AnalyzerContext<RawLanguage> = AnalyzerContext {
             file_id: FileId::zero(),

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -6,8 +6,9 @@ use rome_rowan::{Language, TextRange};
 use std::{any::Any, cmp::Ordering, collections::BinaryHeap};
 
 /// The [QueryMatcher] trait is responsible of running lint rules on
-/// [QueryMatch] instances emitted by the various [Visitor](crate::Visitor)
-/// and push signals wrapped in [SignalEntry] to the signal queue
+/// [QueryMatch](crate::QueryMatch) instances emitted by the various
+/// [Visitor](crate::Visitor) and push signals wrapped in [SignalEntry]
+/// to the signal queue
 pub trait QueryMatcher<L: Language> {
     /// Execute a single query match
     fn match_query(&mut self, params: MatchQueryParams<L>);

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -19,7 +19,7 @@ pub struct MatchQueryParams<'phase, 'query, L: Language> {
     pub phase: Phases,
     pub file_id: FileId,
     pub root: &'phase L::Root,
-    pub text_range: TextRange,
+    pub text_range: fn(&dyn Any) -> TextRange,
     pub query: Box<dyn Any>,
     pub services: &'phase ServiceBag,
     pub signal_queue: &'query mut BinaryHeap<SignalEntry<'phase, L>>,

--- a/crates/rome_analyze/src/query.rs
+++ b/crates/rome_analyze/src/query.rs
@@ -30,8 +30,9 @@ pub trait Queryable: Sized {
 }
 
 pub trait AddVisitor<L: Language> {
-    fn add_visitor<V>(&mut self, phase: Phases, visitor: V)
+    fn add_visitor<F, V>(&mut self, phase: Phases, visitor: F)
     where
+        F: FnOnce() -> V,
         V: Visitor<Language = L> + 'static;
 }
 

--- a/crates/rome_analyze/src/query.rs
+++ b/crates/rome_analyze/src/query.rs
@@ -4,7 +4,7 @@ use rome_rowan::{Language, SyntaxKindSet, TextRange};
 
 use crate::{registry::Phase, services::FromServices, Phases, ServiceBag, Visitor};
 
-/// Trait implemented for all types, for example lint rules can query them to emit diagnostics or code actions.
+/// Trait implemented for types that lint rules can query in order to emit diagnostics or code actions.
 pub trait Queryable: Sized {
     type Input: QueryMatch;
     type Output;
@@ -12,11 +12,18 @@ pub trait Queryable: Sized {
     type Language: Language;
     type Services: FromServices + Phase;
 
+    /// Registers one or more [Visitor] that will emit `Self::Input` query
+    /// matches during the analyzer run
     fn build_visitor(
         analyzer: &mut impl AddVisitor<Self::Language>,
         root: &<Self::Language as Language>::Root,
     );
 
+    /// Returns the type of query matches this [Queryable] expects as inputs
+    ///
+    /// Unless your custom queryable needs to match on a specific
+    /// [SyntaxKindSet], you should not override the default implementation of
+    /// this method
     fn key() -> QueryKey<Self::Language> {
         QueryKey::TypeId(TypeId::of::<Self::Input>())
     }
@@ -29,7 +36,9 @@ pub trait Queryable: Sized {
     fn unwrap_match(services: &ServiceBag, query: &Self::Input) -> Self::Output;
 }
 
+/// This trait is implemented on all types that supports the registration of [Visitor]
 pub trait AddVisitor<L: Language> {
+    /// Registers a [Visitor] for a given `phase`
     fn add_visitor<F, V>(&mut self, phase: Phases, visitor: F)
     where
         F: FnOnce() -> V,

--- a/crates/rome_analyze/src/query.rs
+++ b/crates/rome_analyze/src/query.rs
@@ -1,15 +1,14 @@
-use rome_control_flow::ControlFlowGraph;
-use rome_rowan::{AstNode, Language, SyntaxKindSet, SyntaxNode, TextRange};
+use std::any::TypeId;
 
-use crate::{
-    registry::{NodeLanguage, Phase},
-    services::FromServices,
-    Phases, ServiceBag, SyntaxVisitor, Visitor,
-};
+use rome_rowan::{Language, SyntaxKindSet, TextRange};
+
+use crate::{registry::Phase, services::FromServices, Phases, ServiceBag, Visitor};
 
 /// Trait implemented for all types, for example lint rules can query them to emit diagnostics or code actions.
 pub trait Queryable: Sized {
+    type Input: QueryMatch;
     type Output;
+
     type Language: Language;
     type Services: FromServices + Phase;
 
@@ -18,17 +17,16 @@ pub trait Queryable: Sized {
         root: &<Self::Language as Language>::Root,
     );
 
-    /// Statically declares which [QueryMatch] variant is matched by this
-    /// [Queryable] type. For instance the [Ast] queryable matches on
-    /// [QueryMatch::Syntax], so its key is defined as [QueryKey::Syntax]
-    const KEY: QueryKey<Self::Language>;
+    fn key() -> QueryKey<Self::Language> {
+        QueryKey::TypeId(TypeId::of::<Self::Input>())
+    }
 
     /// Unwrap an instance of `Self` from a [QueryMatch].
     ///
     /// ## Panics
     ///
     /// If the [QueryMatch] variant of `query` doesn't match `Self::KEY`
-    fn unwrap_match(services: &ServiceBag, query: &QueryMatch<Self::Language>) -> Self::Output;
+    fn unwrap_match(services: &ServiceBag, query: &Self::Input) -> Self::Output;
 }
 
 pub trait AddVisitor<L: Language> {
@@ -37,58 +35,14 @@ pub trait AddVisitor<L: Language> {
         V: Visitor<Language = L> + 'static;
 }
 
-/// Enumerate all the types of [Queryable] analyzer visitors may emit
-#[derive(Clone, Debug)]
-pub enum QueryMatch<L: Language> {
-    Syntax(SyntaxNode<L>),
-    SemanticModel(TextRange),
-    ControlFlowGraph(ControlFlowGraph<L>, TextRange),
+/// Marker trait implemented for all the types analyzer visitors may emit
+pub trait QueryMatch: 'static {
+    fn text_range(&self) -> TextRange;
 }
 
-impl<L: Language> QueryMatch<L> {
-    pub fn text_range(&self) -> TextRange {
-        match self {
-            QueryMatch::Syntax(node) => node.text_trimmed_range(),
-            QueryMatch::SemanticModel(range) | QueryMatch::ControlFlowGraph(_, range) => *range,
-        }
-    }
-}
-
-/// Mirrors the variants of [QueryMatch] to statically compute which queries a
-/// given [Queryable] type can match
+/// Represents which type a given [Queryable] type can match, either a specific
+/// subset of syntax node kinds or any generic type
 pub enum QueryKey<L: Language> {
     Syntax(SyntaxKindSet<L>),
-    ControlFlowGraph,
-    SemanticModel,
-}
-
-/// Query type usable by lint rules to match on specific [AstNode] types
-#[derive(Clone)]
-pub struct Ast<N>(pub N);
-
-impl<N> Queryable for Ast<N>
-where
-    N: AstNode + 'static,
-{
-    type Output = N;
-    type Language = NodeLanguage<N>;
-    type Services = ();
-
-    fn build_visitor(
-        analyzer: &mut impl AddVisitor<Self::Language>,
-        _: &<Self::Language as Language>::Root,
-    ) {
-        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
-    }
-
-    /// Match on [QueryMatch::Syntax] if the kind of the syntax node matches
-    /// the kind set of `N`
-    const KEY: QueryKey<Self::Language> = QueryKey::Syntax(N::KIND_SET);
-
-    fn unwrap_match(_: &ServiceBag, query: &QueryMatch<Self::Language>) -> Self::Output {
-        match query {
-            QueryMatch::Syntax(node) => N::unwrap_cast(node.clone()),
-            _ => panic!("tried to unwrap unsupported QueryMatch kind, expected Syntax"),
-        }
-    }
+    TypeId(TypeId),
 }

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -130,6 +130,7 @@ impl<L: Language + Default> RuleRegistry<L> {
 /// Holds a collection of rules for each phase.
 #[derive(Default)]
 struct PhaseRules<L: Language> {
+    /// Maps the [TypeId] of known query matches types to the corresponding list of rules
     type_rules: FxHashMap<TypeId, TypeRules<L>>,
     /// Holds a list of states for all the rules in this phase
     rule_states: Vec<RuleState<L>>,
@@ -188,7 +189,7 @@ impl<L: Language + Default + 'static> RegistryVisitor<L> for RuleRegistryBuilder
                     .type_rules
                     .entry(TypeId::of::<SyntaxNode<L>>())
                     .or_insert_with(|| TypeRules::SyntaxRules { rules: Vec::new() })
-                    else { unreachable!() };
+                    else { unreachable!("the SyntaxNode type has already been registered as a TypeRules instead of a SyntaxRules, this is generally caused by an implementation of `Queryable::key` returning a `QueryKey::TypeId` with the type ID of `SyntaxNode`") };
 
                 // Iterate on all the SyntaxKind variants this node can match
                 for kind in key.iter() {
@@ -214,7 +215,7 @@ impl<L: Language + Default + 'static> RegistryVisitor<L> for RuleRegistryBuilder
                     .type_rules
                     .entry(key)
                     .or_insert_with(|| TypeRules::TypeRules { rules: Vec::new() })
-                    else { unreachable!() };
+                    else { unreachable!("the query type has already been registered as a SyntaxRules instead of a TypeRules, this is generally ca used by an implementation of `Queryable::key` returning a `QueryKey::TypeId` with the type ID of `SyntaxNode`") };
 
                 rules.push(rule);
             }

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -281,7 +281,8 @@ impl<L: Language + 'static> QueryMatcher<L> for RuleRegistry<L> {
     fn match_query(&mut self, mut params: MatchQueryParams<L>) {
         let phase = &mut self.phase_rules[params.phase as usize];
 
-        let Some(rules) = phase.type_rules.get(&params.query.type_id()) else { return };
+        let query_type = params.query.type_id();
+        let Some(rules) = phase.type_rules.get(&query_type) else { return };
 
         let rules = match rules {
             TypeRules::SyntaxRules { rules } => {
@@ -433,8 +434,8 @@ impl<L: Language + Default> RegistryRule<L> {
             };
 
             for result in R::run(&ctx) {
-                let text_range = R::text_range(&ctx, &result)
-                    .unwrap_or_else(|| (params.text_range)(&params.query));
+                let text_range =
+                    R::text_range(&ctx, &result).unwrap_or_else(|| params.query.text_range());
 
                 R::suppressed_nodes(&ctx, &result, &mut state.suppressions);
 

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -433,7 +433,8 @@ impl<L: Language + Default> RegistryRule<L> {
             };
 
             for result in R::run(&ctx) {
-                let text_range = R::text_range(&ctx, &result).unwrap_or(params.text_range);
+                let text_range = R::text_range(&ctx, &result)
+                    .unwrap_or_else(|| (params.text_range)(&params.query));
 
                 R::suppressed_nodes(&ctx, &result, &mut state.suppressions);
 

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -23,7 +23,7 @@ where
         analyzer: &mut impl AddVisitor<Self::Language>,
         _: &<Self::Language as Language>::Root,
     ) {
-        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
+        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default);
     }
 
     fn key() -> QueryKey<Self::Language> {

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -2,7 +2,6 @@ use rome_rowan::{Language, SyntaxNode, WalkEvent};
 
 use crate::{QueryMatch, Visitor, VisitorContext};
 
-#[derive(Default)]
 /// The [SyntaxVisitor] is the simplest form of visitor implemented for the
 /// analyzer, it simply broadcast each [WalkEvent::Enter] as a query match
 /// event for the [SyntaxNode] being entered
@@ -12,6 +11,12 @@ pub struct SyntaxVisitor<L: Language> {
     /// of that subtree. The visitor will then ignore all events until it
     /// receives a [WalkEvent::Leave] for the `skip_subtree` node
     skip_subtree: Option<SyntaxNode<L>>,
+}
+
+impl<L: Language> Default for SyntaxVisitor<L> {
+    fn default() -> Self {
+        Self { skip_subtree: None }
+    }
 }
 
 impl<L: Language> Visitor for SyntaxVisitor<L> {
@@ -116,7 +121,7 @@ mod tests {
             &mut emit_signal,
         );
 
-        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
+        analyzer.add_visitor(Phases::Syntax, Box::new(SyntaxVisitor::default()));
 
         let ctx: AnalyzerContext<RawLanguage> = AnalyzerContext {
             file_id: FileId::zero(),

--- a/crates/rome_analyze/src/visitor.rs
+++ b/crates/rome_analyze/src/visitor.rs
@@ -1,4 +1,4 @@
-use std::collections::BinaryHeap;
+use std::{any::Any, collections::BinaryHeap};
 
 use rome_diagnostics::location::FileId;
 use rome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
@@ -27,13 +27,17 @@ impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
             phase: self.phase,
             file_id: self.file_id,
             root: self.root,
-            text_range: query.text_range(),
+            text_range: read_text_range::<T>,
             query: Box::new(query),
             services: self.services,
             signal_queue: self.signal_queue,
             apply_suppression_comment: self.apply_suppression_comment,
         })
     }
+}
+
+fn read_text_range<T: QueryMatch>(query: &dyn Any) -> TextRange {
+    query.downcast_ref::<T>().unwrap().text_range()
 }
 
 /// Mutable context objects provided to the finish hook of visitors

--- a/crates/rome_analyze/src/visitor.rs
+++ b/crates/rome_analyze/src/visitor.rs
@@ -22,12 +22,13 @@ pub struct VisitorContext<'phase, 'query, L: Language> {
 }
 
 impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
-    pub fn match_query(&mut self, query: QueryMatch<L>) {
+    pub fn match_query<T: QueryMatch>(&mut self, query: T) {
         self.query_matcher.match_query(MatchQueryParams {
             phase: self.phase,
             file_id: self.file_id,
             root: self.root,
-            query,
+            text_range: query.text_range(),
+            query: Box::new(query),
             services: self.services,
             signal_queue: self.signal_queue,
             apply_suppression_comment: self.apply_suppression_comment,

--- a/crates/rome_analyze/src/visitor.rs
+++ b/crates/rome_analyze/src/visitor.rs
@@ -1,10 +1,10 @@
-use std::{any::Any, collections::BinaryHeap};
+use std::collections::BinaryHeap;
 
 use rome_diagnostics::location::FileId;
 use rome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
 
 use crate::{
-    matcher::MatchQueryParams,
+    matcher::{MatchQueryParams, Query},
     registry::{NodeLanguage, Phases},
     LanguageRoot, QueryMatch, QueryMatcher, ServiceBag, SignalEntry, SuppressionCommentEmitter,
 };
@@ -27,17 +27,12 @@ impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
             phase: self.phase,
             file_id: self.file_id,
             root: self.root,
-            text_range: read_text_range::<T>,
-            query: Box::new(query),
+            query: Query::new(query),
             services: self.services,
             signal_queue: self.signal_queue,
             apply_suppression_comment: self.apply_suppression_comment,
         })
     }
-}
-
-fn read_text_range<T: QueryMatch>(query: &dyn Any) -> TextRange {
-    query.downcast_ref::<T>().unwrap().text_range()
 }
 
 /// Mutable context objects provided to the finish hook of visitors

--- a/crates/rome_js_analyze/src/aria_services.rs
+++ b/crates/rome_js_analyze/src/aria_services.rs
@@ -1,9 +1,9 @@
 use rome_analyze::{
-    FromServices, MissingServicesDiagnostic, Phase, Phases, QueryKey, QueryMatch, Queryable,
-    RuleKey, ServiceBag,
+    AddVisitor, FromServices, MissingServicesDiagnostic, Phase, Phases, QueryKey, QueryMatch,
+    Queryable, RuleKey, ServiceBag, SyntaxVisitor,
 };
 use rome_aria::{AriaProperties, AriaRoles};
-use rome_js_syntax::JsLanguage;
+use rome_js_syntax::{AnyJsRoot, JsLanguage};
 use rome_rowan::AstNode;
 use std::sync::Arc;
 
@@ -58,6 +58,10 @@ where
     type Output = N;
     type Language = JsLanguage;
     type Services = AriaServices;
+
+    fn build_visitor(analyzer: &mut impl AddVisitor<JsLanguage>, _: &AnyJsRoot) {
+        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
+    }
 
     /// Match on [QueryMatch::Syntax] if the kind of the syntax node matches
     /// the kind set of `N`

--- a/crates/rome_js_analyze/src/aria_services.rs
+++ b/crates/rome_js_analyze/src/aria_services.rs
@@ -62,7 +62,7 @@ where
     type Services = AriaServices;
 
     fn build_visitor(analyzer: &mut impl AddVisitor<JsLanguage>, _: &AnyJsRoot) {
-        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
+        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default);
     }
 
     fn key() -> QueryKey<Self::Language> {

--- a/crates/rome_js_analyze/src/control_flow.rs
+++ b/crates/rome_js_analyze/src/control_flow.rs
@@ -1,6 +1,8 @@
+use rome_analyze::{AddVisitor, Phases, QueryKey, QueryMatch, Queryable, ServiceBag};
+use rome_js_syntax::AnyJsRoot;
 use rome_js_syntax::JsLanguage;
 
-pub(crate) type ControlFlowGraph = rome_control_flow::ControlFlowGraph<JsLanguage>;
+pub(crate) type JsControlFlowGraph = rome_control_flow::ControlFlowGraph<JsLanguage>;
 pub(crate) type FunctionBuilder = rome_control_flow::builder::FunctionBuilder<JsLanguage>;
 
 mod nodes;
@@ -8,3 +10,24 @@ mod visitor;
 
 pub(crate) use self::visitor::make_visitor;
 pub(crate) use self::visitor::AnyJsControlFlowRoot;
+
+pub(crate) struct ControlFlowGraph(JsControlFlowGraph);
+
+impl Queryable for ControlFlowGraph {
+    type Output = JsControlFlowGraph;
+    type Language = JsLanguage;
+    type Services = ();
+
+    fn build_visitor(analyzer: &mut impl AddVisitor<JsLanguage>, _: &AnyJsRoot) {
+        analyzer.add_visitor(Phases::Syntax, make_visitor());
+    }
+
+    const KEY: QueryKey<Self::Language> = QueryKey::ControlFlowGraph;
+
+    fn unwrap_match(_: &ServiceBag, query: &QueryMatch<Self::Language>) -> Self::Output {
+        match query {
+            QueryMatch::ControlFlowGraph(cfg, _) => cfg.clone(),
+            _ => panic!("tried to unwrap unsupported QueryMatch kind, expected Syntax"),
+        }
+    }
+}

--- a/crates/rome_js_analyze/src/control_flow.rs
+++ b/crates/rome_js_analyze/src/control_flow.rs
@@ -1,8 +1,10 @@
-use rome_analyze::{AddVisitor, Phases, QueryKey, QueryMatch, Queryable, ServiceBag};
+use rome_analyze::QueryMatch;
+use rome_analyze::{AddVisitor, Phases, Queryable, ServiceBag};
 use rome_js_syntax::AnyJsRoot;
 use rome_js_syntax::JsLanguage;
+use rome_js_syntax::TextRange;
 
-pub(crate) type JsControlFlowGraph = rome_control_flow::ControlFlowGraph<JsLanguage>;
+pub type JsControlFlowGraph = rome_control_flow::ControlFlowGraph<JsLanguage>;
 pub(crate) type FunctionBuilder = rome_control_flow::builder::FunctionBuilder<JsLanguage>;
 
 mod nodes;
@@ -11,10 +13,21 @@ mod visitor;
 pub(crate) use self::visitor::make_visitor;
 pub(crate) use self::visitor::AnyJsControlFlowRoot;
 
-pub(crate) struct ControlFlowGraph(JsControlFlowGraph);
+pub struct ControlFlowGraph {
+    pub graph: JsControlFlowGraph,
+    pub range: TextRange,
+}
+
+impl QueryMatch for ControlFlowGraph {
+    fn text_range(&self) -> TextRange {
+        self.range
+    }
+}
 
 impl Queryable for ControlFlowGraph {
+    type Input = ControlFlowGraph;
     type Output = JsControlFlowGraph;
+
     type Language = JsLanguage;
     type Services = ();
 
@@ -22,12 +35,7 @@ impl Queryable for ControlFlowGraph {
         analyzer.add_visitor(Phases::Syntax, make_visitor());
     }
 
-    const KEY: QueryKey<Self::Language> = QueryKey::ControlFlowGraph;
-
-    fn unwrap_match(_: &ServiceBag, query: &QueryMatch<Self::Language>) -> Self::Output {
-        match query {
-            QueryMatch::ControlFlowGraph(cfg, _) => cfg.clone(),
-            _ => panic!("tried to unwrap unsupported QueryMatch kind, expected Syntax"),
-        }
+    fn unwrap_match(_: &ServiceBag, query: &ControlFlowGraph) -> Self::Output {
+        query.graph.clone()
     }
 }

--- a/crates/rome_js_analyze/src/control_flow.rs
+++ b/crates/rome_js_analyze/src/control_flow.rs
@@ -32,7 +32,7 @@ impl Queryable for ControlFlowGraph {
     type Services = ();
 
     fn build_visitor(analyzer: &mut impl AddVisitor<JsLanguage>, _: &AnyJsRoot) {
-        analyzer.add_visitor(Phases::Syntax, make_visitor());
+        analyzer.add_visitor(Phases::Syntax, make_visitor);
     }
 
     fn unwrap_match(_: &ServiceBag, query: &ControlFlowGraph) -> Self::Output {

--- a/crates/rome_js_analyze/src/control_flow/visitor.rs
+++ b/crates/rome_js_analyze/src/control_flow/visitor.rs
@@ -1,12 +1,14 @@
 use std::any::TypeId;
 
-use rome_analyze::{merge_node_visitors, QueryMatch, Visitor, VisitorContext};
+use rome_analyze::{merge_node_visitors, Visitor, VisitorContext};
 use rome_js_syntax::{
     AnyJsFunction, JsConstructorClassMember, JsGetterClassMember, JsGetterObjectMember, JsLanguage,
     JsMethodClassMember, JsMethodObjectMember, JsModule, JsScript, JsSetterClassMember,
     JsSetterObjectMember,
 };
 use rome_rowan::{declare_node_union, AstNode, SyntaxError, SyntaxResult};
+
+use crate::ControlFlowGraph;
 
 use super::{nodes::*, FunctionBuilder};
 
@@ -188,10 +190,10 @@ impl rome_analyze::NodeVisitor<ControlFlowVisitor> for FunctionVisitor {
         _: &mut ControlFlowVisitor,
     ) {
         if let Some(builder) = self.builder {
-            ctx.match_query(QueryMatch::ControlFlowGraph(
-                builder.finish(),
-                node.syntax().text_trimmed_range(),
-            ));
+            ctx.match_query(ControlFlowGraph {
+                graph: builder.finish(),
+                range: node.syntax().text_trimmed_range(),
+            });
         }
     }
 }

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -1,4 +1,3 @@
-pub use crate::registry::visit_registry;
 use crate::suppression_action::apply_suppression_comment;
 use rome_analyze::{
     AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, ControlFlow,
@@ -27,6 +26,9 @@ mod semantic_services;
 mod suppression_action;
 mod syntax;
 pub mod utils;
+
+pub use crate::control_flow::ControlFlowGraph;
+pub use crate::registry::visit_registry;
 
 pub(crate) type JsRuleAction = RuleAction<JsLanguage>;
 

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -1,13 +1,9 @@
 pub use crate::registry::visit_registry;
-use crate::semantic_services::{SemanticModelBuilderVisitor, SemanticModelVisitor};
 use crate::suppression_action::apply_suppression_comment;
-use control_flow::make_visitor;
-use rome_analyze::context::ServiceBagRuleOptionsWrapper;
-use rome_analyze::options::OptionsDeserializationDiagnostic;
 use rome_analyze::{
     AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, ControlFlow,
-    DeserializableRuleOptions, InspectMatcher, LanguageRoot, MatchQueryParams, MetadataRegistry,
-    Phases, RuleAction, RuleRegistry, ServiceBag, SuppressionKind, SyntaxVisitor,
+    InspectMatcher, LanguageRoot, MatchQueryParams, MetadataRegistry, RuleAction, RuleRegistry,
+    SuppressionKind,
 };
 use rome_aria::{AriaProperties, AriaRoles};
 use rome_diagnostics::{category, Diagnostic, FileId};
@@ -45,45 +41,6 @@ pub fn metadata() -> &'static MetadataRegistry {
     }
 
     &METADATA
-}
-
-pub struct RulesConfigurator<'a> {
-    options: &'a AnalyzerOptions,
-    services: &'a mut ServiceBag,
-    diagnostics: Vec<OptionsDeserializationDiagnostic>,
-}
-
-impl<'a, L: rome_rowan::Language + Default> rome_analyze::RegistryVisitor<L>
-    for RulesConfigurator<'a>
-{
-    fn record_rule<R>(&mut self)
-    where
-        R: rome_analyze::Rule + 'static,
-        R::Query: rome_analyze::Queryable<Language = L>,
-        <R::Query as rome_analyze::Queryable>::Output: Clone,
-    {
-        let rule_key = rome_analyze::RuleKey::rule::<R>();
-        let options = if let Some(options) = self.options.configuration.rules.get_rule(&rule_key) {
-            let value = options.value();
-            match <R::Options as DeserializableRuleOptions>::try_from(value.clone()) {
-                Ok(result) => result,
-                Err(error) => {
-                    let err = OptionsDeserializationDiagnostic::new(
-                        rule_key.rule_name(),
-                        value.to_string(),
-                        error,
-                    );
-                    self.diagnostics.push(err);
-                    <R::Options as Default>::default()
-                }
-            }
-        } else {
-            <R::Options as Default>::default()
-        };
-
-        self.services
-            .insert_service(ServiceBagRuleOptionsWrapper::<R>(options));
-    }
 }
 
 /// Run the analyzer on the provided `root`: this process will use the given `filter`
@@ -138,21 +95,14 @@ where
         result
     }
 
-    let mut registry = RuleRegistry::builder(&filter);
+    let mut registry = RuleRegistry::builder(&filter, options, root);
     visit_registry(&mut registry);
 
-    // Parse rule options
-    let mut services = ServiceBag::default();
-    let mut configurator = RulesConfigurator {
-        options,
-        services: &mut services,
-        diagnostics: vec![],
-    };
-    visit_registry(&mut configurator);
+    let (registry, mut services, diagnostics, visitors) = registry.build();
 
     // Bail if we can't parse a rule option
-    if !configurator.diagnostics.is_empty() {
-        for diagnostic in configurator.diagnostics {
+    if !diagnostics.is_empty() {
+        for diagnostic in diagnostics {
             emit_signal(&diagnostic);
         }
         return None;
@@ -160,17 +110,15 @@ where
 
     let mut analyzer = Analyzer::new(
         metadata(),
-        InspectMatcher::new(registry.build(), inspect_matcher),
+        InspectMatcher::new(registry, inspect_matcher),
         parse_linter_suppression_comment,
         apply_suppression_comment,
         &mut emit_signal,
     );
-    analyzer.add_visitor(Phases::Syntax, make_visitor());
-    analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default());
-    analyzer.add_visitor(Phases::Syntax, SemanticModelBuilderVisitor::new(root));
 
-    analyzer.add_visitor(Phases::Semantic, SemanticModelVisitor);
-    analyzer.add_visitor(Phases::Semantic, SyntaxVisitor::default());
+    for ((phase, _), visitor) in visitors {
+        analyzer.add_visitor(phase, visitor);
+    }
 
     services.insert_service(Arc::new(AriaRoles::default()));
     services.insert_service(Arc::new(AriaProperties::default()));

--- a/crates/rome_js_analyze/src/semantic_services.rs
+++ b/crates/rome_js_analyze/src/semantic_services.rs
@@ -1,6 +1,6 @@
 use rome_analyze::{
-    FromServices, MissingServicesDiagnostic, Phase, Phases, QueryKey, QueryMatch, Queryable,
-    RuleKey, ServiceBag, Visitor, VisitorContext, VisitorFinishContext,
+    AddVisitor, FromServices, MissingServicesDiagnostic, Phase, Phases, QueryKey, QueryMatch,
+    Queryable, RuleKey, ServiceBag, SyntaxVisitor, Visitor, VisitorContext, VisitorFinishContext,
 };
 use rome_js_semantic::{SemanticEventExtractor, SemanticModel, SemanticModelBuilder};
 use rome_js_syntax::{AnyJsRoot, JsLanguage, WalkEvent};
@@ -43,6 +43,11 @@ impl Queryable for SemanticServices {
     type Language = JsLanguage;
     type Services = Self;
 
+    fn build_visitor(analyzer: &mut impl AddVisitor<JsLanguage>, root: &AnyJsRoot) {
+        analyzer.add_visitor(Phases::Syntax, SemanticModelBuilderVisitor::new(root));
+        analyzer.add_visitor(Phases::Semantic, SemanticModelVisitor);
+    }
+
     const KEY: QueryKey<Self::Language> = QueryKey::SemanticModel;
 
     fn unwrap_match(services: &ServiceBag, query: &QueryMatch<Self::Language>) -> Self::Output {
@@ -68,6 +73,11 @@ where
     type Language = JsLanguage;
     type Services = SemanticServices;
 
+    fn build_visitor(analyzer: &mut impl AddVisitor<JsLanguage>, root: &AnyJsRoot) {
+        analyzer.add_visitor(Phases::Syntax, SemanticModelBuilderVisitor::new(root));
+        analyzer.add_visitor(Phases::Semantic, SyntaxVisitor::default());
+    }
+
     /// Match on [QueryMatch::Syntax] if the kind of the syntax node matches
     /// the kind set of `N`
     const KEY: QueryKey<Self::Language> = QueryKey::Syntax(N::KIND_SET);
@@ -80,13 +90,13 @@ where
     }
 }
 
-pub(crate) struct SemanticModelBuilderVisitor {
+struct SemanticModelBuilderVisitor {
     extractor: SemanticEventExtractor,
     builder: SemanticModelBuilder,
 }
 
 impl SemanticModelBuilderVisitor {
-    pub(crate) fn new(root: &AnyJsRoot) -> Self {
+    fn new(root: &AnyJsRoot) -> Self {
         Self {
             extractor: SemanticEventExtractor::default(),
             builder: SemanticModelBuilder::new(root.clone()),
@@ -123,7 +133,7 @@ impl Visitor for SemanticModelBuilderVisitor {
     }
 }
 
-pub(crate) struct SemanticModelVisitor;
+pub struct SemanticModelVisitor;
 
 impl Visitor for SemanticModelVisitor {
     type Language = JsLanguage;

--- a/crates/rome_js_analyze/src/semantic_services.rs
+++ b/crates/rome_js_analyze/src/semantic_services.rs
@@ -46,8 +46,8 @@ impl Queryable for SemanticServices {
     type Services = Self;
 
     fn build_visitor(analyzer: &mut impl AddVisitor<JsLanguage>, root: &AnyJsRoot) {
-        analyzer.add_visitor(Phases::Syntax, SemanticModelBuilderVisitor::new(root));
-        analyzer.add_visitor(Phases::Semantic, SemanticModelVisitor);
+        analyzer.add_visitor(Phases::Syntax, || SemanticModelBuilderVisitor::new(root));
+        analyzer.add_visitor(Phases::Semantic, || SemanticModelVisitor);
     }
 
     fn unwrap_match(services: &ServiceBag, _: &SemanticModelEvent) -> Self::Output {
@@ -73,8 +73,8 @@ where
     type Services = SemanticServices;
 
     fn build_visitor(analyzer: &mut impl AddVisitor<JsLanguage>, root: &AnyJsRoot) {
-        analyzer.add_visitor(Phases::Syntax, SemanticModelBuilderVisitor::new(root));
-        analyzer.add_visitor(Phases::Semantic, SyntaxVisitor::default());
+        analyzer.add_visitor(Phases::Syntax, || SemanticModelBuilderVisitor::new(root));
+        analyzer.add_visitor(Phases::Semantic, SyntaxVisitor::default);
     }
 
     fn key() -> QueryKey<Self::Language> {


### PR DESCRIPTION
## Summary

This PR modifies how various types related to the `Queryable` trait are injected into the analyzer infrastructure. This includes:
- Allowing `Queryable` types to dynamically register the `Visitor` instances that emits them to the analyzer
- Replacing the `QueryMatch` enum with `TypeId` and `Box<dyn Any>` to allow any arbitrary type to be emitted as a visitor event

The main goal of this refactor is to allow individual rules to declare custom syntax tree visitors to emit the event they rely upon as an optimization opportunity instead of having to traverse the syntax tree in their `run` method. For instance the `useYield` rule could be implemented like this:

<details>
<summary>Code</summary>

```rust
impl Rule for UseYield {
    type Query = MissingYield;
}

struct MissingYield(AnyFunctionLike);

impl Queryable for MissingYield {
    type Input = Self;
    type Output = AnyFunctionLike;
    
    fn build_visitor(
        analyzer: &mut impl AddVisitor<Self::Language>,
        _: &<Self::Language as Language>::Root,
    ) {
        analyzer.add_visitor(Phases::Syntax, MissingYieldVisitor::default());
    }

    fn unwrap_match(services: &ServiceBag, query: &Self::Input) -> Self::Output {
        query.0.clone()
    }
}

#[derive(Default)]
struct MissingYieldVisitor {
    stack: Vec<(AnyFunctionLike, bool)>,
}

impl Visitor for MissingYieldVisitor {
    fn visit(
        &mut self,
        event: &WalkEvent<SyntaxNode<Self::Language>>,
        ctx: VisitorContext<Self::Language>,
    ) {
        match event {
            WalkEvent::Enter(node) => {
                if let Some(node) = AnyFunctionLike::cast_ref(node) {
                    self.stack.push((node, false));
                }
                
                if let Some((_, has_yield)) = self.stack.last_mut() {
                    if JsYieldExpression::can_cast(node.kind()) {
                        *has_yield = true;
                    }
                }
            }
            WalkEvent::Leave(node) => {
                if let Some(exit_node) = AnyFunctionLike::cast_ref(node) {
                    if let Some((enter_node, has_yield)) = self.stack.pop() {
                        assert_eq!(enter_node, exit_node);
                        if !has_yield {
                            ctx.match_query(MissingYield(enter_node));
                        }
                    }
                }
            }
        }
    }
}
```

</details>

## Test Plan

This is an infrastructure-only change, the code should continue to build and existing tests should continue to pass correctly.

## Documentation

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
