### PR TITLE
feat(rome_cli): enable organize imports via CLI/configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,8 @@ dependencies = [
  "rome_flags",
  "rome_formatter",
  "rome_fs",
+ "rome_json_formatter",
+ "rome_json_parser",
  "rome_lsp",
  "rome_service",
  "rome_text_edit",

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -50,3 +50,5 @@ tikv-jemallocator = "0.5.0"
 [dev-dependencies]
 insta = { workspace = true }
 tokio = { workspace = true, features = ["io-util"] }
+rome_json_formatter = { path = "../rome_json_formatter" }
+rome_json_parser = { path = "../rome_json_parser" }

--- a/crates/rome_cli/src/commands/ci.rs
+++ b/crates/rome_cli/src/commands/ci.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use rome_console::{markup, ConsoleExt};
 use rome_diagnostics::PrintDiagnostic;
+use rome_service::configuration::organize_imports::OrganizeImports;
 use rome_service::configuration::{FormatterConfiguration, LinterConfiguration};
 use rome_service::workspace::UpdateSettingsParams;
 
@@ -34,6 +35,11 @@ pub(crate) fn ci(mut session: CliSession) -> Result<(), CliDiagnostic> {
         .opt_value_from_str("--linter-enabled")
         .map_err(|source| CliDiagnostic::parse_error("--linter-enabled", source))?;
 
+    let organize_imports_enabled = session
+        .args
+        .opt_value_from_str("--organize-imports-enabled")
+        .map_err(|source| CliDiagnostic::parse_error("--organize-imports-enabled", source))?;
+
     let formatter = configuration
         .formatter
         .get_or_insert_with(FormatterConfiguration::default);
@@ -48,6 +54,14 @@ pub(crate) fn ci(mut session: CliSession) -> Result<(), CliDiagnostic> {
 
     if let Some(linter_enabled) = linter_enabled {
         linter.enabled = linter_enabled;
+    }
+
+    let organize_imports = configuration
+        .organize_imports
+        .get_or_insert_with(OrganizeImports::default);
+
+    if let Some(organize_imports_enabled) = organize_imports_enabled {
+        organize_imports.enabled = organize_imports_enabled;
     }
 
     // no point in doing the traversal if all the checks have been disabled

--- a/crates/rome_cli/src/commands/ci.rs
+++ b/crates/rome_cli/src/commands/ci.rs
@@ -65,8 +65,11 @@ pub(crate) fn ci(mut session: CliSession) -> Result<(), CliDiagnostic> {
     }
 
     // no point in doing the traversal if all the checks have been disabled
-    if configuration.is_formatter_disabled() && configuration.is_linter_disabled() {
-        return Err(CliDiagnostic::incompatible_end_configuration("Formatter and Linter are both disabled, can't perform the command. This is probably and error."));
+    if configuration.is_formatter_disabled()
+        && configuration.is_linter_disabled()
+        && configuration.is_organize_imports_disabled()
+    {
+        return Err(CliDiagnostic::incompatible_end_configuration("Formatter, linter and organize imports are disabled, can't perform the command. This is probably and error."));
     }
 
     apply_files_settings_from_cli(&mut session, &mut configuration)?;

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -64,6 +64,7 @@ const CI: Markup = markup! {
 "<Emphasis>"OPTIONS:"</Emphasis>"
     "<Dim>"--formatter-enabled"</Dim>"                      Allow to enable or disable the formatter check. (default: true)
     "<Dim>"--linter-enabled"</Dim>"                         Allow to enable or disable the linter check. (default: true)
+    "<Dim>"--organize-imports-enabled"</Dim>"               Allow to enable or disable the organize imports. (default: true)
     "<Dim>"--max-diagnostics"</Dim>"                        Cap the amount of diagnostics displayed (default: 50)
     "<Dim>"--verbose"</Dim>"                                Print additional verbose advices on diagnostics"
     {FORMAT_OPTIONS}

--- a/crates/rome_cli/tests/commands/init.rs
+++ b/crates/rome_cli/tests/commands/init.rs
@@ -4,6 +4,8 @@ use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use pico_args::Arguments;
 use rome_console::BufferConsole;
 use rome_fs::{FileSystemExt, MemoryFileSystem};
+use rome_json_formatter::context::JsonFormatOptions;
+use rome_json_parser::parse_json;
 use rome_service::DynRef;
 use std::ffi::OsString;
 use std::path::Path;
@@ -29,7 +31,13 @@ fn creates_config_file() {
     let mut content = String::new();
     file.read_to_string(&mut content)
         .expect("failed to read file from memory FS");
-    assert_eq!(content, CONFIG_INIT_DEFAULT);
+    let parsed = parse_json(&CONFIG_INIT_DEFAULT);
+    let formatted =
+        rome_json_formatter::format_node(JsonFormatOptions::default(), &parsed.syntax())
+            .expect("valid format document")
+            .print()
+            .expect("valid format document");
+    assert_eq!(content, formatted.as_code());
 
     drop(file);
 
@@ -66,7 +74,13 @@ fn creates_config_file_when_rome_installed_via_package_manager() {
     let mut content = String::new();
     file.read_to_string(&mut content)
         .expect("failed to read file from memory FS");
-    assert_eq!(content, CONFIG_INIT_DEFAULT_WHEN_INSTALLED);
+    let parsed = parse_json(&CONFIG_INIT_DEFAULT_WHEN_INSTALLED);
+    let formatted =
+        rome_json_formatter::format_node(JsonFormatOptions::default(), &parsed.syntax())
+            .expect("valid format document")
+            .print()
+            .expect("valid format document");
+    assert_eq!(content, formatted.as_code());
 
     drop(file);
 

--- a/crates/rome_cli/tests/commands/init.rs
+++ b/crates/rome_cli/tests/commands/init.rs
@@ -31,7 +31,7 @@ fn creates_config_file() {
     let mut content = String::new();
     file.read_to_string(&mut content)
         .expect("failed to read file from memory FS");
-    let parsed = parse_json(&CONFIG_INIT_DEFAULT);
+    let parsed = parse_json(CONFIG_INIT_DEFAULT);
     let formatted =
         rome_json_formatter::format_node(JsonFormatOptions::default(), &parsed.syntax())
             .expect("valid format document")
@@ -74,7 +74,7 @@ fn creates_config_file_when_rome_installed_via_package_manager() {
     let mut content = String::new();
     file.read_to_string(&mut content)
         .expect("failed to read file from memory FS");
-    let parsed = parse_json(&CONFIG_INIT_DEFAULT_WHEN_INSTALLED);
+    let parsed = parse_json(CONFIG_INIT_DEFAULT_WHEN_INSTALLED);
     let formatted =
         rome_json_formatter::format_node(JsonFormatOptions::default(), &parsed.syntax())
             .expect("valid format document")

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -9,6 +9,9 @@ pub const CONFIG_FORMAT: &str = r#"{
 "#;
 
 pub const CONFIG_INIT_DEFAULT: &str = r#"{
+	"organizeImports": {
+	 	 "enabled": true
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {
@@ -20,6 +23,9 @@ pub const CONFIG_INIT_DEFAULT: &str = r#"{
 
 pub const CONFIG_INIT_DEFAULT_WHEN_INSTALLED: &str = r#"{
 	"$schema": "./node_modules/rome/configuration_schema.json",
+    "organizeImports": {
+	 	 "enabled": true
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/crates/rome_cli/tests/snapshots/main_commands_check/organize_imports.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/organize_imports.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `check.js`
+
+```js
+
+import * as something from "../something";
+import { bar, foom, lorem } from "foo";
+    
+```
+
+# Emitted Messages
+
+```block
+Fixed 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/ci_does_not_organize_imports_via_cli.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/ci_does_not_organize_imports_via_cli.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+import { lorem, foom, bar } from "foo";
+import * as something from "../something";
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/ci_errors_for_all_disabled_checks.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/ci_errors_for_all_disabled_checks.snap
@@ -32,7 +32,7 @@ statement(    ) ; let a = !b || !c;
 internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The combination of configuration and arguments is invalid: 
-    Formatter and Linter are both disabled, can't perform the command. This is probably and error.
+    Formatter, linter and organize imports are disabled, can't perform the command. This is probably and error.
   
 
 

--- a/crates/rome_cli/tests/snapshots/main_commands_init/creates_config_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_init/creates_config_file.snap
@@ -6,6 +6,9 @@ expression: content
 
 ```json
 {
+	"organizeImports": {
+		"enabled": true
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/crates/rome_cli/tests/snapshots/main_commands_init/creates_config_file_when_rome_installed_via_package_manager.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_init/creates_config_file_when_rome_installed_via_package_manager.snap
@@ -7,6 +7,9 @@ expression: content
 ```json
 {
 	"$schema": "./node_modules/rome/configuration_schema.json",
+	"organizeImports": {
+		"enabled": true
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/crates/rome_js_syntax/src/expr_ext.rs
+++ b/crates/rome_js_syntax/src/expr_ext.rs
@@ -842,7 +842,7 @@ impl JsCallExpression {
     ///
     /// Supports maximum of 16 indices to avoid stack overflow. Eeach argument will consume:
     ///
-    /// - 8 bytes for the [Option<AnyJsCallArgument>] result;
+    /// - 8 bytes for the `Option<AnyJsCallArgument>` result;
     /// - 8 bytes for the [usize] argument.
     pub fn get_arguments_by_index<const N: usize>(
         &self,

--- a/crates/rome_js_syntax/src/jsx_ext.rs
+++ b/crates/rome_js_syntax/src/jsx_ext.rs
@@ -245,7 +245,7 @@ impl JsxAttributeList {
     ///
     /// Supports maximum of 16 names to avoid stack overflow. Each attribute will consume:
     ///
-    /// - 8 bytes for the [Option<JsxAttribute>] result;
+    /// - 8 bytes for the `Option<JsxAttribute>` result;
     /// - plus 16 bytes for the [&str] argument.
     pub fn find_by_names<const N: usize>(
         &self,
@@ -414,7 +414,7 @@ impl JsxAttribute {
 impl AnyJsxAttributeValue {
     /// Retrieves the text value of the attribute
     ///
-    /// If the attribute is not a text or a text-like node, [Node] is returned.
+    /// If the attribute is not a text or a text-like node, `Node` is returned.
     ///
     /// ## Examples
     ///

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -798,7 +798,7 @@ impl<L: Language> DoubleEndedIterator for SyntaxSlots<L> {
     }
 }
 
-/// Trait with extension methods for [Option<SyntaxNode>].
+/// Trait with extension methods for `Option<SyntaxNode>`.
 pub trait SyntaxNodeOptionExt<L: Language> {
     /// Returns the kind of the node if self is [Some], [None] otherwise.
     fn kind(&self) -> Option<L::Kind>;

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -50,9 +50,11 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
 
     /// Method to quickly wrap a tree with a node.
     ///
+    /// ```ignore
     /// TreeBuilder::<RawLanguage>::wrap_with_node(RawSyntaxKind(0), |builder| {
     ///     builder.token(RawSyntaxKind(1), "let");
     /// });
+    /// ```
     pub fn wrap_with_node<F>(kind: L::Kind, build: F) -> SyntaxNode<L>
     where
         F: Fn(&mut Self),

--- a/crates/rome_service/src/configuration/javascript.rs
+++ b/crates/rome_service/src/configuration/javascript.rs
@@ -26,7 +26,8 @@ pub struct JavascriptConfiguration {
 }
 
 impl JavascriptConfiguration {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &["formatter", "globals", "organizeImports"];
+    pub(crate) const KNOWN_KEYS: &'static [&'static str] =
+        &["formatter", "globals", "organizeImports"];
 }
 
 impl JavascriptConfiguration {

--- a/crates/rome_service/src/configuration/javascript.rs
+++ b/crates/rome_service/src/configuration/javascript.rs
@@ -20,10 +20,13 @@ pub struct JavascriptConfiguration {
         serialize_with = "crate::serialize_set_of_strings"
     )]
     pub globals: Option<IndexSet<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organize_imports: Option<JavascriptOrganizeImports>,
 }
 
 impl JavascriptConfiguration {
-    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &["formatter", "globals"];
+    pub(crate) const KNOWN_KEYS: &'static [&'static str] = &["formatter", "globals", "organizeImports"];
 }
 
 impl JavascriptConfiguration {
@@ -151,3 +154,8 @@ impl From<PlainSemicolons> for Semicolons {
 impl PlainSemicolons {
     pub(crate) const KNOWN_VALUES: &'static [&'static str] = &["always", "asNeeded"];
 }
+
+#[derive(Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(default, deny_unknown_fields)]
+pub struct JavascriptOrganizeImports {}

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -21,10 +21,12 @@ mod formatter;
 mod generated;
 mod javascript;
 pub mod linter;
+pub mod organize_imports;
 mod parse;
 
 pub use crate::configuration::diagnostics::ConfigurationDiagnostic;
 use crate::configuration::generated::push_to_analyzer_rules;
+use crate::configuration::organize_imports::OrganizeImports;
 use crate::settings::{LanguagesSettings, LinterSettings};
 pub use formatter::{FormatterConfiguration, PlainIndentStyle};
 pub use javascript::{JavascriptConfiguration, JavascriptFormatter};
@@ -39,7 +41,7 @@ use rome_json_parser::parse_json;
 /// The configuration that is contained inside the file `rome.json`
 #[derive(Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Configuration {
     /// A field for the [JSON schema](https://json-schema.org/) specification
     #[serde(rename(serialize = "$schema", deserialize = "$schema"))]
@@ -52,6 +54,10 @@ pub struct Configuration {
     /// The configuration of the formatter
     #[serde(skip_serializing_if = "Option::is_none")]
     pub formatter: Option<FormatterConfiguration>,
+
+    /// The configuration of the formatter
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organize_imports: Option<OrganizeImports>,
 
     /// The configuration for the linter
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -70,6 +76,7 @@ impl Default for Configuration {
                 enabled: true,
                 ..LinterConfiguration::default()
             }),
+            organize_imports: Some(OrganizeImports { enabled: true }),
             formatter: None,
             javascript: None,
             schema: None,
@@ -78,8 +85,14 @@ impl Default for Configuration {
 }
 
 impl Configuration {
-    const KNOWN_KEYS: &'static [&'static str] =
-        &["files", "linter", "formatter", "javascript", "$schema"];
+    const KNOWN_KEYS: &'static [&'static str] = &[
+        "files",
+        "linter",
+        "formatter",
+        "javascript",
+        "$schema",
+        "organizeImports",
+    ];
 }
 
 impl Configuration {

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -103,6 +103,13 @@ impl Configuration {
     pub fn is_linter_disabled(&self) -> bool {
         self.linter.as_ref().map(|f| !f.enabled).unwrap_or(false)
     }
+
+    pub fn is_organize_imports_disabled(&self) -> bool {
+        self.organize_imports
+            .as_ref()
+            .map(|f| !f.enabled)
+            .unwrap_or(false)
+    }
 }
 
 /// The configuration of the filesystem

--- a/crates/rome_service/src/configuration/organize_imports.rs
+++ b/crates/rome_service/src/configuration/organize_imports.rs
@@ -1,0 +1,21 @@
+use crate::settings::AnalyzerSettings;
+use crate::WorkspaceError;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct OrganizeImports {
+    /// Enables the organization of imports
+    pub enabled: bool,
+}
+
+impl TryFrom<OrganizeImports> for AnalyzerSettings {
+    type Error = WorkspaceError;
+
+    fn try_from(organize_imports: OrganizeImports) -> Result<Self, Self::Error> {
+        Ok(Self {
+            organize_imports_enabled: organize_imports.enabled,
+        })
+    }
+}

--- a/crates/rome_service/src/configuration/parse/json.rs
+++ b/crates/rome_service/src/configuration/parse/json.rs
@@ -5,6 +5,7 @@ mod configuration;
 mod formatter;
 mod javascript;
 mod linter;
+mod organize_imports;
 mod rules;
 
 use crate::Configuration;

--- a/crates/rome_service/src/configuration/parse/json/configuration.rs
+++ b/crates/rome_service/src/configuration/parse/json/configuration.rs
@@ -1,3 +1,4 @@
+use crate::configuration::organize_imports::OrganizeImports;
 use crate::configuration::{
     FilesConfiguration, FormatterConfiguration, JavascriptConfiguration, LinterConfiguration,
 };
@@ -7,7 +8,6 @@ use rome_deserialize::{DeserializationDiagnostic, VisitNode};
 use rome_json_syntax::{JsonLanguage, JsonSyntaxNode};
 use rome_rowan::SyntaxNode;
 use std::num::NonZeroU64;
-use crate::configuration::organize_imports::OrganizeImports;
 
 impl VisitJsonNode for FilesConfiguration {}
 

--- a/crates/rome_service/src/configuration/parse/json/configuration.rs
+++ b/crates/rome_service/src/configuration/parse/json/configuration.rs
@@ -7,6 +7,7 @@ use rome_deserialize::{DeserializationDiagnostic, VisitNode};
 use rome_json_syntax::{JsonLanguage, JsonSyntaxNode};
 use rome_rowan::SyntaxNode;
 use std::num::NonZeroU64;
+use crate::configuration::organize_imports::OrganizeImports;
 
 impl VisitJsonNode for FilesConfiguration {}
 
@@ -83,6 +84,11 @@ impl VisitNode<JsonLanguage> for Configuration {
                 let mut javascript = JavascriptConfiguration::default();
                 self.map_to_object(&value, name_text, &mut javascript, diagnostics)?;
                 self.javascript = Some(javascript);
+            }
+            "organizeImports" => {
+                let mut organize_imports = OrganizeImports::default();
+                self.map_to_object(&value, name_text, &mut organize_imports, diagnostics)?;
+                self.organize_imports = Some(organize_imports);
             }
             _ => {}
         }

--- a/crates/rome_service/src/configuration/parse/json/javascript.rs
+++ b/crates/rome_service/src/configuration/parse/json/javascript.rs
@@ -1,5 +1,6 @@
 use crate::configuration::javascript::{
-    PlainQuoteProperties, PlainQuoteStyle, PlainSemicolons, PlainTrailingComma,
+    JavascriptOrganizeImports, PlainQuoteProperties, PlainQuoteStyle, PlainSemicolons,
+    PlainTrailingComma,
 };
 use crate::configuration::{JavascriptConfiguration, JavascriptFormatter};
 use rome_deserialize::json::{has_only_known_keys, with_only_known_variants, VisitJsonNode};
@@ -35,6 +36,16 @@ impl VisitNode<JsonLanguage> for JavascriptConfiguration {
             }
             "globals" => {
                 self.globals = self.map_to_index_set_string(&value, name_text, diagnostics);
+            }
+            "organizeImports" => {
+                let mut javascript_organize_imports = JavascriptOrganizeImports::default();
+                self.map_to_object(
+                    &value,
+                    name_text,
+                    &mut javascript_organize_imports,
+                    diagnostics,
+                )?;
+                self.organize_imports = Some(javascript_organize_imports);
             }
             _ => {}
         }
@@ -159,3 +170,6 @@ impl VisitNode<JsonLanguage> for PlainSemicolons {
         Some(())
     }
 }
+
+impl VisitJsonNode for JavascriptOrganizeImports {}
+impl VisitNode<JsonLanguage> for JavascriptOrganizeImports {}

--- a/crates/rome_service/src/configuration/parse/json/organize_imports.rs
+++ b/crates/rome_service/src/configuration/parse/json/organize_imports.rs
@@ -23,11 +23,8 @@ impl VisitNode<JsonLanguage> for OrganizeImports {
     ) -> Option<()> {
         let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
         let name_text = name.text();
-        match name_text {
-            "enabled" => {
-                self.enabled = self.map_to_boolean(&value, name_text, diagnostics)?;
-            }
-            _ => {}
+        if name_text == "enabled" {
+            self.enabled = self.map_to_boolean(&value, name_text, diagnostics)?;
         }
 
         Some(())

--- a/crates/rome_service/src/configuration/parse/json/organize_imports.rs
+++ b/crates/rome_service/src/configuration/parse/json/organize_imports.rs
@@ -1,0 +1,35 @@
+use crate::configuration::organize_imports::OrganizeImports;
+use rome_deserialize::json::{has_only_known_keys, VisitJsonNode};
+use rome_deserialize::{DeserializationDiagnostic, VisitNode};
+use rome_json_syntax::{JsonLanguage, JsonSyntaxNode};
+use rome_rowan::SyntaxNode;
+
+impl VisitJsonNode for OrganizeImports {}
+
+impl VisitNode<JsonLanguage> for OrganizeImports {
+    fn visit_member_name(
+        &mut self,
+        node: &JsonSyntaxNode,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<()> {
+        has_only_known_keys(node, &["enabled"], diagnostics)
+    }
+
+    fn visit_map(
+        &mut self,
+        key: &SyntaxNode<JsonLanguage>,
+        value: &SyntaxNode<JsonLanguage>,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<()> {
+        let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
+        let name_text = name.text();
+        match name_text {
+            "enabled" => {
+                self.enabled = self.map_to_boolean(&value, name_text, diagnostics)?;
+            }
+            _ => {}
+        }
+
+        Some(())
+    }
+}

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -369,22 +369,19 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
         None
     };
 
-    let filter = match &mut enabled_rules {
+    let mut filter = AnalysisFilter::default();
+    match &mut enabled_rules {
         Some(rules) => {
             if settings.as_ref().analyzer.organize_imports_enabled {
                 rules.push(RuleFilter::Rule("correctness", "organizeImports"));
             }
 
-            let mut filter = AnalysisFilter::from_enabled_rules(Some(rules.as_slice()));
-
+            filter.enabled_rules = Some(rules.as_slice());
             filter.categories =
                 RuleCategories::SYNTAX | RuleCategories::LINT | RuleCategories::ACTION;
-            filter
         }
         _ => {
-            let mut filter = AnalysisFilter::default();
             filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
-            filter
         }
     };
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -53,10 +53,15 @@ pub struct JsLinterSettings {
     pub globals: Vec<String>,
 }
 
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct JsOrganizeImportsSettings {}
+
 impl Language for JsLanguage {
     type FormatterSettings = JsFormatterSettings;
     type LinterSettings = JsLinterSettings;
     type FormatOptions = JsFormatOptions;
+    type OrganizeImportsSettings = JsOrganizeImportsSettings;
 
     fn lookup_settings(languages: &LanguagesSettings) -> &LanguageSettings<Self> {
         &languages.javascript
@@ -357,19 +362,32 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
     let mut tree: AnyJsRoot = parse.tree();
     let mut actions = Vec::new();
 
-    let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
+    let mut enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
         let enabled: IndexSet<RuleFilter> = rules.as_enabled_rules();
         Some(enabled.into_iter().collect())
     } else {
         None
     };
 
-    let mut filter = match &enabled_rules {
-        Some(rules) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
-        _ => AnalysisFilter::default(),
+    let filter = match &mut enabled_rules {
+        Some(rules) => {
+            if settings.as_ref().analyzer.organize_imports_enabled {
+                rules.push(RuleFilter::Rule("correctness", "organizeImports"));
+            }
+
+            let mut filter = AnalysisFilter::from_enabled_rules(Some(rules.as_slice()));
+
+            filter.categories =
+                RuleCategories::SYNTAX | RuleCategories::LINT | RuleCategories::ACTION;
+            filter
+        }
+        _ => {
+            let mut filter = AnalysisFilter::default();
+            filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
+            filter
+        }
     };
 
-    filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
     let mut skipped_suggested_fixes = 0;
     let analyzer_options = compute_analyzer_options(&settings);
     loop {

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -22,6 +22,7 @@ impl Language for JsonLanguage {
     type FormatterSettings = ();
     type LinterSettings = ();
     type FormatOptions = JsonFormatOptions;
+    type OrganizeImportsSettings = ();
 
     fn lookup_settings(language: &LanguagesSettings) -> &LanguageSettings<Self> {
         &language.json

--- a/crates/rome_service/tests/invalid/organize_imports.json
+++ b/crates/rome_service/tests/invalid/organize_imports.json
@@ -1,0 +1,5 @@
+{
+	"organizeImports": {
+		"enabled": "false"
+	}
+}

--- a/crates/rome_service/tests/invalid/organize_imports.json.snap
+++ b/crates/rome_service/tests/invalid/organize_imports.json.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rome_service/tests/spec_tests.rs
+expression: organize_imports.json
+---
+organize_imports.json:3:14 configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The value of key enabled is incorrect. Expected boolean
+  
+    1 │ {
+    2 │ 	"organizeImports": {
+  > 3 │ 		"enabled": "false"
+      │ 		           ^^^^^^^
+    4 │ 	}
+    5 │ }
+  
+
+

--- a/crates/rome_service/tests/invalid/top_level_extraneous_field.json.snap
+++ b/crates/rome_service/tests/invalid/top_level_extraneous_field.json.snap
@@ -19,6 +19,7 @@ top_level_extraneous_field.json:2:2 configuration ━━━━━━━━━━
   - formatter
   - javascript
   - $schema
+  - organizeImports
   
 
 

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -35,6 +35,10 @@
 				{ "$ref": "#/definitions/LinterConfiguration" },
 				{ "type": "null" }
 			]
+		},
+		"organizeImports": {
+			"description": "The configuration of the formatter",
+			"anyOf": [{ "$ref": "#/definitions/OrganizeImports" }, { "type": "null" }]
 		}
 	},
 	"additionalProperties": false,
@@ -327,6 +331,12 @@
 					"type": ["array", "null"],
 					"items": { "type": "string" },
 					"uniqueItems": true
+				},
+				"organize_imports": {
+					"anyOf": [
+						{ "$ref": "#/definitions/JavascriptOrganizeImports" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -355,6 +365,10 @@
 					"allOf": [{ "$ref": "#/definitions/TrailingComma" }]
 				}
 			},
+			"additionalProperties": false
+		},
+		"JavascriptOrganizeImports": {
+			"type": "object",
 			"additionalProperties": false
 		},
 		"LineWidth": {
@@ -765,6 +779,17 @@
 					]
 				}
 			}
+		},
+		"OrganizeImports": {
+			"type": "object",
+			"required": ["enabled"],
+			"properties": {
+				"enabled": {
+					"description": "Enables the organization of imports",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
 		},
 		"Performance": {
 			"description": "A list of rules that belong to this group",

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -42,6 +42,10 @@ export interface Configuration {
 	 * The configuration for the linter
 	 */
 	linter?: LinterConfiguration;
+	/**
+	 * The configuration of the formatter
+	 */
+	organizeImports?: OrganizeImports;
 }
 /**
  * The configuration of the filesystem
@@ -87,6 +91,7 @@ export interface JavascriptConfiguration {
 If defined here, they should not emit diagnostics. 
 	 */
 	globals?: string[];
+	organize_imports?: JavascriptOrganizeImports;
 }
 export interface LinterConfiguration {
 	/**
@@ -101,6 +106,12 @@ export interface LinterConfiguration {
 	 * List of rules
 	 */
 	rules?: Rules;
+}
+export interface OrganizeImports {
+	/**
+	 * Enables the organization of imports
+	 */
+	enabled: boolean;
 }
 export type PlainIndentStyle = "tab" | "space";
 /**
@@ -127,6 +138,7 @@ export interface JavascriptFormatter {
 	 */
 	trailingComma?: TrailingComma;
 }
+export interface JavascriptOrganizeImports {}
 export interface Rules {
 	a11y?: A11y;
 	complexity?: Complexity;

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -35,6 +35,10 @@
 				{ "$ref": "#/definitions/LinterConfiguration" },
 				{ "type": "null" }
 			]
+		},
+		"organizeImports": {
+			"description": "The configuration of the formatter",
+			"anyOf": [{ "$ref": "#/definitions/OrganizeImports" }, { "type": "null" }]
 		}
 	},
 	"additionalProperties": false,
@@ -327,6 +331,12 @@
 					"type": ["array", "null"],
 					"items": { "type": "string" },
 					"uniqueItems": true
+				},
+				"organize_imports": {
+					"anyOf": [
+						{ "$ref": "#/definitions/JavascriptOrganizeImports" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -355,6 +365,10 @@
 					"allOf": [{ "$ref": "#/definitions/TrailingComma" }]
 				}
 			},
+			"additionalProperties": false
+		},
+		"JavascriptOrganizeImports": {
+			"type": "object",
 			"additionalProperties": false
 		},
 		"LineWidth": {
@@ -765,6 +779,17 @@
 					]
 				}
 			}
+		},
+		"OrganizeImports": {
+			"type": "object",
+			"required": ["enabled"],
+			"properties": {
+				"enabled": {
+					"description": "Enables the organization of imports",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
 		},
 		"Performance": {
 			"description": "A list of rules that belong to this group",


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds support for sorting imports via CLI and configuration.

The sorting of imports will be part of the `check` command, as it's best suited for the analyzer (relative discussion about the reasons https://github.com/rome/tools/discussions/3978). 

As for now, there's no configuration in particular for the sort of imports, we should hold onto that and add a new configuration once we think that the algorithm is stable.

Here's the list of changes:
- added a new option `--organize-imports-enabled` for the `rome ci` command;
- added a new `organizeImports` section in the configuration file;
- updated the `fix_all` function in the JavaScript file handlers, which will include the `correctness/organizeImports` rule if the option is enabled;

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new tests to cover the new scenarios 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
