### PR TITLE
feat(rome_service): recycle the node cache across parsing sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,6 +3086,7 @@ dependencies = [
  "rome_json_parser",
  "rome_json_syntax",
  "rome_parser",
+ "rome_rowan",
  "tikv-jemallocator",
  "timing",
  "ureq",

--- a/crates/rome_js_parser/src/parse.rs
+++ b/crates/rome_js_parser/src/parse.rs
@@ -9,7 +9,7 @@ use rome_parser::event::Event;
 use rome_parser::token_source::Trivia;
 use rome_parser::AnyParse;
 
-use rome_rowan::AstNode;
+use rome_rowan::{AstNode, NodeCache};
 use std::marker::PhantomData;
 
 /// A utility struct for managing the result of a parser job
@@ -193,15 +193,24 @@ pub fn parse_module(text: &str) -> Parse<JsModule> {
 
 /// Parses the provided string as a EcmaScript program using the provided syntax features.
 pub fn parse(text: &str, source_type: SourceType) -> Parse<AnyJsRoot> {
+    let mut cache = NodeCache::default();
+    parse_with_cache(text, source_type, &mut cache)
+}
+
+/// Parses the provided string as a EcmaScript program using the provided syntax features and node cache.
+pub fn parse_with_cache(
+    text: &str,
+    source_type: SourceType,
+    cache: &mut NodeCache,
+) -> Parse<AnyJsRoot> {
     tracing::debug_span!("parse").in_scope(move || {
         let (events, errors, tokens) = parse_common(text, source_type);
-        let mut tree_sink = JsLosslessTreeSink::new(text, &tokens);
+        let mut tree_sink = JsLosslessTreeSink::with_cache(text, &tokens, cache);
         rome_parser::event::process(&mut tree_sink, events, errors);
         let (green, parse_errors) = tree_sink.finish();
         Parse::new(green, parse_errors)
     })
 }
-
 /// Losslessly Parse text into an expression [`Parse`](Parse) which can then be turned into an untyped root [`JsSyntaxNode`](JsSyntaxNode).
 /// Or turned into a typed [`JsExpressionSnipped`](JsExpressionSnipped) with [`tree`](Parse::tree).
 pub fn parse_expression(text: &str) -> Parse<JsExpressionSnipped> {

--- a/crates/rome_js_parser/src/parse.rs
+++ b/crates/rome_js_parser/src/parse.rs
@@ -194,11 +194,11 @@ pub fn parse_module(text: &str) -> Parse<JsModule> {
 /// Parses the provided string as a EcmaScript program using the provided syntax features.
 pub fn parse(text: &str, source_type: SourceType) -> Parse<AnyJsRoot> {
     let mut cache = NodeCache::default();
-    parse_with_cache(text, source_type, &mut cache)
+    parse_js_with_cache(text, source_type, &mut cache)
 }
 
 /// Parses the provided string as a EcmaScript program using the provided syntax features and node cache.
-pub fn parse_with_cache(
+pub fn parse_js_with_cache(
     text: &str,
     source_type: SourceType,
     cache: &mut NodeCache,

--- a/crates/rome_json_parser/src/lib.rs
+++ b/crates/rome_json_parser/src/lib.rs
@@ -7,7 +7,7 @@ use rome_json_syntax::{JsonLanguage, JsonRoot, JsonSyntaxNode};
 pub use rome_parser::prelude::*;
 use rome_parser::tree_sink::LosslessTreeSink;
 use rome_parser::AnyParse;
-use rome_rowan::AstNode;
+use rome_rowan::{AstNode, NodeCache};
 
 mod lexer;
 mod parser;
@@ -19,6 +19,11 @@ pub(crate) type JsonLosslessTreeSink<'source> =
     LosslessTreeSink<'source, JsonLanguage, JsonSyntaxFactory>;
 
 pub fn parse_json(source: &str) -> JsonParse {
+    let mut cache = NodeCache::default();
+    parse_json_with_cache(source, &mut cache)
+}
+
+pub fn parse_json_with_cache(source: &str, cache: &mut NodeCache) -> JsonParse {
     tracing::debug_span!("parse").in_scope(move || {
         let mut parser = JsonParser::new(source);
 
@@ -26,7 +31,7 @@ pub fn parse_json(source: &str) -> JsonParse {
 
         let (events, diagnostics, trivia) = parser.finish();
 
-        let mut tree_sink = JsonLosslessTreeSink::new(source, &trivia);
+        let mut tree_sink = JsonLosslessTreeSink::with_cache(source, &trivia, cache);
         rome_parser::event::process(&mut tree_sink, events, diagnostics);
         let (green, diagnostics) = tree_sink.finish();
 

--- a/crates/rome_json_parser/src/lib.rs
+++ b/crates/rome_json_parser/src/lib.rs
@@ -23,6 +23,7 @@ pub fn parse_json(source: &str) -> JsonParse {
     parse_json_with_cache(source, &mut cache)
 }
 
+/// Parses the provided string as JSON program using the provided node cache.
 pub fn parse_json_with_cache(source: &str, cache: &mut NodeCache) -> JsonParse {
     tracing::debug_span!("parse").in_scope(move || {
         let mut parser = JsonParser::new(source);

--- a/crates/rome_parser/src/tree_sink.rs
+++ b/crates/rome_parser/src/tree_sink.rs
@@ -94,6 +94,8 @@ where
         }
     }
 
+    /// Reusing `NodeCache` between different [LosslessTreeSink]`s saves memory.
+    /// It allows to structurally share underlying trees.
     pub fn with_cache(text: &'a str, trivia: &'a [Trivia], cache: &'a mut NodeCache) -> Self {
         Self {
             text,

--- a/crates/rome_parser/src/tree_sink.rs
+++ b/crates/rome_parser/src/tree_sink.rs
@@ -94,7 +94,7 @@ where
         }
     }
 
-    /// Reusing `NodeCache` between different [LosslessTreeSink]`s saves memory.
+    /// Reusing `NodeCache` between different [LosslessTreeSink]s saves memory.
     /// It allows to structurally share underlying trees.
     pub fn with_cache(text: &'a str, trivia: &'a [Trivia], cache: &'a mut NodeCache) -> Self {
         Self {

--- a/crates/rome_parser/src/tree_sink.rs
+++ b/crates/rome_parser/src/tree_sink.rs
@@ -1,7 +1,8 @@
 use crate::prelude::*;
 use crate::token_source::Trivia;
 use rome_rowan::{
-    Language, SyntaxFactory, SyntaxKind, SyntaxNode, TextRange, TextSize, TreeBuilder, TriviaPiece,
+    Language, NodeCache, SyntaxFactory, SyntaxKind, SyntaxNode, TextRange, TextSize, TreeBuilder,
+    TriviaPiece,
 };
 
 /// An abstraction for syntax tree implementations
@@ -37,7 +38,7 @@ where
     trivia_pos: usize,
     parents_count: usize,
     errors: Vec<ParseDiagnostic>,
-    inner: TreeBuilder<'static, L, Factory>,
+    inner: TreeBuilder<'a, L, Factory>,
     /// Signal that the sink must generate an EOF token when its finishing. See [LosslessTreeSink::finish] for more details.
     needs_eof: bool,
     trivia_pieces: Vec<TriviaPiece>,
@@ -87,6 +88,20 @@ where
             trivia_pos: 0,
             parents_count: 0,
             inner: TreeBuilder::default(),
+            errors: vec![],
+            needs_eof: true,
+            trivia_pieces: Vec::with_capacity(128),
+        }
+    }
+
+    pub fn with_cache(text: &'a str, trivia: &'a [Trivia], cache: &'a mut NodeCache) -> Self {
+        Self {
+            text,
+            trivia_list: trivia,
+            text_pos: 0.into(),
+            trivia_pos: 0,
+            parents_count: 0,
+            inner: TreeBuilder::with_cache(cache),
             errors: vec![],
             needs_eof: true,
             trivia_pieces: Vec::with_capacity(128),

--- a/crates/rome_rowan/src/arc.rs
+++ b/crates/rome_rowan/src/arc.rs
@@ -6,7 +6,7 @@ use std::{
     marker::PhantomData,
     mem::{self, ManuallyDrop},
     ops::Deref,
-    ptr,
+    ptr::{self, NonNull},
     sync::atomic::{
         self,
         Ordering::{Acquire, Relaxed, Release},
@@ -91,6 +91,13 @@ impl<T: ?Sized> Arc<T> {
 
     pub(crate) fn ptr(&self) -> *mut ArcInner<T> {
         self.p.as_ptr()
+    }
+
+    #[inline]
+    pub(crate) fn into_raw(self) -> NonNull<T> {
+        let ptr = NonNull::from(&self.inner().data);
+        mem::forget(self);
+        ptr
     }
 }
 

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -7,7 +7,6 @@ mod trivia;
 pub(crate) use self::{
     element::{GreenElement, GreenElementRef},
     node::{Child, Children, GreenNode, GreenNodeData, Slot},
-    node_cache::LiveSet,
     token::{GreenToken, GreenTokenData},
     trivia::GreenTrivia,
 };

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -7,6 +7,7 @@ mod trivia;
 pub(crate) use self::{
     element::{GreenElement, GreenElementRef},
     node::{Child, Children, GreenNode, GreenNodeData, Slot},
+    node_cache::LiveSet,
     token::{GreenToken, GreenTokenData},
     trivia::GreenTrivia,
 };

--- a/crates/rome_rowan/src/green/node.rs
+++ b/crates/rome_rowan/src/green/node.rs
@@ -282,6 +282,13 @@ impl GreenNode {
     }
 
     #[inline]
+    pub(crate) fn into_raw(self) -> ptr::NonNull<GreenNodeData> {
+        // SAFETY: casting from `HeaderSlice<GreenNodeHead, [green::node::Slot]>` to `GreenNodeData`
+        // if safe since `GreenNodeData` is marked as `repr(transparent)`
+        Arc::from_thin(self.ptr).into_raw().cast()
+    }
+
+    #[inline]
     pub(crate) unsafe fn from_raw(ptr: ptr::NonNull<GreenNodeData>) -> GreenNode {
         let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
         let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenNodeHead, Slot>>(arc);

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -42,6 +42,14 @@ impl<T: IntoRawPointer> GenerationalPointer<T> {
     }
 
     fn value(&self) -> &T::Pointee {
+        // SAFETY: This clears the least significant bit from `data`. This bit
+        // should have been set to zero in the original pointer due to the
+        // alignment requirements of the underlying data (this is checked by an
+        // assertion on debug builds), so this essentially extracts the pointer
+        // value from the bit field. Said point is safe to dereference at this
+        // point since we're holding a valid reference to `self` which
+        // guarantees `Drop` has not been called and the memory associated with
+        // the pointer has not been released yet.
         let data = self.data & !1;
         let ptr = data as *const T::Pointee;
         unsafe { &*ptr }

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -173,6 +173,11 @@ impl GreenToken {
     }
 
     #[inline]
+    pub(crate) fn into_raw(self) -> ptr::NonNull<GreenTokenData> {
+        Arc::from_thin(self.ptr).into_raw().cast()
+    }
+
+    #[inline]
     pub(crate) unsafe fn from_raw(ptr: ptr::NonNull<GreenTokenData>) -> GreenToken {
         let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
         let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenTokenHead, u8>>(arc);

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -36,7 +36,7 @@ pub use rome_text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     ast::*,
-    green::RawSyntaxKind,
+    green::{NodeCache, RawSyntaxKind},
     syntax::{
         chain_trivia_pieces, ChainTriviaPiecesIterator, Language, SendNode, SyntaxElement,
         SyntaxElementChildren, SyntaxKind, SyntaxList, SyntaxNode, SyntaxNodeChildren,

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     cow_mut::CowMut,
-    green::{GreenElement, LiveSet, NodeCache, NodeCacheNodeEntryMut},
+    green::{GreenElement, NodeCache, NodeCacheNodeEntryMut},
     syntax::TriviaPiece,
     GreenNode, Language, NodeOrToken, ParsedChildren, SyntaxFactory, SyntaxKind, SyntaxNode,
 };
@@ -16,7 +16,6 @@ pub struct TreeBuilder<'cache, L: Language, S: SyntaxFactory<Kind = L::Kind>> {
     cache: CowMut<'cache, NodeCache>,
     parents: Vec<(L::Kind, usize)>,
     children: Vec<(u64, GreenElement)>,
-    live_set: Option<LiveSet>,
     ph: PhantomData<S>,
 }
 
@@ -26,7 +25,6 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> Default for TreeBuilder<'_, 
             cache: CowMut::default(),
             parents: Vec::default(),
             children: Vec::default(),
-            live_set: None,
             ph: PhantomData,
         }
     }
@@ -41,16 +39,11 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
     /// Reusing `NodeCache` between different [TreeBuilder]`s saves memory.
     /// It allows to structurally share underlying trees.
     pub fn with_cache(cache: &mut NodeCache) -> TreeBuilder<'_, L, S> {
-        let has_cached_nodes = !cache.is_empty();
+        cache.increment_generation();
         TreeBuilder {
             cache: CowMut::Borrowed(cache),
             parents: Vec::new(),
             children: Vec::new(),
-            // We don't need to track the set of live nodes and tokens if the
-            // cache was initially empty, as it means all the entries present
-            // in the cache at the end of the parsing session were inserted by
-            // this instance of the TreeBuilder
-            live_set: has_cached_nodes.then(LiveSet::default),
             ph: PhantomData,
         }
     }
@@ -74,9 +67,7 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
     /// Adds new token to the current branch.
     #[inline]
     pub fn token(&mut self, kind: L::Kind, text: &str) -> &mut Self {
-        let (hash, token) = self
-            .cache
-            .token(kind.to_raw(), text, self.live_set.as_mut());
+        let (hash, token) = self.cache.token(kind.to_raw(), text);
         self.children.push((hash, token.into()));
         self
     }
@@ -90,13 +81,9 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
         leading: &[TriviaPiece],
         trailing: &[TriviaPiece],
     ) {
-        let (hash, token) = self.cache.token_with_trivia(
-            kind.to_raw(),
-            text,
-            leading,
-            trailing,
-            self.live_set.as_mut(),
-        );
+        let (hash, token) = self
+            .cache
+            .token_with_trivia(kind.to_raw(), text, leading, trailing);
         self.children.push((hash, token.into()));
     }
 
@@ -116,7 +103,7 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
         let raw_kind = kind.to_raw();
 
         let slots = &self.children[first_child..];
-        let node_entry = self.cache.node(raw_kind, slots, self.live_set.as_mut());
+        let node_entry = self.cache.node(raw_kind, slots);
 
         let mut build_node = || {
             let children = ParsedChildren::new(&mut self.children, first_child);
@@ -134,7 +121,7 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
             }
             NodeCacheNodeEntryMut::Cached(cached) => {
                 self.children.truncate(first_child);
-                (cached.hash(), cached.node().clone())
+                (cached.hash(), cached.node().to_owned())
             }
         };
 
@@ -199,11 +186,7 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
     #[must_use]
     pub fn finish(mut self) -> SyntaxNode<L> {
         let root = SyntaxNode::new_root(self.finish_green());
-
-        if let Some(live_set) = self.live_set.take() {
-            self.cache.evict_unreachable(live_set);
-        }
-
+        self.cache.sweep_cache();
         root
     }
 

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -36,7 +36,7 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
         TreeBuilder::default()
     }
 
-    /// Reusing `NodeCache` between different [TreeBuilder]`s saves memory.
+    /// Reusing `NodeCache` between different [TreeBuilder]s saves memory.
     /// It allows to structurally share underlying trees.
     pub fn with_cache(cache: &mut NodeCache) -> TreeBuilder<'_, L, S> {
         cache.increment_generation();

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -33,7 +33,7 @@ use rome_js_syntax::{
     AnyJsRoot, JsLanguage, JsSyntaxNode, SourceType, TextRange, TextSize, TokenAtOffset,
 };
 use rome_parser::AnyParse;
-use rome_rowan::{AstNode, BatchMutationExt, Direction};
+use rome_rowan::{AstNode, BatchMutationExt, Direction, NodeCache};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use tracing::debug;
@@ -116,7 +116,12 @@ impl ExtensionHandler for JsFileHandler {
     }
 }
 
-fn parse(rome_path: &RomePath, language_hint: LanguageId, text: &str) -> AnyParse {
+fn parse(
+    rome_path: &RomePath,
+    language_hint: LanguageId,
+    text: &str,
+    cache: &mut NodeCache,
+) -> AnyParse {
     let source_type =
         SourceType::try_from(rome_path.as_path()).unwrap_or_else(|_| match language_hint {
             LanguageId::JavaScriptReact => SourceType::jsx(),
@@ -125,7 +130,7 @@ fn parse(rome_path: &RomePath, language_hint: LanguageId, text: &str) -> AnyPars
             _ => SourceType::js_module(),
         });
 
-    let parse = rome_js_parser::parse(text, source_type);
+    let parse = rome_js_parser::parse_with_cache(text, source_type, cache);
     AnyParse::from(parse)
 }
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -130,7 +130,7 @@ fn parse(
             _ => SourceType::js_module(),
         });
 
-    let parse = rome_js_parser::parse_with_cache(text, source_type, cache);
+    let parse = rome_js_parser::parse_js_with_cache(text, source_type, cache);
     AnyParse::from(parse)
 }
 

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -16,6 +16,8 @@ use rome_json_formatter::context::JsonFormatOptions;
 use rome_json_formatter::format_node;
 use rome_json_syntax::{JsonLanguage, JsonRoot, JsonSyntaxNode};
 use rome_parser::AnyParse;
+use rome_rowan::NodeCache;
+#[cfg(any(debug_assertions, target_family = "wasm"))]
 use rome_rowan::{TextRange, TextSize, TokenAtOffset};
 
 impl Language for JsonLanguage {
@@ -77,8 +79,8 @@ impl ExtensionHandler for JsonFileHandler {
     }
 }
 
-fn parse(_: &RomePath, _: LanguageId, text: &str) -> AnyParse {
-    let parse = rome_json_parser::parse_json(text);
+fn parse(_: &RomePath, _: LanguageId, text: &str, cache: &mut NodeCache) -> AnyParse {
+    let parse = rome_json_parser::parse_json_with_cache(text, cache);
     AnyParse::from(parse)
 }
 

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -13,6 +13,7 @@ use rome_formatter::Printed;
 use rome_fs::RomePath;
 use rome_js_syntax::{TextRange, TextSize};
 use rome_parser::AnyParse;
+use rome_rowan::NodeCache;
 use std::ffi::OsStr;
 
 mod javascript;
@@ -154,7 +155,7 @@ pub(crate) struct Capabilities {
     pub(crate) formatter: FormatterCapabilities,
 }
 
-type Parse = fn(&RomePath, Language, &str) -> AnyParse;
+type Parse = fn(&RomePath, Language, &str, &mut NodeCache) -> AnyParse;
 
 #[derive(Default)]
 pub(crate) struct ParserCapabilities {

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -18,6 +18,7 @@ rome_formatter = { path = "../../crates/rome_formatter"}
 rome_js_formatter = { path = "../../crates/rome_js_formatter"}
 rome_analyze = { path = "../../crates/rome_analyze"}
 rome_js_analyze = { path = "../../crates/rome_js_analyze"}
+rome_rowan = { path = "../../crates/rome_rowan"}
 
 
 pico-args = { version = "0.5.0", features=["eq-separator"] }

--- a/xtask/bench/src/language.rs
+++ b/xtask/bench/src/language.rs
@@ -8,6 +8,7 @@ use rome_js_syntax::{AnyJsRoot, JsSyntaxNode, SourceType};
 use rome_json_formatter::context::{JsonFormatContext, JsonFormatOptions};
 use rome_json_syntax::JsonSyntaxNode;
 use rome_parser::prelude::ParseDiagnostic;
+use rome_rowan::NodeCache;
 
 pub enum Parse<'a> {
     JavaScript(SourceType, &'a str),
@@ -31,6 +32,16 @@ impl<'a> Parse<'a> {
                 Parsed::JavaScript(rome_js_parser::parse(code, *source_type), *source_type)
             }
             Parse::Json(code) => Parsed::Json(rome_json_parser::parse_json(code)),
+        }
+    }
+
+    pub fn parse_with_cache(&self, cache: &mut NodeCache) -> Parsed {
+        match self {
+            Parse::JavaScript(source_type, code) => Parsed::JavaScript(
+                rome_js_parser::parse_js_with_cache(code, *source_type, cache),
+                *source_type,
+            ),
+            Parse::Json(code) => Parsed::Json(rome_json_parser::parse_json_with_cache(code, cache)),
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR aims at improving the performance of running multiple parsing session over the same document by allowing the green node cache to be stored in the workspace alongside the syntax tree and reused by each parser invocation.

As the cache is now long-lived, this requires the implementation of a cache eviction strategy to avoid having the in-memory caches of the open documents grow indefinitely. This behavior is implemented in the `TreeBuilder` with the help of a new `LiveSet` structure that tracks the set of tokens and nodes that were retrieved from the cache or inserted by a given instance of the builder, and drains the entries that have not been marked from the cache when `finish` is called on the builder. This strategy is sufficient as the workspace maintains a node cache per-document, so only the nodes that are part of the latest revision of the syntax tree for this document need to be retained.

## Test Plan

This is an internal change that should not have observable effects (in theory even if the behavior of the cache were incorrect the workspace and parsers should continue to work correctly, but their memory usage characteristics might become less efficient).
I don't expect this change to have a significant impact on benchmarks either as those are only run "cold" on an empty cache, and the set of live nodes doesn't get build in the initial parser run.

## Documentation

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
