### PR TITLE
chore: Upgrade to Rust 1.66.0

### DIFF
--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -380,7 +380,7 @@ mod tests {
             &mut emit_signal,
         );
 
-        analyzer.add_visitor(Phases::Syntax, Box::new(SyntaxVisitor::default()));
+        analyzer.add_visitor(Phases::Syntax, Box::<SyntaxVisitor<RawLanguage>>::default());
 
         let ctx: AnalyzerContext<RawLanguage> = AnalyzerContext {
             file_id: FileId::zero(),

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -161,7 +161,7 @@ mod tests {
             &mut emit_signal,
         );
 
-        analyzer.add_visitor(Phases::Syntax, Box::new(SyntaxVisitor::default()));
+        analyzer.add_visitor(Phases::Syntax, Box::<SyntaxVisitor<RawLanguage>>::default());
 
         let ctx: AnalyzerContext<RawLanguage> = AnalyzerContext {
             file_id: FileId::zero(),

--- a/crates/rome_cli/tests/commands/rage.rs
+++ b/crates/rome_cli/tests/commands/rage.rs
@@ -101,7 +101,7 @@ fn with_server_logs() {
         let log_dir = TestLogDir::new("rome-test-logs");
         fs::create_dir_all(&log_dir.path).expect("Failed to create test log directory");
 
-        fs::write(&log_dir.path.join("server.log.2022-10-14-16"), r#"
+        fs::write(log_dir.path.join("server.log.2022-10-14-16"), r#"
 ┐rome_cli::commands::daemon::Running Server{pid=195434}
 ├─2547ms INFO rome_lsp::server Starting Rome Language Server...
 ├─15333ms INFO rome_lsp::server Starting Rome Language Server...
@@ -135,7 +135,7 @@ INFO rome_cli::commands::daemon Received shutdown signal
         ).expect("Failed to write log file");
 
         fs::write(
-            &log_dir.path.join("server.log.2022-10-14-15"),
+            log_dir.path.join("server.log.2022-10-14-15"),
             r#"
 Not most recent log file
 "#,

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_enum_initializers.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_enum_initializers.rs
@@ -113,7 +113,7 @@ impl Rule for UseEnumInitializers {
                 AnyJsLiteralExpression::JsNumberLiteralExpression(expr) => {
                     Some(AnyJsLiteralExpression::JsNumberLiteralExpression(
                         make::js_number_literal_expression(make::js_number_literal(
-                            expr.as_number()? + f64::from(count as i32),
+                            expr.as_number()? + f64::from(count),
                         )),
                     ))
                 }

--- a/crates/rome_js_parser/src/lexer/mod.rs
+++ b/crates/rome_js_parser/src/lexer/mod.rs
@@ -776,7 +776,7 @@ impl<'src> Lexer<'src> {
                     self.diagnostics.push(diagnostic);
                     return false;
                 }
-                Some(b) if !(b as u8).is_ascii_hexdigit() => {
+                Some(b) if !b.is_ascii_hexdigit() => {
                     self.diagnostics.push(diagnostic);
                     return false;
                 }
@@ -1975,7 +1975,7 @@ impl<'src> Lexer<'src> {
                     } else {
                         let err = ParseDiagnostic::new(
                             self.file_id,
-                            format!("Unexpected token `{}`", chr as char),
+                            format!("Unexpected token `{}`", chr),
                             start..self.position + 1,
                         );
                         self.diagnostics.push(err);

--- a/crates/rome_js_parser/src/syntax/module.rs
+++ b/crates/rome_js_parser/src/syntax/module.rs
@@ -1128,7 +1128,7 @@ fn parse_export_default_clause(p: &mut JsParser) -> ParsedSyntax {
                     )
                     .detail(clause.range(p), "multiple default exports are erroneous")
                     .detail(
-                        &existing_default_item.range.to_owned(),
+                        existing_default_item.range.to_owned(),
                         "the module's default export is first defined here",
                     );
 

--- a/crates/rome_js_parser/src/syntax/typescript/ts_parse_error.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/ts_parse_error.rs
@@ -26,7 +26,7 @@ pub(crate) fn ts_member_cannot_be(
     modifier_name: &str,
 ) -> ParseDiagnostic {
     let msg = format!("{} members cannot be {}", member_type_name, modifier_name);
-    p.err_builder(&msg, range)
+    p.err_builder(msg, range)
 }
 
 pub(crate) fn ts_modifier_cannot_appear_on_a_constructor_declaration(

--- a/crates/rome_json_parser/src/lexer/mod.rs
+++ b/crates/rome_json_parser/src/lexer/mod.rs
@@ -517,7 +517,7 @@ impl<'src> Lexer<'src> {
                                     ParseDiagnostic::new(
                                         self.file_id,
                                         "Invalid escape sequence",
-                                        escape_start..self.text_position() + (c as char).text_len(),
+                                        escape_start..self.text_position() + c.text_len(),
                                     )
                                         .hint(r#"Valid escape sequences are: `\\`, `\/`, `/"`, `\b\`, `\f`, `\n`, `\r`, `\t` or any unicode escape sequence `\uXXXX` where X is hexedecimal number. "#),
                                 );

--- a/crates/rome_lsp/src/utils.rs
+++ b/crates/rome_lsp/src/utils.rs
@@ -38,8 +38,8 @@ pub(crate) fn range(line_index: &LineIndex, range: TextRange) -> Result<lsp::Ran
 
 pub(crate) fn offset(line_index: &LineIndex, position: lsp::Position) -> Result<TextSize> {
     let line_col = LineCol {
-        line: position.line as u32,
-        col: position.character as u32,
+        line: position.line,
+        col: position.character,
     };
 
     line_index

--- a/crates/rome_parser/src/diagnostic.rs
+++ b/crates/rome_parser/src/diagnostic.rs
@@ -392,7 +392,7 @@ impl<P: Parser> ToDiagnostic<P> for ExpectedNodeDiagnosticBuilder {
             )
         };
 
-        let diag = p.err_builder(&msg, self.range);
+        let diag = p.err_builder(msg, self.range);
         diag.detail(self.range, format!("Expected {} here", self.names))
     }
 }

--- a/crates/rome_parser/src/marker.rs
+++ b/crates/rome_parser/src/marker.rs
@@ -209,7 +209,7 @@ impl CompletedMarker {
         }
         new_pos.child_idx = Some(self.start_pos as usize);
         new_pos.start = self.offset;
-        new_pos.old_start(self.old_start as u32)
+        new_pos.old_start(self.old_start)
     }
 
     /// Undo this completion and turns into a `Marker`

--- a/crates/rome_rowan/src/cursor/element.rs
+++ b/crates/rome_rowan/src/cursor/element.rs
@@ -14,12 +14,8 @@ impl SyntaxElement {
         offset: TextSize,
     ) -> SyntaxElement {
         match element {
-            NodeOrToken::Node(node) => {
-                SyntaxNode::new_child(node, parent, slot as u32, offset).into()
-            }
-            NodeOrToken::Token(token) => {
-                SyntaxToken::new(token, parent, slot as u32, offset).into()
-            }
+            NodeOrToken::Node(node) => SyntaxNode::new_child(node, parent, slot, offset).into(),
+            NodeOrToken::Token(token) => SyntaxToken::new(token, parent, slot, offset).into(),
         }
     }
 

--- a/crates/rome_rowan/src/cursor/node.rs
+++ b/crates/rome_rowan/src/cursor/node.rs
@@ -182,7 +182,7 @@ impl SyntaxNode {
                 SyntaxToken::new(
                     token,
                     self.clone(),
-                    child.slot() as u32,
+                    child.slot(),
                     self.offset() + child.rel_offset(),
                 )
             })
@@ -195,7 +195,7 @@ impl SyntaxNode {
                 SyntaxNode::new_child(
                     green,
                     self.clone(),
-                    child.slot() as u32,
+                    child.slot(),
                     self.offset() + child.rel_offset(),
                 )
             })

--- a/crates/tests_macros/src/lib.rs
+++ b/crates/tests_macros/src/lib.rs
@@ -159,7 +159,7 @@ impl Arguments {
             syn::Lit::Str(v) => v.value(),
             _ => return Err("Only string literals supported"),
         };
-        let walker = GlobWalkerBuilder::new(base, &glob)
+        let walker = GlobWalkerBuilder::new(base, glob)
             .build()
             .map_err(|_| "Cannot walk the requested glob")?;
 
@@ -210,7 +210,7 @@ impl Arguments {
                 test_full_path,
                 test_expected_fullpath,
                 test_directory,
-            } = Arguments::get_variables(&file).ok_or("Cannot generate variables for this file")?;
+            } = Arguments::get_variables(file).ok_or("Cannot generate variables for this file")?;
 
             let test_name = transform_file_name(&test_name);
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.65.0"
+channel = "1.66.0"

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -625,7 +625,7 @@ impl NodeModuleInformation {
             .join("src")
             .join(self.dialect.as_str())
             .join(self.concept.as_str())
-            .join(&format!("{}.rs", self.name))
+            .join(format!("{}.rs", self.name))
     }
 }
 

--- a/xtask/codegen/src/generate_analyzer.rs
+++ b/xtask/codegen/src/generate_analyzer.rs
@@ -89,7 +89,7 @@ fn generate_category(
         },
     );
 
-    let (modules, paths): (Vec<_>, Vec<_>) = groups.into_iter().map(|(_, tokens)| tokens).unzip();
+    let (modules, paths): (Vec<_>, Vec<_>) = groups.into_values().unzip();
     let tokens = xtask::reformat(quote! {
         #( #modules )*
         ::rome_analyze::declare_category! {
@@ -148,8 +148,7 @@ fn generate_group(category: &'static str, group: &str) -> Result<()> {
 
     let group_name = format_ident!("{}", to_camel_case(group)?);
 
-    let (rule_imports, rule_names): (Vec<_>, Vec<_>) =
-        rules.into_iter().map(|(_, tokens)| tokens).unzip();
+    let (rule_imports, rule_names): (Vec<_>, Vec<_>) = rules.into_values().unzip();
 
     let tokens = xtask::reformat(quote! {
         use rome_analyze::declare_group;

--- a/xtask/coverage/src/lib.rs
+++ b/xtask/coverage/src/lib.rs
@@ -124,10 +124,10 @@ pub fn run(
     json: bool,
     detail_level: SummaryDetailLevel,
 ) {
-    let mut reporters = MulticastTestReporter::new(Box::new(DefaultReporter::default()));
+    let mut reporters = MulticastTestReporter::new(Box::<DefaultReporter>::default());
 
     let output_target = if json {
-        reporters.add(Box::new(JsonReporter::default()));
+        reporters.add(Box::<JsonReporter>::default());
         OutputTarget::stderr()
     } else {
         OutputTarget::stdout()

--- a/xtask/coverage/src/ts/ts_microsoft.rs
+++ b/xtask/coverage/src/ts/ts_microsoft.rs
@@ -221,7 +221,7 @@ fn should_error(name: &str, run_options: &[String]) -> bool {
             .map(|name| format!("{name}({option}).errors.txt"))
             .unwrap();
 
-        let path = Path::new(REFERENCE_PATH).join(&errors_file_name);
+        let path = Path::new(REFERENCE_PATH).join(errors_file_name);
 
         path.exists()
     })


### PR DESCRIPTION
## Summary

Upgrades the Rust toolchain to version [1.66.0](https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html)

## Test Plan

`cargo build && cargo test` 

## Documentation


- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
