### PR TITLE
fix(rome_js_analyze): `useShorthandArrayType` should handle nested ReadonlyArray and not report to `TsObjectType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Code actions are formatted using Rome's formatter. If the formatter is disabled,
 the code action is not formatted.
+- Fixed an issue that [`useShorthandArrayType`](https://docs.rome.tools/lint/rules/useShorthandArrayType) rule did not handle nested ReadonlyArray types correctly and erroneously reported TsObjectType [#4354](https://github.com/rome/tools/issues/4353)
 
 #### New rules
 - [`noConfusingArrow`](https://docs.rome.tools/lint/rules/noConfusingArrow/)

--- a/crates/rome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
+++ b/crates/rome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
@@ -12,6 +12,8 @@ use crate::JsRuleAction;
 declare_rule! {
     /// When expressing array types, this rule promotes the usage of `T[]` shorthand instead of `Array<T>`.
     ///
+    /// ESLint (typescript-eslint) equivalent: [array-type/array-simple](https://typescript-eslint.io/rules/array-type/#array-simple)
+    ///
     /// ## Examples
     ///
     /// ### Invalid
@@ -169,26 +171,53 @@ fn convert_to_array_type(
                     },
                     _ => Some(param),
                 };
-                element_type.map(|element_type| {
-                    let array_type = make::ts_array_type(
+                element_type.map(|element_type| match array_kind {
+                    TsArrayKind::Simple => AnyTsType::TsArrayType(make::ts_array_type(
                         element_type,
                         make::token(T!['[']),
                         make::token(T![']']),
-                    );
-                    match array_kind {
-                        TsArrayKind::Simple => AnyTsType::TsArrayType(array_type),
-                        TsArrayKind::Readonly => {
-                            let readonly_token = JsSyntaxToken::new_detached(
-                                JsSyntaxKind::TS_READONLY_MODIFIER,
-                                "readonly ",
-                                [],
-                                [TriviaPiece::new(TriviaPieceKind::Whitespace, 1)],
-                            );
-                            AnyTsType::TsTypeOperatorType(make::ts_type_operator_type(
-                                readonly_token,
-                                AnyTsType::TsArrayType(array_type),
-                            ))
+                    )),
+                    TsArrayKind::Readonly => {
+                        let readonly_token = JsSyntaxToken::new_detached(
+                            JsSyntaxKind::TS_READONLY_MODIFIER,
+                            "readonly ",
+                            [],
+                            [TriviaPiece::new(TriviaPieceKind::Whitespace, 1)],
+                        );
+
+                        // Modify `ReadonlyArray<ReadonlyArray<T>>` to `readonly (readonly T[])[]`
+                        if let AnyTsType::TsTypeOperatorType(op) = &element_type {
+                            if let Ok(op) = op.operator_token() {
+                                if op.text_trimmed() == "readonly" {
+                                    return AnyTsType::TsTypeOperatorType(
+                                        make::ts_type_operator_type(
+                                            readonly_token,
+                                            // wrap ArrayType
+                                            AnyTsType::TsArrayType(make::ts_array_type(
+                                                AnyTsType::TsParenthesizedType(
+                                                    make::ts_parenthesized_type(
+                                                        make::token(T!['(']),
+                                                        element_type,
+                                                        make::token(T![')']),
+                                                    ),
+                                                ),
+                                                make::token(T!['[']),
+                                                make::token(T![']']),
+                                            )),
+                                        ),
+                                    );
+                                }
+                            }
                         }
+
+                        AnyTsType::TsTypeOperatorType(make::ts_type_operator_type(
+                            readonly_token,
+                            AnyTsType::TsArrayType(make::ts_array_type(
+                                element_type,
+                                make::token(T!['[']),
+                                make::token(T![']']),
+                            )),
+                        ))
                     }
                 })
             })

--- a/crates/rome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
+++ b/crates/rome_js_analyze/src/analyzers/style/use_shorthand_array_type.rs
@@ -157,6 +157,7 @@ fn convert_to_array_type(
                     | AnyTsType::TsConditionalType(_)
                     | AnyTsType::TsTypeOperatorType(_)
                     | AnyTsType::TsInferType(_)
+                    | AnyTsType::TsObjectType(_)
                     | AnyTsType::TsMappedType(_) => None,
 
                     AnyTsType::TsReferenceType(ty) => match get_array_kind_by_reference(ty) {

--- a/crates/rome_js_analyze/tests/specs/style/useShorthandArrayType/invalid.ts
+++ b/crates/rome_js_analyze/tests/specs/style/useShorthandArrayType/invalid.ts
@@ -8,3 +8,5 @@ let readonlyInvalid1: ReadonlyArray<foo>;
 let readonlyInvalid2: Promise<ReadonlyArray<string>>;
 let readonlyInvalid3: ReadonlyArray<Foo<Bar>>;
 let readonlyInvalid4: ReadonlyArray<[number, number]>;
+let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;

--- a/crates/rome_js_analyze/tests/specs/style/useShorthandArrayType/invalid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/style/useShorthandArrayType/invalid.ts.snap
@@ -14,6 +14,8 @@ let readonlyInvalid1: ReadonlyArray<foo>;
 let readonlyInvalid2: Promise<ReadonlyArray<string>>;
 let readonlyInvalid3: ReadonlyArray<Foo<Bar>>;
 let readonlyInvalid4: ReadonlyArray<[number, number]>;
+let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
 
 ```
 
@@ -211,7 +213,7 @@ invalid.ts:9:23 lint/style/useShorthandArrayType  FIXABLE  ━━━━━━━
    > 9 │ let readonlyInvalid3: ReadonlyArray<Foo<Bar>>;
        │                       ^^^^^^^^^^^^^^^^^^^^^^^
     10 │ let readonlyInvalid4: ReadonlyArray<[number, number]>;
-    11 │ 
+    11 │ let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
   
   i Suggested fix: Use shorthand readonly T[] syntax to replace
   
@@ -220,7 +222,7 @@ invalid.ts:9:23 lint/style/useShorthandArrayType  FIXABLE  ━━━━━━━
      9    │ - let·readonlyInvalid3:·ReadonlyArray<Foo<Bar>>;
         9 │ + let·readonlyInvalid3:·readonly·Foo<Bar>[];
     10 10 │   let readonlyInvalid4: ReadonlyArray<[number, number]>;
-    11 11 │   
+    11 11 │   let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
   
 
 ```
@@ -234,7 +236,8 @@ invalid.ts:10:23 lint/style/useShorthandArrayType  FIXABLE  ━━━━━━�
      9 │ let readonlyInvalid3: ReadonlyArray<Foo<Bar>>;
   > 10 │ let readonlyInvalid4: ReadonlyArray<[number, number]>;
        │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    11 │ 
+    11 │ let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+    12 │ let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
   
   i Suggested fix: Use shorthand readonly T[] syntax to replace
   
@@ -242,7 +245,122 @@ invalid.ts:10:23 lint/style/useShorthandArrayType  FIXABLE  ━━━━━━�
      9  9 │   let readonlyInvalid3: ReadonlyArray<Foo<Bar>>;
     10    │ - let·readonlyInvalid4:·ReadonlyArray<[number,·number]>;
        10 │ + let·readonlyInvalid4:·readonly·[number,·number][];
-    11 11 │   
+    11 11 │   let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+    12 12 │   let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+  
+
+```
+
+```
+invalid.ts:11:23 lint/style/useShorthandArrayType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use shorthand readonly T[] syntax instead of ReadonlyArray<T> syntax.
+  
+     9 │ let readonlyInvalid3: ReadonlyArray<Foo<Bar>>;
+    10 │ let readonlyInvalid4: ReadonlyArray<[number, number]>;
+  > 11 │ let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+       │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+    13 │ 
+  
+  i Suggested fix: Use shorthand readonly T[] syntax to replace
+  
+     9  9 │   let readonlyInvalid3: ReadonlyArray<Foo<Bar>>;
+    10 10 │   let readonlyInvalid4: ReadonlyArray<[number, number]>;
+    11    │ - let·readonlyInvalid5:·ReadonlyArray<ReadonlyArray<number>>;
+       11 │ + let·readonlyInvalid5:·readonly·(readonly·number[])[];
+    12 12 │   let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+    13 13 │   
+  
+
+```
+
+```
+invalid.ts:11:37 lint/style/useShorthandArrayType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use shorthand readonly T[] syntax instead of ReadonlyArray<T> syntax.
+  
+     9 │ let readonlyInvalid3: ReadonlyArray<Foo<Bar>>;
+    10 │ let readonlyInvalid4: ReadonlyArray<[number, number]>;
+  > 11 │ let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+       │                                     ^^^^^^^^^^^^^^^^^^^^^
+    12 │ let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+    13 │ 
+  
+  i Suggested fix: Use shorthand readonly T[] syntax to replace
+  
+     9  9 │   let readonlyInvalid3: ReadonlyArray<Foo<Bar>>;
+    10 10 │   let readonlyInvalid4: ReadonlyArray<[number, number]>;
+    11    │ - let·readonlyInvalid5:·ReadonlyArray<ReadonlyArray<number>>;
+       11 │ + let·readonlyInvalid5:·ReadonlyArray<readonly·number[]>;
+    12 12 │   let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+    13 13 │   
+  
+
+```
+
+```
+invalid.ts:12:23 lint/style/useShorthandArrayType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use shorthand readonly T[] syntax instead of ReadonlyArray<T> syntax.
+  
+    10 │ let readonlyInvalid4: ReadonlyArray<[number, number]>;
+    11 │ let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+  > 12 │ let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+       │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ 
+  
+  i Suggested fix: Use shorthand readonly T[] syntax to replace
+  
+    10 10 │   let readonlyInvalid4: ReadonlyArray<[number, number]>;
+    11 11 │   let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+    12    │ - let·readonlyInvalid6:·ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+       12 │ + let·readonlyInvalid6:·readonly·(readonly·(readonly·number[])[])[];
+    13 13 │   
+  
+
+```
+
+```
+invalid.ts:12:37 lint/style/useShorthandArrayType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use shorthand readonly T[] syntax instead of ReadonlyArray<T> syntax.
+  
+    10 │ let readonlyInvalid4: ReadonlyArray<[number, number]>;
+    11 │ let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+  > 12 │ let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+       │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ 
+  
+  i Suggested fix: Use shorthand readonly T[] syntax to replace
+  
+    10 10 │   let readonlyInvalid4: ReadonlyArray<[number, number]>;
+    11 11 │   let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+    12    │ - let·readonlyInvalid6:·ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+       12 │ + let·readonlyInvalid6:·ReadonlyArray<readonly·(readonly·number[])[]>;
+    13 13 │   
+  
+
+```
+
+```
+invalid.ts:12:51 lint/style/useShorthandArrayType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use shorthand readonly T[] syntax instead of ReadonlyArray<T> syntax.
+  
+    10 │ let readonlyInvalid4: ReadonlyArray<[number, number]>;
+    11 │ let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+  > 12 │ let readonlyInvalid6: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+       │                                                   ^^^^^^^^^^^^^^^^^^^^^
+    13 │ 
+  
+  i Suggested fix: Use shorthand readonly T[] syntax to replace
+  
+    10 10 │   let readonlyInvalid4: ReadonlyArray<[number, number]>;
+    11 11 │   let readonlyInvalid5: ReadonlyArray<ReadonlyArray<number>>;
+    12    │ - let·readonlyInvalid6:·ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>>;
+       12 │ + let·readonlyInvalid6:·ReadonlyArray<ReadonlyArray<readonly·number[]>>;
+    13 13 │   
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/style/useShorthandArrayType/valid.ts
+++ b/crates/rome_js_analyze/tests/specs/style/useShorthandArrayType/valid.ts
@@ -13,6 +13,8 @@ let valid8: Array<string & number>;
 type valid9<T> = T extends Array<infer R> ? R : any;
 // mapped type
 type valid10<T> = { [K in keyof T]: T[K] };
+// object type
+type valid11 = Array<{ value: string; label: string }>;
 
 let readonlyValid1: ReadonlyArray<Foo | Bar>;
 let readonlyValid2: ReadonlyArray<keyof Bar>;

--- a/crates/rome_js_analyze/tests/specs/style/useShorthandArrayType/valid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/style/useShorthandArrayType/valid.ts.snap
@@ -19,6 +19,8 @@ let valid8: Array<string & number>;
 type valid9<T> = T extends Array<infer R> ? R : any;
 // mapped type
 type valid10<T> = { [K in keyof T]: T[K] };
+// object type
+type valid11 = Array<{ value: string; label: string }>;
 
 let readonlyValid1: ReadonlyArray<Foo | Bar>;
 let readonlyValid2: ReadonlyArray<keyof Bar>;

--- a/website/src/pages/lint/rules/useShorthandArrayType.md
+++ b/website/src/pages/lint/rules/useShorthandArrayType.md
@@ -7,6 +7,8 @@ parent: lint/rules/index
 
 When expressing array types, this rule promotes the usage of `T[]` shorthand instead of `Array<T>`.
 
+ESLint (typescript-eslint) equivalent: [array-type/array-simple](https://typescript-eslint.io/rules/array-type/#array-simple)
+
 ## Examples
 
 ### Invalid


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
Closes #4349 #4361 

This pr adds modification for nested `ReadonlyArray` (#4349 ) and reduce false positive (#4361 ).
Currently, our `useShorthandArrayType` follows [typescript-eslint/array-type (array-simple option)](https://typescript-eslint.io/rules/array-type/#array-simple).

And the rule should not report `TsObjectType` in a type `Array` or `ReadonlyArray`.

### Example
```ts
// issue 4349
type Before = ReadonlyArray<ReadonlyArray<T>>
type After = readonly (readonly T[])[]

// issue 4361
type AcceptedObjectType = Array<{x: string, y: string}>
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

`cargo test -p rome_js_analyze -- use_shorthand_array_type`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->


## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- ~~[ ] The PR requires a changelog line~~

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- ~~[ ] The PR requires documentation~~
- ~~[ ] I will create a new PR to update the documentation~~
I updated lint rule doc a bit (describes typescript-eslint rule equivalent).