### PR TITLE
refactor(rome_js_parser): Inroduce TypeContext

### DIFF
--- a/crates/rome_js_parser/src/state.rs
+++ b/crates/rome_js_parser/src/state.rs
@@ -164,12 +164,6 @@ impl ParserState {
             .contains(ParsingContextFlags::BREAK_ALLOWED)
     }
 
-    pub fn allow_conditional_type(&self) -> bool {
-        !self
-            .parsing_context
-            .contains(ParsingContextFlags::DISALLOW_CONDITIONAL_TYPE)
-    }
-
     pub fn strict(&self) -> Option<&StrictMode> {
         self.strict.as_ref()
     }
@@ -377,7 +371,7 @@ bitflags! {
     ///   snapshots each individual boolean field to allow restoring the previous state. With bitflags, all that
     ///   is needed is to copy away the flags field and restore it after.
     #[derive(Default)]
-    pub(crate) struct ParsingContextFlags: u16 {
+    pub(crate) struct ParsingContextFlags: u8 {
         /// Whether the parser is in a generator function like `function* a() {}`
         /// Matches the `Yield` parameter in the ECMA spec
         const IN_GENERATOR = 1 << 0;
@@ -402,8 +396,6 @@ bitflags! {
 
         /// Whatever the parser is in a TypeScript ambient context
         const AMBIENT_CONTEXT = 1 << 7;
-
-        const DISALLOW_CONDITIONAL_TYPE = 1 << 8;
 
         const LOOP = Self::BREAK_ALLOWED.bits | Self::CONTINUE_ALLOWED.bits;
 
@@ -585,27 +577,6 @@ pub(crate) struct EnterType;
 impl ChangeParserStateFlags for EnterType {
     fn compute_new_flags(&self, existing: ParsingContextFlags) -> ParsingContextFlags {
         existing - ParsingContextFlags::IN_ASYNC - ParsingContextFlags::IN_GENERATOR
-    }
-}
-
-pub(crate) struct EnterConditionalTypes(bool);
-
-impl EnterConditionalTypes {
-    pub(crate) const fn allow() -> Self {
-        Self(true)
-    }
-    pub(crate) const fn disallow() -> Self {
-        Self(false)
-    }
-}
-
-impl ChangeParserStateFlags for EnterConditionalTypes {
-    fn compute_new_flags(&self, existing: ParsingContextFlags) -> ParsingContextFlags {
-        if self.0 {
-            existing - ParsingContextFlags::DISALLOW_CONDITIONAL_TYPE
-        } else {
-            existing | ParsingContextFlags::DISALLOW_CONDITIONAL_TYPE
-        }
     }
 }
 

--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -592,7 +592,7 @@ fn parse_binary_or_logical_expression_recursive(
         // as;
         // let precedence = "hello" as const + 3 as number as number;
         if op == T![as] {
-            parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
+            parse_ts_type(p, TypeContext::default()).or_add_diagnostic(p, expected_ts_type);
             let mut as_expression = m.complete(p, TS_AS_EXPRESSION);
 
             if TypeScript.is_unsupported(p) {
@@ -621,7 +621,7 @@ fn parse_binary_or_logical_expression_recursive(
         // test_err ts_satisfies_expression
         // let x = "hello" satisfies string;
         if op == T![satisfies] {
-            parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
+            parse_ts_type(p, TypeContext::default()).or_add_diagnostic(p, expected_ts_type);
             let mut satisfies_expression = m.complete(p, TS_SATISFIES_EXPRESSION);
 
             if TypeScript.is_unsupported(p) {

--- a/crates/rome_js_parser/src/syntax/stmt.rs
+++ b/crates/rome_js_parser/src/syntax/stmt.rs
@@ -1835,7 +1835,7 @@ fn parse_catch_declaration(p: &mut JsParser) -> ParsedSyntax {
                     let annotation = p.start();
                     p.bump(T![:]);
 
-                    if let Some(ty) = parse_ts_type(p).or_add_diagnostic(p, expected_ts_type) {
+                    if let Some(ty) = parse_ts_type(p, TypeContext::default()).or_add_diagnostic(p, expected_ts_type) {
                         if !matches!(ty.kind(p), TS_ANY_TYPE | TS_UNKNOWN_TYPE) {
                             p.error(
                                 p

--- a/crates/rome_js_parser/src/syntax/typescript.rs
+++ b/crates/rome_js_parser/src/syntax/typescript.rs
@@ -73,7 +73,7 @@ pub(crate) fn parse_ts_type_assertion_expression(
 
     let m = p.start();
     p.bump(T![<]);
-    parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
+    parse_ts_type(p, TypeContext::default()).or_add_diagnostic(p, expected_ts_type);
     p.expect(T![>]);
     parse_unary_expr(p, context).or_add_diagnostic(p, expected_expression);
     Present(m.complete(p, TS_TYPE_ASSERTION_EXPRESSION))

--- a/crates/rome_js_parser/src/syntax/typescript/statement.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/statement.rs
@@ -15,7 +15,7 @@ use crate::syntax::stmt::{semi, STMT_RECOVERY_SET};
 use crate::syntax::typescript::ts_parse_error::expected_ts_type;
 use crate::syntax::typescript::{
     expect_ts_type_list, parse_ts_identifier_binding, parse_ts_implements_clause, parse_ts_name,
-    parse_ts_type, parse_ts_type_parameters, TypeMembers,
+    parse_ts_type, parse_ts_type_parameters, TypeContext, TypeMembers,
 };
 use crate::{syntax, Absent, JsParser, ParseRecovery, ParsedSyntax, Present};
 use rome_js_syntax::{JsSyntaxKind::*, *};
@@ -207,9 +207,9 @@ pub(crate) fn parse_ts_type_alias_declaration(p: &mut JsParser) -> ParsedSyntax 
     p.expect(T![type]);
     parse_ts_identifier_binding(p, super::TsIdentifierContext::Type)
         .or_add_diagnostic(p, expected_identifier);
-    parse_ts_type_parameters(p).ok();
+    parse_ts_type_parameters(p, TypeContext::default()).ok();
     p.expect(T![=]);
-    parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
+    parse_ts_type(p, TypeContext::default()).or_add_diagnostic(p, expected_ts_type);
 
     semi(p, TextRange::new(start, p.cur_range().end()));
 
@@ -298,7 +298,7 @@ pub(crate) fn parse_ts_interface_declaration(p: &mut JsParser) -> ParsedSyntax {
     p.expect(T![interface]);
     parse_ts_identifier_binding(p, super::TsIdentifierContext::Type)
         .or_add_diagnostic(p, expected_identifier);
-    parse_ts_type_parameters(p).ok();
+    parse_ts_type_parameters(p, TypeContext::default()).ok();
     eat_interface_heritage_clause(p);
     p.expect(T!['{']);
     TypeMembers.parse_list(p);


### PR DESCRIPTION
## Summary

This PR moves the state tracking if conditional types are allowed from the `ParserState` into a new `TypeContext` explicitly passed as an argument to type parsing methods, similar to the `ExpressionContext` for parsing expressions.

The advantage of an passing the context as an argument over an additional flag on the state is that it is easier to reason about the state of the parser and avoids accidental "leaking" of the conditional types when switching between parsing types and expressions (as it is the case when parsing the function parameters).


## Test Plan

I verified that the fixed regressions are intentional. 

## Documentation


- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
