### PR TITLE
feat(rome_cli): rome migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### CLI
+
+#### Other changes
+- Add new command `rome migrate` the transform the configuration file `rome.json`
+when there are breaking changes.
+
 ### Configuration
 ### Editors
 ### Formatter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,10 @@ dependencies = [
  "rome_js_formatter",
  "rome_json_formatter",
  "rome_json_parser",
+ "rome_json_syntax",
  "rome_lsp",
+ "rome_migrate",
+ "rome_rowan",
  "rome_service",
  "rome_text_edit",
  "rome_text_size",
@@ -2037,6 +2040,18 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "rome_migrate"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "rome_analyze",
+ "rome_diagnostics",
+ "rome_json_parser",
+ "rome_json_syntax",
+ "rome_rowan",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ countme = "3.0.1"
 tokio = { version = "~1.18.5" }
 insta = "1.21.2"
 quote = { version = "1.0.21" }
+lazy_static = "1.4.0"

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { workspace = true }
 tracing-tree = "0.2.2"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 tracing-appender = "0.2"
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 hdrhistogram = { version = "7.5.0", default-features = false }
 crossbeam = "0.8.1"
 rayon = "1.5.1"
@@ -36,6 +36,11 @@ tokio = { workspace = true, features = ["io-std", "io-util", "net", "time", "rt"
 anyhow = "1.0.52"
 dashmap = { workspace = true }
 rome_text_size = { path = "../rome_text_size" }
+rome_json_parser = { path = "../rome_json_parser" }
+rome_json_formatter = { path = "../rome_json_formatter" }
+rome_json_syntax = { path = "../rome_json_syntax" }
+rome_migrate = { path = "../rome_migrate" }
+rome_rowan = { path = "../rome_rowan" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.127"

--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -7,7 +7,7 @@ use rome_service::workspace::{FixFileMode, UpdateSettingsParams};
 
 /// Handler for the "check" command of the Rome CLI
 pub(crate) fn check(mut session: CliSession) -> Result<(), CliDiagnostic> {
-    let (mut configuration, diagnostics) = load_configuration(&mut session)?.consume();
+    let (mut configuration, diagnostics, _) = load_configuration(&mut session)?.consume();
     if !diagnostics.is_empty() {
         let console = &mut session.app.console;
         console.log(markup!{

--- a/crates/rome_cli/src/commands/ci.rs
+++ b/crates/rome_cli/src/commands/ci.rs
@@ -11,7 +11,7 @@ use rome_service::workspace::UpdateSettingsParams;
 
 /// Handler for the "ci" command of the Rome CLI
 pub(crate) fn ci(mut session: CliSession) -> Result<(), CliDiagnostic> {
-    let (mut configuration, diagnostics) = load_configuration(&mut session)?.consume();
+    let (mut configuration, diagnostics, _) = load_configuration(&mut session)?.consume();
 
     if !diagnostics.is_empty() {
         let console = &mut session.app.console;

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 /// Handler for the "format" command of the Rome CLI
 pub(crate) fn format(mut session: CliSession) -> Result<(), CliDiagnostic> {
-    let (mut configuration, diagnostics) = load_configuration(&mut session)?.consume();
+    let (mut configuration, diagnostics, _) = load_configuration(&mut session)?.consume();
     if !diagnostics.is_empty() {
         let console = &mut session.app.console;
         console.log(markup!{

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -10,12 +10,13 @@ const MAIN: Markup = markup! {
     - "<Emphasis>"ci"</Emphasis>"           Run the linter and check the formatting of a set of files
     - "<Emphasis>"format"</Emphasis>"       Run the formatter on a set of files
     - "<Emphasis>"init"</Emphasis>"         Bootstraps a new rome project
+    - "<Emphasis>"help"</Emphasis>"         Prints this help message
+    - "<Emphasis>"lsp-proxy"</Emphasis>"    Acts as a server for the Language Server Protocol over stdin/stdout
+    - "<Emphasis>"migrate"</Emphasis>"      It updates the configuration when there are breaking changes
+    - "<Emphasis>"rage"</Emphasis>"         Prints information for debugging
     - "<Emphasis>"start"</Emphasis>"        Start the Rome daemon server process
     - "<Emphasis>"stop"</Emphasis>"         Stop the Rome daemon server process
-    - "<Emphasis>"lsp-proxy"</Emphasis>"    Acts as a server for the Language Server Protocol over stdin/stdout
-    - "<Emphasis>"rage"</Emphasis>"         Prints information for debugging
     - "<Emphasis>"version"</Emphasis>"      Shows the Rome version information and quit
-    - "<Emphasis>"help"</Emphasis>"         Prints this help message
 
 "<Emphasis>"OPTIONS:"</Emphasis>"
     "<Dim>"--colors=<off|force>"</Dim>"     Set the formatting mode for markup: \"off\" prints everything as plain text, \"force\" forces the formatting of markup using ANSI even if the console output is determined to be incompatible
@@ -146,6 +147,18 @@ const VERSION_HELP_TEXT: Markup = markup! {
     rome version"
 };
 
+const MIGRATE: Markup = markup! {
+"Rome migrate: updates the configuration file to a newer version
+
+"<Emphasis>"EXAMPLES:"</Emphasis>"
+    rome migrate
+    rome migrate --write
+
+"<Emphasis>"OPTIONS:"</Emphasis>"
+    "<Dim>"--write"</Dim>"      It writes the contents to disk
+"
+};
+
 pub(crate) fn help(session: CliSession, command: Option<&str>) -> Result<(), CliDiagnostic> {
     let help_text = match command {
         Some("help") | None => MAIN,
@@ -158,6 +171,7 @@ pub(crate) fn help(session: CliSession, command: Option<&str>) -> Result<(), Cli
         Some("lsp-proxy") => START_LSP_PROXY,
         Some("version") => VERSION_HELP_TEXT,
         Some("rage") => RAGE,
+        Some("migrate") => MIGRATE,
 
         Some(cmd) => return Err(CliDiagnostic::new_unknown_help(cmd)),
     };

--- a/crates/rome_cli/src/commands/migrate.rs
+++ b/crates/rome_cli/src/commands/migrate.rs
@@ -1,0 +1,22 @@
+use crate::configuration::load_configuration;
+use crate::diagnostics::MigrationDiagnostic;
+use crate::execute::{execute_mode, Execution, TraversalMode};
+use crate::{CliDiagnostic, CliSession};
+
+/// Handler for the "check" command of the Rome CLI
+pub(crate) fn migrate(mut session: CliSession) -> Result<(), CliDiagnostic> {
+    let (_, _, path) = load_configuration(&mut session)?.consume();
+    if let Some(path) = path {
+        execute_mode(
+            Execution::new(TraversalMode::Migrate {
+                write: session.args.contains("--dry-run"),
+                configuration_path: path,
+            }),
+            session,
+        )
+    } else {
+        Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
+            reason: "Rome couldn't find the configuration file".to_string(),
+        }))
+    }
+}

--- a/crates/rome_cli/src/commands/mod.rs
+++ b/crates/rome_cli/src/commands/mod.rs
@@ -4,5 +4,6 @@ pub(crate) mod daemon;
 pub(crate) mod format;
 pub(crate) mod help;
 pub(crate) mod init;
+pub(crate) mod migrate;
 pub(crate) mod rage;
 pub(crate) mod version;

--- a/crates/rome_cli/src/commands/rage.rs
+++ b/crates/rome_cli/src/commands/rage.rs
@@ -166,6 +166,7 @@ impl Display for RageConfiguration<'_, '_> {
         match load_config(self.0, ConfigurationBasePath::default()) {
             Ok(None) => KeyValuePair("Status", markup!(<Dim>"unset"</Dim>)).fmt(fmt)?,
             Ok(Some(deserialized)) => {
+                let (deserialized, _) = deserialized;
                 let (configuration, diagnostics) = deserialized.consume();
                 let status = if !diagnostics.is_empty() {
                     for diagnostic in diagnostics {

--- a/crates/rome_cli/src/diagnostics.rs
+++ b/crates/rome_cli/src/diagnostics.rs
@@ -52,6 +52,8 @@ pub enum CliDiagnostic {
     IncompatibleEndConfiguration(IncompatibleEndConfiguration),
     /// No files processed during the file system traversal
     NoFilesWereProcessed(NoFilesWereProcessed),
+    /// Errors thrown when running the `rome migrate` command
+    MigrateError(MigrationDiagnostic),
 }
 
 #[derive(Debug, Diagnostic)]
@@ -258,6 +260,19 @@ pub struct IncompatibleEndConfiguration {
 )]
 pub struct NoFilesWereProcessed;
 
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+	category = "migrate",
+	severity = Error,
+	message(
+		message("Migration has encountered an error: "{{&self.reason}}),
+		description = "Migration has encountered an error: {reason}"
+	)
+)]
+pub struct MigrationDiagnostic {
+    pub reason: String,
+}
+
 /// Advices for the [CliDiagnostic]
 #[derive(Debug, Default)]
 struct CliAdvice {
@@ -422,6 +437,7 @@ impl Diagnostic for CliDiagnostic {
             CliDiagnostic::IncompatibleEndConfiguration(diagnostic) => diagnostic.category(),
             CliDiagnostic::NoFilesWereProcessed(diagnostic) => diagnostic.category(),
             CliDiagnostic::FileCheckApply(diagnostic) => diagnostic.category(),
+            CliDiagnostic::MigrateError(diagnostic) => diagnostic.category(),
         }
     }
 
@@ -442,6 +458,7 @@ impl Diagnostic for CliDiagnostic {
             CliDiagnostic::IncompatibleEndConfiguration(diagnostic) => diagnostic.tags(),
             CliDiagnostic::NoFilesWereProcessed(diagnostic) => diagnostic.tags(),
             CliDiagnostic::FileCheckApply(diagnostic) => diagnostic.tags(),
+            CliDiagnostic::MigrateError(diagnostic) => diagnostic.tags(),
         }
     }
 
@@ -462,6 +479,7 @@ impl Diagnostic for CliDiagnostic {
             CliDiagnostic::IncompatibleEndConfiguration(diagnostic) => diagnostic.severity(),
             CliDiagnostic::NoFilesWereProcessed(diagnostic) => diagnostic.severity(),
             CliDiagnostic::FileCheckApply(diagnostic) => diagnostic.severity(),
+            CliDiagnostic::MigrateError(diagnostic) => diagnostic.severity(),
         }
     }
 
@@ -482,6 +500,7 @@ impl Diagnostic for CliDiagnostic {
             CliDiagnostic::IncompatibleEndConfiguration(diagnostic) => diagnostic.location(),
             CliDiagnostic::NoFilesWereProcessed(diagnostic) => diagnostic.location(),
             CliDiagnostic::FileCheckApply(diagnostic) => diagnostic.location(),
+            CliDiagnostic::MigrateError(diagnostic) => diagnostic.location(),
         }
     }
 
@@ -502,6 +521,7 @@ impl Diagnostic for CliDiagnostic {
             CliDiagnostic::IncompatibleEndConfiguration(diagnostic) => diagnostic.message(fmt),
             CliDiagnostic::NoFilesWereProcessed(diagnostic) => diagnostic.message(fmt),
             CliDiagnostic::FileCheckApply(diagnostic) => diagnostic.message(fmt),
+            CliDiagnostic::MigrateError(diagnostic) => diagnostic.message(fmt),
         }
     }
 
@@ -522,6 +542,7 @@ impl Diagnostic for CliDiagnostic {
             CliDiagnostic::IncompatibleEndConfiguration(diagnostic) => diagnostic.description(fmt),
             CliDiagnostic::NoFilesWereProcessed(diagnostic) => diagnostic.description(fmt),
             CliDiagnostic::FileCheckApply(diagnostic) => diagnostic.description(fmt),
+            CliDiagnostic::MigrateError(diagnostic) => diagnostic.description(fmt),
         }
     }
 
@@ -542,6 +563,7 @@ impl Diagnostic for CliDiagnostic {
             CliDiagnostic::IncompatibleEndConfiguration(diagnostic) => diagnostic.advices(visitor),
             CliDiagnostic::NoFilesWereProcessed(diagnostic) => diagnostic.advices(visitor),
             CliDiagnostic::FileCheckApply(diagnostic) => diagnostic.advices(visitor),
+            CliDiagnostic::MigrateError(diagnostic) => diagnostic.advices(visitor),
         }
     }
 
@@ -566,6 +588,7 @@ impl Diagnostic for CliDiagnostic {
             }
             CliDiagnostic::NoFilesWereProcessed(diagnostic) => diagnostic.verbose_advices(visitor),
             CliDiagnostic::FileCheckApply(diagnostic) => diagnostic.verbose_advices(visitor),
+            CliDiagnostic::MigrateError(diagnostic) => diagnostic.verbose_advices(visitor),
         }
     }
 
@@ -586,6 +609,7 @@ impl Diagnostic for CliDiagnostic {
             CliDiagnostic::IncompatibleEndConfiguration(diagnostic) => diagnostic.source(),
             CliDiagnostic::NoFilesWereProcessed(diagnostic) => diagnostic.source(),
             CliDiagnostic::FileCheckApply(diagnostic) => diagnostic.source(),
+            CliDiagnostic::MigrateError(diagnostic) => diagnostic.source(),
         }
     }
 }

--- a/crates/rome_cli/src/execute/diagnostics.rs
+++ b/crates/rome_cli/src/execute/diagnostics.rs
@@ -1,0 +1,149 @@
+use rome_diagnostics::adapters::{IoError, StdError};
+use rome_diagnostics::{Advices, Category, Diagnostic, DiagnosticExt, Error, Severity, Visit};
+use rome_text_edit::TextEdit;
+use std::io;
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+    category = "format",
+    message = "File content differs from formatting output"
+)]
+pub(crate) struct CIFormatDiffDiagnostic<'a> {
+    #[location(resource)]
+    pub(crate) file_name: &'a str,
+    #[advice]
+    pub(crate) diff: ContentDiffAdvice<'a>,
+}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+    category = "organizeImports",
+    message = "Import statements differs from the output"
+)]
+pub(crate) struct CIOrganizeImportsDiffDiagnostic<'a> {
+    #[location(resource)]
+    pub(crate) file_name: &'a str,
+    #[advice]
+    pub(crate) diff: ContentDiffAdvice<'a>,
+}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+category = "format",
+severity = Information,
+message = "Formatter would have printed the following content:"
+)]
+pub(crate) struct FormatDiffDiagnostic<'a> {
+    #[location(resource)]
+    pub(crate) file_name: &'a str,
+    #[advice]
+    pub(crate) diff: ContentDiffAdvice<'a>,
+}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+	category = "organizeImports",
+	severity = Information,
+	message = "Import statements could be sorted:"
+)]
+pub(crate) struct OrganizeImportsDiffDiagnostic<'a> {
+    #[location(resource)]
+    pub(crate) file_name: &'a str,
+    #[advice]
+    pub(crate) diff: ContentDiffAdvice<'a>,
+}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+	category = "migrate",
+	severity = Information,
+	message = "Configuration file can be updated."
+)]
+pub(crate) struct MigrateDiffDiagnostic<'a> {
+    #[location(resource)]
+    pub(crate) file_name: &'a str,
+    #[advice]
+    pub(crate) diff: ContentDiffAdvice<'a>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ContentDiffAdvice<'a> {
+    pub(crate) old: &'a str,
+    pub(crate) new: &'a str,
+}
+
+impl Advices for ContentDiffAdvice<'_> {
+    fn record(&self, visitor: &mut dyn Visit) -> io::Result<()> {
+        let diff = TextEdit::from_unicode_words(self.old, self.new);
+        visitor.record_diff(&diff)
+    }
+}
+
+#[derive(Debug, Diagnostic)]
+pub(crate) struct TraversalDiagnostic<'a> {
+    #[location(resource)]
+    pub(crate) file_name: Option<&'a str>,
+    #[severity]
+    pub(crate) severity: Severity,
+    #[category]
+    pub(crate) category: &'static Category,
+    #[message]
+    #[description]
+    pub(crate) message: &'a str,
+}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(category = "internalError/panic", tags(INTERNAL))]
+pub(crate) struct PanicDiagnostic {
+    #[description]
+    #[message]
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(category = "files/missingHandler", message = "unhandled file type")]
+pub(crate) struct UnhandledDiagnostic;
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(category = "parse", message = "Skipped file with syntax errors")]
+pub(crate) struct SkippedDiagnostic;
+
+/// Extension trait for turning [Display]-able error types into [TraversalError]
+pub(crate) trait ResultExt {
+    type Result;
+    fn with_file_path_and_code(
+        self,
+        file_path: String,
+        code: &'static Category,
+    ) -> Result<Self::Result, Error>;
+}
+
+impl<T, E> ResultExt for Result<T, E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    type Result = T;
+
+    fn with_file_path_and_code(
+        self,
+        file_path: String,
+        code: &'static Category,
+    ) -> Result<Self::Result, Error> {
+        self.map_err(move |err| {
+            StdError::from(err)
+                .with_category(code)
+                .with_file_path(file_path)
+        })
+    }
+}
+
+/// Extension trait for turning [io::Error] into [Error]
+pub(crate) trait ResultIoExt: ResultExt {
+    fn with_file_path(self, file_path: String) -> Result<Self::Result, Error>;
+}
+
+impl<T> ResultIoExt for io::Result<T> {
+    fn with_file_path(self, file_path: String) -> Result<Self::Result, Error> {
+        self.map_err(|error| IoError::from(error).with_file_path(file_path))
+    }
+}

--- a/crates/rome_cli/src/execute/migrate.rs
+++ b/crates/rome_cli/src/execute/migrate.rs
@@ -1,0 +1,102 @@
+use crate::execute::diagnostics::{ContentDiffAdvice, MigrateDiffDiagnostic};
+use crate::{CliDiagnostic, CliSession};
+use rome_console::{markup, ConsoleExt};
+use rome_diagnostics::PrintDiagnostic;
+use rome_fs::OpenOptions;
+use rome_json_syntax::JsonRoot;
+use rome_migrate::{migrate_configuration, ControlFlow};
+use rome_rowan::AstNode;
+use rome_service::workspace::FixAction;
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+pub(crate) fn run(
+    session: CliSession,
+    write: bool,
+    configuration_path: PathBuf,
+    verbose: bool,
+) -> Result<(), CliDiagnostic> {
+    let fs = &*session.app.fs;
+    let open_options = if write {
+        OpenOptions::default().write(true)
+    } else {
+        OpenOptions::default().read(true)
+    };
+    let mut configuration_file =
+        fs.open_with_options(configuration_path.as_path(), open_options)?;
+    let mut configuration_content = String::new();
+    configuration_file.read_to_string(&mut configuration_content)?;
+    let parsed = rome_json_parser::parse_json(&configuration_content);
+    let mut errors = 0;
+    let mut tree = parsed.tree();
+    let mut actions = Vec::new();
+    loop {
+        let (action, _) = migrate_configuration(
+            &tree.value().unwrap(),
+            configuration_path.as_path(),
+            |signal| {
+                let current_diagnostic = signal.diagnostic();
+
+                if current_diagnostic.is_some() {
+                    errors += 1;
+                }
+
+                if let Some(action) = signal.actions().next() {
+                    return ControlFlow::Break(action);
+                }
+
+                ControlFlow::Continue(())
+            },
+        );
+
+        match action {
+            Some(action) => {
+                if let Some((range, _)) = action.mutation.as_text_edits() {
+                    tree = match JsonRoot::cast(action.mutation.commit()) {
+                        Some(tree) => tree,
+                        None => return Err(CliDiagnostic::check_error()),
+                    };
+                    actions.push(FixAction {
+                        rule_name: action
+                            .rule_name
+                            .map(|(group, rule)| (Cow::Borrowed(group), Cow::Borrowed(rule))),
+                        range,
+                    });
+                }
+            }
+            None => {
+                break;
+            }
+        }
+    }
+    let console = &mut *session.app.console;
+    let new_configuration_content = tree.to_string();
+
+    if configuration_content != new_configuration_content {
+        if write {
+            configuration_file.set_content(tree.to_string().as_bytes())?;
+            console.log(markup!{
+					<Info>"The configuration "<Emphasis>{{configuration_path.display().to_string()}}</Emphasis>" has been successfully migrated"</Info>
+				})
+        } else {
+            let file_name = configuration_path.display().to_string();
+            let diagnostic = MigrateDiffDiagnostic {
+                file_name: &file_name,
+                diff: ContentDiffAdvice {
+                    old: configuration_content.as_str(),
+                    new: new_configuration_content.as_str(),
+                },
+            };
+            console.error(markup! {
+					{if verbose { PrintDiagnostic::verbose(&diagnostic) } else { PrintDiagnostic::simple(&diagnostic) }}
+				});
+        }
+    } else {
+        console.log(markup! {
+            <Info>
+            "Your configuration file is up to date."
+            </Info>
+        })
+    }
+    Ok(())
+}

--- a/crates/rome_cli/src/execute/process_file.rs
+++ b/crates/rome_cli/src/execute/process_file.rs
@@ -1,7 +1,6 @@
+use crate::execute::diagnostics::{ResultExt, ResultIoExt, SkippedDiagnostic, UnhandledDiagnostic};
+use crate::execute::traverse::TraversalOptions;
 use crate::execute::TraversalMode;
-use crate::traversal::{
-    ResultExt, ResultIoExt, SkippedDiagnostic, TraversalOptions, UnhandledDiagnostic,
-};
 use crate::{CliDiagnostic, FormatterReportFileDetail};
 use rome_diagnostics::{category, DiagnosticExt, Error};
 use rome_fs::{OpenOptions, RomePath};
@@ -101,6 +100,7 @@ pub(crate) fn process_file(ctx: &TraversalOptions, path: &Path) -> FileResult {
                 .and(supported_format.reason.as_ref())
                 .and(supported_organize_imports.reason.as_ref()),
             TraversalMode::Format { .. } => supported_format.reason.as_ref(),
+            TraversalMode::Migrate { .. } => None,
         };
 
         if let Some(reason) = unsupported_reason {
@@ -285,6 +285,7 @@ pub(crate) fn process_file(ctx: &TraversalOptions, path: &Path) -> FileResult {
                 }
                 TraversalMode::CI { .. } => false,
                 TraversalMode::Format { write, .. } => *write,
+                TraversalMode::Migrate { write: dry_run, .. } => *dry_run,
             };
 
             let printed = file_guard

--- a/crates/rome_cli/src/execute/std_in.rs
+++ b/crates/rome_cli/src/execute/std_in.rs
@@ -1,0 +1,49 @@
+//! In here, there are the operations that run via standard input
+//!
+use crate::execute::Execution;
+use crate::{CliDiagnostic, CliSession};
+use rome_console::{markup, ConsoleExt};
+use rome_fs::RomePath;
+use rome_service::workspace::{
+    FeatureName, FormatFileParams, Language, OpenFileParams, SupportsFeatureParams,
+};
+
+pub(crate) fn run<'a>(
+    session: CliSession,
+    mode: &'a Execution,
+    rome_path: RomePath,
+    content: &'a str,
+) -> Result<(), CliDiagnostic> {
+    let workspace = &*session.app.workspace;
+    let console = &mut *session.app.console;
+
+    if mode.is_format() {
+        let unsupported_format_reason = workspace
+            .supports_feature(SupportsFeatureParams {
+                path: rome_path.clone(),
+                feature: FeatureName::Format,
+            })?
+            .reason;
+        if unsupported_format_reason.is_none() {
+            workspace.open_file(OpenFileParams {
+                path: rome_path.clone(),
+                version: 0,
+                content: content.into(),
+                language_hint: Language::default(),
+            })?;
+            let printed = workspace.format_file(FormatFileParams { path: rome_path })?;
+
+            console.append(markup! {
+                {printed.as_code()}
+            });
+        } else {
+            console.append(markup! {
+                {content}
+            });
+            console.error(markup!{
+                    <Warn>"The content was not formatted because the formatter is currently disabled."</Warn>
+                })
+        }
+    }
+    Ok(())
+}

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -22,7 +22,6 @@ mod panic;
 mod parse_arguments;
 mod reports;
 mod service;
-mod traversal;
 
 pub use diagnostics::CliDiagnostic;
 pub(crate) use execute::{execute_mode, Execution, TraversalMode};
@@ -89,6 +88,7 @@ impl<'app> CliSession<'app> {
             Some("start") => commands::daemon::start(self),
             Some("stop") => commands::daemon::stop(self),
             Some("lsp-proxy") => commands::daemon::lsp_proxy(),
+            Some("migrate") => commands::migrate::migrate(self),
 
             // Internal commands
             Some("__run_server") => commands::daemon::run_server(self),

--- a/crates/rome_cli/tests/commands/migrate.rs
+++ b/crates/rome_cli/tests/commands/migrate.rs
@@ -1,0 +1,66 @@
+use crate::run_cli;
+use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
+use pico_args::Arguments;
+use rome_console::BufferConsole;
+use rome_fs::{FileSystemExt, MemoryFileSystem};
+use rome_service::DynRef;
+use std::ffi::OsString;
+use std::path::Path;
+
+#[test]
+fn migrate_config_up_to_date() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"{ "linter": { "enabled": true } }"#;
+
+    let configuration_path = Path::new("rome.json");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Arguments::from_vec(vec![OsString::from("migrate")]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let mut file = fs.open(configuration_path).expect("file to open");
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .expect("failed to read file from memory FS");
+
+    assert_eq!(content, configuration);
+
+    drop(file);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "migrate_config_up_to_date",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn missing_configuration_file() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Arguments::from_vec(vec![OsString::from("migrate")]),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "missing_configuration_file",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/rome_cli/tests/commands/mod.rs
+++ b/crates/rome_cli/tests/commands/mod.rs
@@ -2,5 +2,6 @@ mod check;
 mod ci;
 mod format;
 mod init;
+mod migrate;
 mod rage;
 mod version;

--- a/crates/rome_cli/tests/snapshots/main_commands_migrate/migrate_config_up_to_date.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_migrate/migrate_config_up_to_date.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{ "linter": { "enabled": true } }
+```
+
+# Emitted Messages
+
+```block
+Your configuration file is up to date.
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_migrate/missing_configuration_file.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_migrate/missing_configuration_file.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Termination Message
+
+```block
+migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Migration has encountered an error: Rome couldn't find the configuration file
+  
+
+
+```
+
+

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -174,6 +174,7 @@ define_categories! {
     "format",
     "configuration",
     "organizeImports",
+    "migrate",
     "deserialize",
     "internalError/io",
     "internalError/fs",

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -23,7 +23,7 @@ roaring = "0.10.1"
 rustc-hash = { workspace = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["raw_value"] }
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 natord = "1.0.9"
 
 [dev-dependencies]

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -381,7 +381,7 @@ impl Session {
         };
 
         let status = match load_config(&self.fs, base_path) {
-            Ok(Some(deserialized)) => {
+            Ok(Some((deserialized, _))) => {
                 let (configuration, diagnostics) = deserialized.consume();
                 if diagnostics.is_empty() {
                     warn!("The deserialization of the configuration resulted in errors. Rome will its defaults where possible.");

--- a/crates/rome_migrate/Cargo.toml
+++ b/crates/rome_migrate/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rome_migrate"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rome_rowan = { path = "../rome_rowan" }
+rome_json_syntax = { path = "../rome_json_syntax"}
+rome_json_parser = { path = "../rome_json_parser"}
+rome_analyze = { path = "../rome_analyze"}
+rome_diagnostics = { path = "../rome_diagnostics"}
+lazy_static = { workspace = true }

--- a/crates/rome_migrate/src/analyzers.rs
+++ b/crates/rome_migrate/src/analyzers.rs
@@ -1,0 +1,29 @@
+use crate::analyzers::rule_set::RuleSet;
+use rome_analyze::{GroupCategory, RegistryVisitor, RuleCategory, RuleGroup};
+use rome_json_syntax::JsonLanguage;
+
+mod rule_set;
+
+pub(crate) struct MigrationGroup;
+pub(crate) struct MigrationCategory;
+
+impl RuleGroup for MigrationGroup {
+    type Language = JsonLanguage;
+    type Category = MigrationCategory;
+    const NAME: &'static str = "migrations";
+
+    fn record_rules<V: RegistryVisitor<Self::Language> + ?Sized>(registry: &mut V) {
+        // Order here is important, rules should be added from the most old, to the most recent
+        // v13.0.0
+        registry.record_rule::<RuleSet>();
+    }
+}
+
+impl GroupCategory for MigrationCategory {
+    type Language = JsonLanguage;
+    const CATEGORY: RuleCategory = RuleCategory::Action;
+
+    fn record_groups<V: RegistryVisitor<Self::Language> + ?Sized>(registry: &mut V) {
+        registry.record_group::<MigrationGroup>();
+    }
+}

--- a/crates/rome_migrate/src/analyzers/rule_set.rs
+++ b/crates/rome_migrate/src/analyzers/rule_set.rs
@@ -1,0 +1,25 @@
+use crate::declare_migration;
+use rome_analyze::context::RuleContext;
+use rome_analyze::{Ast, Rule};
+use rome_json_syntax::JsonObjectValue;
+
+declare_migration! {
+    pub(crate) RuleSet {
+        version: "11.0.0",
+        name: "ruleSet",
+    }
+}
+
+impl Rule for RuleSet {
+    type Query = Ast<JsonObjectValue>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(_: &RuleContext<Self>) -> Self::Signals {
+        // TODO: write rule to create a "ruleSet" config
+        // ruleSet -> "recommended", "all", "none" as a starter
+        // It should merge "recommended" and "all"
+        None
+    }
+}

--- a/crates/rome_migrate/src/lib.rs
+++ b/crates/rome_migrate/src/lib.rs
@@ -1,0 +1,123 @@
+mod analyzers;
+mod macros;
+mod registry;
+
+use crate::registry::visit_migration_registry;
+pub use rome_analyze::ControlFlow;
+use rome_analyze::{
+    AnalysisFilter, Analyzer, AnalyzerContext, AnalyzerOptions, AnalyzerSignal, InspectMatcher,
+    LanguageRoot, MatchQueryParams, MetadataRegistry, RuleRegistry,
+};
+use rome_diagnostics::Error;
+use rome_json_syntax::JsonLanguage;
+use std::convert::Infallible;
+use std::path::Path;
+
+/// Return the static [MetadataRegistry] for the JS analyzer rules
+pub fn metadata() -> &'static MetadataRegistry {
+    lazy_static::lazy_static! {
+        static ref METADATA: MetadataRegistry = {
+            let mut metadata = MetadataRegistry::default();
+            visit_migration_registry(&mut metadata);
+            metadata
+        };
+    }
+
+    &METADATA
+}
+
+/// Run the analyzer on the provided `root`: this process will use the given `filter`
+/// to selectively restrict analysis to specific rules / a specific source range,
+/// then call `emit_signal` when an analysis rule emits a diagnostic or action.
+/// Additionally, this function takes a `inspect_matcher` function that can be
+/// used to inspect the "query matches" emitted by the analyzer before they are
+/// processed by the lint rules registry
+pub fn analyze_with_inspect_matcher<'a, V, F, B>(
+    root: &LanguageRoot<JsonLanguage>,
+    configuration_file_path: &'a Path,
+    inspect_matcher: V,
+    mut emit_signal: F,
+) -> (Option<B>, Vec<Error>)
+where
+    V: FnMut(&MatchQueryParams<JsonLanguage>) + 'a,
+    F: FnMut(&dyn AnalyzerSignal<JsonLanguage>) -> ControlFlow<B> + 'a,
+    B: 'a,
+{
+    let filter = AnalysisFilter::default();
+    let options = AnalyzerOptions::default();
+    let mut registry = RuleRegistry::builder(&filter, &options, root);
+    visit_migration_registry(&mut registry);
+
+    let (migration_registry, services, diagnostics, visitors) = registry.build();
+
+    // Bail if we can't parse a rule option
+    if !diagnostics.is_empty() {
+        return (None, diagnostics);
+    }
+
+    let mut analyzer = Analyzer::new(
+        metadata(),
+        InspectMatcher::new(migration_registry, inspect_matcher),
+        |_| -> Vec<Result<_, Infallible>> { unreachable!() },
+        |_| {},
+        &mut emit_signal,
+    );
+
+    for ((phase, _), visitor) in visitors {
+        analyzer.add_visitor(phase, visitor);
+    }
+
+    let globals: Vec<_> = options
+        .configuration
+        .globals
+        .iter()
+        .map(|global| global.as_str())
+        .collect();
+    (
+        analyzer.run(AnalyzerContext {
+            root: root.clone(),
+            range: filter.range,
+            services,
+            globals: globals.as_slice(),
+            file_path: configuration_file_path,
+        }),
+        diagnostics,
+    )
+}
+
+pub fn migrate_configuration<'a, F, B>(
+    root: &LanguageRoot<JsonLanguage>,
+    configuration_file_path: &'a Path,
+    emit_signal: F,
+) -> (Option<B>, Vec<Error>)
+where
+    F: FnMut(&dyn AnalyzerSignal<JsonLanguage>) -> ControlFlow<B> + 'a,
+    B: 'a,
+{
+    analyze_with_inspect_matcher(root, configuration_file_path, |_| {}, emit_signal)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::migrate_configuration;
+    use rome_analyze::{ControlFlow, Never};
+    use rome_json_parser::parse_json;
+    use std::path::Path;
+
+    #[test]
+    #[ignore]
+    fn smoke() {
+        let source = r#"{ "something": "else" }"#;
+
+        let parsed = parse_json(source);
+
+        migrate_configuration(&parsed.tree().value().unwrap(), Path::new(""), |signal| {
+            for action in signal.actions() {
+                let new_code = action.mutation.commit();
+                eprintln!("{new_code}");
+            }
+
+            ControlFlow::<Never>::Continue(())
+        });
+    }
+}

--- a/crates/rome_migrate/src/macros.rs
+++ b/crates/rome_migrate/src/macros.rs
@@ -1,0 +1,26 @@
+#[macro_export]
+macro_rules! declare_migration {
+    (  $vis:vis $id:ident {
+        version: $version:literal,
+        name: $name:tt,
+        $( $key:ident: $value:expr, )*
+    } ) => {
+        $vis enum $id {}
+
+        impl rome_analyze::RuleMeta for $id {
+            type Group = $crate::analyzers::MigrationGroup;
+            const METADATA: rome_analyze::RuleMetadata =
+                rome_analyze::RuleMetadata::new($version, $name, "") $( .$key($value) )*;
+        }
+
+        // Declare a new `rule_category!` macro in the module context that
+        // expands to the category of this rule
+        // This is implemented by calling the `group_category!` macro from the
+        // parent module (that should be declared by a call to `declare_group!`)
+        // and providing it with the name of this rule as a string literal token
+        #[allow(unused_macros)]
+        macro_rules! rule_category {
+            () => { super::group_category!( $name ) };
+        }
+    };
+}

--- a/crates/rome_migrate/src/registry.rs
+++ b/crates/rome_migrate/src/registry.rs
@@ -1,0 +1,7 @@
+use crate::analyzers::MigrationCategory;
+use rome_analyze::RegistryVisitor;
+use rome_json_syntax::JsonLanguage;
+
+pub fn visit_migration_registry<V: RegistryVisitor<JsonLanguage>>(registry: &mut V) {
+    registry.record_category::<MigrationCategory>();
+}

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -139,7 +139,8 @@ impl FilesConfiguration {
 /// - [Option]: sometimes not having a configuration file should not be an error, so we need this type.
 /// - [Deserialized]: result of the deserialization of the configuration.
 /// - [Configuration]: the type needed to [Deserialized] to infer the return type.
-type LoadConfig = Result<Option<Deserialized<Configuration>>, WorkspaceError>;
+/// - [PathBuf]: the path of where the first `rome.json` path was found
+type LoadConfig = Result<Option<(Deserialized<Configuration>, PathBuf)>, WorkspaceError>;
 
 #[derive(Debug, Default, PartialEq)]
 pub enum ConfigurationBasePath {
@@ -210,7 +211,7 @@ pub fn load_config(
 
                 let deserialized = deserialize_from_json_str::<Configuration>(&buffer)
                     .with_file_path(&configuration_path.display().to_string());
-                Ok(Some(deserialized))
+                Ok(Some((deserialized, configuration_path)))
             }
             Err(err) => {
                 // base paths from users are not eligible for auto discovery

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -1022,6 +1022,7 @@ export type Category =
 	| "format"
 	| "configuration"
 	| "organizeImports"
+	| "migrate"
 	| "deserialize"
 	| "internalError/io"
 	| "internalError/fs"


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a command to Rome CLI called `rome migrate`.

The command intends to migrate Rome's configuration to a new version when breaking changes occur. As for now there aren't any migrations, so the command will always output the same message.

The migration uses the existing analyzer infrastructure of the crate `rome_analyzer`. Migrations are just Rules under the category `RuleCategories::Action`. Using this infrastructure, we can name the migrations, document them and use their version.


I took the opportunity to refactor a bit the internals of the CLI:
- moved diagnostics into a `diagnostics.rs` file
- moved the code that does `stdin` operations into a specific file/function => this will become useful for doing linting via `stdin`
- moved the code to migrate the configuration file into a separate file


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

For now, I just created few test cases

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
