### PR TITLE
feat(rome_js_analyzer): read globals from analyzer options

### DIFF
--- a/crates/rome_analyze/src/context.rs
+++ b/crates/rome_analyze/src/context.rs
@@ -16,6 +16,7 @@ where
     root: &'a RuleRoot<R>,
     bag: &'a ServiceBag,
     services: RuleServiceBag<R>,
+    globals: &'a [&'a str],
 }
 
 impl<'a, R> RuleContext<'a, R>
@@ -26,6 +27,7 @@ where
         query_result: &'a RuleQueryResult<R>,
         root: &'a RuleRoot<R>,
         services: &'a ServiceBag,
+        globals: &'a [&'a str],
     ) -> Result<Self, Error> {
         let rule_key = RuleKey::rule::<R>();
         Ok(Self {
@@ -33,6 +35,7 @@ where
             root,
             bag: services,
             services: FromServices::from_services(&rule_key, services)?,
+            globals,
         })
     }
 
@@ -88,6 +91,11 @@ where
             .get_service::<ServiceBagRuleOptionsWrapper<R>>()
             .unwrap();
         options
+    }
+
+    /// Checks whether the provided text belongs to globals
+    pub fn is_global(&self, text: &str) -> bool {
+        self.globals.contains(&text)
     }
 }
 

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -76,7 +76,7 @@ pub struct AnalyzerContext<'a, L: Language> {
     pub root: LanguageRoot<L>,
     pub services: ServiceBag,
     pub range: Option<TextRange>,
-    pub options: &'a AnalyzerOptions,
+    pub globals: &'a [&'a str],
 }
 
 impl<'analyzer, L, Matcher, Break, Diag> Analyzer<'analyzer, L, Matcher, Break, Diag>
@@ -140,6 +140,7 @@ where
                 root: &ctx.root,
                 services: &ctx.services,
                 range: ctx.range,
+                globals: ctx.globals,
                 apply_suppression_comment,
             };
 
@@ -217,6 +218,8 @@ struct PhaseRunner<'analyzer, 'phase, L: Language, Matcher, Break, Diag> {
     services: &'phase ServiceBag,
     /// Optional text range to restrict the analysis to
     range: Option<TextRange>,
+    /// Options passed to the analyzer
+    globals: &'phase [&'phase str],
 }
 
 /// Single entry for a suppression comment in the `line_suppressions` buffer
@@ -275,6 +278,7 @@ where
                     query_matcher: self.query_matcher,
                     signal_queue: &mut self.signal_queue,
                     apply_suppression_comment: self.apply_suppression_comment,
+                    globals: self.globals,
                 };
 
                 visitor.visit(&node_event, ctx);
@@ -299,6 +303,7 @@ where
                     query_matcher: self.query_matcher,
                     signal_queue: &mut self.signal_queue,
                     apply_suppression_comment: self.apply_suppression_comment,
+                    globals: self.globals,
                 };
 
                 visitor.visit(&event, ctx);

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -26,6 +26,7 @@ pub struct MatchQueryParams<'phase, 'query, L: Language> {
     pub services: &'phase ServiceBag,
     pub signal_queue: &'query mut BinaryHeap<SignalEntry<'phase, L>>,
     pub apply_suppression_comment: SuppressionCommentEmitter<L>,
+    pub globals: &'phase [&'phase str],
 }
 
 /// Wrapper type for a [QueryMatch]
@@ -206,9 +207,9 @@ mod tests {
 
     use crate::SuppressionKind;
     use crate::{
-        signals::DiagnosticSignal, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal,
-        ControlFlow, MetadataRegistry, Never, Phases, QueryMatcher, RuleKey, ServiceBag,
-        SignalEntry, SyntaxVisitor,
+        signals::DiagnosticSignal, Analyzer, AnalyzerContext, AnalyzerSignal, ControlFlow,
+        MetadataRegistry, Never, Phases, QueryMatcher, RuleKey, ServiceBag, SignalEntry,
+        SyntaxVisitor,
     };
 
     use super::MatchQueryParams;
@@ -379,7 +380,7 @@ mod tests {
             root,
             range: None,
             services: ServiceBag::default(),
-            options: &AnalyzerOptions::default(),
+            globals: &[],
         };
 
         let result: Option<Never> = analyzer.run(ctx);

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -223,6 +223,7 @@ impl<L: Language + Default + 'static> RegistryVisitor<L> for RuleRegistryBuilder
         phase.rule_states.push(RuleState::default());
 
         let rule_key = RuleKey::rule::<R>();
+
         let deserialized =
             if let Some(options) = self.options.configuration.rules.get_rule(&rule_key) {
                 let value = options.value();
@@ -425,11 +426,12 @@ impl<L: Language + Default> RegistryRule<L> {
             // if the query doesn't match
             let query_result = params.query.downcast_ref().unwrap();
             let query_result = <R::Query as Queryable>::unwrap_match(params.services, query_result);
-
-            let ctx = match RuleContext::new(&query_result, params.root, params.services) {
-                Ok(ctx) => ctx,
-                Err(error) => return Err(error),
-            };
+            let ctx =
+                match RuleContext::new(&query_result, params.root, params.services, params.globals)
+                {
+                    Ok(ctx) => ctx,
+                    Err(error) => return Err(error),
+                };
 
             for result in R::run(&ctx) {
                 let text_range =
@@ -443,6 +445,7 @@ impl<L: Language + Default> RegistryRule<L> {
                     result,
                     params.services,
                     params.apply_suppression_comment,
+                    params.globals,
                 ));
 
                 params.signal_queue.push(SignalEntry {

--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -232,7 +232,8 @@ impl_group_language!(
     T00, T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11, T12, T13, T14, T15, T16, T17, T18,
     T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31, T32, T33, T34, T35, T36, T37,
     T38, T39, T40, T41, T42, T43, T44, T45, T46, T47, T48, T49, T50, T51, T52, T53, T54, T55, T56,
-    T57, T58, T59
+    T57, T58, T59, T60, T61, T62, T63, T64, T65, T66, T67, T68, T69, T70, T71, T72, T73, T74, T75,
+    T76, T77, T78, T79, T80, T81, T82, T83, T84, T85, T86, T87, T88, T89
 );
 
 // pub trait DeserializableRuleOptions: Default + DeserializeOwned + Sized {

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -100,9 +100,8 @@ mod tests {
     use std::convert::Infallible;
 
     use crate::{
-        matcher::MatchQueryParams, registry::Phases, Analyzer, AnalyzerContext, AnalyzerOptions,
-        AnalyzerSignal, ControlFlow, MetadataRegistry, Never, QueryMatcher, ServiceBag,
-        SyntaxVisitor,
+        matcher::MatchQueryParams, registry::Phases, Analyzer, AnalyzerContext, AnalyzerSignal,
+        ControlFlow, MetadataRegistry, Never, QueryMatcher, ServiceBag, SyntaxVisitor,
     };
 
     #[derive(Default)]
@@ -165,7 +164,7 @@ mod tests {
             root,
             range: None,
             services: ServiceBag::default(),
-            options: &AnalyzerOptions::default(),
+            globals: &[],
         };
 
         let result: Option<Never> = analyzer.run(ctx);

--- a/crates/rome_analyze/src/visitor.rs
+++ b/crates/rome_analyze/src/visitor.rs
@@ -17,6 +17,7 @@ pub struct VisitorContext<'phase, 'query, L: Language> {
     pub(crate) query_matcher: &'query mut dyn QueryMatcher<L>,
     pub(crate) signal_queue: &'query mut BinaryHeap<SignalEntry<'phase, L>>,
     pub apply_suppression_comment: SuppressionCommentEmitter<L>,
+    pub globals: &'phase [&'phase str],
 }
 
 impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
@@ -28,6 +29,7 @@ impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
             services: self.services,
             signal_queue: self.signal_queue,
             apply_suppression_comment: self.apply_suppression_comment,
+            globals: self.globals,
         })
     }
 }

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -1430,3 +1430,40 @@ fn top_level_not_all_down_level_all() {
         result,
     ));
 }
+
+#[test]
+fn ignore_configured_globals() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let rome_json = r#"{
+        "javascript": {
+            "globals": ["foo", "bar"]
+        }
+    }"#;
+
+    // style/useSingleVarDeclarator
+    let code = r#"foo.call(); bar.call();"#;
+
+    let file_path = Path::new("fix.js");
+    fs.insert(file_path.into(), code.as_bytes());
+
+    let config_path = Path::new("rome.json");
+    fs.insert(config_path.into(), rome_json.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Arguments::from_vec(vec![OsString::from("check"), file_path.as_os_str().into()]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "ignore_configured_globals",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/rome_cli/tests/snapshots/main_commands_check/ignore_configured_globals.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/ignore_configured_globals.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "javascript": {
+    "globals": ["foo", "bar"]
+  }
+}
+```
+
+## `fix.js`
+
+```js
+foo.call(); bar.call();
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -120,12 +120,18 @@ where
 
     services.insert_service(Arc::new(AriaRoles::default()));
     services.insert_service(Arc::new(AriaProperties::default()));
+    let globals: Vec<_> = options
+        .configuration
+        .globals
+        .iter()
+        .map(|global| global.as_str())
+        .collect();
     (
         analyzer.run(AnalyzerContext {
             root: root.clone(),
             range: filter.range,
             services,
-            options,
+            globals: globals.as_slice(),
         }),
         diagnostics,
     )

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
@@ -45,6 +45,10 @@ impl Rule for NoUndeclaredVariables {
                 let token = identifier.value_token().ok()?;
                 let text = token.text_trimmed();
 
+                if ctx.is_global(text) {
+                    return None;
+                }
+
                 // Typescript Const Assertion
                 if text == "const" && under_as_expression {
                     return None;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

The analyzer infrastructure has had  for a while the `globals` field available in the configuration, although it wasn't documented because it wasn't used.

This PR implements the logic to read these globals and update the `noUnusedVariables` rule to consume it. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I created a new test case to make sure the feature works.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
