### PR TITLE
feat(rome_js_parser): TS 5.0 `export type *`

### DIFF
--- a/crates/rome_js_factory/src/generated/node_factory.rs
+++ b/crates/rome_js_factory/src/generated/node_factory.rs
@@ -991,6 +991,7 @@ pub fn js_export_from_clause(
         star_token,
         from_token,
         source,
+        type_token: None,
         export_as: None,
         assertion: None,
         semicolon_token: None,
@@ -1000,11 +1001,16 @@ pub struct JsExportFromClauseBuilder {
     star_token: SyntaxToken,
     from_token: SyntaxToken,
     source: JsModuleSource,
+    type_token: Option<SyntaxToken>,
     export_as: Option<JsExportAsClause>,
     assertion: Option<JsImportAssertion>,
     semicolon_token: Option<SyntaxToken>,
 }
 impl JsExportFromClauseBuilder {
+    pub fn with_type_token(mut self, type_token: SyntaxToken) -> Self {
+        self.type_token = Some(type_token);
+        self
+    }
     pub fn with_export_as(mut self, export_as: JsExportAsClause) -> Self {
         self.export_as = Some(export_as);
         self
@@ -1021,6 +1027,7 @@ impl JsExportFromClauseBuilder {
         JsExportFromClause::unwrap_cast(SyntaxNode::new_detached(
             JsSyntaxKind::JS_EXPORT_FROM_CLAUSE,
             [
+                self.type_token.map(|token| SyntaxElement::Token(token)),
                 Some(SyntaxElement::Token(self.star_token)),
                 self.export_as
                     .map(|token| SyntaxElement::Node(token.into_syntax())),

--- a/crates/rome_js_factory/src/generated/syntax_factory.rs
+++ b/crates/rome_js_factory/src/generated/syntax_factory.rs
@@ -1593,8 +1593,15 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_EXPORT_FROM_CLAUSE => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<6usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<7usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if element.kind() == T![type] {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
                 if let Some(element) = &current_element {
                     if element.kind() == T ! [*] {
                         slots.mark_present();

--- a/crates/rome_js_formatter/src/js/module/export_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_from_clause.rs
@@ -12,6 +12,7 @@ pub(crate) struct FormatJsExportFromClause;
 impl FormatNodeRule<JsExportFromClause> for FormatJsExportFromClause {
     fn fmt_fields(&self, node: &JsExportFromClause, f: &mut JsFormatter) -> FormatResult<()> {
         let JsExportFromClauseFields {
+            type_token,
             star_token,
             export_as,
             from_token,
@@ -19,6 +20,10 @@ impl FormatNodeRule<JsExportFromClause> for FormatJsExportFromClause {
             assertion,
             semicolon_token,
         } = node.as_fields();
+
+        if let Some(type_token) = type_token {
+            write!(f, [type_token.format(), space()])?;
+        }
 
         write!(f, [star_token.format(), space(),])?;
 

--- a/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts
@@ -16,3 +16,7 @@ export   =   b;
 export  import  a  =   b;
 
 export  declare  class   E {  }
+
+export  type  *  from  "types";
+
+export  type  *  as  types   from  "types";

--- a/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/module/export_clause.ts
+assertion_line: 212
+info: ts/module/export_clause.ts
 ---
 
 # Input
@@ -25,6 +25,10 @@ export   =   b;
 export  import  a  =   b;
 
 export  declare  class   E {  }
+
+export  type  *  from  "types";
+
+export  type  *  as  types   from  "types";
 
 ```
 
@@ -63,6 +67,10 @@ export = b;
 export import a = b;
 
 export declare class E {}
+
+export type * from "types";
+
+export type * as types from "types";
 ```
 
 

--- a/crates/rome_js_parser/src/syntax/auxiliary.rs
+++ b/crates/rome_js_parser/src/syntax/auxiliary.rs
@@ -50,7 +50,11 @@ pub(crate) fn is_nth_at_declaration_clause(p: &mut JsParser, n: usize) -> bool {
         return false;
     }
 
-    if p.nth_at(n, T![type]) || p.nth_at(n, T![interface]) {
+    if p.nth_at(n, T![type]) && !p.nth_at(n + 1, T![*]) && !p.nth_at(n + 1, T!['{']) {
+        return true;
+    }
+
+    if p.nth_at(n, T![interface]) {
         return true;
     }
 

--- a/crates/rome_js_parser/test_data/inline/err/export_from_clause_err.js
+++ b/crates/rome_js_parser/test_data/inline/err/export_from_clause_err.js
@@ -2,3 +2,7 @@ export *;
 export * from 5;
 export as from "test";
 export from "test";
+export type *;
+export type * from;
+export type * as from;
+export type * as ns from;

--- a/crates/rome_js_parser/test_data/inline/err/export_from_clause_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_from_clause_err.rast
@@ -5,6 +5,7 @@ JsModule {
         JsExport {
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportFromClause {
+                type_token: missing (optional),
                 star_token: STAR@7..8 "*" [] [],
                 export_as: missing (optional),
                 from_token: missing (required),
@@ -16,6 +17,7 @@ JsModule {
         JsExport {
             export_token: EXPORT_KW@9..17 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
+                type_token: missing (optional),
                 star_token: STAR@17..19 "*" [] [Whitespace(" ")],
                 export_as: missing (optional),
                 from_token: FROM_KW@19..24 "from" [] [Whitespace(" ")],
@@ -33,6 +35,7 @@ JsModule {
         JsExport {
             export_token: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
+                type_token: missing (optional),
                 star_token: missing (required),
                 export_as: JsExportAsClause {
                     as_token: AS_KW@34..37 "as" [] [Whitespace(" ")],
@@ -51,6 +54,7 @@ JsModule {
         JsExport {
             export_token: EXPORT_KW@49..57 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
+                type_token: missing (optional),
                 star_token: missing (required),
                 export_as: missing (optional),
                 from_token: FROM_KW@57..62 "from" [] [Whitespace(" ")],
@@ -61,32 +65,92 @@ JsModule {
                 semicolon_token: SEMICOLON@68..69 ";" [] [],
             },
         },
+        JsExport {
+            export_token: EXPORT_KW@69..77 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportFromClause {
+                type_token: TYPE_KW@77..82 "type" [] [Whitespace(" ")],
+                star_token: STAR@82..83 "*" [] [],
+                export_as: missing (optional),
+                from_token: missing (required),
+                source: missing (required),
+                assertion: missing (optional),
+                semicolon_token: SEMICOLON@83..84 ";" [] [],
+            },
+        },
+        JsExport {
+            export_token: EXPORT_KW@84..92 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportFromClause {
+                type_token: TYPE_KW@92..97 "type" [] [Whitespace(" ")],
+                star_token: STAR@97..99 "*" [] [Whitespace(" ")],
+                export_as: missing (optional),
+                from_token: FROM_KW@99..103 "from" [] [],
+                source: missing (required),
+                assertion: missing (optional),
+                semicolon_token: SEMICOLON@103..104 ";" [] [],
+            },
+        },
+        JsExport {
+            export_token: EXPORT_KW@104..112 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportFromClause {
+                type_token: TYPE_KW@112..117 "type" [] [Whitespace(" ")],
+                star_token: STAR@117..119 "*" [] [Whitespace(" ")],
+                export_as: JsExportAsClause {
+                    as_token: AS_KW@119..122 "as" [] [Whitespace(" ")],
+                    exported_name: JsLiteralExportName {
+                        value: IDENT@122..126 "from" [] [],
+                    },
+                },
+                from_token: missing (required),
+                source: missing (required),
+                assertion: missing (optional),
+                semicolon_token: SEMICOLON@126..127 ";" [] [],
+            },
+        },
+        JsExport {
+            export_token: EXPORT_KW@127..135 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportFromClause {
+                type_token: TYPE_KW@135..140 "type" [] [Whitespace(" ")],
+                star_token: STAR@140..142 "*" [] [Whitespace(" ")],
+                export_as: JsExportAsClause {
+                    as_token: AS_KW@142..145 "as" [] [Whitespace(" ")],
+                    exported_name: JsLiteralExportName {
+                        value: IDENT@145..148 "ns" [] [Whitespace(" ")],
+                    },
+                },
+                from_token: FROM_KW@148..152 "from" [] [],
+                source: missing (required),
+                assertion: missing (optional),
+                semicolon_token: SEMICOLON@152..153 ";" [] [],
+            },
+        },
     ],
-    eof_token: EOF@69..70 "" [Newline("\n")] [],
+    eof_token: EOF@153..154 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..70
+0: JS_MODULE@0..154
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..69
+  2: JS_MODULE_ITEM_LIST@0..153
     0: JS_EXPORT@0..9
       0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@7..9
-        0: STAR@7..8 "*" [] []
-        1: (empty)
+        0: (empty)
+        1: STAR@7..8 "*" [] []
         2: (empty)
         3: (empty)
         4: (empty)
-        5: SEMICOLON@8..9 ";" [] []
+        5: (empty)
+        6: SEMICOLON@8..9 ";" [] []
     1: JS_EXPORT@9..24
       0: EXPORT_KW@9..17 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@17..24
-        0: STAR@17..19 "*" [] [Whitespace(" ")]
-        1: (empty)
-        2: FROM_KW@19..24 "from" [] [Whitespace(" ")]
-        3: (empty)
+        0: (empty)
+        1: STAR@17..19 "*" [] [Whitespace(" ")]
+        2: (empty)
+        3: FROM_KW@19..24 "from" [] [Whitespace(" ")]
         4: (empty)
         5: (empty)
+        6: (empty)
     2: JS_EXPRESSION_STATEMENT@24..26
       0: JS_NUMBER_LITERAL_EXPRESSION@24..25
         0: JS_NUMBER_LITERAL@24..25 "5" [] []
@@ -95,26 +159,74 @@ JsModule {
       0: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@34..49
         0: (empty)
-        1: JS_EXPORT_AS_CLAUSE@34..42
+        1: (empty)
+        2: JS_EXPORT_AS_CLAUSE@34..42
           0: AS_KW@34..37 "as" [] [Whitespace(" ")]
           1: JS_LITERAL_EXPORT_NAME@37..42
             0: IDENT@37..42 "from" [] [Whitespace(" ")]
-        2: (empty)
-        3: JS_MODULE_SOURCE@42..48
+        3: (empty)
+        4: JS_MODULE_SOURCE@42..48
           0: JS_STRING_LITERAL@42..48 "\"test\"" [] []
-        4: (empty)
-        5: SEMICOLON@48..49 ";" [] []
+        5: (empty)
+        6: SEMICOLON@48..49 ";" [] []
     4: JS_EXPORT@49..69
       0: EXPORT_KW@49..57 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@57..69
         0: (empty)
         1: (empty)
-        2: FROM_KW@57..62 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@62..68
+        2: (empty)
+        3: FROM_KW@57..62 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@62..68
           0: JS_STRING_LITERAL@62..68 "\"test\"" [] []
+        5: (empty)
+        6: SEMICOLON@68..69 ";" [] []
+    5: JS_EXPORT@69..84
+      0: EXPORT_KW@69..77 "export" [Newline("\n")] [Whitespace(" ")]
+      1: JS_EXPORT_FROM_CLAUSE@77..84
+        0: TYPE_KW@77..82 "type" [] [Whitespace(" ")]
+        1: STAR@82..83 "*" [] []
+        2: (empty)
+        3: (empty)
         4: (empty)
-        5: SEMICOLON@68..69 ";" [] []
-  3: EOF@69..70 "" [Newline("\n")] []
+        5: (empty)
+        6: SEMICOLON@83..84 ";" [] []
+    6: JS_EXPORT@84..104
+      0: EXPORT_KW@84..92 "export" [Newline("\n")] [Whitespace(" ")]
+      1: JS_EXPORT_FROM_CLAUSE@92..104
+        0: TYPE_KW@92..97 "type" [] [Whitespace(" ")]
+        1: STAR@97..99 "*" [] [Whitespace(" ")]
+        2: (empty)
+        3: FROM_KW@99..103 "from" [] []
+        4: (empty)
+        5: (empty)
+        6: SEMICOLON@103..104 ";" [] []
+    7: JS_EXPORT@104..127
+      0: EXPORT_KW@104..112 "export" [Newline("\n")] [Whitespace(" ")]
+      1: JS_EXPORT_FROM_CLAUSE@112..127
+        0: TYPE_KW@112..117 "type" [] [Whitespace(" ")]
+        1: STAR@117..119 "*" [] [Whitespace(" ")]
+        2: JS_EXPORT_AS_CLAUSE@119..126
+          0: AS_KW@119..122 "as" [] [Whitespace(" ")]
+          1: JS_LITERAL_EXPORT_NAME@122..126
+            0: IDENT@122..126 "from" [] []
+        3: (empty)
+        4: (empty)
+        5: (empty)
+        6: SEMICOLON@126..127 ";" [] []
+    8: JS_EXPORT@127..153
+      0: EXPORT_KW@127..135 "export" [Newline("\n")] [Whitespace(" ")]
+      1: JS_EXPORT_FROM_CLAUSE@135..153
+        0: TYPE_KW@135..140 "type" [] [Whitespace(" ")]
+        1: STAR@140..142 "*" [] [Whitespace(" ")]
+        2: JS_EXPORT_AS_CLAUSE@142..148
+          0: AS_KW@142..145 "as" [] [Whitespace(" ")]
+          1: JS_LITERAL_EXPORT_NAME@145..148
+            0: IDENT@145..148 "ns" [] [Whitespace(" ")]
+        3: FROM_KW@148..152 "from" [] []
+        4: (empty)
+        5: (empty)
+        6: SEMICOLON@152..153 ";" [] []
+  3: EOF@153..154 "" [Newline("\n")] []
 --
 export_from_clause_err.js:1:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -156,7 +268,7 @@ export_from_clause_err.js:3:8 parse ━━━━━━━━━━━━━━�
   > 3 │ export as from "test";
       │        ^^
     4 │ export from "test";
-    5 │ 
+    5 │ export type *;
   
   i Remove as
   
@@ -170,7 +282,7 @@ export_from_clause_err.js:3:16 parse ━━━━━━━━━━━━━━�
   > 3 │ export as from "test";
       │                ^^^^^^
     4 │ export from "test";
-    5 │ 
+    5 │ export type *;
   
   i Remove "test"
   
@@ -183,12 +295,85 @@ export_from_clause_err.js:4:8 parse ━━━━━━━━━━━━━━�
     3 │ export as from "test";
   > 4 │ export from "test";
       │        ^^^^
-    5 │ 
+    5 │ export type *;
+    6 │ export type * from;
   
   i Remove from
+  
+--
+export_from_clause_err.js:5:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `from` but instead found `;`
+  
+    3 │ export as from "test";
+    4 │ export from "test";
+  > 5 │ export type *;
+      │              ^
+    6 │ export type * from;
+    7 │ export type * as from;
+  
+  i Remove ;
+  
+--
+export_from_clause_err.js:6:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected a string literal but instead found ';'
+  
+    4 │ export from "test";
+    5 │ export type *;
+  > 6 │ export type * from;
+      │                   ^
+    7 │ export type * as from;
+    8 │ export type * as ns from;
+  
+  i Expected a string literal here
+  
+    4 │ export from "test";
+    5 │ export type *;
+  > 6 │ export type * from;
+      │                   ^
+    7 │ export type * as from;
+    8 │ export type * as ns from;
+  
+--
+export_from_clause_err.js:7:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `from` but instead found `;`
+  
+    5 │ export type *;
+    6 │ export type * from;
+  > 7 │ export type * as from;
+      │                      ^
+    8 │ export type * as ns from;
+    9 │ 
+  
+  i Remove ;
+  
+--
+export_from_clause_err.js:8:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected a string literal but instead found ';'
+  
+    6 │ export type * from;
+    7 │ export type * as from;
+  > 8 │ export type * as ns from;
+      │                         ^
+    9 │ 
+  
+  i Expected a string literal here
+  
+    6 │ export type * from;
+    7 │ export type * as from;
+  > 8 │ export type * as ns from;
+      │                         ^
+    9 │ 
   
 --
 export *;
 export * from 5;
 export as from "test";
 export from "test";
+export type *;
+export type * from;
+export type * as from;
+export type * as ns from;

--- a/crates/rome_js_parser/test_data/inline/ok/export_from_clause.js
+++ b/crates/rome_js_parser/test_data/inline/ok/export_from_clause.js
@@ -5,3 +5,5 @@ export * from "a";
 export * as c from "b";
 export * as default from "b"
 export * from "mod" assert { type: "json" }
+export type * from "types";
+export type * as types from "types";

--- a/crates/rome_js_parser/test_data/inline/ok/export_from_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_from_clause.rast
@@ -61,6 +61,7 @@ JsModule {
         JsExport {
             export_token: EXPORT_KW@71..79 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
+                type_token: missing (optional),
                 star_token: STAR@79..81 "*" [] [Whitespace(" ")],
                 export_as: missing (optional),
                 from_token: FROM_KW@81..86 "from" [] [Whitespace(" ")],
@@ -74,6 +75,7 @@ JsModule {
         JsExport {
             export_token: EXPORT_KW@90..98 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
+                type_token: missing (optional),
                 star_token: STAR@98..100 "*" [] [Whitespace(" ")],
                 export_as: JsExportAsClause {
                     as_token: AS_KW@100..103 "as" [] [Whitespace(" ")],
@@ -92,6 +94,7 @@ JsModule {
         JsExport {
             export_token: EXPORT_KW@114..122 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
+                type_token: missing (optional),
                 star_token: STAR@122..124 "*" [] [Whitespace(" ")],
                 export_as: JsExportAsClause {
                     as_token: AS_KW@124..127 "as" [] [Whitespace(" ")],
@@ -110,6 +113,7 @@ JsModule {
         JsExport {
             export_token: EXPORT_KW@143..151 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
+                type_token: missing (optional),
                 star_token: STAR@151..153 "*" [] [Whitespace(" ")],
                 export_as: missing (optional),
                 from_token: FROM_KW@153..158 "from" [] [Whitespace(" ")],
@@ -131,14 +135,47 @@ JsModule {
                 semicolon_token: missing (optional),
             },
         },
+        JsExport {
+            export_token: EXPORT_KW@187..195 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportFromClause {
+                type_token: TYPE_KW@195..200 "type" [] [Whitespace(" ")],
+                star_token: STAR@200..202 "*" [] [Whitespace(" ")],
+                export_as: missing (optional),
+                from_token: FROM_KW@202..207 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@207..214 "\"types\"" [] [],
+                },
+                assertion: missing (optional),
+                semicolon_token: SEMICOLON@214..215 ";" [] [],
+            },
+        },
+        JsExport {
+            export_token: EXPORT_KW@215..223 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportFromClause {
+                type_token: TYPE_KW@223..228 "type" [] [Whitespace(" ")],
+                star_token: STAR@228..230 "*" [] [Whitespace(" ")],
+                export_as: JsExportAsClause {
+                    as_token: AS_KW@230..233 "as" [] [Whitespace(" ")],
+                    exported_name: JsLiteralExportName {
+                        value: IDENT@233..239 "types" [] [Whitespace(" ")],
+                    },
+                },
+                from_token: FROM_KW@239..244 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@244..251 "\"types\"" [] [],
+                },
+                assertion: missing (optional),
+                semicolon_token: SEMICOLON@251..252 ";" [] [],
+            },
+        },
     ],
-    eof_token: EOF@187..188 "" [Newline("\n")] [],
+    eof_token: EOF@252..253 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..188
+0: JS_MODULE@0..253
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..187
+  2: JS_MODULE_ITEM_LIST@0..252
     0: JS_EXPORT@0..37
       0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_FROM_CLAUSE@7..37
@@ -182,48 +219,52 @@ JsModule {
     2: JS_EXPORT@71..90
       0: EXPORT_KW@71..79 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@79..90
-        0: STAR@79..81 "*" [] [Whitespace(" ")]
-        1: (empty)
-        2: FROM_KW@81..86 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@86..89
+        0: (empty)
+        1: STAR@79..81 "*" [] [Whitespace(" ")]
+        2: (empty)
+        3: FROM_KW@81..86 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@86..89
           0: JS_STRING_LITERAL@86..89 "\"a\"" [] []
-        4: (empty)
-        5: SEMICOLON@89..90 ";" [] []
+        5: (empty)
+        6: SEMICOLON@89..90 ";" [] []
     3: JS_EXPORT@90..114
       0: EXPORT_KW@90..98 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@98..114
-        0: STAR@98..100 "*" [] [Whitespace(" ")]
-        1: JS_EXPORT_AS_CLAUSE@100..105
+        0: (empty)
+        1: STAR@98..100 "*" [] [Whitespace(" ")]
+        2: JS_EXPORT_AS_CLAUSE@100..105
           0: AS_KW@100..103 "as" [] [Whitespace(" ")]
           1: JS_LITERAL_EXPORT_NAME@103..105
             0: IDENT@103..105 "c" [] [Whitespace(" ")]
-        2: FROM_KW@105..110 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@110..113
+        3: FROM_KW@105..110 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@110..113
           0: JS_STRING_LITERAL@110..113 "\"b\"" [] []
-        4: (empty)
-        5: SEMICOLON@113..114 ";" [] []
+        5: (empty)
+        6: SEMICOLON@113..114 ";" [] []
     4: JS_EXPORT@114..143
       0: EXPORT_KW@114..122 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@122..143
-        0: STAR@122..124 "*" [] [Whitespace(" ")]
-        1: JS_EXPORT_AS_CLAUSE@124..135
+        0: (empty)
+        1: STAR@122..124 "*" [] [Whitespace(" ")]
+        2: JS_EXPORT_AS_CLAUSE@124..135
           0: AS_KW@124..127 "as" [] [Whitespace(" ")]
           1: JS_LITERAL_EXPORT_NAME@127..135
             0: IDENT@127..135 "default" [] [Whitespace(" ")]
-        2: FROM_KW@135..140 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@140..143
+        3: FROM_KW@135..140 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@140..143
           0: JS_STRING_LITERAL@140..143 "\"b\"" [] []
-        4: (empty)
         5: (empty)
+        6: (empty)
     5: JS_EXPORT@143..187
       0: EXPORT_KW@143..151 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@151..187
-        0: STAR@151..153 "*" [] [Whitespace(" ")]
-        1: (empty)
-        2: FROM_KW@153..158 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@158..164
+        0: (empty)
+        1: STAR@151..153 "*" [] [Whitespace(" ")]
+        2: (empty)
+        3: FROM_KW@153..158 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@158..164
           0: JS_STRING_LITERAL@158..164 "\"mod\"" [] [Whitespace(" ")]
-        4: JS_IMPORT_ASSERTION@164..187
+        5: JS_IMPORT_ASSERTION@164..187
           0: ASSERT_KW@164..171 "assert" [] [Whitespace(" ")]
           1: L_CURLY@171..173 "{" [] [Whitespace(" ")]
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@173..186
@@ -232,5 +273,30 @@ JsModule {
               1: COLON@177..179 ":" [] [Whitespace(" ")]
               2: JS_STRING_LITERAL@179..186 "\"json\"" [] [Whitespace(" ")]
           3: R_CURLY@186..187 "}" [] []
+        6: (empty)
+    6: JS_EXPORT@187..215
+      0: EXPORT_KW@187..195 "export" [Newline("\n")] [Whitespace(" ")]
+      1: JS_EXPORT_FROM_CLAUSE@195..215
+        0: TYPE_KW@195..200 "type" [] [Whitespace(" ")]
+        1: STAR@200..202 "*" [] [Whitespace(" ")]
+        2: (empty)
+        3: FROM_KW@202..207 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@207..214
+          0: JS_STRING_LITERAL@207..214 "\"types\"" [] []
         5: (empty)
-  3: EOF@187..188 "" [Newline("\n")] []
+        6: SEMICOLON@214..215 ";" [] []
+    7: JS_EXPORT@215..252
+      0: EXPORT_KW@215..223 "export" [Newline("\n")] [Whitespace(" ")]
+      1: JS_EXPORT_FROM_CLAUSE@223..252
+        0: TYPE_KW@223..228 "type" [] [Whitespace(" ")]
+        1: STAR@228..230 "*" [] [Whitespace(" ")]
+        2: JS_EXPORT_AS_CLAUSE@230..239
+          0: AS_KW@230..233 "as" [] [Whitespace(" ")]
+          1: JS_LITERAL_EXPORT_NAME@233..239
+            0: IDENT@233..239 "types" [] [Whitespace(" ")]
+        3: FROM_KW@239..244 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@244..251
+          0: JS_STRING_LITERAL@244..251 "\"types\"" [] []
+        5: (empty)
+        6: SEMICOLON@251..252 ";" [] []
+  3: EOF@252..253 "" [Newline("\n")] []

--- a/crates/rome_js_syntax/src/generated/nodes.rs
+++ b/crates/rome_js_syntax/src/generated/nodes.rs
@@ -1960,6 +1960,7 @@ impl JsExportFromClause {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn as_fields(&self) -> JsExportFromClauseFields {
         JsExportFromClauseFields {
+            type_token: self.type_token(),
             star_token: self.star_token(),
             export_as: self.export_as(),
             from_token: self.from_token(),
@@ -1968,18 +1969,19 @@ impl JsExportFromClause {
             semicolon_token: self.semicolon_token(),
         }
     }
+    pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 0usize)
+        support::required_token(&self.syntax, 1usize)
     }
-    pub fn export_as(&self) -> Option<JsExportAsClause> { support::node(&self.syntax, 1usize) }
+    pub fn export_as(&self) -> Option<JsExportAsClause> { support::node(&self.syntax, 2usize) }
     pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 2usize)
+        support::required_token(&self.syntax, 3usize)
     }
     pub fn source(&self) -> SyntaxResult<JsModuleSource> {
-        support::required_node(&self.syntax, 3usize)
+        support::required_node(&self.syntax, 4usize)
     }
-    pub fn assertion(&self) -> Option<JsImportAssertion> { support::node(&self.syntax, 4usize) }
-    pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 5usize) }
+    pub fn assertion(&self) -> Option<JsImportAssertion> { support::node(&self.syntax, 5usize) }
+    pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 6usize) }
 }
 #[cfg(feature = "serde")]
 impl Serialize for JsExportFromClause {
@@ -1992,6 +1994,7 @@ impl Serialize for JsExportFromClause {
 }
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct JsExportFromClauseFields {
+    pub type_token: Option<SyntaxToken>,
     pub star_token: SyntaxResult<SyntaxToken>,
     pub export_as: Option<JsExportAsClause>,
     pub from_token: SyntaxResult<SyntaxToken>,
@@ -16557,6 +16560,10 @@ impl AstNode for JsExportFromClause {
 impl std::fmt::Debug for JsExportFromClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsExportFromClause")
+            .field(
+                "type_token",
+                &support::DebugOptionalElement(self.type_token()),
+            )
             .field("star_token", &support::DebugSyntaxResult(self.star_token()))
             .field(
                 "export_as",

--- a/crates/rome_js_syntax/src/generated/nodes_mut.rs
+++ b/crates/rome_js_syntax/src/generated/nodes_mut.rs
@@ -949,40 +949,46 @@ impl JsExportDefaultExpressionClause {
     }
 }
 impl JsExportFromClause {
+    pub fn with_type_token(self, element: Option<SyntaxToken>) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(0usize..=0usize, once(element.map(|element| element.into()))),
+        )
+    }
     pub fn with_star_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(0usize..=0usize, once(Some(element.into()))),
+                .splice_slots(1usize..=1usize, once(Some(element.into()))),
         )
     }
     pub fn with_export_as(self, element: Option<JsExportAsClause>) -> Self {
         Self::unwrap_cast(self.syntax.splice_slots(
-            1usize..=1usize,
+            2usize..=2usize,
             once(element.map(|element| element.into_syntax().into())),
         ))
     }
     pub fn with_from_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(2usize..=2usize, once(Some(element.into()))),
+                .splice_slots(3usize..=3usize, once(Some(element.into()))),
         )
     }
     pub fn with_source(self, element: JsModuleSource) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(3usize..=3usize, once(Some(element.into_syntax().into()))),
+                .splice_slots(4usize..=4usize, once(Some(element.into_syntax().into()))),
         )
     }
     pub fn with_assertion(self, element: Option<JsImportAssertion>) -> Self {
         Self::unwrap_cast(self.syntax.splice_slots(
-            4usize..=4usize,
+            5usize..=5usize,
             once(element.map(|element| element.into_syntax().into())),
         ))
     }
     pub fn with_semicolon_token(self, element: Option<SyntaxToken>) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(5usize..=5usize, once(element.map(|element| element.into()))),
+                .splice_slots(6usize..=6usize, once(element.map(|element| element.into()))),
         )
     }
 }

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -1446,6 +1446,7 @@ JsExportNamedSpecifier =
     exported_name: JsLiteralExportName
 
 JsExportFromClause =
+	'type'?
 	'*'
 	export_as: JsExportAsClause?
 	'from'


### PR DESCRIPTION
## Summary

Part of #4227.
This adds the support for `export type *`.

## Test Plan

Tests included.

## Documentation

#2400 and #4227 have to be implemented before updating the TypeScript supported version on the website.

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
