### PR TITLE
fix(rome_lsp): handle did_change changes correctly regardless of order

### DIFF
--- a/crates/rome_lsp/src/handlers/text_document.rs
+++ b/crates/rome_lsp/src/handlers/text_document.rs
@@ -47,8 +47,8 @@ pub(crate) async fn did_change(
     let version = params.text_document.version;
 
     let rome_path = session.file_path(&url)?;
-    let doc = session.document(&url)?;
 
+    let mut doc = session.document(&url)?;
     let mut content = doc.content;
     tracing::trace!("old document: {content:?}");
 
@@ -59,6 +59,7 @@ pub(crate) async fn did_change(
                 let range = Range::<usize>::from(text_range);
                 tracing::trace!("replace range {range:?} with {:?}", change.text);
                 content.replace_range(range, &change.text);
+                doc = Document::new(version, &content);
             }
             None => {
                 tracing::trace!("replace content {:?}", change.text);
@@ -69,7 +70,7 @@ pub(crate) async fn did_change(
 
     tracing::trace!("new document: {content:?}");
 
-    let doc = Document::new(version, &content);
+    doc = Document::new(version, &content);
 
     session.workspace.change_file(ChangeFileParams {
         path: rome_path,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes a bug with handling of the incremental changes passed through the `textDocument/didChange` LSP request. When changes were ordered from top-to-bottom then server failed to apply correctly subsequent changes since the line_index has to be calculated relative to the document state with previous change applied. When changes are ordered from bottom-to-top then things happen to work correctly.

Fixes #4094

(Note that I don't really code in Rust so make sure to review my 3 lines of changes thoroughly. :))

## Test Plan

Added a test that has changes ordered from top-to-bottom rather than bottom-to-top like the existing [document_lifecycle test](https://github.com/rome/tools/blob/ab659119a27485c2c6922337e6e08d03c1c8ed37/crates/rome_lsp/tests/server.rs#L323-L323) that doesn't reproduce the issue.
And to make the test more tricky, first change removes first line completely so that next changes have to re-adjust start line index.

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
