### PR TITLE
fix(xtask): `just new-lintrule` document generation error

### DIFF
--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -35,7 +35,7 @@ declare_rule! {{
     ///
     /// Add a link to the corresponding ESLint rule (if any):
     ///
-    /// Source: https://eslint.org/docs/latest/rules/<rule-name>
+    /// Source: https://eslint.org/docs/latest/rules/rule-name
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

When I execute `just new-lintrule crates/rome_js_analyze/src/analyzers/nursery noNonInteractiveTabindex`, the result has an error like this:

![Screenshot 2023-03-18 at 2 10 36](https://user-images.githubusercontent.com/38400669/225974290-48e64634-78da-4f8b-b059-d7c08d324e2a.png)

- It seems like the pattern `<rule_name>` on the `declare_rule!` macro is invalid case: https://github.com/rome/tools/blob/9f502577b2e8711f4c6cced00f9bd1b8c42a97e7/xtask/lintdoc/src/main.rs#L390
- So I removed `<` and `>`.

This pr fixes this error.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
