### PR TITLE
fix(rome_formatter): format range has incorrect source map #4149

### DIFF
--- a/crates/rome_formatter/src/comments/builder.rs
+++ b/crates/rome_formatter/src/comments/builder.rs
@@ -584,7 +584,7 @@ impl<'a> SourceParentheses<'a> {
         match self {
             SourceParentheses::Empty => token.parent().unwrap(),
             SourceParentheses::SourceMap { map, .. } => {
-                debug_assert_eq!(&map.text()[parentheses_source_range], ")");
+                debug_assert_eq!(map.source().text_slice(parentheses_source_range), ")");
 
                 // How this works: We search the outer most node that, in the source document ends right after the `)`.
                 // The issue is, it is possible that multiple nodes end right after the `)`

--- a/crates/rome_formatter/src/verbatim.rs
+++ b/crates/rome_formatter/src/verbatim.rs
@@ -104,7 +104,10 @@ where
         let original_source = f.context().source_map().map_or_else(
             || self.node.text_trimmed().to_string(),
             |source_map| {
-                source_map.text()[trimmed_source_range.cover_offset(start_source)].to_string()
+                source_map
+                    .source()
+                    .text_slice(trimmed_source_range.cover_offset(start_source))
+                    .to_string()
             },
         );
 

--- a/crates/rome_js_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/parameters.rs
@@ -212,7 +212,7 @@ pub(crate) fn should_hug_function_parameters(
                                     matches!(type_annotation.ty(), Ok(AnyTsType::TsObjectType(_)))
                                 }),
                             AnyJsBinding(JsBogusBinding(_)) => {
-                                return Err(FormatError::SyntaxError)
+                                return Err(FormatError::SyntaxError);
                             }
                         }
                     }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -413,6 +413,40 @@ mod tests {
     use rome_rowan::{TextRange, TextSize};
 
     #[test]
+    fn test_format_range_parentheses_binary() {
+        let input = "import React from 'react'; function test() { const AppShelled = () => (1 + 2) } function one() {return 1}";
+        let range_start = TextSize::try_from(input.find("(1").unwrap() - 1).unwrap();
+        let range_end = TextSize::try_from(input.find("2)").unwrap() + 1).unwrap();
+
+        let tree = parse(input, SourceType::tsx());
+        let result = format_range(
+            JsFormatOptions::new(SourceType::tsx()),
+            &tree.syntax(),
+            TextRange::new(range_start, range_end),
+        );
+        let result = result.expect("range formatting failed");
+
+        assert_eq!(result.as_code(), "const AppShelled = () => 1 + 2");
+    }
+
+    #[test]
+    fn test_format_range_parentheses_jsx() {
+        let input = "import React from 'react'; function test() { const AppShelled = () => (<Component />) } function lol() {return 1}";
+        let range_start = TextSize::try_from(input.find("(<").unwrap() - 1).unwrap();
+        let range_end = TextSize::try_from(input.find(">)").unwrap() + 1).unwrap();
+
+        let tree = parse(input, SourceType::tsx());
+        let result = format_range(
+            JsFormatOptions::new(SourceType::tsx()),
+            &tree.syntax(),
+            TextRange::new(range_start, range_end),
+        );
+        let result = result.expect("range formatting failed");
+
+        assert_eq!(result.as_code(), "const AppShelled = () => <Component />");
+    }
+
+    #[test]
     fn test_range_formatting() {
         let input = "
 while(

--- a/crates/rome_js_formatter/src/syntax_rewriter.rs
+++ b/crates/rome_js_formatter/src/syntax_rewriter.rs
@@ -13,7 +13,7 @@ use rome_rowan::{
 use std::collections::BTreeSet;
 
 pub(super) fn transform(root: JsSyntaxNode) -> (JsSyntaxNode, TransformSourceMap) {
-    let mut rewriter = JsFormatSyntaxRewriter::default();
+    let mut rewriter = JsFormatSyntaxRewriter::with_offset(root.text_range().start());
     let transformed = rewriter.transform(root);
     (transformed, rewriter.finish())
 }
@@ -41,6 +41,15 @@ struct JsFormatSyntaxRewriter {
     /// parenthesized expressions but the ranges of the `(` trailing trivia pieces no longer match the source ranges because
     /// they are now off by 1 because of the removed `(`.
     l_paren_source_position: BTreeSet<TextSize>,
+}
+
+impl JsFormatSyntaxRewriter {
+    pub fn with_offset(offset: TextSize) -> Self {
+        JsFormatSyntaxRewriter {
+            source_map: TransformSourceMapBuilder::with_offset(offset),
+            ..Default::default()
+        }
+    }
 }
 
 impl JsFormatSyntaxRewriter {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
https://github.com/rome/tools/issues/4149
This PR tries to fix several issues when we format a node with a range.
1. The transform function builds the source map by iterating over all tokens and pushing source text in the builder. This correctly builds up the source text for the sub-tree, but the offsets are incorrect if the root isn't at the start of the document.
2. The transform function can `detach` a node if it updates a tree (`splice_slots`) while a traversing. We must return transformed a node back into the original tree to correct offset and sometimes a formatting result depends on a `parent` kind.


## Test Plan

`cargo test`

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
