### PR TITLE
fix(rome_js_analyze): `noRedeclaration` declaration merging

### DIFF
--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid-declaration-merging.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid-declaration-merging.ts
@@ -1,0 +1,16 @@
+// Type and value merging
+export type Order = -1 | 0 | 1;
+
+interface Order {
+	f(): void;
+}
+
+class Order {
+	prop: number;
+}
+
+enum Order {
+	Lower = -1,
+	Equal = 0,
+	Upper = 1,
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid-declaration-merging.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid-declaration-merging.ts.snap
@@ -1,0 +1,97 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 91
+expression: invalid-declaration-merging.ts
+---
+# Input
+```js
+// Type and value merging
+export type Order = -1 | 0 | 1;
+
+interface Order {
+	f(): void;
+}
+
+class Order {
+	prop: number;
+}
+
+enum Order {
+	Lower = -1,
+	Equal = 0,
+	Upper = 1,
+}
+
+```
+
+# Diagnostics
+```
+invalid-declaration-merging.ts:4:11 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'Order'. Consider to delete it or rename it
+  
+    2 │ export type Order = -1 | 0 | 1;
+    3 │ 
+  > 4 │ interface Order {
+      │           ^^^^^
+    5 │ 	f(): void;
+    6 │ }
+  
+  i 'Order' is defined here.
+  
+    1 │ // Type and value merging
+  > 2 │ export type Order = -1 | 0 | 1;
+      │             ^^^^^
+    3 │ 
+    4 │ interface Order {
+  
+
+```
+
+```
+invalid-declaration-merging.ts:8:7 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'Order'. Consider to delete it or rename it
+  
+     6 │ }
+     7 │ 
+   > 8 │ class Order {
+       │       ^^^^^
+     9 │ 	prop: number;
+    10 │ }
+  
+  i 'Order' is defined here.
+  
+    1 │ // Type and value merging
+  > 2 │ export type Order = -1 | 0 | 1;
+      │             ^^^^^
+    3 │ 
+    4 │ interface Order {
+  
+
+```
+
+```
+invalid-declaration-merging.ts:12:6 lint/nursery/noRedeclaration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Shouldn't redeclare 'Order'. Consider to delete it or rename it
+  
+    10 │ }
+    11 │ 
+  > 12 │ enum Order {
+       │      ^^^^^
+    13 │ 	Lower = -1,
+    14 │ 	Equal = 0,
+  
+  i 'Order' is defined here.
+  
+    1 │ // Type and value merging
+  > 2 │ export type Order = -1 | 0 | 1;
+      │             ^^^^^
+    3 │ 
+    4 │ interface Order {
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.jsonc
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.jsonc
@@ -24,5 +24,6 @@
 	"function f() { var a; var a; }",
 	"function f() { var a; if (test) { var a; } }",
 	"for (var a, a;;);",
-	"for (;;){ var a, a,;}"
+	"for (;;){ var a, a,;}",
+	"function f(x) { var x = 5; }"
 ]

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/invalid.jsonc.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 91
 expression: invalid.jsonc
 ---
 # Input
@@ -525,6 +526,11 @@ invalid.jsonc:1:18 lint/nursery/noRedeclaration ━━━━━━━━━━�
       │               ^
   
 
+```
+
+# Input
+```js
+function f(x) { var x = 5; }
 ```
 
 

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid-declaration-merging.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid-declaration-merging.ts
@@ -1,0 +1,88 @@
+// Type and value merging
+export type Order = -1 | 0 | 1;
+export const Order = {
+	LOWER: -1,
+	EQUAL: 0,
+	UPPER: 1,
+} as const;
+
+export type Direction = "Up" | "Down";
+export namespace Direction {
+	export const Up = "Up";
+	export type Up = "Up";
+	export const Down = "Down";
+	export type Down = "Down";
+}
+
+export type Person = {
+	readonly name: string;
+};
+export function Person(name: string): Person {
+	return { name };
+}
+
+interface Organization {
+	readonly name: string;
+}
+export function Organization(name: string): Organization {
+	return { name };
+}
+
+// Interface merging
+export interface Splitted {
+	f(): void;
+}
+export interface Splitted {
+	g(): void;
+}
+
+// interface, class, and namespace merging
+export interface MoralPerson {
+	phantom(): void;
+}
+export class MoralPerson {
+	name: string;
+	constructor(name: string) {
+		this.name = name;
+	}
+}
+export namespace MoralPerson {
+	export function from(name: string) {
+		return new MoralPerson(name);
+	}
+}
+
+// function and namespace merging
+export function mod(): void {}
+export namespace MoralPerson {
+	export function f(): void {}
+}
+
+// enum and namespace merging
+export enum Orientation {
+	North,
+	East,
+	South,
+	West,
+}
+export namespace Orientation {
+	export function f(): void {}
+}
+
+// namespace merging
+export namespace X {
+	export function f(): void {}
+}
+export namespace X {
+	export function g(): void {}
+}
+
+// enum merging
+export enum Orientation2 {
+	North = 0,
+	South = 1,
+}
+export enum Orientation2 {
+	East = 2,
+	West = 3,
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid-declaration-merging.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid-declaration-merging.ts.snap
@@ -1,0 +1,99 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 91
+expression: valid-declaration-merging.ts
+---
+# Input
+```js
+// Type and value merging
+export type Order = -1 | 0 | 1;
+export const Order = {
+	LOWER: -1,
+	EQUAL: 0,
+	UPPER: 1,
+} as const;
+
+export type Direction = "Up" | "Down";
+export namespace Direction {
+	export const Up = "Up";
+	export type Up = "Up";
+	export const Down = "Down";
+	export type Down = "Down";
+}
+
+export type Person = {
+	readonly name: string;
+};
+export function Person(name: string): Person {
+	return { name };
+}
+
+interface Organization {
+	readonly name: string;
+}
+export function Organization(name: string): Organization {
+	return { name };
+}
+
+// Interface merging
+export interface Splitted {
+	f(): void;
+}
+export interface Splitted {
+	g(): void;
+}
+
+// interface, class, and namespace merging
+export interface MoralPerson {
+	phantom(): void;
+}
+export class MoralPerson {
+	name: string;
+	constructor(name: string) {
+		this.name = name;
+	}
+}
+export namespace MoralPerson {
+	export function from(name: string) {
+		return new MoralPerson(name);
+	}
+}
+
+// function and namespace merging
+export function mod(): void {}
+export namespace MoralPerson {
+	export function f(): void {}
+}
+
+// enum and namespace merging
+export enum Orientation {
+	North,
+	East,
+	South,
+	West,
+}
+export namespace Orientation {
+	export function f(): void {}
+}
+
+// namespace merging
+export namespace X {
+	export function f(): void {}
+}
+export namespace X {
+	export function g(): void {}
+}
+
+// enum merging
+export enum Orientation2 {
+	North = 0,
+	South = 1,
+}
+export enum Orientation2 {
+	East = 2,
+	West = 3,
+}
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid-duplicate.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid-duplicate.ts
@@ -1,0 +1,17 @@
+const obj = {
+	a: 1,
+	a: 2,
+};
+
+function f(x: number, x: number): void {}
+
+class A {
+	g(x: number): number;
+	g(x: string): string;
+	g(x: number | string): number | string {
+		return x;
+	}
+
+	f(): void {}
+	f(): void {}
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid-duplicate.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noRedeclaration/valid-duplicate.ts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+assertion_line: 91
+expression: valid-duplicate.ts
+---
+# Input
+```js
+const obj = {
+	a: 1,
+	a: 2,
+};
+
+function f(x: number, x: number): void {}
+
+class A {
+	g(x: number): number;
+	g(x: string): string;
+	g(x: number | string): number | string {
+		return x;
+	}
+
+	f(): void {}
+	f(): void {}
+}
+
+```
+
+

--- a/website/src/pages/lint/rules/noRedeclaration.md
+++ b/website/src/pages/lint/rules/noRedeclaration.md
@@ -35,6 +35,52 @@ var a = 10;
 </code></pre>
 
 ```jsx
+let a = 3;
+let a = 10;
+```
+
+<pre class="language-text"><code class="language-text">nursery/noRedeclaration.js:2:5 <a href="https://docs.rome.tools/lint/rules/noRedeclaration">lint/nursery/noRedeclaration</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Shouldn't redeclare 'a'. Consider to delete it or rename it</span>
+  
+    <strong>1 │ </strong>let a = 3;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>let a = 10;
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">'a' is defined here.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>let a = 3;
+   <strong>   │ </strong>    <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>let a = 10;
+    <strong>3 │ </strong>
+  
+</code></pre>
+
+```jsx
+function f() {}
+function f() {}
+```
+
+<pre class="language-text"><code class="language-text">nursery/noRedeclaration.js:2:10 <a href="https://docs.rome.tools/lint/rules/noRedeclaration">lint/nursery/noRedeclaration</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Shouldn't redeclare 'f'. Consider to delete it or rename it</span>
+  
+    <strong>1 │ </strong>function f() {}
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>function f() {}
+   <strong>   │ </strong>         <strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">'f' is defined here.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>function f() {}
+   <strong>   │ </strong>         <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>function f() {}
+    <strong>3 │ </strong>
+  
+</code></pre>
+
+```jsx
 class C {
     static {
         var c = 3;
@@ -62,6 +108,29 @@ class C {
    <strong>   │ </strong>            <strong><span style="color: Tomato;">^</span></strong>
     <strong>4 │ </strong>        var c = 10;
     <strong>5 │ </strong>    }
+  
+</code></pre>
+
+```ts
+type Person = { name: string; }
+class Person { name: string; }
+```
+
+<pre class="language-text"><code class="language-text">nursery/noRedeclaration.js:2:7 <a href="https://docs.rome.tools/lint/rules/noRedeclaration">lint/nursery/noRedeclaration</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Shouldn't redeclare 'Person'. Consider to delete it or rename it</span>
+  
+    <strong>1 │ </strong>type Person = { name: string; }
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>class Person { name: string; }
+   <strong>   │ </strong>      <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">'Person' is defined here.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>type Person = { name: string; }
+   <strong>   │ </strong>     <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>class Person { name: string; }
+    <strong>3 │ </strong>
   
 </code></pre>
 


### PR DESCRIPTION
## Summary

Fixes #4287.

While I was fixing the issue, I realized that [noDuplicateParameters](https://docs.rome.tools/lint/rules/noduplicateparameters/) and `noRedeclaration` have some intersections. We could merge these two rules in another PR?

EDIT: this PR also allows duplicate parameters. To prevent duplicate parameters use `noSuplicateParameters` instead.

## Test Plan

Extended.

## Documentation

Updated.

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
