### PR TITLE
feat(rome_cli): rename `--apply-suggested` to `--apply-unsafe`

### DIFF
--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -15,12 +15,12 @@ pub(crate) fn check(mut session: CliSession) -> Result<(), CliDiagnostic> {
         .update_settings(UpdateSettingsParams { configuration })?;
 
     let apply = session.args.contains("--apply");
-    let apply_suggested = session.args.contains("--apply-suggested");
+    let apply_suggested = session.args.contains("--apply-unsafe");
 
     let fix_file_mode = if apply && apply_suggested {
         return Err(CliDiagnostic::incompatible_arguments(
             "--apply",
-            "--apply-suggested",
+            "--apply-unsafe",
         ));
     } else if !apply && !apply_suggested {
         None

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -35,7 +35,7 @@ const CHECK: Markup = markup! {
 
 "<Emphasis>"OPTIONS:"</Emphasis>"
     "<Dim>"--apply"</Dim>"                       Apply safe fixes
-    "<Dim>"--apply-suggested"</Dim>"             Apply safe and suggested fixes
+    "<Dim>"--apply-unsafe"</Dim>"                Apply safe and unsafe fixes
     "<Dim>"--max-diagnostics"</Dim>"             Cap the amount of diagnostics displayed (default: 20)
     "<Dim>"--verbose"</Dim>"                     Print additional verbose advices on diagnostics
 "

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -569,7 +569,7 @@ fn process_messages(options: ProcessMessagesOptions) {
     if mode.is_check() && total_skipped_suggested_fixes > 0 {
         console.log(markup! {
             <Warn>"Skipped "{total_skipped_suggested_fixes}" suggested fixes.\n"</Warn>
-            <Info>"If you wish to apply the suggested fixes, use the command "<Emphasis>"rome check --apply-suggested\n"</Emphasis></Info>
+            <Info>"If you wish to apply the suggested (unsafe) fixes, use the command "<Emphasis>"rome check --apply-unsafe\n"</Emphasis></Info>
         })
     }
 

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -278,7 +278,7 @@ fn apply_suggested_error() {
         &mut console,
         Arguments::from_vec(vec![
             OsString::from("check"),
-            OsString::from("--apply-suggested"),
+            OsString::from("--apply-unsafe"),
             OsString::from("--apply"),
             file_path.as_os_str().into(),
         ]),
@@ -308,7 +308,7 @@ fn apply_suggested() {
         &mut console,
         Arguments::from_vec(vec![
             OsString::from("check"),
-            OsString::from("--apply-suggested"),
+            OsString::from("--apply-unsafe"),
             file_path.as_os_str().into(),
         ]),
     );

--- a/crates/rome_cli/tests/snapshots/main_commands_check/apply_noop.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/apply_noop.snap
@@ -14,7 +14,7 @@ if(a != 0) {}
 
 ```block
 Skipped 1 suggested fixes.
-If you wish to apply the suggested fixes, use the command rome check --apply-suggested
+If you wish to apply the suggested (unsafe) fixes, use the command rome check --apply-unsafe
 
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/apply_ok.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/apply_ok.snap
@@ -14,7 +14,7 @@ if(a != 0) {}
 
 ```block
 Skipped 1 suggested fixes.
-If you wish to apply the suggested fixes, use the command rome check --apply-suggested
+If you wish to apply the suggested (unsafe) fixes, use the command rome check --apply-unsafe
 
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/apply_suggested_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/apply_suggested_error.snap
@@ -16,7 +16,7 @@ console.log(a);
 ```block
 flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Incompatible arguments --apply and --apply-suggested
+  × Incompatible arguments --apply and --apply-unsafe
   
 
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/should_disable_a_rule_group.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/should_disable_a_rule_group.snap
@@ -32,7 +32,7 @@ try {
 
 ```block
 Skipped 1 suggested fixes.
-If you wish to apply the suggested fixes, use the command rome check --apply-suggested
+If you wish to apply the suggested (unsafe) fixes, use the command rome check --apply-unsafe
 
 ```
 


### PR DESCRIPTION
BREAKING CHANGE: rename `--apply-suggested` to `--apply-unsafe`

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to the changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #3782 

In #3782, some users expressed that the argument's name doesn't sufficiently describe its intent and result. This PR changes the name of `--apply-suggested` to `--apply-unsafe`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I updated the snapshot tests. The current CI should work.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
