### PR TITLE
fix(rome_js_semantic): add `TsTypeParameterName` to bindings

### DIFF
--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -173,13 +173,17 @@ mod tests {
             String::from_utf8(buffer).unwrap()
         }
 
-        const SOURCE: &str = r#"a = a"#;
+        const SOURCE: &str = r#"class Foo {
+     f(a: P): undefined;
+     f(a: P): bool;
+     f(a: P, b: D) {}
+   }"#;
 
-        let parsed = parse(SOURCE, SourceType::jsx());
+        let parsed = parse(SOURCE, SourceType::tsx());
 
         let mut error_ranges: Vec<TextRange> = Vec::new();
         let options = AnalyzerOptions::default();
-        let rule_filter = RuleFilter::Rule("nursery", "noSelfAssignment");
+        let rule_filter = RuleFilter::Rule("nursery", "noRedeclaration");
         analyze(
             &parsed.tree(),
             AnalysisFilter {

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_unused_variables.rs
@@ -241,6 +241,7 @@ impl Rule for NoUnusedVariables {
         let name = match binding {
             AnyJsIdentifierBinding::JsIdentifierBinding(binding) => binding.name_token().ok()?,
             AnyJsIdentifierBinding::TsIdentifierBinding(binding) => binding.name_token().ok()?,
+            AnyJsIdentifierBinding::TsTypeParameterName(binding) => binding.ident_token().ok()?,
         };
 
         let name = name.token_text_trimmed();
@@ -354,6 +355,9 @@ impl Rule for NoUnusedVariables {
                     }
                     AnyJsIdentifierBinding::TsIdentifierBinding(binding) => {
                         binding.name_token().ok()?
+                    }
+                    AnyJsIdentifierBinding::TsTypeParameterName(binding) => {
+                        binding.ident_token().ok()?
                     }
                 };
                 let name_trimmed = name.text_trimmed();

--- a/crates/rome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/rome_js_semantic/src/semantic_model/binding.rs
@@ -1,5 +1,7 @@
 use super::*;
-use rome_js_syntax::{binding_ext::AnyJsIdentifierBinding, AnyJsBinding, TextRange};
+use rome_js_syntax::{
+    binding_ext::AnyJsIdentifierBinding, AnyJsBinding, TextRange, TsTypeParameterName,
+};
 
 /// Internal type with all the semantic data of a specific binding
 #[derive(Debug)]
@@ -134,6 +136,7 @@ impl IsBindingAstNode for JsIdentifierBinding {}
 impl IsBindingAstNode for TsIdentifierBinding {}
 impl IsBindingAstNode for AnyJsIdentifierBinding {}
 impl IsBindingAstNode for AnyJsBinding {}
+impl IsBindingAstNode for TsTypeParameterName {}
 
 /// Extension method to allow nodes that have declaration to easily
 /// get its binding.

--- a/crates/rome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/rome_js_semantic/src/semantic_model/builder.rs
@@ -53,6 +53,7 @@ impl SemanticModelBuilder {
             | TS_IDENTIFIER_BINDING
             | JS_REFERENCE_IDENTIFIER
             | JSX_REFERENCE_IDENTIFIER
+            | TS_TYPE_PARAMETER_NAME
             | JS_IDENTIFIER_ASSIGNMENT => {
                 self.node_by_range.insert(node.text_range(), node.clone());
             }

--- a/crates/rome_js_semantic/src/tests/references.rs
+++ b/crates/rome_js_semantic/src/tests/references.rs
@@ -41,7 +41,7 @@ assert_semantics! {
     a = 2;
     let b = a/*READ A*/ + 1;
     console.log(a, b);
-    
+
     var a/*#A*/;
 }
 f();",
@@ -49,8 +49,8 @@ f();",
     a = 1;
     let b = a/*READ A*/ + 1;
     console.log(a, b);
-    if (true) {  
-        var a/*#A*/;      
+    if (true) {
+        var a/*#A*/;
     }
 }
 f();"#,
@@ -201,7 +201,7 @@ assert_semantics! {
     ok_unresolved_reference_arguments,
         r#"function f() {
             console.log(arguments/*?*/);
-        
+
             for(let i = 0;i < arguments/*?*/.length; ++i) {
                 console.log(arguments/*?*/[i]);
             }
@@ -231,16 +231,16 @@ assert_semantics! {
 assert_semantics! {
     ok_reference_static_initialization_block,
         "const a/*#A1*/ = 1;
-        console.log(a/*READ A1*/); 
-        
-        class A { 
+        console.log(a/*READ A1*/);
+
+        class A {
             static {
-                console.log(a/*READ A2*/);  
-                const a/*#A2*/ = 2; 
-                console.log(a/*READ A2*/); 
-            }  
+                console.log(a/*READ A2*/);
+                const a/*#A2*/ = 2;
+                console.log(a/*READ A2*/);
+            }
         };
-        
+
         console.log(a/*READ A1*/);",
 }
 
@@ -248,4 +248,6 @@ assert_semantics! {
 assert_semantics! {
     ok_typescript_function_type,
         "function f (a/*#A1*/, b: (a/*#A2*/) => any) { return b(a/*READ A1*/); };",
+    ok_typescript_type_parameter_name,
+        "type A = { [key/*#A1*/ in P]: key/*READ A1*/ }",
 }

--- a/crates/rome_js_syntax/src/binding_ext.rs
+++ b/crates/rome_js_syntax/src/binding_ext.rs
@@ -14,6 +14,7 @@ use crate::{
     TsIndexSignatureParameter, TsInterfaceDeclaration, TsMethodSignatureClassMember,
     TsMethodSignatureTypeMember, TsModuleDeclaration, TsPropertyParameter,
     TsSetterSignatureClassMember, TsSetterSignatureTypeMember, TsTypeAliasDeclaration,
+    TsTypeParameterName,
 };
 use rome_rowan::{declare_node_union, AstNode, SyntaxResult};
 
@@ -43,7 +44,7 @@ declare_node_union! {
 }
 
 declare_node_union! {
-    pub AnyJsIdentifierBinding = JsIdentifierBinding | TsIdentifierBinding
+    pub AnyJsIdentifierBinding = JsIdentifierBinding | TsIdentifierBinding | TsTypeParameterName
 }
 
 fn declaration(node: &JsSyntaxNode) -> Option<AnyJsBindingDeclaration> {
@@ -122,6 +123,7 @@ impl AnyJsIdentifierBinding {
         match self {
             AnyJsIdentifierBinding::JsIdentifierBinding(binding) => binding.name_token(),
             AnyJsIdentifierBinding::TsIdentifierBinding(binding) => binding.name_token(),
+            AnyJsIdentifierBinding::TsTypeParameterName(binding) => binding.ident_token(),
         }
     }
 
@@ -129,6 +131,7 @@ impl AnyJsIdentifierBinding {
         let node = match self {
             AnyJsIdentifierBinding::JsIdentifierBinding(binding) => &binding.syntax,
             AnyJsIdentifierBinding::TsIdentifierBinding(binding) => &binding.syntax,
+            AnyJsIdentifierBinding::TsTypeParameterName(binding) => &binding.syntax,
         };
         declaration(node)
     }
@@ -152,6 +155,9 @@ impl AnyJsIdentifierBinding {
             }
             AnyJsIdentifierBinding::TsIdentifierBinding(binding) => {
                 AnyJsIdentifierBinding::TsIdentifierBinding(binding.with_name_token(name_token))
+            }
+            AnyJsIdentifierBinding::TsTypeParameterName(binding) => {
+                AnyJsIdentifierBinding::TsTypeParameterName(binding.with_ident_token(name_token))
             }
         }
     }

--- a/website/src/pages/lint/rules/noRedeclaration.md
+++ b/website/src/pages/lint/rules/noRedeclaration.md
@@ -72,6 +72,14 @@ var a = 3;
 a = 10;
 ```
 
+```ts
+class Foo {
+    bar(a: A);
+    bar(a: A, b: B);
+    bar(a: A, b: B) {}
+}
+```
+
 ## Related links
 
 - [Disable a rule](/linter/#disable-a-lint-rule)


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

When https://github.com/rome/tools/pull/4053 was merged, it unveiled an issue in our semantic model.

The CI didn't fail because it doesn't  run some script, but the command `check` was failing on such codes:

```ts
type P = {
	[key in P]: D
}
```

This PR fixes the issue, where we track `key` as bindings.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test case

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
