### PR TITLE
fix(js_semantic):handle exported modules and their members

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
@@ -150,7 +150,7 @@ fn is_property_parameter_ok_not_be_used(parameter: TsPropertyParameter) -> Optio
     Some(false)
 }
 
-fn is_is_ambient_context(node: &JsSyntaxNode) -> bool {
+fn is_ambient_context(node: &JsSyntaxNode) -> bool {
     node.ancestors()
         .any(|x| x.kind() == JsSyntaxKind::TS_DECLARE_STATEMENT)
 }
@@ -205,7 +205,7 @@ fn suggested_fix_if_unused(binding: &AnyJsIdentifierBinding) -> Option<Suggested
 
         // declarations need to be check if they are under `declare`
         node @ AnyJsBindingDeclaration::JsVariableDeclarator(_) => {
-            let is_binding_ok = is_is_ambient_context(&node.syntax().clone());
+            let is_binding_ok = is_ambient_context(node.syntax());
             if !is_binding_ok {
                 suggestion_for_binding(binding)
             } else {
@@ -219,7 +219,7 @@ fn suggested_fix_if_unused(binding: &AnyJsIdentifierBinding) -> Option<Suggested
         | node @ AnyJsBindingDeclaration::TsEnumDeclaration(_)
         | node @ AnyJsBindingDeclaration::TsModuleDeclaration(_)
         | node @ AnyJsBindingDeclaration::TsImportEqualsDeclaration(_) => {
-            if is_is_ambient_context(&node.syntax().clone()) {
+            if is_ambient_context(node.syntax()) {
                 None
             } else {
                 Some(SuggestedFix::NoSuggestion)

--- a/crates/rome_js_analyze/tests/suppression/correctness/noUnusedVariables/ts-module-export.ts
+++ b/crates/rome_js_analyze/tests/suppression/correctness/noUnusedVariables/ts-module-export.ts
@@ -1,0 +1,3 @@
+export module MyModule {
+	export function id() {}
+}

--- a/crates/rome_js_analyze/tests/suppression/correctness/noUnusedVariables/ts-module-export.ts.snap
+++ b/crates/rome_js_analyze/tests/suppression/correctness/noUnusedVariables/ts-module-export.ts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 351
+expression: ambient-module.ts
+---
+# Input
+```js
+export module MyModule {
+	export function id() {}
+}
+
+```
+
+

--- a/crates/rome_js_semantic/src/tests/scopes.rs
+++ b/crates/rome_js_semantic/src/tests/scopes.rs
@@ -63,7 +63,7 @@ assert_semantics! {
     ",
 }
 
-// modules
+// Modules
 assert_semantics! {
     ok_scope_module, "module/*START M*/ M {}/*END M*/;",
 }


### PR DESCRIPTION
## Summary

Fixes #4179.

This also recognize exported members of a module.

## Test Plan

Test included.
By the way I am not sure to understand why `noUnusedVariables` is not in `tests/specs`.

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
