### PR TITLE
fix(rome_formatter): fix format range

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -1192,12 +1192,12 @@ pub fn format_range<Language: FormatLanguage>(
                             // e.g
                             // ...
                             // SourceMarker {
-                            //     source: 94,
-                            //     dest: 99, <----- both markers have the same dest.
+                            //     source: 94, <----- but we need to use this source position to get correct substring in the source
+                            //     dest: 99,
                             // },
                             // SourceMarker {
-                            //     source: 96, <----- but we need to use this source position to get correct substring in the source
-                            //     dest: 99,
+                            //     source: 96,
+                            //     dest: 99, <----- both markers have the same dest.
                             // },
                             // ...
                             Some(prev_marker)

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -413,40 +413,6 @@ mod tests {
     use rome_rowan::{TextRange, TextSize};
 
     #[test]
-    fn test_format_range_parentheses_binary() {
-        let input = "import React from 'react'; function test() { const AppShelled = () => (1 + 2) } function one() {return 1}";
-        let range_start = TextSize::try_from(input.find("(1").unwrap() - 1).unwrap();
-        let range_end = TextSize::try_from(input.find("2)").unwrap() + 1).unwrap();
-
-        let tree = parse(input, SourceType::tsx());
-        let result = format_range(
-            JsFormatOptions::new(SourceType::tsx()),
-            &tree.syntax(),
-            TextRange::new(range_start, range_end),
-        );
-        let result = result.expect("range formatting failed");
-
-        assert_eq!(result.as_code(), "const AppShelled = () => 1 + 2");
-    }
-
-    #[test]
-    fn test_format_range_parentheses_jsx() {
-        let input = "import React from 'react'; function test() { const AppShelled = () => (<Component />) } function lol() {return 1}";
-        let range_start = TextSize::try_from(input.find("(<").unwrap() - 1).unwrap();
-        let range_end = TextSize::try_from(input.find(">)").unwrap() + 1).unwrap();
-
-        let tree = parse(input, SourceType::tsx());
-        let result = format_range(
-            JsFormatOptions::new(SourceType::tsx()),
-            &tree.syntax(),
-            TextRange::new(range_start, range_end),
-        );
-        let result = result.expect("range formatting failed");
-
-        assert_eq!(result.as_code(), "const AppShelled = () => <Component />");
-    }
-
-    #[test]
     fn test_range_formatting() {
         let input = "
 while(
@@ -525,51 +491,6 @@ function() {
         assert_eq!(
             result.range(),
             Some(TextRange::new(range_start, range_end + TextSize::from(1)))
-        );
-    }
-
-    #[test]
-    fn test_range_formatting_semicolon() {
-        let input = "
-    statement_1()
-    statement_2()
-    statement_3()
-";
-
-        let range_start = TextSize::try_from(input.find("statement_2").unwrap()).unwrap();
-        let range_end = range_start + TextSize::of("statement_2()");
-
-        let tree = parse_script(input);
-        let result = format_range(
-            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
-            &tree.syntax(),
-            TextRange::new(range_start, range_end),
-        );
-
-        let result = result.expect("range formatting failed");
-        assert_eq!(result.as_code(), "statement_2();");
-        assert_eq!(result.range(), Some(TextRange::new(range_start, range_end)));
-    }
-
-    #[test]
-    fn test_range_formatting_expression() {
-        let input = "1 + 2 + 3 + 4 + 5";
-
-        let range_start = TextSize::try_from(input.find("3 + 4").unwrap()).unwrap();
-        let range_end = range_start + TextSize::of("3 + 4");
-
-        let tree = parse_script(input);
-        let result = format_range(
-            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
-            &tree.syntax(),
-            TextRange::new(range_start, range_end),
-        );
-
-        let result = result.expect("range formatting failed");
-        assert_eq!(result.as_code(), "1 + 2 + 3 + 4 + 5;");
-        assert_eq!(
-            result.range(),
-            Some(TextRange::new(TextSize::from(0), TextSize::of(input)))
         );
     }
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js
@@ -1,0 +1,1 @@
+1 + 2 + <<<ROME_RANGE_START>>>3 + 4<<<ROME_RANGE_END>>> + 5

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+info: js/module/expression/binary_range_expression.js
+---
+
+# Input
+
+```js
+1 + 2 + 3 + 4 + 5
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+1 + 2 + 3 + 4 + 5;
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js
@@ -1,0 +1,3 @@
+statement_1()
+<<<ROME_RANGE_START>>>statement_2()<<<ROME_RANGE_END>>>
+statement_3()

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
@@ -1,0 +1,54 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+info: js/module/no-semi/semicolons_range.js
+---
+
+# Input
+
+```js
+statement_1()
+statement_2()
+statement_3()
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+statement_1()
+statement_2();
+statement_3()
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: As needed
+-----
+
+```js
+statement_1()
+statement_2()
+statement_3()
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js
@@ -1,0 +1,1 @@
+import React from 'react'; function test() { const AppShelled = () => <<<ROME_RANGE_START>>>(1 + 2)<<<ROME_RANGE_END>>> } function one() {return 1}

--- a/crates/rome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
@@ -1,0 +1,38 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+info: js/module/parentheses/range_parentheses_binary.js
+---
+
+# Input
+
+```js
+import React from 'react'; function test() { const AppShelled = () => (1 + 2) } function one() {return 1}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+import React from 'react'; function test() { const AppShelled = () => 1 + 2 } function one() {return 1}
+```
+
+# Lines exceeding max width of 80 characters
+```
+    1: import React from 'react'; function test() { const AppShelled = () => 1 + 2 } function one() {return 1}
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js
@@ -1,0 +1,10 @@
+a?.b
+const a = () => {sdasdsa;
+	kek;
+	dsad<<<ROME_RANGE_START>>>sa;
+	123;
+	("y̆es");
+};
+console.log("🚀".length);
+		<<<ROME_RANGE_END>>>
+("Jan 1, 2018 – Jan 1, 2019");

--- a/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
@@ -1,0 +1,52 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+info: js/module/range/range_parenthesis_after_semicol.js
+---
+
+# Input
+
+```js
+a?.b
+const a = () => {sdasdsa;
+	kek;
+	dsadsa;
+	123;
+	("y̆es");
+};
+console.log("🚀".length);
+		
+("Jan 1, 2018 – Jan 1, 2019");
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+a?.b
+const a = () => {
+	sdasdsa;
+	kek;
+	dsadsa;
+	123;
+	("y̆es");
+};
+console.log("🚀".length);
+
+("Jan 1, 2018 – Jan 1, 2019");
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js
@@ -1,0 +1,8 @@
+a?.b
+const a = () => {sdasdsa;
+	kek;
+	dsad<<<ROME_RANGE_START>>>sa;
+	123;
+	("y̆es");
+};
+console.log("🚀".length);<<<ROME_RANGE_END>>>("Jan 1, 2018 – Jan 1, 2019");

--- a/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
@@ -1,0 +1,49 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+info: js/module/range_parenthesis_after_semicol_1.js
+---
+
+# Input
+
+```js
+a?.b
+const a = () => {sdasdsa;
+	kek;
+	dsadsa;
+	123;
+	("y̆es");
+};
+console.log("🚀".length);("Jan 1, 2018 – Jan 1, 2019");
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+a?.b
+const a = () => {
+	sdasdsa;
+	kek;
+	dsadsa;
+	123;
+	("y̆es");
+};
+console.log("🚀".length);
+("Jan 1, 2018 – Jan 1, 2019");
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/js/module/string/parentheses_token.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/parentheses_token.js
@@ -1,0 +1,1 @@
+("Jan 1, <<<ROME_RANGE_START>>>2018 – Jan 1, 2019<<<ROME_RANGE_END>>>")

--- a/crates/rome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
@@ -1,0 +1,63 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+info: js/module/string/parentheses_token.js
+---
+
+# Input
+
+```js
+("Jan 1, 2018 – Jan 1, 2019")
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+("Jan 1, 2018 – Jan 1, 2019")
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Single Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+('Jan 1, 2018 – Jan 1, 2019')
+```
+
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: Preserve
+Trailing comma: All
+Semicolons: Always
+-----
+
+```js
+("Jan 1, 2018 – Jan 1, 2019")
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/jsx/parentheses_range.jsx
+++ b/crates/rome_js_formatter/tests/specs/jsx/parentheses_range.jsx
@@ -1,0 +1,1 @@
+import React from 'react'; function test() { const AppShelled = () => <<<ROME_RANGE_START>>>(<Component />)<<<ROME_RANGE_END>>> } function lol() {return 1}

--- a/crates/rome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
@@ -1,0 +1,38 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+info: jsx/parentheses_range.jsx
+---
+
+# Input
+
+```jsx
+import React from 'react'; function test() { const AppShelled = () => (<Component />) } function lol() {return 1}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```jsx
+import React from 'react'; function test() { const AppShelled = () => <Component /> } function lol() {return 1}
+```
+
+# Lines exceeding max width of 80 characters
+```
+    1: import React from 'react'; function test() { const AppShelled = () => <Component /> } function lol() {return 1}
+```
+
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

1. Fix format issues with incorrect replace rage in the source text.

- `crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap`
- `crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap`

2. Introduce `<<<ROME_RANGE_START>>>` and `<<<ROME_RANGE_END>>>` for snapshot testing.
3. Fix format the range issue if we get a token in the transformed tree.

UPD:

Let say we want to format with range ``range = 5..94`` this code: 

```
a?.b
const a = () => {sdasdsa;
	kek;
	dsad<<<ROME_RANGE_START>>>sa;
	123;
	("y̆es");
};
console.log("🚀".length);
		<<<ROME_RANGE_END>>>
("Jan 1, 2018 – Jan 1, 2019");
```

We need to calculate `source` and `dest` ranges. 

- `source` range we use to find a position in the source text where we need to replace the substring. 
- `dest` range we use to get the substring from the formatted code that we need to replace in the source text.

The example has a problem for the right end. We get the result:
```
a?.b
const a = () => {
	sdasdsa;
	kek;
	dsadsa;
	123;
	("y̆es");
};
console.log("🚀".length);

( <--- the problem
		
("Jan 1, 2018 – Jan 1, 2019");
```

it has the following source map:

```
   ...
    SourceMarker {
        source: 93,
        dest: 96,
    },
    SourceMarker {
        source: 94,
        dest: 97,
    },
    SourceMarker {
        source: 94,
        dest: 99,
    },
    SourceMarker {        <----- Now we take this range.
                                 Because we have a condition `marker.source <= prev_marker.source`
        source: 94,
        dest: 100,       <----- here
    },
    SourceMarker {   <---- But we need to take this one.
        source: 99,     
        dest: 100,       <----- and here
    },
    SourceMarker {
        source: 133,
        dest: 133,
    },
    ...
```

We can solve the issue by checking markers with the same dest but a greater source.


The same logic we can apply for a left side.

## Test Plan

`cargo test`

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
