### PR TITLE
fix(website): Associate labels with the right controls

### DIFF
--- a/website/src/playground/tabs/SettingsTab.tsx
+++ b/website/src/playground/tabs/SettingsTab.tsx
@@ -581,7 +581,7 @@ function FormatterSettings({
 				</div>
 
 				<div className="field-row">
-					<label htmlFor="trailingComma">Semicolons</label>
+					<label htmlFor="semicolons">Semicolons</label>
 					<select
 						id="semicolons"
 						name="semicolons"
@@ -623,7 +623,7 @@ function LinterSettings({
 					<label htmlFor="linting-enabled">Linter enabled</label>
 				</div>
 				<div className="field-row">
-					<label htmlFor="trailingComma">Lint Rules</label>
+					<label htmlFor="lint-rules">Lint Rules</label>
 					<select
 						id="lint-rules"
 						aria-describedby="lint-rules-description"


### PR DESCRIPTION
## Summary

The `for` attribute of these `<label>`s were incorrectly copied.

## Test Plan

In the playground **Settings** tab, hover or click the **Semicolons** or **Lint Rules** labels.

## Documentation

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
