### PR TITLE
refactor(rome_js_analyze): `has_truthy_value`

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/nursery/no_redundant_alt.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_redundant_alt.rs
@@ -59,25 +59,11 @@ impl Rule for NoRedundantAlt {
         }
         let aria_hidden_attribute = node.find_attribute_by_name("aria-hidden");
         if let Some(aria_hidden) = aria_hidden_attribute {
-            let is_false = match aria_hidden.initializer()?.value().ok()? {
-                AnyJsxAttributeValue::AnyJsxTag(_) => false,
-                AnyJsxAttributeValue::JsxExpressionAttributeValue(aria_hidden) => {
-                    aria_hidden
-                        .expression()
-                        .ok()?
-                        .as_any_js_literal_expression()?
-                        .as_js_boolean_literal_expression()?
-                        .value_token()
-                        .ok()?
-                        .text_trimmed()
-                        == "false"
-                }
-                AnyJsxAttributeValue::JsxString(aria_hidden) => {
-                    aria_hidden.inner_string_text().ok()? == "false"
-                }
-            };
+            let has_truthy_value = aria_hidden
+                .has_truthy_value(|value| value.text() == "true")
+                .ok()?;
 
-            if !is_false {
+            if has_truthy_value {
                 return None;
             }
         }

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery/use_aria_prop_types.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery/use_aria_prop_types.rs
@@ -3,11 +3,8 @@ use rome_analyze::context::RuleContext;
 use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_aria::AriaPropertyTypeEnum;
 use rome_console::markup;
-use rome_js_syntax::{
-    AnyJsExpression, AnyJsLiteralExpression, AnyJsxAttributeValue, JsSyntaxToken, JsxAttribute,
-    TextRange,
-};
-use rome_rowan::{AstNode, AstNodeList};
+use rome_js_syntax::{JsSyntaxToken, JsxAttribute, TextRange};
+use rome_rowan::AstNode;
 use std::slice::Iter;
 
 declare_rule! {
@@ -76,42 +73,13 @@ impl Rule for UseAriaPropTypes {
         let attribute_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
 
         if let Some(aria_property) = aria_properties.get_property(attribute_name.text_trimmed()) {
-            let attribute_value = node.initializer()?.value().ok()?;
             let attribute_value_range = node.range();
-            let attribute_text = match attribute_value {
-                AnyJsxAttributeValue::JsxString(string) => Some(string.inner_string_text().ok()?),
-                AnyJsxAttributeValue::JsxExpressionAttributeValue(expression) => {
-                    match expression.expression().ok()? {
-                        AnyJsExpression::JsTemplateExpression(template) => {
-                            if template.elements().is_empty() {
-                                // Early error, the template literal is empty
-                                return Some(UseAriaProptypesState {
-                                    attribute_value_range,
-                                    allowed_values: aria_property.values(),
-                                    attribute_name,
-                                    property_type: aria_property.property_type(),
-                                });
-                            }
-                            template.elements().iter().next().and_then(|chunk| {
-                                Some(
-                                    chunk
-                                        .as_js_template_chunk_element()?
-                                        .template_chunk_token()
-                                        .ok()?
-                                        .token_text_trimmed(),
-                                )
-                            })
-                        }
-                        AnyJsExpression::AnyJsLiteralExpression(
-                            AnyJsLiteralExpression::JsStringLiteralExpression(string),
-                        ) => Some(string.inner_string_text().ok()?),
-                        _ => None,
-                    }
-                }
-                _ => return None,
-            }?;
-
-            if !aria_property.contains_correct_value(attribute_text.text()) {
+            if !node
+                .has_truthy_value(|value| {
+                    !value.text().is_empty() && aria_property.contains_correct_value(value.text())
+                })
+                .ok()?
+            {
                 return Some(UseAriaProptypesState {
                     attribute_value_range,
                     allowed_values: aria_property.values(),

--- a/crates/rome_js_syntax/src/jsx_ext.rs
+++ b/crates/rome_js_syntax/src/jsx_ext.rs
@@ -499,7 +499,7 @@ impl JsxAttribute {
                 _ => None,
             };
 
-            Ok(result.map(|token| closure(token)).unwrap_or(true))
+            Ok(result.map(closure).unwrap_or(true))
         } else {
             // values that don't have initializer get a `true` at compile time, making them
             // truthy


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR refactors some common logic among some rules; the new code is now implemented as API for the `JsxAttribute`.

This is a pattern that is popping up in our rules, it was good to have a specialized function that checks value of the attributes.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current snapshots should not change.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
