### PR TITLE
website(docs): Enhance the documentation for the config-path option

### DIFF
--- a/website/src/pages/cli.mdx
+++ b/website/src/pages/cli.mdx
@@ -75,7 +75,7 @@ The maximum allowed size for source code files in bytes.
 
 Set a directory where to read the `rome.json` configuration file from.
 Rome will try to read a `rome.json` configuration file from the specified directory.
-This is optional. Rome will automatically try to discover a the `rome.json` configuration file by default.
+This is optional. Rome will try to auto discover a `rome.json` configuration file by default.
 
 > **Important**: when passing `--config-path`, the auto discovery of the `rome.json` configuration file is disabled.
 

--- a/website/src/pages/cli.mdx
+++ b/website/src/pages/cli.mdx
@@ -73,10 +73,11 @@ The maximum allowed size for source code files in bytes.
 
 ### `--config-path`
 
-Tell Rome in which path to find the configuration file `rome.json`.
+Set a directory where to read the `rome.json` configuration file from.
+Rome will try to read a `rome.json` configuration file from the specified directory.
+This is optional. Rome will automatically try to discover a the `rome.json` configuration file by default.
 
-> **Warning**: when passing `--config-path`, the auto discovery of the `rome.json` file is disabled.
-
+> **Important**: when passing `--config-path`, the auto discovery of the `rome.json` configuration file is disabled.
 
 ## Global Options
 

--- a/website/src/pages/configuration.mdx
+++ b/website/src/pages/configuration.mdx
@@ -12,11 +12,12 @@ import CodeBlockHeader from "/components/CodeBlockHeader.astro";
 
 # Configuration
 
-The configuration file is considered **optional**, Rome has good defaults. Use the configuration
-file to change those defaults.
+Using configuration is considered **optional**, Rome has good defaults. Use the configuration to change those defaults.
 
 The Rome configuration file is named `rome.json` and should be placed in the root directory of your project. The root
 directory is usually the directory containing your project's `package.json`.
+
+Rome will try to auto discover a `rome.json` configuration file by default, you do not need to set a path to it.
 
 Here's an example:
 


### PR DESCRIPTION
Enhances the documentation for the new config-path option and defuses some strong wording (~Warning~ -> Important).

Related

- https://github.com/rome/tools/pull/4002