### PR TITLE
feat(rome_service): apply formatter to code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,18 @@
 - Fix an issue where formatting of JSX string literals property values were using incorrect quotes [#4054](https://github.com/rome/tools/issues/4054)
 
 ### Linter
+
+#### Other changes
+
+- Code actions are formatted using Rome's formatter. If the formatter is disabled,
+the code action is not formatted.
+
 #### New rules
 - [`noConfusingArrow`](https://docs.rome.tools/lint/rules/noConfusingArrow/)
 - [`noRedundantRoles`](https://docs.rome.tools/lint/rules/noRedundantRoles/)
 - [`noNoninteractiveTabindex`](https://docs.rome.tools/lint/rules/noNoninteractiveTabindex/)
 - [`noAriaUnsupportedElements`](https://docs.rome.tools/lint/rules/noAriaUnsupportedElements/)
+
 ### Parser
 
 - Allow module syntax in `cts` files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,7 @@ dependencies = [
  "rome_flags",
  "rome_formatter",
  "rome_fs",
+ "rome_js_formatter",
  "rome_json_formatter",
  "rome_json_parser",
  "rome_lsp",

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -51,4 +51,5 @@ tikv-jemallocator = "0.5.0"
 insta = { workspace = true }
 tokio = { workspace = true, features = ["io-util"] }
 rome_json_formatter = { path = "../rome_json_formatter" }
+rome_js_formatter = { path = "../rome_js_formatter" }
 rome_json_parser = { path = "../rome_json_parser" }

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -38,8 +38,7 @@ const NEW_SYMBOL: &str = "new Symbol(\"\");";
 const FIX_BEFORE: &str = "
 (1 >= -0)
 ";
-const FIX_AFTER: &str = "
-(1 >= 0)
+const FIX_AFTER: &str = "1 >= 0;
 ";
 
 const APPLY_SUGGESTED_BEFORE: &str = "let a = 4;
@@ -49,8 +48,8 @@ console.log(a);
 
 const APPLY_SUGGESTED_AFTER: &str = "const a = 4;\nconsole.log(a);\n";
 
-const NO_DEBUGGER_BEFORE: &str = "debugger;";
-const NO_DEBUGGER_AFTER: &str = "debugger;";
+const NO_DEBUGGER_BEFORE: &str = "debugger;\n";
+const NO_DEBUGGER_AFTER: &str = "debugger;\n";
 
 const UPGRADE_SEVERITY_CODE: &str = r#"if(!cond) { exprA(); } else { exprB() }"#;
 
@@ -332,7 +331,7 @@ function f() { arguments; }
 
     let expected = "const a = 4;
 console.log(a);
-function f() { arguments; }
+function f() {\n\targuments;\n}
 ";
 
     let test1 = Path::new("test1.js");
@@ -533,7 +532,7 @@ fn should_disable_a_rule_group() {
         .read_to_string(&mut buffer)
         .unwrap();
 
-    assert_eq!(buffer, FIX_BEFORE);
+    assert_eq!(buffer, "1 >= -0;\n");
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),

--- a/crates/rome_cli/tests/snapshots/main_commands_check/apply_noop.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/apply_noop.snap
@@ -5,8 +5,7 @@ expression: content
 ## `fix.js`
 
 ```js
-
-(1 >= 0)
+1 >= 0;
 
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/apply_ok.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/apply_ok.snap
@@ -5,8 +5,7 @@ expression: content
 ## `fix.js`
 
 ```js
-
-(1 >= 0)
+1 >= 0;
 
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/apply_unsafe_with_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/apply_unsafe_with_error.snap
@@ -7,7 +7,9 @@ expression: content
 ```js
 const a = 4;
 console.log(a);
-function f() { arguments; }
+function f() {
+	arguments;
+}
 
 ```
 
@@ -16,7 +18,9 @@ function f() { arguments; }
 ```js
 const a = 4;
 console.log(a);
-function f() { arguments; }
+function f() {
+	arguments;
+}
 
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/should_disable_a_rule.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/should_disable_a_rule.snap
@@ -21,6 +21,7 @@ expression: content
 
 ```js
 debugger;
+
 ```
 
 # Emitted Messages

--- a/crates/rome_cli/tests/snapshots/main_commands_check/should_disable_a_rule_group.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/should_disable_a_rule_group.snap
@@ -20,8 +20,7 @@ expression: content
 ## `fix.js`
 
 ```js
-
-(1 >= -0)
+1 >= -0;
 
 ```
 

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -1025,7 +1025,7 @@ async fn pull_fix_all() -> Result<()> {
                     character: 0,
                 },
             },
-            new_text: String::from("if(a === 0) {}\nif(a === 0) {}\nif(a === 0) {}"),
+            new_text: String::from("if (a === 0) {\n}\nif (a === 0) {\n}\nif (a === 0) {\n}\n"),
         }],
     );
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -364,6 +364,8 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
         rules,
         fix_file_mode,
         settings,
+        should_format,
+        rome_path,
     } = params;
 
     let mut tree: AnyJsRoot = parse.tree();
@@ -451,8 +453,18 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
                 }
             }
             None => {
+                let code = if should_format {
+                    format_node(
+                        settings.format_options::<JsLanguage>(rome_path),
+                        tree.syntax(),
+                    )?
+                    .print()?
+                    .into_code()
+                } else {
+                    tree.syntax().to_string()
+                };
                 return Ok(FixFileResult {
-                    code: tree.syntax().to_string(),
+                    code,
                     skipped_suggested_fixes,
                     actions,
                     errors: errors.into(),

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -145,6 +145,9 @@ pub struct FixAllParams<'a> {
     pub(crate) rules: Option<&'a Rules>,
     pub(crate) fix_file_mode: FixFileMode,
     pub(crate) settings: SettingsHandle<'a>,
+    /// Whether it should format the code action
+    pub(crate) should_format: bool,
+    pub(crate) rome_path: &'a RomePath,
 }
 
 #[derive(Default)]

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -516,11 +516,14 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone(), Some(FeatureName::Lint))?;
 
         let rules = settings.linter().rules.as_ref();
+        let should_format = settings.formatter().enabled;
         fix_all(FixAllParams {
             parse,
             rules,
             fix_file_mode: params.fix_file_mode,
             settings: self.settings(),
+            should_format,
+            rome_path: &params.path,
         })
     }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

With this PR, the code emitted by the analyzer actions is now formatted using Rome's internal formatter. After all the analyzer actions have been committed to the current code, the formatting is applied at the end. 

If the formatter is disabled, no formatting is applied.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Existing tests should be updated.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
