### PR TITLE
fix(rome_js_semantic): semantic model considering static init block as scope

### DIFF
--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -290,6 +290,7 @@ impl SemanticEventExtractor {
             | JS_CLASS_EXPORT_DEFAULT_DECLARATION
             | JS_CLASS_EXPRESSION
             | JS_FUNCTION_BODY
+            | JS_STATIC_INITIALIZATION_BLOCK_CLASS_MEMBER
             | TS_MODULE_DECLARATION
             | TS_INTERFACE_DECLARATION
             | TS_ENUM_DECLARATION
@@ -557,6 +558,7 @@ impl SemanticEventExtractor {
             | JS_FOR_IN_STATEMENT
             | JS_SWITCH_STATEMENT
             | JS_CATCH_CLAUSE
+            | JS_STATIC_INITIALIZATION_BLOCK_CLASS_MEMBER
             | TS_DECLARE_FUNCTION_DECLARATION
             | TS_FUNCTION_TYPE
             | TS_INTERFACE_DECLARATION

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -227,8 +227,25 @@ assert_semantics! {
         "class C { static { () => a/*READ A*/; let a/*#A*/ = 1; } };",
 }
 
-// Typescript types
 
+// Static Initialization Block
+assert_semantics! {
+    ok_reference_static_initialization_block,
+        "const a/*#A1*/ = 1; 
+        console.log(a/*READ A1*/); 
+        
+        class A { 
+            static {
+                console.log(a/*READ A2*/);  
+                const a/*#A2*/ = 2; 
+                console.log(a/*READ A2*/); 
+            }  
+        };
+        
+        console.log(a/*READ A1*/);",
+}
+
+// Typescript types
 assert_semantics! {
     ok_typescript_function_type,
         "function f (a/*#A1*/, b: (a/*#A2*/) => any) { return b(a/*READ A1*/); };",

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -227,11 +227,10 @@ assert_semantics! {
         "class C { static { () => a/*READ A*/; let a/*#A*/ = 1; } };",
 }
 
-
 // Static Initialization Block
 assert_semantics! {
     ok_reference_static_initialization_block,
-        "const a/*#A1*/ = 1; 
+        "const a/*#A1*/ = 1;
         console.log(a/*READ A1*/); 
         
         class A { 

--- a/crates/rome_js_semantic/src/tests/scopes.rs
+++ b/crates/rome_js_semantic/src/tests/scopes.rs
@@ -41,7 +41,7 @@ assert_semantics! {
 // Static Initialization Block
 assert_semantics! {
     ok_scope_static_initialization_block,
-        "class A { 
+        "class A {
             static/*START A*/ {
                 const a/*@ A*/ = 2; 
             }/*END A*/  

--- a/crates/rome_js_semantic/src/tests/scopes.rs
+++ b/crates/rome_js_semantic/src/tests/scopes.rs
@@ -38,6 +38,16 @@ assert_semantics! {
     ok_scope_class_setter, ";class A { set/*START A*/ name(v) {}/*END A*/ }",
 }
 
+// Static Initialization Block
+assert_semantics! {
+    ok_scope_static_initialization_block,
+        "class A { 
+            static/*START A*/ {
+                const a/*@ A*/ = 2; 
+            }/*END A*/  
+        };",
+}
+
 // Type parameters
 assert_semantics! {
     ok_type_parameter, "export type /*START A*/ EventHandler<Event /*# Event */ /*@ A */ extends string> = `on${ Event /*READ Event */ }` /*END A*/",


### PR DESCRIPTION
## Summary

This PR fix a hole in the semantic model scope that was not considering static init blocks.

## Test Plan

```
> cargo test -p rome_js_semantic -- ok_scope_static_initialization_block
> cargo test -p rome_js_semantic -- ok_reference_static_initialization_block
```

## Documentation

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
