### PR TITLE
fix(rome_service): correctly parse enums

### DIFF
--- a/crates/rome_cli/tests/snapshots/main_commands_format/applies_custom_configuration_over_config_file_issue_3175_v2.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/applies_custom_configuration_over_config_file_issue_3175_v2.snap
@@ -26,20 +26,6 @@ function f() {
 # Emitted Messages
 
 ```block
-file.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Formatter would have printed the following content:
-  
-    1 1 │   function f() {
-    2   │ - ··return·'hey';
-      2 │ + ··return·"hey";
-    3 3 │   }
-    4 4 │   
-  
-
-```
-
-```block
 Compared 1 file(s) in <TIME>
 ```
 

--- a/crates/rome_service/src/configuration/parse/json/javascript.rs
+++ b/crates/rome_service/src/configuration/parse/json/javascript.rs
@@ -107,7 +107,7 @@ impl VisitNode<JsonLanguage> for PlainQuoteStyle {
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
         let node = with_only_known_variants(node, PlainQuoteStyle::KNOWN_VALUES, diagnostics)?;
-        if node.value_token().ok()?.text() == "single" {
+        if node.inner_string_text().ok()?.text() == "single" {
             *self = PlainQuoteStyle::Single;
         } else {
             *self = PlainQuoteStyle::Double;
@@ -123,7 +123,7 @@ impl VisitNode<JsonLanguage> for PlainQuoteProperties {
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
         let node = with_only_known_variants(node, PlainQuoteProperties::KNOWN_VALUES, diagnostics)?;
-        if node.value_token().ok()?.text() == "asNeeded" {
+        if node.inner_string_text().ok()?.text() == "asNeeded" {
             *self = PlainQuoteProperties::AsNeeded;
         } else {
             *self = PlainQuoteProperties::Preserve;
@@ -139,7 +139,7 @@ impl VisitNode<JsonLanguage> for PlainTrailingComma {
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
         let node = with_only_known_variants(node, PlainTrailingComma::KNOWN_VALUES, diagnostics)?;
-        match node.value_token().ok()?.text() {
+        match node.inner_string_text().ok()?.text() {
             "all" => {
                 *self = PlainTrailingComma::All;
             }
@@ -162,7 +162,7 @@ impl VisitNode<JsonLanguage> for PlainSemicolons {
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
         let node = with_only_known_variants(node, PlainSemicolons::KNOWN_VALUES, diagnostics)?;
-        if node.value_token().ok()?.text() == "asNeeded" {
+        if node.inner_string_text().ok()?.text() == "asNeeded" {
             *self = PlainSemicolons::AsNeeded;
         } else {
             *self = PlainSemicolons::Always;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/4285

I forgot to use `inner_string_text` instead of `value_token`. Now the configuration is correctly parsed and applied.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Snapshot tests are correctly updated.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
