### PR TITLE
feat(rome_lsp): pull diagnostics for `rome.json`

### DIFF
--- a/crates/rome_analyze/src/rule.rs
+++ b/crates/rome_analyze/src/rule.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use rome_console::fmt::Display;
 use rome_console::{markup, MarkupBuf};
-use rome_deserialize::json::{deserialize_from_json, JsonDeserialize, VisitJsonNode};
+use rome_deserialize::json::{deserialize_from_json_str, JsonDeserialize, VisitJsonNode};
 use rome_deserialize::Deserialized;
 use rome_diagnostics::advice::CodeSuggestionAdvice;
 use rome_diagnostics::location::AsSpan;
@@ -244,7 +244,7 @@ impl_group_language!(
 
 pub trait DeserializableRuleOptions: Default + Sized + JsonDeserialize + VisitJsonNode {
     fn from(value: String) -> Deserialized<Self> {
-        deserialize_from_json(&value)
+        deserialize_from_json_str(&value)
     }
 }
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_exhaustive_dependencies.rs
@@ -5,7 +5,7 @@ use rome_analyze::{
 };
 use rome_console::markup;
 use rome_deserialize::json::{
-    deserialize_from_json, has_only_known_keys, JsonDeserialize, VisitJsonNode,
+    deserialize_from_json_str, has_only_known_keys, JsonDeserialize, VisitJsonNode,
 };
 use rome_deserialize::{DeserializationDiagnostic, Deserialized, VisitNode};
 use rome_js_semantic::{Capture, SemanticModel};
@@ -253,7 +253,7 @@ impl JsonDeserialize for HooksOptions {
 
 impl DeserializableRuleOptions for HooksOptions {
     fn from(value: String) -> Deserialized<Self> {
-        deserialize_from_json(&value)
+        deserialize_from_json_str(&value)
     }
 }
 

--- a/crates/rome_service/src/configuration/diagnostics.rs
+++ b/crates/rome_service/src/configuration/diagnostics.rs
@@ -215,7 +215,7 @@ pub struct InvalidIgnorePattern {
 mod test {
     use crate::configuration::diagnostics::ConfigurationDiagnostic;
     use crate::{Configuration, MatchOptions, Matcher};
-    use rome_deserialize::json::deserialize_from_json;
+    use rome_deserialize::json::deserialize_from_json_str;
     use rome_diagnostics::{print_diagnostic_to_string, DiagnosticExt, Error};
 
     fn snap_diagnostic(test_name: &str, diagnostic: Error) {
@@ -268,7 +268,7 @@ mod test {
     #[test]
     fn deserialization_error() {
         let content = "{ \n\n\"formatter\" }";
-        let result = deserialize_from_json::<Configuration>(content);
+        let result = deserialize_from_json_str::<Configuration>(content);
 
         assert!(result.has_errors());
         for diagnostic in result.into_diagnostics() {
@@ -291,6 +291,6 @@ mod test {
     }
   }
 }"#;
-        let _result = deserialize_from_json::<Configuration>(content).into_deserialized();
+        let _result = deserialize_from_json_str::<Configuration>(content).into_deserialized();
     }
 }

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -32,7 +32,7 @@ pub use formatter::{FormatterConfiguration, PlainIndentStyle};
 pub use javascript::{JavascriptConfiguration, JavascriptFormatter};
 pub use linter::{LinterConfiguration, RuleConfiguration, Rules};
 use rome_analyze::{AnalyzerConfiguration, AnalyzerRules};
-use rome_deserialize::json::deserialize_from_json;
+use rome_deserialize::json::deserialize_from_json_str;
 use rome_deserialize::Deserialized;
 use rome_js_analyze::metadata;
 use rome_json_formatter::context::JsonFormatOptions;
@@ -208,7 +208,7 @@ pub fn load_config(
                     );
                 }
 
-                let deserialized = deserialize_from_json::<Configuration>(&buffer)
+                let deserialized = deserialize_from_json_str::<Configuration>(&buffer)
                     .with_file_path(&configuration_path.display().to_string());
                 Ok(Some(deserialized))
             }

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -184,6 +184,7 @@ pub(crate) struct LintParams<'a> {
     pub(crate) rules: Option<&'a Rules>,
     pub(crate) settings: SettingsHandle<'a>,
     pub(crate) max_diagnostics: u64,
+    pub(crate) path: &'a RomePath,
 }
 
 pub(crate) struct LintResults {

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -381,6 +381,7 @@ impl Workspace for WorkspaceServer {
                 rules,
                 settings: self.settings(),
                 max_diagnostics: params.max_diagnostics,
+                path: &params.path,
             });
 
             (

--- a/crates/rome_service/tests/spec_tests.rs
+++ b/crates/rome_service/tests/spec_tests.rs
@@ -1,4 +1,4 @@
-use rome_deserialize::json::deserialize_from_json;
+use rome_deserialize::json::deserialize_from_json_str;
 use rome_diagnostics::{print_diagnostic_to_string, DiagnosticExt};
 use rome_service::Configuration;
 use std::ffi::OsStr;
@@ -14,7 +14,7 @@ fn run_invalid_configurations(input: &'static str, _: &str, _: &str, _: &str) {
         .unwrap_or_else(|err| panic!("failed to read {:?}: {:?}", input_file, err));
 
     let result = match extension {
-        "json" => deserialize_from_json::<Configuration>(input_code.as_str()),
+        "json" => deserialize_from_json_str::<Configuration>(input_code.as_str()),
         _ => {
             panic!("Extension not supported");
         }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a minor improvement to the LSP. When the workspace requests diagnostics for a JSON file, we check if the file being analyzed is a `rome.json` file and attempt to deserialize and return additional diagnostics.

While the schema is already valuable for the majority of the cases:
- sometimes, people don't use the JSON schema, or they are not aware of it;
- there are situations where we run specific validations;

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added a new test case. I also tested locally.

<img width="974" alt="Screenshot 2023-03-13 at 20 45 13" src="https://user-images.githubusercontent.com/602478/224829202-991b5cf1-c71b-44fd-96a0-8ae0983d0acb.png">


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
