### PR TITLE
chore: Update fs_extra to fix future incompatibility warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "fs_extra"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fst"


### PR DESCRIPTION
## Summary

Fixes `warning: the following packages contain code that will be rejected by a future version of Rust: fs_extra v1.2.0` from `cargo build`.

- webdesus/fs_extra#38

## Test Plan

Run `cargo build`.

## Documentation

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
