### PR TITLE
fix(rome_js_analyze): handle default clause in `useSingleCaseStetement`

### DIFF
--- a/crates/rome_js_analyze/tests/specs/style/useSingleCaseStatement.js
+++ b/crates/rome_js_analyze/tests/specs/style/useSingleCaseStatement.js
@@ -5,15 +5,17 @@ switch (foo) {
         foo;
 }
 
+switch (foo) { case false: let foo = ''; foo; }
+
 switch (foo) {
     // comment
-    case false :
+    case false:
         let foo = '';
         foo;
 }
 
 switch (foo) {
-    case false : // comment
+    case false: // comment
         let foo = '';
         foo;
 }
@@ -39,4 +41,47 @@ switch (foo) {
 
 switch (foo) {
     case true:
+}
+
+switch (foo) {
+    case true:
+    default:
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    // comment
+    default:
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    default: // comment
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    default
+    /* comment */ :
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    case true:
+    default:
+        'yes';
+}
+
+switch (foo) {
+    default: {
+        // empty
+    }
+}
+
+switch (foo) {
+    default:
 }

--- a/crates/rome_js_analyze/tests/specs/style/useSingleCaseStatement.js.snap
+++ b/crates/rome_js_analyze/tests/specs/style/useSingleCaseStatement.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 92
 expression: useSingleCaseStatement.js
 ---
 # Input
@@ -11,15 +12,17 @@ switch (foo) {
         foo;
 }
 
+switch (foo) { case false: let foo = ''; foo; }
+
 switch (foo) {
     // comment
-    case false :
+    case false:
         let foo = '';
         foo;
 }
 
 switch (foo) {
-    case false : // comment
+    case false: // comment
         let foo = '';
         foo;
 }
@@ -47,13 +50,56 @@ switch (foo) {
     case true:
 }
 
+switch (foo) {
+    case true:
+    default:
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    // comment
+    default:
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    default: // comment
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    default
+    /* comment */ :
+        let foo = '';
+        foo;
+}
+
+switch (foo) {
+    case true:
+    default:
+        'yes';
+}
+
+switch (foo) {
+    default: {
+        // empty
+    }
+}
+
+switch (foo) {
+    default:
+}
+
 ```
 
 # Diagnostics
 ```
 useSingleCaseStatement.js:4:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! A switch case should only have a single statement. If you want more, then wrap it in a block.
+  ! A switch clause should only have a single statement.
   
     2 │     case true:
     3 │     case false:
@@ -64,7 +110,7 @@ useSingleCaseStatement.js:4:9 lint/style/useSingleCaseStatement  FIXABLE  ━━
     6 │ }
     7 │ 
   
-  i Suggested fix: Wrap the statements in a block
+  i Suggested fix: Wrap the statements in a block.
   
      1  1 │   switch (foo) {
      2  2 │       case true:
@@ -80,88 +126,223 @@ useSingleCaseStatement.js:4:9 lint/style/useSingleCaseStatement  FIXABLE  ━━
 ```
 
 ```
-useSingleCaseStatement.js:11:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+useSingleCaseStatement.js:8:28 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! A switch case should only have a single statement. If you want more, then wrap it in a block.
+  ! A switch clause should only have a single statement.
   
-     9 │     // comment
-    10 │     case false :
-  > 11 │         let foo = '';
+     6 │ }
+     7 │ 
+   > 8 │ switch (foo) { case false: let foo = ''; foo; }
+       │                            ^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ switch (foo) {
+  
+  i Suggested fix: Wrap the statements in a block.
+  
+    8 │ switch·(foo)·{·case·false:·{·let·foo·=·'';·foo;·}}
+      │                            ++                    +
+
+```
+
+```
+useSingleCaseStatement.js:13:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A switch clause should only have a single statement.
+  
+    11 │     // comment
+    12 │     case false:
+  > 13 │         let foo = '';
        │         ^^^^^^^^^^^^^
-  > 12 │         foo;
+  > 14 │         foo;
        │         ^^^^
-    13 │ }
-    14 │ 
+    15 │ }
+    16 │ 
   
-  i Suggested fix: Wrap the statements in a block
+  i Suggested fix: Wrap the statements in a block.
   
-     8  8 │   switch (foo) {
-     9  9 │       // comment
-    10    │ - ····case·false·:
-       10 │ + ····case·false·:·{
-    11 11 │           let foo = '';
-    12 12 │           foo;
-       13 │ + ····}
-    13 14 │   }
-    14 15 │   
+    10 10 │   switch (foo) {
+    11 11 │       // comment
+    12    │ - ····case·false:
+       12 │ + ····case·false:·{
+    13 13 │           let foo = '';
+    14 14 │           foo;
+       15 │ + ····}
+    15 16 │   }
+    16 17 │   
   
 
 ```
 
 ```
-useSingleCaseStatement.js:17:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+useSingleCaseStatement.js:19:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! A switch case should only have a single statement. If you want more, then wrap it in a block.
+  ! A switch clause should only have a single statement.
   
-    15 │ switch (foo) {
-    16 │     case false : // comment
-  > 17 │         let foo = '';
+    17 │ switch (foo) {
+    18 │     case false: // comment
+  > 19 │         let foo = '';
        │         ^^^^^^^^^^^^^
-  > 18 │         foo;
+  > 20 │         foo;
        │         ^^^^
-    19 │ }
-    20 │ 
+    21 │ }
+    22 │ 
   
-  i Suggested fix: Wrap the statements in a block
+  i Suggested fix: Wrap the statements in a block.
   
-    14 14 │   
-    15 15 │   switch (foo) {
-    16    │ - ····case·false·:·//·comment
-       16 │ + ····case·false·:·{·//·comment
-    17 17 │           let foo = '';
-    18 18 │           foo;
-       19 │ + ····}
-    19 20 │   }
-    20 21 │   
+    16 16 │   
+    17 17 │   switch (foo) {
+    18    │ - ····case·false:·//·comment
+       18 │ + ····case·false:·{·//·comment
+    19 19 │           let foo = '';
+    20 20 │           foo;
+       21 │ + ····}
+    21 22 │   }
+    22 23 │   
   
 
 ```
 
 ```
-useSingleCaseStatement.js:24:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+useSingleCaseStatement.js:26:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! A switch case should only have a single statement. If you want more, then wrap it in a block.
+  ! A switch clause should only have a single statement.
   
-    22 │     case false
-    23 │     /* comment */ :
-  > 24 │         let foo = '';
+    24 │     case false
+    25 │     /* comment */ :
+  > 26 │         let foo = '';
        │         ^^^^^^^^^^^^^
-  > 25 │         foo;
+  > 27 │         foo;
        │         ^^^^
-    26 │ }
-    27 │ 
+    28 │ }
+    29 │ 
   
-  i Suggested fix: Wrap the statements in a block
+  i Suggested fix: Wrap the statements in a block.
   
-    21 21 │   switch (foo) {
-    22 22 │       case false
-    23    │ - ····/*·comment·*/·:
-       23 │ + ····/*·comment·*/·:·{
-    24 24 │           let foo = '';
-    25 25 │           foo;
-       26 │ + ····}
-    26 27 │   }
-    27 28 │   
+    23 23 │   switch (foo) {
+    24 24 │       case false
+    25    │ - ····/*·comment·*/·:
+       25 │ + ····/*·comment·*/·:·{
+    26 26 │           let foo = '';
+    27 27 │           foo;
+       28 │ + ····}
+    28 29 │   }
+    29 30 │   
+  
+
+```
+
+```
+useSingleCaseStatement.js:49:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A switch clause should only have a single statement.
+  
+    47 │     case true:
+    48 │     default:
+  > 49 │         let foo = '';
+       │         ^^^^^^^^^^^^^
+  > 50 │         foo;
+       │         ^^^^
+    51 │ }
+    52 │ 
+  
+  i Suggested fix: Wrap the statements in a block.
+  
+    46 46 │   switch (foo) {
+    47 47 │       case true:
+    48    │ - ····default:
+       48 │ + ····default:·{
+    49 49 │           let foo = '';
+    50 50 │           foo;
+       51 │ + ····}
+    51 52 │   }
+    52 53 │   
+  
+
+```
+
+```
+useSingleCaseStatement.js:56:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A switch clause should only have a single statement.
+  
+    54 │     // comment
+    55 │     default:
+  > 56 │         let foo = '';
+       │         ^^^^^^^^^^^^^
+  > 57 │         foo;
+       │         ^^^^
+    58 │ }
+    59 │ 
+  
+  i Suggested fix: Wrap the statements in a block.
+  
+    53 53 │   switch (foo) {
+    54 54 │       // comment
+    55    │ - ····default:
+       55 │ + ····default:·{
+    56 56 │           let foo = '';
+    57 57 │           foo;
+       58 │ + ····}
+    58 59 │   }
+    59 60 │   
+  
+
+```
+
+```
+useSingleCaseStatement.js:62:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A switch clause should only have a single statement.
+  
+    60 │ switch (foo) {
+    61 │     default: // comment
+  > 62 │         let foo = '';
+       │         ^^^^^^^^^^^^^
+  > 63 │         foo;
+       │         ^^^^
+    64 │ }
+    65 │ 
+  
+  i Suggested fix: Wrap the statements in a block.
+  
+    59 59 │   
+    60 60 │   switch (foo) {
+    61    │ - ····default:·//·comment
+       61 │ + ····default:·{·//·comment
+    62 62 │           let foo = '';
+    63 63 │           foo;
+       64 │ + ····}
+    64 65 │   }
+    65 66 │   
+  
+
+```
+
+```
+useSingleCaseStatement.js:69:9 lint/style/useSingleCaseStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A switch clause should only have a single statement.
+  
+    67 │     default
+    68 │     /* comment */ :
+  > 69 │         let foo = '';
+       │         ^^^^^^^^^^^^^
+  > 70 │         foo;
+       │         ^^^^
+    71 │ }
+    72 │ 
+  
+  i Suggested fix: Wrap the statements in a block.
+  
+    66 66 │   switch (foo) {
+    67 67 │       default
+    68    │ - ····/*·comment·*/·:
+       68 │ + ····/*·comment·*/·:·{
+    69 69 │           let foo = '';
+    70 70 │           foo;
+       71 │ + ····}
+    71 72 │   }
+    72 73 │   
   
 
 ```

--- a/crates/rome_rowan/src/syntax/token.rs
+++ b/crates/rome_rowan/src/syntax/token.rs
@@ -188,20 +188,16 @@ impl<L: Language> SyntaxToken<L> {
         }
     }
 
-    /// Return the leading whitespace and newline until the first leading newline or token.
-    pub fn indentation_trivia(&self) -> Vec<SyntaxTriviaPiece<L>> {
+    /// Return whitespace and newlines that juxtapose the token until the first non-whitespace item.
+    pub fn indentation_trivia(&self) -> impl ExactSizeIterator<Item = SyntaxTriviaPiece<L>> {
         let leading_trivia = self.leading_trivia().pieces();
         let skip_count = leading_trivia.len()
             - leading_trivia
                 .rev()
-                .position(|x| x.is_newline())
+                .position(|x| !x.is_whitespace())
                 .map(|pos| pos + 1)
                 .unwrap_or(0);
-        self.leading_trivia()
-            .pieces()
-            .skip(skip_count)
-            .filter(|x| x.is_newline() || x.is_whitespace())
-            .collect::<Vec<_>>()
+        self.leading_trivia().pieces().skip(skip_count)
     }
 
     /// Return a new version of this token with its leading trivia replaced with `trivia`

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -2131,7 +2131,7 @@ pub struct Style {
     #[doc = "When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_shorthand_array_type: Option<RuleConfiguration>,
-    #[doc = "Enforces case clauses have a single statement, emits a quick fix wrapping the statements in a block"]
+    #[doc = "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_single_case_statement: Option<RuleConfiguration>,
     #[doc = "Disallow multiple variable declarations in the same variable statement"]

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -985,7 +985,7 @@
 					]
 				},
 				"useSingleCaseStatement": {
-					"description": "Enforces case clauses have a single statement, emits a quick fix wrapping the statements in a block",
+					"description": "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -604,7 +604,7 @@ export interface Style {
 	 */
 	useShorthandArrayType?: RuleConfiguration;
 	/**
-	 * Enforces case clauses have a single statement, emits a quick fix wrapping the statements in a block
+	 * Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.
 	 */
 	useSingleCaseStatement?: RuleConfiguration;
 	/**

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -985,7 +985,7 @@
 					]
 				},
 				"useSingleCaseStatement": {
-					"description": "Enforces case clauses have a single statement, emits a quick fix wrapping the statements in a block",
+					"description": "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -321,8 +321,8 @@ When expressing array types, this rule promotes the usage of <code>T[]</code> sh
 <h3 data-toc-exclude id="useSingleCaseStatement">
 	<a href="/lint/rules/useSingleCaseStatement">useSingleCaseStatement</a>
 </h3>
-Enforces case clauses have a single statement, emits a quick fix wrapping
-the statements in a block
+Enforces switch clauses have a single statement, emits a quick fix wrapping
+the statements in a block.
 </section>
 <section class="rule">
 <h3 data-toc-exclude id="useSingleVarDeclarator">

--- a/website/src/pages/lint/rules/useSingleCaseStatement.md
+++ b/website/src/pages/lint/rules/useSingleCaseStatement.md
@@ -5,8 +5,8 @@ parent: lint/rules/index
 
 # useSingleCaseStatement (since v0.7.0)
 
-Enforces case clauses have a single statement, emits a quick fix wrapping
-the statements in a block
+Enforces switch clauses have a single statement, emits a quick fix wrapping
+the statements in a block.
 
 ## Examples
 
@@ -23,7 +23,7 @@ switch (foo) {
 
 <pre class="language-text"><code class="language-text">style/useSingleCaseStatement.js:4:9 <a href="https://docs.rome.tools/lint/rules/useSingleCaseStatement">lint/style/useSingleCaseStatement</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">A switch case should only have a single statement. If you want more, then wrap it in a block.</span>
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">A </span><span style="color: Orange;"><strong>switch clause</strong></span><span style="color: Orange;"> should only have a single statement.</span>
   
     <strong>2 │ </strong>    case true:
     <strong>3 │ </strong>    case false:
@@ -34,7 +34,7 @@ switch (foo) {
     <strong>6 │ </strong>}
     <strong>7 │ </strong>
   
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Wrap the statements in a block</span>
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Wrap the statements in a block.</span>
   
     <strong>1</strong> <strong>1</strong><strong> │ </strong>  switch (foo) {
     <strong>2</strong> <strong>2</strong><strong> │ </strong>      case true:


### PR DESCRIPTION

## Summary

Closes #4068.
I also updated the diagnostic for better consistency with other rules.

By the way, the rule should certainly be renamed to `useSingleSwitchClauseStatement`.
Unfortunately, this is a stable rule.

I personally could rather deprecate the rule, once [`noSwitchDeclarations`](https://github.com/rome/tools/pull/3917) becomes merged or stable.

## Test Plan

New Unit test for `default` switch clauses.

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
