### PR TITLE
feat(rome_js_analyze): noNoninteractiveTabindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### New rules
 - [`noConfusingArrow`](https://docs.rome.tools/lint/rules/noConfusingArrow/)
 - [`noRedundantRoles`](https://docs.rome.tools/lint/rules/noRedundantRoles/)
+- [`noNoninteractiveTabindex`](https://docs.rome.tools/lint/rules/noNoninteractiveTabindex/)
 ### Parser
 ### VSCode
 ### JavaScript APIs

--- a/crates/rome_aria/src/roles.rs
+++ b/crates/rome_aria/src/roles.rs
@@ -747,6 +747,7 @@ impl<'a> AriaRoles {
         "table",
         "term",
         "textbox",
+        "generic",
     ];
 
     /// It returns the metadata of a role, if it exits.
@@ -820,6 +821,7 @@ impl<'a> AriaRoles {
             "region" => &RegionRole as &dyn AriaRoleDefinition,
             "presentation" => &PresentationRole as &dyn AriaRoleDefinition,
             "document" => &DocumentRole as &dyn AriaRoleDefinition,
+            "generic" => &GenericRole as &dyn AriaRoleDefinition,
             _ => return None,
         };
         Some(result)
@@ -1003,6 +1005,7 @@ impl<'a> AriaRoles {
                 "table" => &TableRole as &dyn AriaRoleDefinitionWithConcepts,
                 "term" => &TermRole as &dyn AriaRoleDefinitionWithConcepts,
                 "textbox" => &TextboxRole as &dyn AriaRoleDefinitionWithConcepts,
+                "generic" => &GenericRole as &dyn AriaRoleDefinitionWithConcepts,
                 _ => return false,
             };
             if let Some(mut concepts) = role.concepts_by_element_name(element_name) {

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -99,7 +99,11 @@ define_categories! {
     "lint/nursery/noUselessCatch": "https://docs.rome.tools/lint/rules/noUselessCatch",
 "lint/nursery/noParameterAssign": "https://docs.rome.tools/lint/rules/noParameterAssign",
 "lint/nursery/noNamespace": "https://docs.rome.tools/lint/rules/noNamespace",
+<<<<<<< HEAD
 "lint/nursery/noConfusingArrow": "https://docs.rome.tools/lint/rules/noConfusingArrow",
+=======
+"lint/nursery/noNoninteractiveTabindex": "https://docs.rome.tools/lint/rules/noNoninteractiveTabindex",
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
     // Insert new nursery rule here
     "lint/nursery/noRedeclare": "https://docs.rome.tools/lint/rules/noRedeclare",
     "lint/nursery/useNamespaceKeyword": "https://docs.rome.tools/lint/rules/useNamespaceKeyword",

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -99,11 +99,8 @@ define_categories! {
     "lint/nursery/noUselessCatch": "https://docs.rome.tools/lint/rules/noUselessCatch",
 "lint/nursery/noParameterAssign": "https://docs.rome.tools/lint/rules/noParameterAssign",
 "lint/nursery/noNamespace": "https://docs.rome.tools/lint/rules/noNamespace",
-<<<<<<< HEAD
 "lint/nursery/noConfusingArrow": "https://docs.rome.tools/lint/rules/noConfusingArrow",
-=======
 "lint/nursery/noNoninteractiveTabindex": "https://docs.rome.tools/lint/rules/noNoninteractiveTabindex",
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
     // Insert new nursery rule here
     "lint/nursery/noRedeclare": "https://docs.rome.tools/lint/rules/noRedeclare",
     "lint/nursery/useNamespaceKeyword": "https://docs.rome.tools/lint/rules/useNamespaceKeyword",

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery.rs
@@ -2,17 +2,10 @@
 
 use rome_analyze::declare_group;
 mod no_noninteractive_element_to_interactive_role;
-<<<<<<< HEAD
-mod no_redundant_roles;
-=======
 mod no_noninteractive_tabindex;
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+mod no_redundant_roles;
 mod use_aria_prop_types;
 mod use_aria_props_for_role;
 mod use_valid_aria_props;
 mod use_valid_lang;
-<<<<<<< HEAD
-declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole , self :: no_redundant_roles :: NoRedundantRoles , self :: use_aria_prop_types :: UseAriaPropTypes , self :: use_aria_props_for_role :: UseAriaPropsForRole , self :: use_valid_aria_props :: UseValidAriaProps , self :: use_valid_lang :: UseValidLang ,] } }
-=======
-declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole , self :: no_noninteractive_tabindex :: NoNoninteractiveTabindex , self :: use_aria_prop_types :: UseAriaPropTypes , self :: use_aria_props_for_role :: UseAriaPropsForRole , self :: use_valid_aria_props :: UseValidAriaProps , self :: use_valid_lang :: UseValidLang ,] } }
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole , self :: no_noninteractive_tabindex :: NoNoninteractiveTabindex , self :: no_redundant_roles :: NoRedundantRoles , self :: use_aria_prop_types :: UseAriaPropTypes , self :: use_aria_props_for_role :: UseAriaPropsForRole , self :: use_valid_aria_props :: UseValidAriaProps , self :: use_valid_lang :: UseValidLang ,] } }

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery.rs
@@ -2,9 +2,17 @@
 
 use rome_analyze::declare_group;
 mod no_noninteractive_element_to_interactive_role;
+<<<<<<< HEAD
 mod no_redundant_roles;
+=======
+mod no_noninteractive_tabindex;
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
 mod use_aria_prop_types;
 mod use_aria_props_for_role;
 mod use_valid_aria_props;
 mod use_valid_lang;
+<<<<<<< HEAD
 declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole , self :: no_redundant_roles :: NoRedundantRoles , self :: use_aria_prop_types :: UseAriaPropTypes , self :: use_aria_props_for_role :: UseAriaPropsForRole , self :: use_valid_aria_props :: UseValidAriaProps , self :: use_valid_lang :: UseValidLang ,] } }
+=======
+declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole , self :: no_noninteractive_tabindex :: NoNoninteractiveTabindex , self :: use_aria_prop_types :: UseAriaPropTypes , self :: use_aria_props_for_role :: UseAriaPropsForRole , self :: use_valid_aria_props :: UseValidAriaProps , self :: use_valid_lang :: UseValidLang ,] } }
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_element_to_interactive_role.rs
@@ -100,6 +100,13 @@ impl Rule for NoNoninteractiveElementToInteractiveRole {
             if aria_roles.is_not_interactive_element(element_name.text_trimmed())
                 && aria_roles.is_role_interactive(role_attribute_value.text())
             {
+                // <div> and <span> are considered neither interactive nor non-interactive, depending on the presence or absence of the role attribute.
+                // We don't report <div> and <span> here, because we cannot determine whether they are interactive or non-interactive.
+                let role_sensitive_elements = ["div", "span"];
+                if role_sensitive_elements.contains(&element_name.text_trimmed()) {
+                    return None;
+                }
+
                 return Some(RuleState {
                     attribute_range: role_attribute.range(),
                     element_name: element_name.text_trimmed().to_string(),

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_tabindex.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery/no_noninteractive_tabindex.rs
@@ -1,0 +1,217 @@
+use crate::aria_services::Aria;
+use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
+use rome_aria::AriaRoles;
+use rome_console::markup;
+use rome_js_syntax::{
+    jsx_ext::AnyJsxElement, AnyJsExpression, AnyJsLiteralExpression, AnyJsxAttributeValue,
+    JsNumberLiteralExpression, JsStringLiteralExpression, JsUnaryExpression, TextRange,
+};
+use rome_rowan::{declare_node_union, AstNode, AstNodeList};
+
+declare_rule! {
+    /// Enforce that `tabIndex` is not assigned to non-interactive HTML elements.
+    ///
+    /// When using the tab key to navigate a webpage, limit it to interactive elements.
+    /// You don't need to add tabindex to items in an unordered list as assistive technology can navigate through the HTML.
+    /// Keep the tab ring small, which is the order of elements when tabbing, for a more efficient and accessible browsing experience.
+    ///
+    /// ESLint (eslint-plugin-jsx-a11y) Equivalent: [no-noninteractive-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-tabindex.md)
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <div tabIndex="0" />
+    /// ```
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <div role="article" tabIndex="0" />
+    /// ```
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <article tabIndex="0" />
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```jsx
+    /// <div />
+    /// ```
+    ///
+    /// ```jsx
+    /// <MyButton tabIndex={0} />
+    /// ```
+    ///
+    /// ```jsx
+    /// <article tabIndex="-1" />
+    /// ```
+    ///
+    pub(crate) NoNoninteractiveTabindex {
+        version: "next",
+        name: "noNoninteractiveTabindex",
+        recommended: false,
+    }
+}
+
+declare_node_union! {
+    /// Subset of expressions supported by this rule.
+    ///
+    /// ## Examples
+    ///
+    /// - `JsStringLiteralExpression` &mdash; `"5"`
+    /// - `JsNumberLiteralExpression` &mdash; `5`
+    /// - `JsUnaryExpression` &mdash; `+5` | `-5`
+    ///
+    pub(crate) AnyNumberLikeExpression = JsStringLiteralExpression | JsNumberLiteralExpression | JsUnaryExpression
+}
+
+impl AnyNumberLikeExpression {
+    /// Returns the value of a number-like expression; it returns the expression
+    /// text for literal expressions. However, for unary expressions, it only
+    /// returns the value for signed numeric expressions.
+    pub(crate) fn value(&self) -> Option<String> {
+        match self {
+            AnyNumberLikeExpression::JsStringLiteralExpression(string_literal) => {
+                return Some(string_literal.inner_string_text().ok()?.to_string());
+            }
+            AnyNumberLikeExpression::JsNumberLiteralExpression(number_literal) => {
+                return Some(number_literal.value_token().ok()?.to_string());
+            }
+            AnyNumberLikeExpression::JsUnaryExpression(unary_expression) => {
+                if unary_expression.is_signed_numeric_literal().ok()? {
+                    return Some(unary_expression.text());
+                }
+            }
+        }
+        None
+    }
+}
+
+pub(crate) struct RuleState {
+    attribute_range: TextRange,
+    element_name: String,
+}
+
+impl Rule for NoNoninteractiveTabindex {
+    type Query = Aria<AnyJsxElement>;
+    type State = RuleState;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        if !node.is_element() {
+            return None;
+        }
+
+        let element_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
+        let aria_roles = ctx.aria_roles();
+
+        if aria_roles.is_not_interactive_element(element_name.text_trimmed()) {
+            let tabindex_attribute = node.find_attribute_by_name("tabIndex")?;
+            let tabindex_attribute_value = tabindex_attribute.initializer()?.value().ok()?;
+            if attribute_has_negative_tabindex(&tabindex_attribute_value)? {
+                return None;
+            }
+
+            let role_attribute = node.find_attribute_by_name("role");
+            let Some(role_attribute) = role_attribute else {
+                    return Some(RuleState {
+                        attribute_range: tabindex_attribute.range(),
+                        element_name: element_name.text_trimmed().to_string(),
+                    })
+                };
+
+            let role_attribute_value = role_attribute.initializer()?.value().ok()?;
+            if attribute_has_interactive_role(&role_attribute_value, aria_roles)? {
+                return None;
+            }
+
+            return Some(RuleState {
+                attribute_range: tabindex_attribute.range(),
+                element_name: element_name.text_trimmed().to_string(),
+            });
+        }
+        None
+    }
+
+    fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                state.attribute_range,
+                markup! {
+                "The HTML element "<Emphasis>{{&state.element_name}}</Emphasis>" is non-interactive. Do not use "<Emphasis>"tabIndex"</Emphasis>"."
+
+                },
+            )
+            .note(markup! {
+                "Adding non-interactive elements to the keyboard navigation flow can confuse users."
+            }),
+        )
+    }
+}
+
+/// Verifies if number string is an integer less than 0.
+/// Non-integer numbers are considered valid.
+fn is_negative_tabindex(number_like_string: &str) -> bool {
+    let number_string_result = number_like_string.trim().parse::<i32>();
+    match number_string_result {
+        Ok(number) => number < 0,
+        Err(_) => true,
+    }
+}
+
+/// Checks if the given tabindex attribute value has negative integer or not.
+fn attribute_has_negative_tabindex(
+    tabindex_attribute_value: &AnyJsxAttributeValue,
+) -> Option<bool> {
+    match tabindex_attribute_value {
+        AnyJsxAttributeValue::JsxString(jsx_string) => {
+            let value = jsx_string.inner_string_text().ok()?.to_string();
+            Some(is_negative_tabindex(&value))
+        }
+        AnyJsxAttributeValue::JsxExpressionAttributeValue(value) => {
+            let expression = value.expression().ok()?;
+            let expression_value =
+                AnyNumberLikeExpression::cast_ref(expression.syntax())?.value()?;
+            Some(is_negative_tabindex(&expression_value))
+        }
+        _ => None,
+    }
+}
+
+/// Checks if the given role attribute value is interactive or not based on ARIA roles.
+fn attribute_has_interactive_role(
+    role_attribute_value: &AnyJsxAttributeValue,
+    aria_roles: &AriaRoles,
+) -> Option<bool> {
+    let role_attribute_value = match role_attribute_value {
+        AnyJsxAttributeValue::JsxString(string) => string.inner_string_text().ok(),
+        AnyJsxAttributeValue::JsxExpressionAttributeValue(expression) => {
+            match expression.expression().ok()? {
+                AnyJsExpression::AnyJsLiteralExpression(
+                    AnyJsLiteralExpression::JsStringLiteralExpression(string),
+                ) => string.inner_string_text().ok(),
+                AnyJsExpression::JsTemplateExpression(template) => {
+                    if template.elements().len() == 1 {
+                        template
+                            .elements()
+                            .iter()
+                            .next()?
+                            .as_js_template_chunk_element()?
+                            .template_chunk_token()
+                            .ok()
+                            .map(|t| t.token_text_trimmed())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }?;
+    Some(aria_roles.is_role_interactive(role_attribute_value.text()))
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveTabindex/invalid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveTabindex/invalid.jsx
@@ -1,0 +1,5 @@
+<>
+	<div tabIndex="0"></div>
+	<div role="article" tabIndex="0"></div>
+	<article tabIndex={0} />
+</>;

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveTabindex/invalid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveTabindex/invalid.jsx.snap
@@ -1,0 +1,66 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid.jsx
+---
+# Input
+```js
+<>
+	<div tabIndex="0"></div>
+	<div role="article" tabIndex="0"></div>
+	<article tabIndex={0} />
+</>;
+
+```
+
+# Diagnostics
+```
+invalid.jsx:2:7 lint/nursery/noNoninteractiveTabindex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element div is non-interactive. Do not use tabIndex.
+  
+    1 │ <>
+  > 2 │ 	<div tabIndex="0"></div>
+      │ 	     ^^^^^^^^^^^^
+    3 │ 	<div role="article" tabIndex="0"></div>
+    4 │ 	<article tabIndex={0} />
+  
+  i Adding non-interactive elements to the keyboard navigation flow can confuse users.
+  
+
+```
+
+```
+invalid.jsx:3:22 lint/nursery/noNoninteractiveTabindex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element div is non-interactive. Do not use tabIndex.
+  
+    1 │ <>
+    2 │ 	<div tabIndex="0"></div>
+  > 3 │ 	<div role="article" tabIndex="0"></div>
+      │ 	                    ^^^^^^^^^^^^
+    4 │ 	<article tabIndex={0} />
+    5 │ </>;
+  
+  i Adding non-interactive elements to the keyboard navigation flow can confuse users.
+  
+
+```
+
+```
+invalid.jsx:4:11 lint/nursery/noNoninteractiveTabindex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The HTML element article is non-interactive. Do not use tabIndex.
+  
+    2 │ 	<div tabIndex="0"></div>
+    3 │ 	<div role="article" tabIndex="0"></div>
+  > 4 │ 	<article tabIndex={0} />
+      │ 	         ^^^^^^^^^^^^
+    5 │ </>;
+    6 │ 
+  
+  i Adding non-interactive elements to the keyboard navigation flow can confuse users.
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveTabindex/valid.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveTabindex/valid.jsx
@@ -1,0 +1,12 @@
+<>
+	<button tabIndex="0"></button>
+	<span role="button" tabIndex="0"></span>
+	<span role="article" tabIndex="-1"></span>
+	<MyButton tabIndex={0} />
+	<article tabIndex="-1"></article>
+	<div tabIndex="-1"></div>
+	<article tabIndex={-1}></article>
+	<div tabIndex={-1}></div>
+	<div></div>
+	<button tabIndex="-1"></button>
+</>;

--- a/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveTabindex/valid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNoninteractiveTabindex/valid.jsx.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid.jsx
+---
+# Input
+```js
+<>
+	<button tabIndex="0"></button>
+	<span role="button" tabIndex="0"></span>
+	<span role="article" tabIndex="-1"></span>
+	<MyButton tabIndex={0} />
+	<article tabIndex="-1"></article>
+	<div tabIndex="-1"></div>
+	<article tabIndex={-1}></article>
+	<div tabIndex={-1}></div>
+	<div></div>
+	<button tabIndex="-1"></button>
+</>;
+
+```
+
+

--- a/crates/rome_js_unicode_table/src/tables.rs
+++ b/crates/rome_js_unicode_table/src/tables.rs
@@ -787,7 +787,9 @@ pub mod derived_property {
         ('𱍐', '𲎯'),
         ('\u{e0100}', '\u{e01ef}'),
     ];
-    pub fn ID_Continue(c: char) -> bool { super::bsearch_range_table(c, ID_Continue_table) }
+    pub fn ID_Continue(c: char) -> bool {
+        super::bsearch_range_table(c, ID_Continue_table)
+    }
     pub const ID_Start_table: &[(char, char)] = &[
         ('A', 'Z'),
         ('a', 'z'),
@@ -1449,5 +1451,7 @@ pub mod derived_property {
         ('𰀀', '𱍊'),
         ('𱍐', '𲎯'),
     ];
-    pub fn ID_Start(c: char) -> bool { super::bsearch_range_table(c, ID_Start_table) }
+    pub fn ID_Start(c: char) -> bool {
+        super::bsearch_range_table(c, ID_Start_table)
+    }
 }

--- a/crates/rome_js_unicode_table/src/tables.rs
+++ b/crates/rome_js_unicode_table/src/tables.rs
@@ -787,9 +787,7 @@ pub mod derived_property {
         ('𱍐', '𲎯'),
         ('\u{e0100}', '\u{e01ef}'),
     ];
-    pub fn ID_Continue(c: char) -> bool {
-        super::bsearch_range_table(c, ID_Continue_table)
-    }
+    pub fn ID_Continue(c: char) -> bool { super::bsearch_range_table(c, ID_Continue_table) }
     pub const ID_Start_table: &[(char, char)] = &[
         ('A', 'Z'),
         ('a', 'z'),
@@ -1451,7 +1449,5 @@ pub mod derived_property {
         ('𰀀', '𱍊'),
         ('𱍐', '𲎯'),
     ];
-    pub fn ID_Start(c: char) -> bool {
-        super::bsearch_range_table(c, ID_Start_table)
-    }
+    pub fn ID_Start(c: char) -> bool { super::bsearch_range_table(c, ID_Start_table) }
 }

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -188,15 +188,9 @@ impl Rules {
             None
         }
     }
-    pub(crate) const fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
-    pub(crate) const fn is_all(&self) -> bool {
-        matches!(self.all, Some(true))
-    }
-    pub(crate) const fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
+    pub(crate) const fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) const fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
+    pub(crate) const fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
     #[doc = r" It returns a tuple of filters. The first element of the tuple are the enabled rules,"]
     #[doc = r" while the second element are the disabled rules."]
     #[doc = r""]
@@ -440,18 +434,12 @@ impl A11y {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool {
-        matches!(self.all, Some(true))
-    }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
+    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
+    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_access_key.as_ref() {
@@ -591,9 +579,7 @@ impl A11y {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::GROUP_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -601,9 +587,7 @@ impl A11y {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 12] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 13] {
-        Self::ALL_RULES_AS_FILTERS
-    }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 13] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -700,18 +684,12 @@ impl Complexity {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool {
-        matches!(self.all, Some(true))
-    }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
+    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
+    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_extra_boolean_cast.as_ref() {
@@ -787,9 +765,7 @@ impl Complexity {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::GROUP_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -797,9 +773,7 @@ impl Complexity {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 4] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 6] {
-        Self::ALL_RULES_AS_FILTERS
-    }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 6] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -968,18 +942,12 @@ impl Correctness {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool {
-        matches!(self.all, Some(true))
-    }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
+    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
+    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_children_prop.as_ref() {
@@ -1159,9 +1127,7 @@ impl Correctness {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::GROUP_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -1169,9 +1135,7 @@ impl Correctness {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 15] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 17] {
-        Self::ALL_RULES_AS_FILTERS
-    }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 17] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -1552,18 +1516,12 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool {
-        matches!(self.all, Some(true))
-    }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
+    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
+    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_assign_in_expressions.as_ref() {
@@ -2053,9 +2011,7 @@ impl Nursery {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::GROUP_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -2063,9 +2019,7 @@ impl Nursery {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 39] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 48] {
-        Self::ALL_RULES_AS_FILTERS
-    }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 48] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2162,18 +2116,12 @@ impl Performance {
         [RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0])];
     const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 1] =
         [RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0])];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool {
-        matches!(self.all, Some(true))
-    }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
+    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
+    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_delete.as_ref() {
@@ -2193,9 +2141,7 @@ impl Performance {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::GROUP_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -2203,9 +2149,7 @@ impl Performance {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 1] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 1] {
-        Self::ALL_RULES_AS_FILTERS
-    }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 1] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2266,18 +2210,12 @@ impl Security {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool {
-        matches!(self.all, Some(true))
-    }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
+    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
+    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_dangerously_set_inner_html.as_ref() {
@@ -2307,9 +2245,7 @@ impl Security {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::GROUP_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -2317,9 +2253,7 @@ impl Security {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 2] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 2] {
-        Self::ALL_RULES_AS_FILTERS
-    }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 2] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2493,18 +2427,12 @@ impl Style {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool {
-        matches!(self.all, Some(true))
-    }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
+    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
+    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_arguments.as_ref() {
@@ -2714,9 +2642,7 @@ impl Style {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::GROUP_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -2724,9 +2650,7 @@ impl Style {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 12] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 20] {
-        Self::ALL_RULES_AS_FILTERS
-    }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 20] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2944,18 +2868,12 @@ impl Suspicious {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool {
-        !matches!(self.recommended, Some(false))
-    }
+    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool {
-        matches!(self.all, Some(true))
-    }
-    pub(crate) fn is_not_all(&self) -> bool {
-        matches!(self.all, Some(false))
-    }
+    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
+    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_array_index_key.as_ref() {
@@ -3185,9 +3103,7 @@ impl Suspicious {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool {
-        Self::GROUP_RULES.contains(&rule_name)
-    }
+    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -3195,9 +3111,7 @@ impl Suspicious {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 21] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 22] {
-        Self::ALL_RULES_AS_FILTERS
-    }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 22] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -188,9 +188,15 @@ impl Rules {
             None
         }
     }
-    pub(crate) const fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
-    pub(crate) const fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
-    pub(crate) const fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
+    pub(crate) const fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
+    pub(crate) const fn is_all(&self) -> bool {
+        matches!(self.all, Some(true))
+    }
+    pub(crate) const fn is_not_all(&self) -> bool {
+        matches!(self.all, Some(false))
+    }
     #[doc = r" It returns a tuple of filters. The first element of the tuple are the enabled rules,"]
     #[doc = r" while the second element are the disabled rules."]
     #[doc = r""]
@@ -434,12 +440,18 @@ impl A11y {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
-    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
+    pub(crate) fn is_all(&self) -> bool {
+        matches!(self.all, Some(true))
+    }
+    pub(crate) fn is_not_all(&self) -> bool {
+        matches!(self.all, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_access_key.as_ref() {
@@ -579,7 +591,9 @@ impl A11y {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::GROUP_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -587,7 +601,9 @@ impl A11y {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 12] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 13] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 13] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -684,12 +700,18 @@ impl Complexity {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
-    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
+    pub(crate) fn is_all(&self) -> bool {
+        matches!(self.all, Some(true))
+    }
+    pub(crate) fn is_not_all(&self) -> bool {
+        matches!(self.all, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_extra_boolean_cast.as_ref() {
@@ -765,7 +787,9 @@ impl Complexity {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::GROUP_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -773,7 +797,9 @@ impl Complexity {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 4] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 6] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 6] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -942,12 +968,18 @@ impl Correctness {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
-    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
+    pub(crate) fn is_all(&self) -> bool {
+        matches!(self.all, Some(true))
+    }
+    pub(crate) fn is_not_all(&self) -> bool {
+        matches!(self.all, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_children_prop.as_ref() {
@@ -1127,7 +1159,9 @@ impl Correctness {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::GROUP_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -1135,7 +1169,9 @@ impl Correctness {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 15] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 17] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 17] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -1334,11 +1370,7 @@ pub struct Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-<<<<<<< HEAD
-    pub(crate) const GROUP_RULES: [&'static str; 47] = [
-=======
-    pub(crate) const GROUP_RULES: [&'static str; 46] = [
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+    pub(crate) const GROUP_RULES: [&'static str; 48] = [
         "noAssignInExpressions",
         "noBannedTypes",
         "noClassAssign",
@@ -1445,19 +1477,11 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
-<<<<<<< HEAD
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
-=======
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
@@ -1467,30 +1491,18 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
-<<<<<<< HEAD
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
-    ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 47] = [
-=======
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 46] = [
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 48] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -1537,17 +1549,21 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
-<<<<<<< HEAD
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
-=======
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
-    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
+    pub(crate) fn is_all(&self) -> bool {
+        matches!(self.all, Some(true))
+    }
+    pub(crate) fn is_not_all(&self) -> bool {
+        matches!(self.all, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_assign_in_expressions.as_ref() {
@@ -1630,268 +1646,166 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-<<<<<<< HEAD
         if let Some(rule) = self.no_noninteractive_element_to_interactive_role.as_ref() {
-=======
-        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.no_parameter_assign.as_ref() {
+        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_parameter_properties.as_ref() {
+        if let Some(rule) = self.no_parameter_assign.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_prototype_builtins.as_ref() {
+        if let Some(rule) = self.no_parameter_properties.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_redeclare.as_ref() {
-=======
-        if let Some(rule) = self.no_redeclaration.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_prototype_builtins.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_redundant_alt.as_ref() {
+        if let Some(rule) = self.no_redeclare.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_redundant_roles.as_ref() {
-=======
-        if let Some(rule) = self.no_restricted_globals.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_redundant_alt.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_restricted_globals.as_ref() {
-=======
-        if let Some(rule) = self.no_self_assign.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_redundant_roles.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_self_assign.as_ref() {
-=======
-        if let Some(rule) = self.no_self_compare.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_restricted_globals.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_self_compare.as_ref() {
-=======
-        if let Some(rule) = self.no_svg_without_title.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_self_assign.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_svg_without_title.as_ref() {
-=======
-        if let Some(rule) = self.no_switch_declarations.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_self_compare.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_switch_declarations.as_ref() {
-=======
-        if let Some(rule) = self.no_unreachable_super.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_svg_without_title.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_unreachable_super.as_ref() {
-=======
-        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_switch_declarations.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
-=======
-        if let Some(rule) = self.no_unused_labels.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_unreachable_super.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_unused_labels.as_ref() {
-=======
-        if let Some(rule) = self.no_useless_catch.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_useless_catch.as_ref() {
-=======
-        if let Some(rule) = self.no_useless_rename.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_unused_labels.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_useless_rename.as_ref() {
-=======
-        if let Some(rule) = self.no_useless_switch_case.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_useless_catch.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_useless_switch_case.as_ref() {
-=======
-        if let Some(rule) = self.no_with.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_useless_rename.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_with.as_ref() {
-=======
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_useless_switch_case.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
-=======
-        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_with.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
-=======
-        if let Some(rule) = self.use_camel_case.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_camel_case.as_ref() {
-=======
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
-=======
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_camel_case.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
-=======
-        if let Some(rule) = self.use_iframe_title.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_iframe_title.as_ref() {
-=======
-        if let Some(rule) = self.use_is_nan.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_is_nan.as_ref() {
-=======
-        if let Some(rule) = self.use_media_caption.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_iframe_title.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_media_caption.as_ref() {
-=======
-        if let Some(rule) = self.use_namespace_keyword.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_namespace_keyword.as_ref() {
-=======
-        if let Some(rule) = self.use_valid_aria_props.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_media_caption.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_valid_aria_props.as_ref() {
-=======
-        if let Some(rule) = self.use_valid_lang.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_namespace_keyword.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_valid_lang.as_ref() {
-=======
-        if let Some(rule) = self.use_yield.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_valid_aria_props.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_yield.as_ref() {
+        if let Some(rule) = self.use_valid_lang.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-=======
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_yield.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
+            }
+        }
         index_set
     }
     pub(crate) fn get_disabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -1976,272 +1890,172 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-<<<<<<< HEAD
         if let Some(rule) = self.no_noninteractive_element_to_interactive_role.as_ref() {
-=======
-        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.no_parameter_assign.as_ref() {
+        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_parameter_properties.as_ref() {
+        if let Some(rule) = self.no_parameter_assign.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_prototype_builtins.as_ref() {
+        if let Some(rule) = self.no_parameter_properties.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_redeclare.as_ref() {
-=======
-        if let Some(rule) = self.no_redeclaration.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_prototype_builtins.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_redundant_alt.as_ref() {
+        if let Some(rule) = self.no_redeclare.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_redundant_roles.as_ref() {
-=======
-        if let Some(rule) = self.no_restricted_globals.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_redundant_alt.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_restricted_globals.as_ref() {
-=======
-        if let Some(rule) = self.no_self_assign.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_redundant_roles.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_self_assign.as_ref() {
-=======
-        if let Some(rule) = self.no_self_compare.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_restricted_globals.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_self_compare.as_ref() {
-=======
-        if let Some(rule) = self.no_svg_without_title.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_self_assign.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_svg_without_title.as_ref() {
-=======
-        if let Some(rule) = self.no_switch_declarations.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_self_compare.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_switch_declarations.as_ref() {
-=======
-        if let Some(rule) = self.no_unreachable_super.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_svg_without_title.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_unreachable_super.as_ref() {
-=======
-        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_switch_declarations.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
-=======
-        if let Some(rule) = self.no_unused_labels.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_unreachable_super.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_unused_labels.as_ref() {
-=======
-        if let Some(rule) = self.no_useless_catch.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_useless_catch.as_ref() {
-=======
-        if let Some(rule) = self.no_useless_rename.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_unused_labels.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_useless_rename.as_ref() {
-=======
-        if let Some(rule) = self.no_useless_switch_case.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_useless_catch.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_useless_switch_case.as_ref() {
-=======
-        if let Some(rule) = self.no_with.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_useless_rename.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.no_with.as_ref() {
-=======
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_useless_switch_case.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
-=======
-        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.no_with.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
-=======
-        if let Some(rule) = self.use_camel_case.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_camel_case.as_ref() {
-=======
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
-=======
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_camel_case.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
-=======
-        if let Some(rule) = self.use_iframe_title.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_iframe_title.as_ref() {
-=======
-        if let Some(rule) = self.use_is_nan.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_is_nan.as_ref() {
-=======
-        if let Some(rule) = self.use_media_caption.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_iframe_title.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_media_caption.as_ref() {
-=======
-        if let Some(rule) = self.use_namespace_keyword.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_namespace_keyword.as_ref() {
-=======
-        if let Some(rule) = self.use_valid_aria_props.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_media_caption.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_valid_aria_props.as_ref() {
-=======
-        if let Some(rule) = self.use_valid_lang.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_namespace_keyword.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_valid_lang.as_ref() {
-=======
-        if let Some(rule) = self.use_yield.as_ref() {
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_valid_aria_props.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-<<<<<<< HEAD
-        if let Some(rule) = self.use_yield.as_ref() {
+        if let Some(rule) = self.use_valid_lang.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-=======
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+        if let Some(rule) = self.use_yield.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
+            }
+        }
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::GROUP_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -2249,11 +2063,9 @@ impl Nursery {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 39] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-<<<<<<< HEAD
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 47] { Self::ALL_RULES_AS_FILTERS }
-=======
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 46] { Self::ALL_RULES_AS_FILTERS }
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 48] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2350,12 +2162,18 @@ impl Performance {
         [RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0])];
     const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 1] =
         [RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0])];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
-    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
+    pub(crate) fn is_all(&self) -> bool {
+        matches!(self.all, Some(true))
+    }
+    pub(crate) fn is_not_all(&self) -> bool {
+        matches!(self.all, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_delete.as_ref() {
@@ -2375,7 +2193,9 @@ impl Performance {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::GROUP_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -2383,7 +2203,9 @@ impl Performance {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 1] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 1] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 1] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2444,12 +2266,18 @@ impl Security {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
-    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
+    pub(crate) fn is_all(&self) -> bool {
+        matches!(self.all, Some(true))
+    }
+    pub(crate) fn is_not_all(&self) -> bool {
+        matches!(self.all, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_dangerously_set_inner_html.as_ref() {
@@ -2479,7 +2307,9 @@ impl Security {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::GROUP_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -2487,7 +2317,9 @@ impl Security {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 2] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 2] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 2] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2661,12 +2493,18 @@ impl Style {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
-    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
+    pub(crate) fn is_all(&self) -> bool {
+        matches!(self.all, Some(true))
+    }
+    pub(crate) fn is_not_all(&self) -> bool {
+        matches!(self.all, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_arguments.as_ref() {
@@ -2876,7 +2714,9 @@ impl Style {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::GROUP_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -2884,7 +2724,9 @@ impl Style {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 12] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 20] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 20] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -3102,12 +2944,18 @@ impl Suspicious {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
     ];
-    pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
+    pub(crate) fn is_recommended(&self) -> bool {
+        !matches!(self.recommended, Some(false))
+    }
     pub(crate) const fn is_not_recommended(&self) -> bool {
         matches!(self.recommended, Some(false))
     }
-    pub(crate) fn is_all(&self) -> bool { matches!(self.all, Some(true)) }
-    pub(crate) fn is_not_all(&self) -> bool { matches!(self.all, Some(false)) }
+    pub(crate) fn is_all(&self) -> bool {
+        matches!(self.all, Some(true))
+    }
+    pub(crate) fn is_not_all(&self) -> bool {
+        matches!(self.all, Some(false))
+    }
     pub(crate) fn get_enabled_rules(&self) -> IndexSet<RuleFilter> {
         let mut index_set = IndexSet::new();
         if let Some(rule) = self.no_array_index_key.as_ref() {
@@ -3337,7 +3185,9 @@ impl Suspicious {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> bool { Self::GROUP_RULES.contains(&rule_name) }
+    pub(crate) fn has_rule(rule_name: &str) -> bool {
+        Self::GROUP_RULES.contains(&rule_name)
+    }
     #[doc = r" Checks if, given a rule name, it is marked as recommended"]
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
@@ -3345,7 +3195,9 @@ impl Suspicious {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 21] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 22] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 22] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -1238,6 +1238,9 @@ pub struct Nursery {
     #[doc = "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_noninteractive_element_to_interactive_role: Option<RuleConfiguration>,
+    #[doc = "Enforce that tabIndex is not assigned to non-interactive HTML elements."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_noninteractive_tabindex: Option<RuleConfiguration>,
     #[doc = "Disallow reassigning function parameters."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_parameter_assign: Option<RuleConfiguration>,
@@ -1331,7 +1334,11 @@ pub struct Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
+<<<<<<< HEAD
     pub(crate) const GROUP_RULES: [&'static str; 47] = [
+=======
+    pub(crate) const GROUP_RULES: [&'static str; 46] = [
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
         "noAssignInExpressions",
         "noBannedTypes",
         "noClassAssign",
@@ -1349,6 +1356,7 @@ impl Nursery {
         "noInvalidConstructorSuper",
         "noNamespace",
         "noNoninteractiveElementToInteractiveRole",
+        "noNoninteractiveTabindex",
         "noParameterAssign",
         "noParameterProperties",
         "noPrototypeBuiltins",
@@ -1437,11 +1445,18 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+<<<<<<< HEAD
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+=======
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
@@ -1452,6 +1467,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
+<<<<<<< HEAD
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]),
@@ -1463,6 +1479,18 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
     ];
     const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 47] = [
+=======
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
+    ];
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 46] = [
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -1509,7 +1537,10 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
+<<<<<<< HEAD
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
+=======
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
     ];
     pub(crate) fn is_recommended(&self) -> bool { !matches!(self.recommended, Some(false)) }
     pub(crate) const fn is_not_recommended(&self) -> bool {
@@ -1599,7 +1630,11 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_noninteractive_element_to_interactive_role.as_ref() {
+=======
+        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
@@ -1619,7 +1654,11 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_redeclare.as_ref() {
+=======
+        if let Some(rule) = self.no_redeclaration.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
@@ -1629,131 +1668,230 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_redundant_roles.as_ref() {
+=======
+        if let Some(rule) = self.no_restricted_globals.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_restricted_globals.as_ref() {
+=======
+        if let Some(rule) = self.no_self_assign.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_self_assign.as_ref() {
+=======
+        if let Some(rule) = self.no_self_compare.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_self_compare.as_ref() {
+=======
+        if let Some(rule) = self.no_svg_without_title.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_svg_without_title.as_ref() {
+=======
+        if let Some(rule) = self.no_switch_declarations.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_switch_declarations.as_ref() {
+=======
+        if let Some(rule) = self.no_unreachable_super.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_unreachable_super.as_ref() {
+=======
+        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
+=======
+        if let Some(rule) = self.no_unused_labels.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_unused_labels.as_ref() {
+=======
+        if let Some(rule) = self.no_useless_catch.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_useless_catch.as_ref() {
+=======
+        if let Some(rule) = self.no_useless_rename.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_useless_rename.as_ref() {
+=======
+        if let Some(rule) = self.no_useless_switch_case.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_useless_switch_case.as_ref() {
+=======
+        if let Some(rule) = self.no_with.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_with.as_ref() {
+=======
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_aria_prop_types.as_ref() {
+=======
+        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_aria_props_for_role.as_ref() {
+=======
+        if let Some(rule) = self.use_camel_case.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_camel_case.as_ref() {
+=======
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+=======
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+=======
+        if let Some(rule) = self.use_iframe_title.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_iframe_title.as_ref() {
+=======
+        if let Some(rule) = self.use_is_nan.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_is_nan.as_ref() {
+=======
+        if let Some(rule) = self.use_media_caption.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_media_caption.as_ref() {
+=======
+        if let Some(rule) = self.use_namespace_keyword.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_namespace_keyword.as_ref() {
+=======
+        if let Some(rule) = self.use_valid_aria_props.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_valid_aria_props.as_ref() {
+=======
+        if let Some(rule) = self.use_valid_lang.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_valid_lang.as_ref() {
+=======
+        if let Some(rule) = self.use_yield.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_yield.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
+=======
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
         index_set
     }
     pub(crate) fn get_disabled_rules(&self) -> IndexSet<RuleFilter> {
@@ -1838,7 +1976,11 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_noninteractive_element_to_interactive_role.as_ref() {
+=======
+        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
@@ -1858,7 +2000,11 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_redeclare.as_ref() {
+=======
+        if let Some(rule) = self.no_redeclaration.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
@@ -1868,131 +2014,230 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_redundant_roles.as_ref() {
+=======
+        if let Some(rule) = self.no_restricted_globals.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_restricted_globals.as_ref() {
+=======
+        if let Some(rule) = self.no_self_assign.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_self_assign.as_ref() {
+=======
+        if let Some(rule) = self.no_self_compare.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_self_compare.as_ref() {
+=======
+        if let Some(rule) = self.no_svg_without_title.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_svg_without_title.as_ref() {
+=======
+        if let Some(rule) = self.no_switch_declarations.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_switch_declarations.as_ref() {
+=======
+        if let Some(rule) = self.no_unreachable_super.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_unreachable_super.as_ref() {
+=======
+        if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_unsafe_optional_chaining.as_ref() {
+=======
+        if let Some(rule) = self.no_unused_labels.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_unused_labels.as_ref() {
+=======
+        if let Some(rule) = self.no_useless_catch.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_useless_catch.as_ref() {
+=======
+        if let Some(rule) = self.no_useless_rename.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_useless_rename.as_ref() {
+=======
+        if let Some(rule) = self.no_useless_switch_case.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_useless_switch_case.as_ref() {
+=======
+        if let Some(rule) = self.no_with.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.no_with.as_ref() {
+=======
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_aria_prop_types.as_ref() {
+=======
+        if let Some(rule) = self.use_aria_props_for_role.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_aria_props_for_role.as_ref() {
+=======
+        if let Some(rule) = self.use_camel_case.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_camel_case.as_ref() {
+=======
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+=======
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+=======
+        if let Some(rule) = self.use_iframe_title.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_iframe_title.as_ref() {
+=======
+        if let Some(rule) = self.use_is_nan.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_is_nan.as_ref() {
+=======
+        if let Some(rule) = self.use_media_caption.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_media_caption.as_ref() {
+=======
+        if let Some(rule) = self.use_namespace_keyword.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_namespace_keyword.as_ref() {
+=======
+        if let Some(rule) = self.use_valid_aria_props.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_valid_aria_props.as_ref() {
+=======
+        if let Some(rule) = self.use_valid_lang.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_valid_lang.as_ref() {
+=======
+        if let Some(rule) = self.use_yield.as_ref() {
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
+<<<<<<< HEAD
         if let Some(rule) = self.use_yield.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
+=======
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
@@ -2004,7 +2249,11 @@ impl Nursery {
     pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 39] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
+<<<<<<< HEAD
     pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 47] { Self::ALL_RULES_AS_FILTERS }
+=======
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 46] { Self::ALL_RULES_AS_FILTERS }
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2043,6 +2292,7 @@ impl Nursery {
             "noNoninteractiveElementToInteractiveRole" => {
                 self.no_noninteractive_element_to_interactive_role.as_ref()
             }
+            "noNoninteractiveTabindex" => self.no_noninteractive_tabindex.as_ref(),
             "noParameterAssign" => self.no_parameter_assign.as_ref(),
             "noParameterProperties" => self.no_parameter_properties.as_ref(),
             "noPrototypeBuiltins" => self.no_prototype_builtins.as_ref(),

--- a/crates/rome_service/src/configuration/parse/json/rules.rs
+++ b/crates/rome_service/src/configuration/parse/json/rules.rs
@@ -928,6 +928,7 @@ impl VisitNode<JsonLanguage> for Nursery {
                 "noInvalidConstructorSuper",
                 "noNamespace",
                 "noNoninteractiveElementToInteractiveRole",
+                "noNoninteractiveTabindex",
                 "noParameterAssign",
                 "noParameterProperties",
                 "noPrototypeBuiltins",
@@ -1275,6 +1276,24 @@ impl VisitNode<JsonLanguage> for Nursery {
                     let mut configuration = RuleConfiguration::default();
                     self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
                     self.no_noninteractive_element_to_interactive_role = Some(configuration);
+                }
+                _ => {
+                    diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
+                        "object or string",
+                        value.range(),
+                    ));
+                }
+            },
+            "noNoninteractiveTabindex" => match value {
+                AnyJsonValue::JsonStringValue(_) => {
+                    let mut configuration = RuleConfiguration::default();
+                    self.map_to_known_string(&value, name_text, &mut configuration, diagnostics)?;
+                    self.no_noninteractive_tabindex = Some(configuration);
+                }
+                AnyJsonValue::JsonObjectValue(_) => {
+                    let mut configuration = RuleConfiguration::default();
+                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
+                    self.no_noninteractive_tabindex = Some(configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -601,6 +601,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noNoninteractiveTabindex": {
+					"description": "Enforce that tabIndex is not assigned to non-interactive HTML elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noParameterAssign": {
 					"description": "Disallow reassigning function parameters.",
 					"anyOf": [

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -948,13 +948,9 @@ export type Category =
 	| "lint/nursery/noUselessCatch"
 	| "lint/nursery/noParameterAssign"
 	| "lint/nursery/noNamespace"
-<<<<<<< HEAD
 	| "lint/nursery/noConfusingArrow"
-	| "lint/nursery/noRedeclare"
-=======
 	| "lint/nursery/noNoninteractiveTabindex"
-	| "lint/nursery/noRedeclaration"
->>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
+	| "lint/nursery/noRedeclare"
 	| "lint/nursery/useNamespaceKeyword"
 	| "lint/nursery/noRedundantRoles"
 	| "lint/performance/noDelete"

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -425,6 +425,10 @@ export interface Nursery {
 	 */
 	noNoninteractiveElementToInteractiveRole?: RuleConfiguration;
 	/**
+	 * Enforce that tabIndex is not assigned to non-interactive HTML elements.
+	 */
+	noNoninteractiveTabindex?: RuleConfiguration;
+	/**
 	 * Disallow reassigning function parameters.
 	 */
 	noParameterAssign?: RuleConfiguration;
@@ -944,8 +948,13 @@ export type Category =
 	| "lint/nursery/noUselessCatch"
 	| "lint/nursery/noParameterAssign"
 	| "lint/nursery/noNamespace"
+<<<<<<< HEAD
 	| "lint/nursery/noConfusingArrow"
 	| "lint/nursery/noRedeclare"
+=======
+	| "lint/nursery/noNoninteractiveTabindex"
+	| "lint/nursery/noRedeclaration"
+>>>>>>> e910953dca (feat(rome_js_analyze): noNoninteractiveTabindex)
 	| "lint/nursery/useNamespaceKeyword"
 	| "lint/nursery/noRedundantRoles"
 	| "lint/performance/noDelete"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -601,6 +601,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noNoninteractiveTabindex": {
+					"description": "Enforce that tabIndex is not assigned to non-interactive HTML elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noParameterAssign": {
 					"description": "Disallow reassigning function parameters.",
 					"anyOf": [

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -738,6 +738,12 @@ Disallow the use of TypeScript's <code>namespace</code>s.
 Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.
 </section>
 <section class="rule">
+<h3 data-toc-exclude id="noNoninteractiveTabindex">
+	<a href="/lint/rules/noNoninteractiveTabindex">noNoninteractiveTabindex</a>
+</h3>
+Enforce that <code>tabIndex</code> is not assigned to non-interactive HTML elements.
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noParameterAssign">
 	<a href="/lint/rules/noParameterAssign">noParameterAssign</a>
 </h3>

--- a/website/src/pages/lint/rules/noNoninteractiveTabindex.md
+++ b/website/src/pages/lint/rules/noNoninteractiveTabindex.md
@@ -1,0 +1,85 @@
+---
+title: Lint Rule noNoninteractiveTabindex
+parent: lint/rules/index
+---
+
+# noNoninteractiveTabindex (since vnext)
+
+Enforce that `tabIndex` is not assigned to non-interactive HTML elements.
+
+When using the tab key to navigate a webpage, limit it to interactive elements.
+You don't need to add tabindex to items in an unordered list as assistive technology can navigate through the HTML.
+Keep the tab ring small, which is the order of elements when tabbing, for a more efficient and accessible browsing experience.
+
+ESLint (eslint-plugin-jsx-a11y) Equivalent: [no-noninteractive-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-tabindex.md)
+
+## Examples
+
+### Invalid
+
+```jsx
+<div tabIndex="0" />
+```
+
+<pre class="language-text"><code class="language-text">nursery/noNoninteractiveTabindex.js:1:6 <a href="https://docs.rome.tools/lint/rules/noNoninteractiveTabindex">lint/nursery/noNoninteractiveTabindex</a> ━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The HTML element </span><span style="color: Orange;"><strong>div</strong></span><span style="color: Orange;"> is non-interactive. Do not use </span><span style="color: Orange;"><strong>tabIndex</strong></span><span style="color: Orange;">.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;div tabIndex=&quot;0&quot; /&gt;
+   <strong>   │ </strong>     <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Adding non-interactive elements to the keyboard navigation flow can confuse users.</span>
+  
+</code></pre>
+
+```jsx
+<div role="article" tabIndex="0" />
+```
+
+<pre class="language-text"><code class="language-text">nursery/noNoninteractiveTabindex.js:1:21 <a href="https://docs.rome.tools/lint/rules/noNoninteractiveTabindex">lint/nursery/noNoninteractiveTabindex</a> ━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The HTML element </span><span style="color: Orange;"><strong>div</strong></span><span style="color: Orange;"> is non-interactive. Do not use </span><span style="color: Orange;"><strong>tabIndex</strong></span><span style="color: Orange;">.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;div role=&quot;article&quot; tabIndex=&quot;0&quot; /&gt;
+   <strong>   │ </strong>                    <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Adding non-interactive elements to the keyboard navigation flow can confuse users.</span>
+  
+</code></pre>
+
+```jsx
+<article tabIndex="0" />
+```
+
+<pre class="language-text"><code class="language-text">nursery/noNoninteractiveTabindex.js:1:10 <a href="https://docs.rome.tools/lint/rules/noNoninteractiveTabindex">lint/nursery/noNoninteractiveTabindex</a> ━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The HTML element </span><span style="color: Orange;"><strong>article</strong></span><span style="color: Orange;"> is non-interactive. Do not use </span><span style="color: Orange;"><strong>tabIndex</strong></span><span style="color: Orange;">.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&lt;article tabIndex=&quot;0&quot; /&gt;
+   <strong>   │ </strong>         <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Adding non-interactive elements to the keyboard navigation flow can confuse users.</span>
+  
+</code></pre>
+
+## Valid
+
+```jsx
+<div />
+```
+
+```jsx
+<MyButton tabIndex={0} />
+```
+
+```jsx
+<article tabIndex="-1" />
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #3817

- I reused parsing logics written in [no_positive_tabindex.rs](https://github.com/rome/tools/blob/main/crates/rome_js_analyze/src/semantic_analyzers/a11y/no_positive_tabindex.rs)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan


`cargo test -p rome_js_analyze -- no_noninteractive_tabindex`

- test cases: https://github.com/rome/tools/blob/archived-js/internal/compiler/lint/rules/a11y/noNoninteractiveTabindex.test.toml (file.tsx)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
