### PR TITLE
refactor(rome_js_anaylze): introduce StaticValue enum for checking value of the JSX attributes or JS expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,13 @@
 - Fix an issue where formatting of JSX string literals property values were using incorrect quotes [#4054](https://github.com/rome/tools/issues/4054)
 
 ### Linter
-
 #### New rules
-
 - [`noConfusingArrow`](https://docs.rome.tools/lint/rules/noConfusingArrow/)
 - [`noRedundantRoles`](https://docs.rome.tools/lint/rules/noRedundantRoles/)
 - [`noNoninteractiveTabindex`](https://docs.rome.tools/lint/rules/noNoninteractiveTabindex/)
-
-#### Other changes
-
-- Refactor common logic for checking value of the JSX attributes or JS expressions [#4073](https://github.com/rome/tools/pull/4073)
-
 ### Parser
 
-- Allow module syntax in `cts` files [#4317](https://github.com/rome/tools/pull/4317)
+- Allow module syntax in `cts` files
 
 ### VSCode
 ### JavaScript APIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,20 @@
 - Fix an issue where formatting of JSX string literals property values were using incorrect quotes [#4054](https://github.com/rome/tools/issues/4054)
 
 ### Linter
+
 #### New rules
+
 - [`noConfusingArrow`](https://docs.rome.tools/lint/rules/noConfusingArrow/)
 - [`noRedundantRoles`](https://docs.rome.tools/lint/rules/noRedundantRoles/)
 - [`noNoninteractiveTabindex`](https://docs.rome.tools/lint/rules/noNoninteractiveTabindex/)
+
+#### Other changes
+
+- Refactor common logic for checking value of the JSX attributes or JS expressions [#4073](https://github.com/rome/tools/pull/4073)
+
 ### Parser
 
-- Allow module syntax in `cts` files
+- Allow module syntax in `cts` files [#4317](https://github.com/rome/tools/pull/4317)
 
 ### VSCode
 ### JavaScript APIs

--- a/crates/rome_js_analyze/src/analyzers/a11y/no_blank_target.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/no_blank_target.rs
@@ -164,7 +164,8 @@ impl Rule for NoBlankTarget {
         let message = if let Some(rel_attribute) = rel_attribute {
             let old_jsx_string = rel_attribute.initializer()?.value().ok()?;
             let old_jsx_string = old_jsx_string.as_jsx_string()?;
-            let rel_text = old_jsx_string.inner_string_text().ok()?;
+            let rel_quoted_string = old_jsx_string.inner_string_text().ok()?;
+            let rel_text = rel_quoted_string.text();
             let new_text = format!("\"noreferrer {rel_text}\"");
             let new_jsx_string = jsx_string(jsx_ident(&new_text));
             mutation.replace_node(old_jsx_string.clone(), new_jsx_string);

--- a/crates/rome_js_analyze/src/analyzers/a11y/use_alt_text.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/use_alt_text.rs
@@ -152,7 +152,7 @@ fn input_has_type_image(element: &JsxSelfClosingElement) -> Option<bool> {
         let initializer = prop.initializer()?.value().ok()?;
         let initializer = initializer.as_jsx_string()?;
 
-        if initializer.inner_string_text().ok()? == "image" {
+        if initializer.inner_string_text().ok()?.text() == "image" {
             return Some(true);
         }
         return None;

--- a/crates/rome_js_analyze/src/analyzers/a11y/use_anchor_content.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/use_anchor_content.rs
@@ -224,8 +224,8 @@ fn is_aria_hidden_truthy(aria_hidden_attribute: JsxAttribute) -> Option<bool> {
         }
         AnyJsxAttributeValue::AnyJsxTag(_) => false,
         AnyJsxAttributeValue::JsxString(aria_hidden_string) => {
-            let aria_hidden_value = aria_hidden_string.inner_string_text().ok()?;
-            aria_hidden_value == "true"
+            let quoted_string = aria_hidden_string.inner_string_text().ok()?;
+            quoted_string.text() == "true"
         }
     })
 }
@@ -243,8 +243,8 @@ fn is_expression_truthy(expression: AnyJsExpression) -> Option<bool> {
             } else if let AnyJsLiteralExpression::JsStringLiteralExpression(string_literal) =
                 literal_expression
             {
-                let text = string_literal.inner_string_text().ok()?;
-                text == "true"
+                let quoted_string = string_literal.inner_string_text().ok()?;
+                quoted_string.text() == "true"
             } else {
                 false
             }

--- a/crates/rome_js_analyze/src/analyzers/a11y/use_html_lang.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/use_html_lang.rs
@@ -104,7 +104,7 @@ used by screen readers when no user default is specified."
 }
 
 fn is_valid_lang_attribute(attr: JsxAttribute) -> Option<()> {
-    if attr.is_value_undefined_or_null() {
+    if attr.is_value_null_or_undefined() {
         return None;
     }
 

--- a/crates/rome_js_analyze/src/analyzers/a11y/use_key_with_mouse_events.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/use_key_with_mouse_events.rs
@@ -107,9 +107,10 @@ impl Rule for UseKeyWithMouseEvents {
 fn has_valid_focus_attributes(elem: &AnyJsxElement) -> bool {
     if let Some(on_mouse_over_attribute) = elem.find_attribute_by_name("onMouseOver") {
         if !elem.has_trailing_spread_prop(on_mouse_over_attribute) {
-            return elem
-                .find_attribute_by_name("onFocus")
-                .map_or(false, |it| !it.is_value_undefined_or_null());
+            return elem.find_attribute_by_name("onFocus").map_or(false, |it| {
+                !it.as_static_value()
+                    .map_or(false, |value| value.is_null_or_undefined())
+            });
         }
     }
     true
@@ -118,9 +119,10 @@ fn has_valid_focus_attributes(elem: &AnyJsxElement) -> bool {
 fn has_valid_blur_attributes(elem: &AnyJsxElement) -> bool {
     if let Some(on_mouse_attribute) = elem.find_attribute_by_name("onMouseOut") {
         if !elem.has_trailing_spread_prop(on_mouse_attribute) {
-            return elem
-                .find_attribute_by_name("onBlur")
-                .map_or(false, |it| !it.is_value_undefined_or_null());
+            return elem.find_attribute_by_name("onBlur").map_or(false, |it| {
+                !it.as_static_value()
+                    .map_or(false, |value| value.is_null_or_undefined())
+            });
         }
     }
     true

--- a/crates/rome_js_analyze/src/analyzers/a11y/use_valid_anchor.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/use_valid_anchor.rs
@@ -290,8 +290,8 @@ fn is_invalid_anchor(anchor_attribute: &JsxAttribute) -> Option<UseValidAnchorSt
                 AnyJsExpression::AnyJsLiteralExpression(
                     AnyJsLiteralExpression::JsStringLiteralExpression(string_literal),
                 ) => {
-                    let text = string_literal.inner_string_text().ok()?;
-                    if text == "#" {
+                    let quoted_string = string_literal.inner_string_text().ok()?;
+                    if quoted_string.text() == "#" {
                         return Some(UseValidAnchorState::IncorrectHref(
                             string_literal.syntax().text_trimmed_range(),
                         ));
@@ -327,7 +327,8 @@ fn is_invalid_anchor(anchor_attribute: &JsxAttribute) -> Option<UseValidAnchorSt
         }
         AnyJsxAttributeValue::AnyJsxTag(_) => {}
         AnyJsxAttributeValue::JsxString(href_string) => {
-            let href_value = href_string.inner_string_text().ok()?;
+            let quoted_string = href_string.inner_string_text().ok()?;
+            let href_value = quoted_string.text();
 
             // href="#" or href="javascript:void(0)"
             if href_value == "#" || href_value.contains("javascript:") {

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
@@ -152,7 +152,8 @@ impl CaseMismatchInfo {
 
     fn compare_call_with_literal(call: JsCallExpression, literal: AnyJsExpression) -> Option<Self> {
         let expected_case = ExpectedStringCase::from_call(&call)?;
-        let literal_value = literal.as_string_constant()?;
+        let string_constant = literal.as_string_constant()?;
+        let literal_value = string_constant.text();
         let expected_value = expected_case.convert(&literal_value);
         if literal_value != expected_value {
             Some(Self {

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
@@ -152,8 +152,8 @@ impl CaseMismatchInfo {
 
     fn compare_call_with_literal(call: JsCallExpression, literal: AnyJsExpression) -> Option<Self> {
         let expected_case = ExpectedStringCase::from_call(&call)?;
-        let string_constant = literal.as_string_constant()?;
-        let literal_value = string_constant.text();
+        let static_value = literal.as_static_value()?;
+        let literal_value = static_value.text();
         let expected_value = expected_case.convert(&literal_value);
         if literal_value != expected_value {
             Some(Self {

--- a/crates/rome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness/no_string_case_mismatch.rs
@@ -154,7 +154,7 @@ impl CaseMismatchInfo {
         let expected_case = ExpectedStringCase::from_call(&call)?;
         let static_value = literal.as_static_value()?;
         let literal_value = static_value.text();
-        let expected_value = expected_case.convert(&literal_value);
+        let expected_value = expected_case.convert(literal_value);
         if literal_value != expected_value {
             Some(Self {
                 expected_case,

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_redundant_alt.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_redundant_alt.rs
@@ -73,7 +73,7 @@ impl Rule for NoRedundantAlt {
                         == "false"
                 }
                 AnyJsxAttributeValue::JsxString(aria_hidden) => {
-                    aria_hidden.inner_string_text().ok()? == "false"
+                    aria_hidden.inner_string_text().ok()?.text() == "false"
                 }
             };
 

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_svg_without_title.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_svg_without_title.rs
@@ -159,8 +159,8 @@ fn is_valid_attribute_value(
             let opening_element = jsx_element.opening_element().ok()?;
             let maybe_attribute = opening_element.find_attribute_by_name("id").ok()?;
             let child_attribute_value = maybe_attribute?.initializer()?.value().ok()?;
-            let is_valid = attribute_value.inner_text_value().ok()??.text()
-                == child_attribute_value.inner_text_value().ok()??.text();
+            let is_valid = attribute_value.as_static_value()?.text()
+                == child_attribute_value.as_static_value()?.text();
             Some(is_valid)
         })
         .any(|x| x);

--- a/crates/rome_js_analyze/src/analyzers/style/use_numeric_literals.rs
+++ b/crates/rome_js_analyze/src/analyzers/style/use_numeric_literals.rs
@@ -116,7 +116,8 @@ impl CallInfo {
             .next()?
             .ok()?
             .as_any_js_expression()?
-            .as_string_constant()?;
+            .as_string_constant()?
+            .to_string();
         let radix = args
             .next()?
             .ok()?

--- a/crates/rome_js_analyze/src/analyzers/style/use_numeric_literals.rs
+++ b/crates/rome_js_analyze/src/analyzers/style/use_numeric_literals.rs
@@ -116,6 +116,7 @@ impl CallInfo {
             .next()?
             .ok()?
             .as_any_js_expression()?
+            .as_static_value()?
             .as_string_constant()?
             .to_string();
         let radix = args

--- a/crates/rome_js_analyze/src/aria_analyzers/nursery/use_valid_lang.rs
+++ b/crates/rome_js_analyze/src/aria_analyzers/nursery/use_valid_lang.rs
@@ -58,8 +58,9 @@ impl Rule for UseValidLang {
         if element_text.text_trimmed() == "html" {
             let attribute = node.find_attribute_by_name("lang")?;
             let attribute_value = attribute.initializer()?.value().ok()?;
-            let attribute_text = attribute_value.inner_text_value().ok()??;
-            let mut split_value = attribute_text.text().split('-');
+            let attribute_static_value = attribute_value.as_static_value()?;
+            let attribute_text = attribute_static_value.text();
+            let mut split_value = attribute_text.split('-');
             match (split_value.next(), split_value.next()) {
                 (Some(language), Some(country)) => {
                     if !ctx.is_valid_iso_language(language) {

--- a/crates/rome_js_analyze/src/aria_services.rs
+++ b/crates/rome_js_analyze/src/aria_services.rs
@@ -58,9 +58,9 @@ impl AriaServices {
                     continue
                 };
                 let initializer = initializer.value().ok()?;
-                let text = initializer.inner_text_value().ok()??;
+                let static_value = initializer.as_static_value()?;
                 // handle multiple values e.g. `<div class="wrapper document">`
-                let values = text.split(' ');
+                let values = static_value.text().split(' ');
                 let values = values.map(|s| s.to_string()).collect::<Vec<String>>();
                 defined_attributes.entry(name).or_insert(values);
             }

--- a/crates/rome_js_analyze/src/semantic_analyzers/a11y/use_button_type.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/a11y/use_button_type.rs
@@ -109,7 +109,7 @@ impl Rule for UseButtonType {
                     .as_js_string_literal_expression()?;
 
                 // case sensitive is important, <button> is different from <Button>
-                if first_argument.inner_string_text().ok()? == "button" {
+                if first_argument.inner_string_text().ok()?.text() == "button" {
                     return if let Some(props) = react_create_element.props.as_ref() {
                         let type_member = react_create_element.find_prop_by_name("type");
                         if let Some(member) = type_member {

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_iframe_title.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_iframe_title.rs
@@ -103,8 +103,8 @@ impl Rule for UseIframeTitle {
 
         match attribute_value {
             AnyJsxAttributeValue::JsxString(str) => {
-                let text = str.inner_string_text().ok()?;
-                let is_valid_string = !text.is_empty() && text != r#"``"#;
+                let quoted_string = str.inner_string_text().ok()?;
+                let is_valid_string = !quoted_string.is_empty() && quoted_string.text() != r#"``"#;
                 if is_valid_string {
                     return None;
                 }

--- a/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/style/no_shouty_constants.rs
@@ -66,7 +66,7 @@ fn is_id_and_string_literal_inner_text_equal(
         .as_js_string_literal_expression()?;
     let literal_text = literal.inner_string_text().ok()?;
 
-    if id_text.len() != usize::from(literal_text.len()) {
+    if id_text.len() != literal_text.len() {
         return None;
     }
 

--- a/crates/rome_js_analyze/tests/specs/style/useNumericLiterals/invalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/style/useNumericLiterals/invalid.js.snap
@@ -419,6 +419,21 @@ invalid.js:18:1 lint/style/useNumericLiterals ━━━━━━━━━━━�
 ```
 
 ```
+invalid.js:19:1 lint/style/useNumericLiterals ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use octal literals instead of parseInt()
+  
+    17 │ parseInt(`1F7`, 16) === 255;
+    18 │ parseInt('', 8);
+  > 19 │ parseInt(``, 8);
+       │ ^^^^^^^^^^^^^^^
+    20 │ parseInt(`7999`, 8);
+    21 │ parseInt(`1234`, 2);
+  
+
+```
+
+```
 invalid.js:20:1 lint/style/useNumericLiterals ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use octal literals instead of parseInt()

--- a/crates/rome_js_syntax/src/expr_ext.rs
+++ b/crates/rome_js_syntax/src/expr_ext.rs
@@ -631,7 +631,7 @@ impl AnyJsExpression {
             .and_then(|it| it.name().ok())
     }
 
-    /// Return the expression is a string of given value if the given expression is
+    /// Return `true` if the static value match the given string value and it is
     /// 1. A string literal
     /// 2. A template literal with no substitutions
     pub fn is_string_constant(&self, text: &str) -> bool {

--- a/crates/rome_js_syntax/src/expr_ext.rs
+++ b/crates/rome_js_syntax/src/expr_ext.rs
@@ -1,19 +1,19 @@
 //! Extensions for things which are not easily generated in ast expr nodes
 use crate::numbers::parse_js_number;
+use crate::static_value::{QuotedString, StaticValue, StringConstant};
 use crate::{
     AnyJsCallArgument, AnyJsExpression, AnyJsLiteralExpression, AnyJsTemplateElement,
     JsArrayExpression, JsArrayHole, JsAssignmentExpression, JsBinaryExpression, JsCallExpression,
-    JsComputedMemberExpression, JsIdentifierExpression, JsLiteralMemberName, JsLogicalExpression,
-    JsNewExpression, JsNumberLiteralExpression, JsObjectExpression, JsPostUpdateExpression,
-    JsReferenceIdentifier, JsRegexLiteralExpression, JsStaticMemberExpression,
-    JsStringLiteralExpression, JsSyntaxKind, JsSyntaxToken, JsTemplateExpression,
-    JsUnaryExpression, OperatorPrecedence, T,
+    JsComputedMemberExpression, JsLiteralMemberName, JsLogicalExpression, JsNewExpression,
+    JsNumberLiteralExpression, JsObjectExpression, JsPostUpdateExpression, JsReferenceIdentifier,
+    JsRegexLiteralExpression, JsStaticMemberExpression, JsStringLiteralExpression, JsSyntaxKind,
+    JsSyntaxToken, JsTemplateExpression, JsUnaryExpression, OperatorPrecedence, T,
 };
 use crate::{JsPreUpdateExpression, JsSyntaxKind::*};
 use core::iter;
 use rome_rowan::{
-    declare_node_union, AstNode, AstSeparatedList, NodeOrToken, SyntaxResult, SyntaxTokenText,
-    TextRange, TextSize,
+    declare_node_union, AstNode, AstNodeList, AstSeparatedList, NodeOrToken, SyntaxResult,
+    TextRange,
 };
 use std::collections::HashSet;
 
@@ -266,29 +266,13 @@ impl JsBinaryExpression {
             self.operator(),
             Ok(JsBinaryOperator::StrictInequality | JsBinaryOperator::Inequality)
         ) {
-            let right = self.right()?;
-
-            let is_right_null_expression = right
-                .as_any_js_literal_expression()
-                .map_or(false, |expression| {
-                    expression.as_js_null_literal_expression().is_some()
-                });
-
-            if is_right_null_expression {
-                return Ok(true);
-            }
-
-            let is_right_undefined_expression = right
-                .as_js_identifier_expression()
-                .map(|expression| expression.is_undefined())
-                .transpose()?
-                .unwrap_or(false);
-
-            if is_right_undefined_expression {
-                return Ok(true);
-            }
+            Ok(self
+                .right()?
+                .as_static_value()
+                .map_or(false, |value| value.is_null_or_undefined()))
+        } else {
+            Ok(false)
         }
-        Ok(false)
     }
 }
 
@@ -528,23 +512,8 @@ impl JsStringLiteralExpression {
     ///     .with_leading_trivia(vec![(TriviaPieceKind::Whitespace, " ")]));
     /// assert_eq!(string.inner_string_text().unwrap().text(), "foo");
     /// ```
-    pub fn inner_string_text(&self) -> SyntaxResult<SyntaxTokenText> {
-        let value = self.value_token()?;
-        let mut text = value.token_text_trimmed();
-
-        static QUOTES: [char; 2] = ['"', '\''];
-
-        if text.starts_with(QUOTES) {
-            let range = text.range().add_start(TextSize::from(1));
-            text = text.slice(range);
-        }
-
-        if text.ends_with(QUOTES) {
-            let range = text.range().sub_end(TextSize::from(1));
-            text = text.slice(range);
-        }
-
-        Ok(text)
+    pub fn inner_string_text(&self) -> SyntaxResult<QuotedString> {
+        Ok(QuotedString::new(self.value_token()?))
     }
 }
 
@@ -569,21 +538,6 @@ impl JsTemplateExpression {
             start.text_range().start(),
             self.syntax().text_range().end(),
         ))
-    }
-
-    /// Return token if the template is a string constant.
-    pub fn as_string_constant(&self) -> Option<JsSyntaxToken> {
-        if self.tag().is_some() {
-            return None;
-        }
-
-        let mut elements = self.elements().into_iter();
-        match (elements.next(), elements.next()) {
-            (Some(AnyJsTemplateElement::JsTemplateChunkElement(chunk)), None) => {
-                chunk.template_chunk_token().ok()
-            }
-            _ => None,
-        }
     }
 }
 
@@ -684,33 +638,53 @@ impl AnyJsExpression {
     /// 1. A string literal
     /// 2. A template literal with no substitutions
     pub fn is_string_constant(&self, text: &str) -> bool {
-        self.with_string_constant(|it| it == text).unwrap_or(false)
+        if let Some(str_const) = self.as_string_constant() {
+            str_const.text() == text
+        } else {
+            false
+        }
     }
 
     /// Return the string value if the given expression is
     /// 1. A string literal
     /// 2. A template literal with no substitutions
-    pub fn as_string_constant(&self) -> Option<String> {
-        self.with_string_constant(|it| it.to_string())
+    pub fn as_string_constant(&self) -> Option<StringConstant> {
+        StringConstant::try_from(self.as_static_value()?).ok()
     }
 
-    /// Call the given closure if the given expression is
-    /// 1. A string literal
-    /// 2. A template literal with no substitutions
-    fn with_string_constant<R>(&self, f: impl FnOnce(&str) -> R) -> Option<R> {
+    pub fn as_static_value(&self) -> Option<StaticValue> {
         match self {
-            Self::JsTemplateExpression(t) => t.as_string_constant().map(|it| f(it.text_trimmed())),
-            Self::AnyJsLiteralExpression(AnyJsLiteralExpression::JsStringLiteralExpression(s)) => {
-                s.inner_string_text().ok().map(|it| f(&it))
+            AnyJsExpression::AnyJsLiteralExpression(literal) => literal.as_static_value(),
+            AnyJsExpression::JsTemplateExpression(template) => {
+                let element_list = template.elements();
+
+                if element_list.len() > 1 {
+                    return None;
+                }
+
+                if element_list.len() == 0 {
+                    return Some(StaticValue::TemplateChunk(None));
+                }
+
+                match element_list.first()? {
+                    AnyJsTemplateElement::JsTemplateChunkElement(element) => Some(
+                        StaticValue::TemplateChunk(Some(element.template_chunk_token().ok()?)),
+                    ),
+                    AnyJsTemplateElement::JsTemplateElement(element) => {
+                        element.expression().ok()?.as_static_value()
+                    }
+                }
+            }
+            AnyJsExpression::JsIdentifierExpression(identifier) => {
+                let identifier_token = identifier.name().ok()?.value_token().ok()?;
+                match identifier_token.text_trimmed() {
+                    "undefined" => Some(StaticValue::Undefined(identifier_token)),
+                    "NaN" => Some(StaticValue::Number(identifier_token)),
+                    _ => None,
+                }
             }
             _ => None,
         }
-    }
-}
-
-impl JsIdentifierExpression {
-    pub fn is_undefined(&self) -> SyntaxResult<bool> {
-        Ok(self.name()?.value_token()?.text_trimmed() == "undefined")
     }
 }
 
@@ -733,6 +707,27 @@ impl AnyJsLiteralExpression {
             AnyJsLiteralExpression::JsStringLiteralExpression(expression) => {
                 expression.value_token()
             }
+        }
+    }
+
+    pub fn as_static_value(&self) -> Option<StaticValue> {
+        match self {
+            AnyJsLiteralExpression::JsBigintLiteralExpression(bigint) => {
+                Some(StaticValue::BigInt(bigint.value_token().ok()?))
+            }
+            AnyJsLiteralExpression::JsBooleanLiteralExpression(boolean) => {
+                Some(StaticValue::Boolean(boolean.value_token().ok()?))
+            }
+            AnyJsLiteralExpression::JsNullLiteralExpression(null) => {
+                Some(StaticValue::Null(null.value_token().ok()?))
+            }
+            AnyJsLiteralExpression::JsNumberLiteralExpression(number) => {
+                Some(StaticValue::Number(number.value_token().ok()?))
+            }
+            AnyJsLiteralExpression::JsRegexLiteralExpression(_) => None,
+            AnyJsLiteralExpression::JsStringLiteralExpression(string) => Some(StaticValue::String(
+                QuotedString::new(string.value_token().ok()?),
+            )),
         }
     }
 }

--- a/crates/rome_js_syntax/src/jsx_ext.rs
+++ b/crates/rome_js_syntax/src/jsx_ext.rs
@@ -382,6 +382,11 @@ impl JsxAttribute {
 }
 
 impl AnyJsxAttributeValue {
+    pub fn is_value_null_or_undefined(&self) -> bool {
+        self.as_static_value()
+            .map_or(false, |it| it.is_null_or_undefined())
+    }
+
     pub fn as_static_value(&self) -> Option<StaticValue> {
         match self {
             AnyJsxAttributeValue::AnyJsxTag(_) => None,

--- a/crates/rome_js_syntax/src/lib.rs
+++ b/crates/rome_js_syntax/src/lib.rs
@@ -13,6 +13,7 @@ pub mod jsx_ext;
 pub mod modifier_ext;
 pub mod numbers;
 pub mod source_type;
+pub mod static_value;
 pub mod stmt_ext;
 pub mod suppression;
 mod syntax_node;

--- a/crates/rome_js_syntax/src/static_value.rs
+++ b/crates/rome_js_syntax/src/static_value.rs
@@ -1,0 +1,121 @@
+use crate::{
+    JsSyntaxKind::{JSX_IDENT, JSX_STRING_LITERAL, JS_STRING_LITERAL},
+    JsSyntaxToken,
+};
+
+use std::ops::Deref;
+
+#[derive(PartialEq, Eq, Clone)]
+pub struct QuotedString(JsSyntaxToken);
+
+impl QuotedString {
+    pub fn new(token: JsSyntaxToken) -> Self {
+        assert!(matches!(
+            token.kind(),
+            JSX_IDENT | JS_STRING_LITERAL | JSX_STRING_LITERAL
+        ));
+
+        Self(token)
+    }
+
+    pub fn text(&self) -> &str {
+        self.0
+            .text_trimmed()
+            .trim_start_matches(['"', '\''])
+            .trim_end_matches(['"', '\''])
+    }
+
+    pub fn quoted_text(&self) -> &str {
+        self.0.text_trimmed()
+    }
+}
+
+impl Deref for QuotedString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.text()
+    }
+}
+
+pub enum StaticValue {
+    Boolean(JsSyntaxToken),
+    Null(JsSyntaxToken),
+    Undefined(JsSyntaxToken),
+    Number(JsSyntaxToken),
+    BigInt(JsSyntaxToken),
+    String(QuotedString),
+    TemplateChunk(Option<JsSyntaxToken>),
+}
+
+impl StaticValue {
+    pub fn is_falsy(&self) -> bool {
+        match self {
+            StaticValue::Boolean(token) => token.text_trimmed() == "false",
+            StaticValue::Null(_) => true,
+            StaticValue::Undefined(_) => true,
+            StaticValue::Number(token) => matches!(token.text_trimmed(), "0" | "-0" | "+0" | "NaN"),
+            StaticValue::BigInt(token) => matches!(token.text_trimmed(), "0n"),
+            StaticValue::String(token) => token.text().is_empty(),
+            StaticValue::TemplateChunk(token) => token
+                .as_ref()
+                .map_or(true, |it| it.text_trimmed().is_empty()),
+        }
+    }
+
+    pub fn text(&self) -> &str {
+        match self {
+            StaticValue::Boolean(token) => token.text_trimmed(),
+            StaticValue::Null(token) => token.text_trimmed(),
+            StaticValue::Undefined(token) => token.text_trimmed(),
+            StaticValue::Number(token) => token.text_trimmed(),
+            StaticValue::BigInt(token) => token.text_trimmed(),
+            StaticValue::String(token) => token.text(),
+            StaticValue::TemplateChunk(token) => token.as_ref().map_or("", |it| it.text_trimmed()),
+        }
+    }
+
+    pub fn is_null_or_undefined(&self) -> bool {
+        matches!(self, StaticValue::Null(_) | StaticValue::Undefined(_))
+    }
+
+    pub fn is_undefined(&self) -> bool {
+        matches!(self, StaticValue::Undefined(_))
+    }
+}
+
+pub enum StringConstant {
+    TemplateChunk(Option<JsSyntaxToken>),
+    String(QuotedString),
+}
+
+impl StringConstant {
+    pub fn text(&self) -> &str {
+        match self {
+            StringConstant::TemplateChunk(token) => {
+                token.as_ref().map_or("", |it| it.text_trimmed())
+            }
+            StringConstant::String(quoted) => quoted.text(),
+        }
+    }
+}
+
+impl Deref for StringConstant {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.text()
+    }
+}
+
+impl TryFrom<StaticValue> for StringConstant {
+    type Error = ();
+
+    fn try_from(from: StaticValue) -> Result<Self, Self::Error> {
+        match from {
+            StaticValue::TemplateChunk(token) => Ok(StringConstant::TemplateChunk(token)),
+            StaticValue::String(token) => Ok(StringConstant::String(token)),
+            _ => Err(()),
+        }
+    }
+}

--- a/crates/rome_js_syntax/src/static_value.rs
+++ b/crates/rome_js_syntax/src/static_value.rs
@@ -1,5 +1,5 @@
 use crate::{
-    JsSyntaxKind::{JSX_IDENT, JSX_STRING_LITERAL, JS_STRING_LITERAL},
+    JsSyntaxKind::{IDENT, JSX_IDENT, JSX_STRING_LITERAL, JS_STRING_LITERAL},
     JsSyntaxToken,
 };
 
@@ -12,7 +12,7 @@ impl QuotedString {
     pub fn new(token: JsSyntaxToken) -> Self {
         assert!(matches!(
             token.kind(),
-            JSX_IDENT | JS_STRING_LITERAL | JSX_STRING_LITERAL
+            IDENT | JSX_IDENT | JS_STRING_LITERAL | JSX_STRING_LITERAL
         ));
 
         Self(token)

--- a/crates/rome_js_syntax/src/static_value.rs
+++ b/crates/rome_js_syntax/src/static_value.rs
@@ -75,47 +75,21 @@ impl StaticValue {
         }
     }
 
+    pub fn is_string_constant(&self, text: &str) -> bool {
+        match self {
+            StaticValue::String(_) | StaticValue::TemplateChunk(_) => self.text() == text,
+            _ => false,
+        }
+    }
+
+    pub fn as_string_constant(&self) -> Option<&str> {
+        match self {
+            StaticValue::String(_) | StaticValue::TemplateChunk(_) => Some(self.text()),
+            _ => None,
+        }
+    }
+
     pub fn is_null_or_undefined(&self) -> bool {
         matches!(self, StaticValue::Null(_) | StaticValue::Undefined(_))
-    }
-
-    pub fn is_undefined(&self) -> bool {
-        matches!(self, StaticValue::Undefined(_))
-    }
-}
-
-pub enum StringConstant {
-    TemplateChunk(Option<JsSyntaxToken>),
-    String(QuotedString),
-}
-
-impl StringConstant {
-    pub fn text(&self) -> &str {
-        match self {
-            StringConstant::TemplateChunk(token) => {
-                token.as_ref().map_or("", |it| it.text_trimmed())
-            }
-            StringConstant::String(quoted) => quoted.text(),
-        }
-    }
-}
-
-impl Deref for StringConstant {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        self.text()
-    }
-}
-
-impl TryFrom<StaticValue> for StringConstant {
-    type Error = ();
-
-    fn try_from(from: StaticValue) -> Result<Self, Self::Error> {
-        match from {
-            StaticValue::TemplateChunk(token) => Ok(StringConstant::TemplateChunk(token)),
-            StaticValue::String(token) => Ok(StringConstant::String(token)),
-            _ => Err(()),
-        }
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR introduces common logic for checking expression values based on #4073 and discussion. This is useful when implementing some aria rules that checks value of the JSX attributes.

After merge in this PR, I will refactor much more in the current codebases using this methods.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I need to keep the current tests passed. I updated `useNumericLiterals/invalid.js.snap` because the previous code didn't handle empty template string correctly.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
