### PR TITLE
fix(rome_js_formatter): mapped type formatting

### DIFF
--- a/crates/rome_js_formatter/tests/specs/ts/type/mapped_type.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/type/mapped_type.ts
@@ -1,0 +1,1 @@
+type LongNameHereToCauseLineBreak_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ={ [K in "foo"]: string };

--- a/crates/rome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+assertion_line: 212
+info: ts/type/mapped_type.ts
+---
+
+# Input
+
+```ts
+type LongNameHereToCauseLineBreak_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ={ [K in "foo"]: string };
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```ts
+type LongNameHereToCauseLineBreak_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
+	{ [K in "foo"]: string };
+```
+
+# Lines exceeding max width of 80 characters
+```
+    1: type LongNameHereToCauseLineBreak_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
+```
+
+


### PR DESCRIPTION
## Summary

Fixes #4165

## Test Plan

Test included to avoid regression.

## Documentation

No change.

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
