### PR TITLE
fix(rome_js_formatter): no comment reordeing in default clause

### DIFF
--- a/crates/rome_js_formatter/src/comments.rs
+++ b/crates/rome_js_formatter/src/comments.rs
@@ -174,7 +174,7 @@ impl CommentStyle for JsCommentStyle {
                 .or_else(handle_call_expression_comment)
                 .or_else(handle_continue_break_comment)
                 .or_else(handle_mapped_type_comment)
-                .or_else(handle_switch_default_case_comment)
+                //.or_else(handle_switch_default_case_comment)
                 .or_else(handle_import_export_specifier_comment),
             CommentTextPosition::OwnLine => handle_member_expression_comment(comment)
                 .or_else(handle_function_declaration_comment)

--- a/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/case_clause.rs
@@ -33,7 +33,7 @@ impl FormatNodeRule<JsCaseClause> for FormatJsCaseClause {
         );
 
         if consequent.is_empty() {
-            // Skip inserting an indent block is the consequent is empty to print
+            // Skip inserting an indent block if the consequent is empty to print
             // the trailing comments for the case clause inline if there is no
             // block to push them into
             write!(f, [hard_line_break()])

--- a/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
+++ b/crates/rome_js_formatter/src/js/auxiliary/default_clause.rs
@@ -15,20 +15,20 @@ impl FormatNodeRule<JsDefaultClause> for FormatJsDefaultClause {
             consequent,
         } = node.as_fields();
 
-        let first_child_is_block_stmt = matches!(
+        write!(f, [default_token.format(), colon_token.format()])?;
+
+        let is_first_child_block_stmt = matches!(
             consequent.iter().next(),
             Some(AnyJsStatement::JsBlockStatement(_))
         );
 
-        write!(f, [default_token.format(), colon_token.format()])?;
-
-        if f.comments().has_dangling_comments(node.syntax()) {
-            write!(f, [space(), format_dangling_comments(node.syntax())])?;
-        }
+        //if f.comments().has_dangling_comments(node.syntax()) {
+        //    write!(f, [space(), format_dangling_comments(node.syntax())])?;
+        //}
 
         if consequent.is_empty() {
             write!(f, [hard_line_break()])
-        } else if first_child_is_block_stmt {
+        } else if is_first_child_block_stmt {
             write!(f, [space(), consequent.format()])
         } else {
             // no line break needed after because it is added by the indent in the switch statement
@@ -42,8 +42,8 @@ impl FormatNodeRule<JsDefaultClause> for FormatJsDefaultClause {
         }
     }
 
-    fn fmt_dangling_comments(&self, _: &JsDefaultClause, _: &mut JsFormatter) -> FormatResult<()> {
-        // Handled inside of `fmt_fields`
-        Ok(())
-    }
+    //fn fmt_dangling_comments(&self, _: &JsDefaultClause, _: &mut JsFormatter) -> FormatResult<()> {
+    //    // Handled inside of `fmt_fields`
+    //    Ok(())
+    //}
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/switch/comments.js.snap.new
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/switch/comments.js.snap.new
@@ -1,0 +1,188 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+assertion_line: 212
+info: js/switch/comments.js
+---
+
+# Input
+
+```js
+switch (true) {
+  case true:
+  // Good luck getting here
+
+  case false:
+}
+
+switch (true) {
+  case true:
+
+  // Good luck getting here
+  case false:
+}
+
+switch(x) {
+  case x: {
+  }
+
+  // other
+
+  case y: {
+  }
+}
+
+switch(x) {
+  default: // comment
+    break;
+}
+
+switch(x) {
+  default: // comment
+    {break;}
+}
+
+switch(x) {
+  default: {// comment
+    break;}
+}
+
+switch(x) {
+  default: /* comment */
+    break;
+}
+
+switch(x) {
+  default: /* comment */
+    {break;}
+}
+
+switch(x) {
+  default: {/* comment */
+    break;}
+}
+
+switch(x) {
+  default: /* comment */ {
+    break;}
+}
+
+```
+
+
+# Prettier differences
+
+```diff
+--- Prettier
++++ Rome
+@@ -23,13 +23,14 @@
+ }
+ 
+ switch (x) {
+-  default: // comment
++  default:
++    // comment
+     break;
+ }
+ 
+ switch (x) {
+-  default: {
+-    // comment
++  default: // comment
++  {
+     break;
+   }
+ }
+@@ -42,12 +43,14 @@
+ }
+ 
+ switch (x) {
+-  default: /* comment */
++  default:
++    /* comment */
+     break;
+ }
+ 
+ switch (x) {
+-  default: /* comment */ {
++  default: /* comment */
++  {
+     break;
+   }
+ }
+```
+
+# Output
+
+```js
+switch (true) {
+  case true:
+  // Good luck getting here
+
+  case false:
+}
+
+switch (true) {
+  case true:
+
+  // Good luck getting here
+  case false:
+}
+
+switch (x) {
+  case x: {
+  }
+
+  // other
+
+  case y: {
+  }
+}
+
+switch (x) {
+  default:
+    // comment
+    break;
+}
+
+switch (x) {
+  default: // comment
+  {
+    break;
+  }
+}
+
+switch (x) {
+  default: {
+    // comment
+    break;
+  }
+}
+
+switch (x) {
+  default:
+    /* comment */
+    break;
+}
+
+switch (x) {
+  default: /* comment */
+  {
+    break;
+  }
+}
+
+switch (x) {
+  default: {
+    /* comment */
+    break;
+  }
+}
+
+switch (x) {
+  default: /* comment */ {
+    break;
+  }
+}
+```
+
+


### PR DESCRIPTION
## Summary

This is a tentative fix for #4254 that is blocking #4234.

For now, the fix avoids comments reordering in default clauses and the reformat failure.

However, this makes a regression on prettier compatibility.
Indeed, the following code:

```js
switch(5){
  default: // comment
    break;
}
```

is formatted to:

```js
switch(5){
  default:
    // comment
    break;
}
```

`// comment` should not be moved.

Any help could be welcome!

## Test Plan

- [ ] Regression test to include

## Documentation

No change.

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
