### PR TITLE
chore: change `12.0.0` to `next`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/nursery/no_assign_in_expressions.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_assign_in_expressions.rs
@@ -46,7 +46,7 @@ declare_rule! {
     /// a = 1;
     /// ```
     pub(crate) NoAssignInExpressions {
-        version: "12.0.0",
+        version: "next",
         name: "noAssignInExpressions",
         recommended: true,
     }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_comma_operator.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_comma_operator.rs
@@ -39,7 +39,7 @@ declare_rule! {
     /// ```
     ///
     pub(crate) NoCommaOperator {
-        version: "12.0.0",
+        version: "next",
         name: "noCommaOperator",
         recommended: true,
     }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_redundant_alt.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_redundant_alt.rs
@@ -40,7 +40,7 @@ declare_rule! {
     /// ```
     ///
     pub(crate) NoRedundantAlt {
-        version: "12.0.0",
+        version: "next",
         name: "noRedundantAlt",
         recommended: true,
     }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_self_compare.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_self_compare.rs
@@ -28,7 +28,7 @@ declare_rule! {
     /// ```
     ///
     pub(crate) NoSelfCompare {
-        version: "12.0.0",
+        version: "next",
         name: "noSelfCompare",
         recommended: true,
     }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_useless_switch_case.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_useless_switch_case.rs
@@ -60,7 +60,7 @@ declare_rule! {
     /// ```
     ///
     pub(crate) NoUselessSwitchCase {
-        version: "12.0.0",
+        version: "next",
         name: "noUselessSwitchCase",
         recommended: true,
     }

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_with.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_with.rs
@@ -23,7 +23,7 @@ declare_rule! {
     /// }
     /// ```
     pub(crate) NoWith {
-        version: "12.0.0",
+        version: "next",
         name: "noWith",
         recommended: true,
     }

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery/use_aria_prop_types.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery/use_aria_prop_types.rs
@@ -50,7 +50,7 @@ declare_rule! {
     /// - [ARIA Spec, States and Properties](https://www.w3.org/TR/wai-aria/#states_and_properties)
     /// - [Chrome Audit Rules, AX_ARIA_04](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_04)
     pub(crate) UseAriaPropTypes {
-        version: "12.0.0",
+        version: "next",
         name: "useAriaPropTypes",
         recommended: false,
     }

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery/use_valid_lang.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery/use_valid_lang.rs
@@ -29,7 +29,7 @@ declare_rule! {
     /// <Html lang="en-babab" />
     /// ```
     pub(crate) UseValidLang {
-        version: "12.0.0",
+        version: "next",
         name: "useValidLang",
         recommended: true,
     }

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_class_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_class_assign.rs
@@ -66,7 +66,7 @@ declare_rule! {
     /// ```
     ///
     pub(crate) NoClassAssign {
-        version: "12.0.0",
+        version: "next",
         name: "noClassAssign",
         recommended: true,
     }

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_hook_at_top_level.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_hook_at_top_level.rs
@@ -36,7 +36,7 @@ declare_rule! {
     /// ```
     ///
     pub(crate) UseHookAtTopLevel {
-        version: "12.0.0",
+        version: "next",
         name: "useHookAtTopLevel",
         recommended: false,
     }

--- a/website/src/pages/lint/rules/noAssignInExpressions.md
+++ b/website/src/pages/lint/rules/noAssignInExpressions.md
@@ -3,7 +3,7 @@ title: Lint Rule noAssignInExpressions
 parent: lint/rules/index
 ---
 
-# noAssignInExpressions (since v12.0.0)
+# noAssignInExpressions (since vnext)
 
 Disallow assignments in expressions.
 

--- a/website/src/pages/lint/rules/noClassAssign.md
+++ b/website/src/pages/lint/rules/noClassAssign.md
@@ -3,7 +3,7 @@ title: Lint Rule noClassAssign
 parent: lint/rules/index
 ---
 
-# noClassAssign (since v12.0.0)
+# noClassAssign (since vnext)
 
 Disallow reassigning class members.
 

--- a/website/src/pages/lint/rules/noCommaOperator.md
+++ b/website/src/pages/lint/rules/noCommaOperator.md
@@ -3,7 +3,7 @@ title: Lint Rule noCommaOperator
 parent: lint/rules/index
 ---
 
-# noCommaOperator (since v12.0.0)
+# noCommaOperator (since vnext)
 
 Disallow comma operator.
 

--- a/website/src/pages/lint/rules/noRedundantAlt.md
+++ b/website/src/pages/lint/rules/noRedundantAlt.md
@@ -3,7 +3,7 @@ title: Lint Rule noRedundantAlt
 parent: lint/rules/index
 ---
 
-# noRedundantAlt (since v12.0.0)
+# noRedundantAlt (since vnext)
 
 Enforce `img` alt prop does not contain the word "image", "picture", or "photo".
 

--- a/website/src/pages/lint/rules/noSelfCompare.md
+++ b/website/src/pages/lint/rules/noSelfCompare.md
@@ -3,7 +3,7 @@ title: Lint Rule noSelfCompare
 parent: lint/rules/index
 ---
 
-# noSelfCompare (since v12.0.0)
+# noSelfCompare (since vnext)
 
 Disallow comparisons where both sides are exactly the same.
 

--- a/website/src/pages/lint/rules/noUselessSwitchCase.md
+++ b/website/src/pages/lint/rules/noUselessSwitchCase.md
@@ -3,7 +3,7 @@ title: Lint Rule noUselessSwitchCase
 parent: lint/rules/index
 ---
 
-# noUselessSwitchCase (since v12.0.0)
+# noUselessSwitchCase (since vnext)
 
 Disallow useless `case` in `switch` statements.
 

--- a/website/src/pages/lint/rules/noWith.md
+++ b/website/src/pages/lint/rules/noWith.md
@@ -3,7 +3,7 @@ title: Lint Rule noWith
 parent: lint/rules/index
 ---
 
-# noWith (since v12.0.0)
+# noWith (since vnext)
 
 Disallow `with` statements in non-strict contexts.
 

--- a/website/src/pages/lint/rules/useAriaPropTypes.md
+++ b/website/src/pages/lint/rules/useAriaPropTypes.md
@@ -3,7 +3,7 @@ title: Lint Rule useAriaPropTypes
 parent: lint/rules/index
 ---
 
-# useAriaPropTypes (since v12.0.0)
+# useAriaPropTypes (since vnext)
 
 Enforce that ARIA state and property values are valid.
 

--- a/website/src/pages/lint/rules/useHookAtTopLevel.md
+++ b/website/src/pages/lint/rules/useHookAtTopLevel.md
@@ -3,7 +3,7 @@ title: Lint Rule useHookAtTopLevel
 parent: lint/rules/index
 ---
 
-# useHookAtTopLevel (since v12.0.0)
+# useHookAtTopLevel (since vnext)
 
 Enforce that all React hooks are being called from the Top Level
 component functions.

--- a/website/src/pages/lint/rules/useValidLang.md
+++ b/website/src/pages/lint/rules/useValidLang.md
@@ -3,7 +3,7 @@ title: Lint Rule useValidLang
 parent: lint/rules/index
 ---
 
-# useValidLang (since v12.0.0)
+# useValidLang (since vnext)
 
 Ensure that the attribute passed to the `lang` attribute is a correct ISO language and/or country.
 

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -44,7 +44,7 @@ declare_rule! {{
     /// ```
     ///
     pub(crate) {rule_name_upper_camel} {{
-        version: "12.0.0",
+        version: "next",
         name: "{rule_name_lower_camel}",
         recommended: false,
     }}
@@ -55,14 +55,14 @@ impl Rule for {rule_name_upper_camel} {{
     type State = Reference;
     type Signals = Vec<Self::State>;
     type Options = ();
-    
+
     fn run(ctx: &RuleContext<Self>) -> Vec<Self::State> {{
         let binding = ctx.query();
         let model = ctx.model();
 
         binding.all_references(model).collect()
     }}
-    
+
     fn diagnostic(_: &RuleContext<Self>, reference: &Self::State) -> Option<RuleDiagnostic> {{
         Some(
             RuleDiagnostic::new(


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR changes the new rules that have `version: "12.0.0."` to `version: "next"`.

Considering that we don't know yet the entity of the new version, `"next"` is actually the best way to have rules that are under development.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Codegen

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
