### PR TITLE
feat(rome_js_analyze): analyzer metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,15 @@
 + import "module" with {}
 ```
 - Fix an issue where JSON formatter does not respect `lineWidth` for arrays [#4351](https://github.com/rome/tools/issues/4351)
+
 ### Linter
 
 #### Other changes
 
 - Code actions are formatted using Rome's formatter. If the formatter is disabled,
 the code action is not formatted.
-- Fixed an issue that [`useShorthandArrayType`](https://docs.rome.tools/lint/rules/useShorthandArrayType) rule did not handle nested ReadonlyArray types correctly and erroneously reported TsObjectType [#4354](https://github.com/rome/tools/issues/4353)
+- Fixed an issue that [`useShorthandArrayType`](https://docs.rome.tools/lint/rules/useShorthandArrayType) rule did not handle nested ReadonlyArray types correctly and erroneously reported TsObjectType [#4354](https://github.com/rome/tools/issues/4353).
+- [`noUndeclaredVariables`](https://docs.rome.tools/lint/rules/noUndeclaredVariables) detects globals based on the file type.
 
 - Fix an issue when `noUndeclaredVariables` incorrectly identifies `AggregateError` as an undeclared variable. [#4365](https://github.com/rome/tools/issues/4365)
 #### New rules

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BinaryHeap};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops;
+use std::path::Path;
 
 mod categories;
 pub mod context;
@@ -77,6 +78,7 @@ pub struct AnalyzerContext<'a, L: Language> {
     pub services: ServiceBag,
     pub range: Option<TextRange>,
     pub globals: &'a [&'a str],
+    pub file_path: &'a Path,
 }
 
 impl<'analyzer, L, Matcher, Break, Diag> Analyzer<'analyzer, L, Matcher, Break, Diag>
@@ -142,6 +144,7 @@ where
                 range: ctx.range,
                 globals: ctx.globals,
                 apply_suppression_comment,
+                file_path: ctx.file_path,
             };
 
             // The first phase being run will inspect the tokens and parse the
@@ -220,6 +223,8 @@ struct PhaseRunner<'analyzer, 'phase, L: Language, Matcher, Break, Diag> {
     range: Option<TextRange>,
     /// Options passed to the analyzer
     globals: &'phase [&'phase str],
+    /// The [Path] of the current file
+    file_path: &'phase Path,
 }
 
 /// Single entry for a suppression comment in the `line_suppressions` buffer
@@ -279,6 +284,7 @@ where
                     signal_queue: &mut self.signal_queue,
                     apply_suppression_comment: self.apply_suppression_comment,
                     globals: self.globals,
+                    file_path: self.file_path,
                 };
 
                 visitor.visit(&node_event, ctx);
@@ -304,6 +310,7 @@ where
                     signal_queue: &mut self.signal_queue,
                     apply_suppression_comment: self.apply_suppression_comment,
                     globals: self.globals,
+                    file_path: self.file_path,
                 };
 
                 visitor.visit(&event, ctx);

--- a/crates/rome_analyze/src/matcher.rs
+++ b/crates/rome_analyze/src/matcher.rs
@@ -3,6 +3,7 @@ use crate::{
     SuppressionCommentEmitter,
 };
 use rome_rowan::{Language, TextRange};
+use std::path::Path;
 use std::{
     any::{Any, TypeId},
     cmp::Ordering,
@@ -27,6 +28,7 @@ pub struct MatchQueryParams<'phase, 'query, L: Language> {
     pub signal_queue: &'query mut BinaryHeap<SignalEntry<'phase, L>>,
     pub apply_suppression_comment: SuppressionCommentEmitter<L>,
     pub globals: &'phase [&'phase str],
+    pub file_path: &'phase Path,
 }
 
 /// Wrapper type for a [QueryMatch]
@@ -197,6 +199,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;
+    use std::path::Path;
 
     use rome_diagnostics::{category, DiagnosticExt};
     use rome_diagnostics::{Diagnostic, Severity};
@@ -381,6 +384,7 @@ mod tests {
             range: None,
             services: ServiceBag::default(),
             globals: &[],
+            file_path: Path::new(""),
         };
 
         let result: Option<Never> = analyzer.run(ctx);

--- a/crates/rome_analyze/src/options.rs
+++ b/crates/rome_analyze/src/options.rs
@@ -1,9 +1,11 @@
 use crate::RuleKey;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::fmt::Debug;
+use std::path::PathBuf;
 
 /// A convenient new type data structure to store the options that belong to a rule
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct RuleOptions(String);
 
 impl RuleOptions {
@@ -19,7 +21,7 @@ impl RuleOptions {
 }
 
 /// A convenient new type data structure to insert and get rules
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct AnalyzerRules(HashMap<RuleKey, RuleOptions>);
 
 impl AnalyzerRules {
@@ -35,7 +37,7 @@ impl AnalyzerRules {
 }
 
 /// A data structured derived from the `rome.json` file
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct AnalyzerConfiguration {
     /// A list of rules and their options
     pub rules: AnalyzerRules,
@@ -47,8 +49,11 @@ pub struct AnalyzerConfiguration {
 }
 
 /// A set of information useful to the analyzer infrastructure
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct AnalyzerOptions {
     /// A data structured derived from the [`rome.json`] file
     pub configuration: AnalyzerConfiguration,
+
+    /// The file that is being analyzed
+    pub file_path: PathBuf,
 }

--- a/crates/rome_analyze/src/registry.rs
+++ b/crates/rome_analyze/src/registry.rs
@@ -426,12 +426,16 @@ impl<L: Language + Default> RegistryRule<L> {
             // if the query doesn't match
             let query_result = params.query.downcast_ref().unwrap();
             let query_result = <R::Query as Queryable>::unwrap_match(params.services, query_result);
-            let ctx =
-                match RuleContext::new(&query_result, params.root, params.services, params.globals)
-                {
-                    Ok(ctx) => ctx,
-                    Err(error) => return Err(error),
-                };
+            let ctx = match RuleContext::new(
+                &query_result,
+                params.root,
+                params.services,
+                params.globals,
+                params.file_path,
+            ) {
+                Ok(ctx) => ctx,
+                Err(error) => return Err(error),
+            };
 
             for result in R::run(&ctx) {
                 let text_range =
@@ -446,6 +450,7 @@ impl<L: Language + Default> RegistryRule<L> {
                     params.services,
                     params.apply_suppression_comment,
                     params.globals,
+                    params.file_path,
                 ));
 
                 params.signal_queue.push(SignalEntry {

--- a/crates/rome_analyze/src/syntax.rs
+++ b/crates/rome_analyze/src/syntax.rs
@@ -98,6 +98,7 @@ mod tests {
         AstNode, SyntaxNode,
     };
     use std::convert::Infallible;
+    use std::path::Path;
 
     use crate::{
         matcher::MatchQueryParams, registry::Phases, Analyzer, AnalyzerContext, AnalyzerSignal,
@@ -165,6 +166,7 @@ mod tests {
             range: None,
             services: ServiceBag::default(),
             globals: &[],
+            file_path: Path::new(""),
         };
 
         let result: Option<Never> = analyzer.run(ctx);

--- a/crates/rome_analyze/src/visitor.rs
+++ b/crates/rome_analyze/src/visitor.rs
@@ -1,4 +1,5 @@
 use std::collections::BinaryHeap;
+use std::path::Path;
 
 use rome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
 
@@ -18,6 +19,7 @@ pub struct VisitorContext<'phase, 'query, L: Language> {
     pub(crate) signal_queue: &'query mut BinaryHeap<SignalEntry<'phase, L>>,
     pub apply_suppression_comment: SuppressionCommentEmitter<L>,
     pub globals: &'phase [&'phase str],
+    pub file_path: &'phase Path,
 }
 
 impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
@@ -30,6 +32,7 @@ impl<'phase, 'query, L: Language> VisitorContext<'phase, 'query, L> {
             signal_queue: self.signal_queue,
             apply_suppression_comment: self.apply_suppression_comment,
             globals: self.globals,
+            file_path: self.file_path,
         })
     }
 }

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -148,7 +148,7 @@ pub(crate) fn write_analysis_to_snapshot(
         None
     };
 
-    let (_, errors) = rome_js_analyze::analyze(&root, filter, &options, |event| {
+    let (_, errors) = rome_js_analyze::analyze(&root, filter, &options, source_type, |event| {
         if let Some(mut diag) = event.diagnostic() {
             for action in event.actions() {
                 if check_action_type.is_suppression() {

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidTsInJs.js
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidTsInJs.js
@@ -1,0 +1,2 @@
+ArrayLike;
+PromiseLike;

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidTsInJs.js.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalidTsInJs.js.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalidTsInJs.js
+---
+# Input
+```js
+ArrayLike;
+PromiseLike;
+
+```
+
+# Diagnostics
+```
+invalidTsInJs.js:1:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The ArrayLike variable is undeclared
+  
+  > 1 │ ArrayLike;
+      │ ^^^^^^^^^
+    2 │ PromiseLike;
+    3 │ 
+  
+
+```
+
+```
+invalidTsInJs.js:2:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The PromiseLike variable is undeclared
+  
+    1 │ ArrayLike;
+  > 2 │ PromiseLike;
+      │ ^^^^^^^^^^^
+    3 │ 
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validTsGlobals.ts
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validTsGlobals.ts
@@ -1,0 +1,1 @@
+type B<T> = PromiseLike<T>;

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validTsGlobals.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validTsGlobals.ts.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: validTsGlobals.ts
+---
+# Input
+```js
+type B<T> = PromiseLike<T>;
+
+```
+
+

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -216,6 +216,7 @@ fn code_actions(
     _range: TextRange,
     _rules: Option<&Rules>,
     _settings: SettingsHandle,
+    _path: &RomePath,
 ) -> PullActionsResult {
     PullActionsResult {
         actions: Vec::new(),

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -197,7 +197,8 @@ pub(crate) struct LintResults {
 }
 
 type Lint = fn(LintParams) -> LintResults;
-type CodeActions = fn(AnyParse, TextRange, Option<&Rules>, SettingsHandle) -> PullActionsResult;
+type CodeActions =
+    fn(AnyParse, TextRange, Option<&Rules>, SettingsHandle, &RomePath) -> PullActionsResult;
 type FixAll = fn(FixAllParams) -> Result<FixFileResult, WorkspaceError>;
 type Rename = fn(&RomePath, AnyParse, TextSize, String) -> Result<RenameResult, WorkspaceError>;
 type OrganizeImports = fn(AnyParse) -> Result<OrganizeImportsResult, WorkspaceError>;

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -453,7 +453,13 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(params.path.clone(), Some(FeatureName::Lint))?;
         let settings = self.settings.read().unwrap();
         let rules = settings.linter().rules.as_ref();
-        Ok(code_actions(parse, params.range, rules, self.settings()))
+        Ok(code_actions(
+            parse,
+            params.range,
+            rules,
+            self.settings(),
+            &params.path,
+        ))
     }
 
     /// Runs the given file through the formatter using the provided options

--- a/website/src/pages/lint/rules/noUndeclaredVariables.md
+++ b/website/src/pages/lint/rules/noUndeclaredVariables.md
@@ -25,6 +25,28 @@ foobar;
   
 </code></pre>
 
+```jsx
+// throw diagnostic for JavaScript files
+PromiseLike;
+```
+
+<pre class="language-text"><code class="language-text">correctness/noUndeclaredVariables.js:2:1 <a href="https://docs.rome.tools/lint/rules/noUndeclaredVariables">lint/correctness/noUndeclaredVariables</a> ━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Orange;">  </span></strong><strong><span style="color: Orange;">⚠</span></strong> <span style="color: Orange;">The </span><span style="color: Orange;"><strong>PromiseLike</strong></span><span style="color: Orange;"> variable is undeclared</span>
+  
+    <strong>1 │ </strong>// throw diagnostic for JavaScript files
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>PromiseLike;
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+</code></pre>
+
+### Valid
+
+```ts
+type B<T> = PromiseLike<T>
+```
+
 ## Related links
 
 - [Disable a rule](/linter/#disable-a-lint-rule)

--- a/xtask/bench/src/language.rs
+++ b/xtask/bench/src/language.rs
@@ -123,7 +123,7 @@ impl Analyze {
                     ..AnalysisFilter::default()
                 };
                 let options = AnalyzerOptions::default();
-                analyze(root, filter, &options, |event| {
+                analyze(root, filter, &options, SourceType::default(), |event| {
                     black_box(event.diagnostic());
                     black_box(event.actions());
                     ControlFlow::<Never>::Continue(())

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -551,7 +551,7 @@ fn assert_lint(
                 };
 
                 let options = AnalyzerOptions::default();
-                let (_, diagnostics) = analyze(&root, filter, &options, |signal| {
+                let (_, diagnostics) = analyze(&root, filter, &options, source_type, |signal| {
                     if let Some(mut diag) = signal.diagnostic() {
                         let category = diag.category().expect("linter diagnostic has no code");
                         let severity = settings.get_severity_from_rule_code(category).expect(


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds two new metadata to the analyzer infrastructure:
 - the `file_path` of the file being analyzed; this will be useful for some other rules that like https://github.com/rome/tools/discussions/4282.
 - the `SourceType`, which will allow making the rules smarter. In this PR, I updated `noUndeclaredVariables`, where the rule doesn't check TypeScript global variables if the file being analyzed is a JavaScript file. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I created a new test case for the rule that was updated

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
