### PR TITLE
fix(rome_cli): prevent exploration of ignored directories

### DIFF
--- a/crates/rome_cli/src/execute.rs
+++ b/crates/rome_cli/src/execute.rs
@@ -20,6 +20,15 @@ pub(crate) struct Execution {
     max_diagnostics: u16,
 }
 
+impl Execution {
+    pub(crate) fn as_feature_name(&self) -> FeatureName {
+        match self.traversal_mode {
+            TraversalMode::Format { .. } => FeatureName::Format,
+            _ => FeatureName::Lint,
+        }
+    }
+}
+
 pub(crate) enum TraversalMode {
     /// This mode is enabled when running the command `rome check`
     Check {

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -649,7 +649,7 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
 
     fn can_handle(&self, rome_path: &RomePath) -> bool {
         if rome_path.is_dir() {
-            if self
+            let can_handle = !self
                 .workspace
                 .is_path_ignored(IsPathIgnoredParams {
                     rome_path: rome_path.clone(),
@@ -658,12 +658,8 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
                 .unwrap_or_else(|err| {
                     self.push_diagnostic(err.into());
                     false
-                })
-            {
-                return false;
-            } else {
-                return true;
-            }
+                });
+            return can_handle;
         }
 
         let can_lint = self.can_lint(rome_path);

--- a/crates/rome_cli/src/traversal.rs
+++ b/crates/rome_cli/src/traversal.rs
@@ -14,7 +14,7 @@ use rome_diagnostics::{
 };
 use rome_fs::{FileSystem, OpenOptions, PathInterner, RomePath};
 use rome_fs::{TraversalContext, TraversalScope};
-use rome_service::workspace::{SupportsFeatureResult, UnsupportedReason};
+use rome_service::workspace::{IsPathIgnoredParams, SupportsFeatureResult, UnsupportedReason};
 use rome_service::{
     workspace::{
         FeatureName, FileGuard, Language, OpenFileParams, RuleCategories, SupportsFeatureParams,
@@ -648,6 +648,24 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
     }
 
     fn can_handle(&self, rome_path: &RomePath) -> bool {
+        if rome_path.is_dir() {
+            if self
+                .workspace
+                .is_path_ignored(IsPathIgnoredParams {
+                    rome_path: rome_path.clone(),
+                    feature: self.execution.as_feature_name(),
+                })
+                .unwrap_or_else(|err| {
+                    self.push_diagnostic(err.into());
+                    false
+                })
+            {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
         let can_lint = self.can_lint(rome_path);
         let can_format = self.can_format(rome_path);
 

--- a/crates/rome_fs/src/fs/os.rs
+++ b/crates/rome_fs/src/fs/os.rs
@@ -158,7 +158,6 @@ impl<'scope> TraversalScope<'scope> for OsTraversalScope<'scope> {
 
 /// Default list of ignored directories, in the future will be supplanted by
 /// detecting and parsing .ignore files
-/// TODO: add support for ignore files in Rome
 const DEFAULT_IGNORE: &[&str; 5] = &[".git", ".svn", ".hg", ".yarn", "node_modules"];
 
 /// Traverse a single directory
@@ -268,9 +267,11 @@ fn handle_dir_entry<'scope>(
     }
 
     if file_type.is_dir() {
-        scope.spawn(move |scope| {
-            handle_dir(scope, ctx, &path, origin_path);
-        });
+        if ctx.can_handle(&RomePath::new(path.clone())) {
+            scope.spawn(move |scope| {
+                handle_dir(scope, ctx, &path, origin_path);
+            });
+        }
         return;
     }
 

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -509,6 +509,7 @@ impl ServerFactory {
         builder = builder.custom_method("rome/rage", LSPServer::rage);
 
         workspace_method!(builder, supports_feature);
+        workspace_method!(builder, is_path_ignored);
         workspace_method!(builder, update_settings);
         workspace_method!(builder, open_file);
         workspace_method!(builder, get_syntax_tree);

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -109,7 +109,7 @@ pub enum UnsupportedReason {
     FileNotSupported,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum FeatureName {
     Format,
@@ -334,6 +334,13 @@ impl RageEntry {
     }
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct IsPathIgnoredParams {
+    pub rome_path: RomePath,
+    pub feature: FeatureName,
+}
+
 pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// Checks whether a certain feature is supported. There are different conditions:
     /// - Rome doesn't recognize a file, so it can't provide the feature;
@@ -343,6 +350,14 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
         &self,
         params: SupportsFeatureParams,
     ) -> Result<SupportsFeatureResult, WorkspaceError>;
+
+    /// Checks if the current path is ignored by the workspace, against a particular feature.
+    ///
+    /// Takes as input the path of the file that workspace is currently processing and
+    /// a list of paths to match against.
+    ///
+    /// If the file path matches, than `true` is returned and it should be considered ignored.
+    fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError>;
 
     /// Update the global settings for this workspace
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError>;

--- a/crates/rome_service/src/workspace/client.rs
+++ b/crates/rome_service/src/workspace/client.rs
@@ -1,14 +1,14 @@
+use crate::workspace::{
+    IsPathIgnoredParams, RageParams, RageResult, ServerInfo, SupportsFeatureResult,
+};
+use crate::{TransportError, Workspace, WorkspaceError};
+use rome_formatter::Printed;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::json;
 use std::{
     panic::RefUnwindSafe,
     sync::atomic::{AtomicU64, Ordering},
 };
-
-use rome_formatter::Printed;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::json;
-
-use crate::workspace::{RageParams, RageResult, ServerInfo, SupportsFeatureResult};
-use crate::{TransportError, Workspace, WorkspaceError};
 
 use super::{
     ChangeFileParams, CloseFileParams, FixFileParams, FixFileResult, FormatFileParams,
@@ -104,6 +104,10 @@ where
         params: SupportsFeatureParams,
     ) -> Result<SupportsFeatureResult, WorkspaceError> {
         self.request("rome/supports_feature", params)
+    }
+
+    fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError> {
+        self.request("rome/is_path_ignored", params)
     }
 
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError> {

--- a/rome.json
+++ b/rome.json
@@ -2,7 +2,7 @@
 	"$schema": "./npm/rome/configuration_schema.json",
 	"files": {
 		"ignore": [
-			"website/build",
+			"build",
 			"dist",
 			"target"
 		]

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
 				"start": "astro dev",
 				"format": "cargo rome-cli-dev format --write .",
 				"tsc": "tsc --skipLibCheck",
-				"check": "cargo rome-cli-dev check ./src",
+				"check": "cargo rome-cli-dev check ./",
 				"start:playground": "pnpm build:wasm-dev && pnpm start",
 				"build": "pnpm build:wasm && pnpm build:js",
 				"build:js": "astro build",


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR changes how the traversal works, making the traversal more aware of the ignored paths.

At the moment, Rome tries to traverse all ignored paths, and we check if **the single file** is ignored. This is very inefficient for two reasons:

- we don't cache when a file is ignored, so we need to check it every single time;
- we end up traversing even ignored folders like `dist/`, `target/`, etc., all folders that have built artefacts;

With this PR, I added a new method to the workspace to check if the path is ignored and changed the `can_handle` function to take into consideration directories. If a directory is ignored, then we stop the traversal.

This changes how the ignored paths should be expressed. I had to change the paths in our `rome.json`. Because of that, I consider this fix a  **BREAKING CHANGE**.

On the other hand, this fix will improve the performance of our traversal logic :) 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current tests should pass.

I tested locally that `node_modules`, `target` and `dist` folders are not traversed.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
