### PR TITLE
fix(rome_js_analyze): lint/correctness/noUndeclaredVariables incorrectly identifies AggregateError as an undeclared variable. #4365

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Code actions are formatted using Rome's formatter. If the formatter is disabled,
 the code action is not formatted.
 
-- Fix `noUndeclaredVariables` incorrectly identifies `AggregateError` as an undeclared variable. https://github.com/rome/tools/issues/4365
+- Fix an issue when `noUndeclaredVariables` incorrectly identifies `AggregateError` as an undeclared variable. [#4365](https://github.com/rome/tools/issues/4365)
 #### New rules
 - [`noConfusingArrow`](https://docs.rome.tools/lint/rules/noConfusingArrow/)
 - [`noRedundantRoles`](https://docs.rome.tools/lint/rules/noRedundantRoles/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Code actions are formatted using Rome's formatter. If the formatter is disabled,
 the code action is not formatted.
 
+- Fix `noUndeclaredVariables` incorrectly identifies `AggregateError` as an undeclared variable. https://github.com/rome/tools/issues/4365
 #### New rules
 - [`noConfusingArrow`](https://docs.rome.tools/lint/rules/noConfusingArrow/)
 - [`noRedundantRoles`](https://docs.rome.tools/lint/rules/noRedundantRoles/)

--- a/crates/rome_js_analyze/src/globals/runtime.rs
+++ b/crates/rome_js_analyze/src/globals/runtime.rs
@@ -1,4 +1,5 @@
-pub const BUILTIN: [&str; 65] = [
+pub const BUILTIN: [&str; 66] = [
+    "AggregateError",
     "Array",
     "ArrayBuffer",
     "Atomics",
@@ -295,7 +296,8 @@ pub const ES_2020: [&str; 63] = [
     "valueOf",
 ];
 
-pub const ES_2021: [&str; 65] = [
+pub const ES_2021: [&str; 66] = [
+    "AggregateError",
     "Array",
     "ArrayBuffer",
     "Atomics",

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.js
@@ -10,3 +10,4 @@ assignment = "value";
 document;
 navigator;
 new ArrayBuffer();
+new AggregateError();

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.js.snap
@@ -16,6 +16,8 @@ assignment = "value";
 document;
 navigator;
 new ArrayBuffer();
+new AggregateError();
+
 ```
 
 # Diagnostics


### PR DESCRIPTION

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix https://github.com/rome/tools/issues/4365

## Test Plan

`cargo test`

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
