### PR TITLE
docs(rome_js_analyze): `noParameterAssign` in release 12.0.0

### DIFF
--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_parameter_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_parameter_assign.rs
@@ -56,7 +56,7 @@ declare_rule! {
     /// ```
     ///
     pub(crate) NoParameterAssign {
-        version: "next",
+        version: "12.0.0",
         name: "noParameterAssign",
         recommended: true,
     }

--- a/website/src/pages/lint/rules/noParameterAssign.md
+++ b/website/src/pages/lint/rules/noParameterAssign.md
@@ -3,7 +3,7 @@ title: Lint Rule noParameterAssign
 parent: lint/rules/index
 ---
 
-# noParameterAssign (since vnext)
+# noParameterAssign (since v12.0.0)
 
 Disallow reassigning `function` parameters.
 


### PR DESCRIPTION

## Summary

Fix the version of `noParameterAssign`.

## Test Plan

/

## Documentation

/

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
