### PR TITLE
fix: add missing license to the generated packages on CI

### DIFF
--- a/npm/rome/scripts/generate-packages.mjs
+++ b/npm/rome/scripts/generate-packages.mjs
@@ -24,11 +24,12 @@ function generateNativePackage(platform, arch) {
 	fs.mkdirSync(packageRoot);
 
 	// Generate the package.json manifest
-	const { version } = rootManifest;
+	const { version, license } = rootManifest;
 
 	const manifest = JSON.stringify({
 		name: packageName,
 		version,
+		license,
 		os: [platform],
 		cpu: [arch],
 	});


### PR DESCRIPTION
## Summary

This PR just add the license to the autogenerated packages marked as optional dependencies of the main package.

This was causing problems with some systems that require licenses. 

This was referenced [on this issue](https://github.com/rome/tools/issues/4290).

Closes https://github.com/rome/tools/issues/4290

## Test Plan

AFAIK, this is only executed on CI whenever a new version is deployed, so no tests are required.

## Documentation

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
