### PR TITLE
fix(vscode): Text duplication when using VSCode git utilities #4338

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ when there are breaking changes.
 
 ### Configuration
 ### Editors
+ - Fixed an issue where the VSCode extension duplicates text when using VSCode git utilities [#4338]
 ### Formatter
 
 - Fix an issue where formatting of JSX string literals property values were using incorrect quotes [#4054](https://github.com/rome/tools/issues/4054)

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -59,11 +59,11 @@ export async function activate(context: ExtensionContext) {
 	);
 
 	const documentSelector: DocumentFilter[] = [
-		{ language: "javascript" },
-		{ language: "typescript" },
-		{ language: "javascriptreact" },
-		{ language: "typescriptreact" },
-		{ language: "json" },
+		{ language: "javascript", scheme: "file" },
+		{ language: "typescript", scheme: "file" },
+		{ language: "javascriptreact", scheme: "file" },
+		{ language: "typescriptreact", scheme: "file" },
+		{ language: "json", scheme: "file" },
 	];
 
 	const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix #4338

It seems that we are receiving two different DidOpenTextDocument events with different URI schemes. The first one has the scheme "file", which indicates that the file is being accessed directly from the file system. The second one has the scheme "git", which suggests that the file is being accessed from a Git repository. After that we're receiving an change event.

```
rome_lsp::handlers::text_document::did_open{params=DidOpenTextDocumentParams { text_document: TextDocumentItem { uri: Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/lo.ts", query: None, fragment: None }, language_id: "typescript", version: 1, text: "console.log(\"before\");\n" } }}


│ ├─┐rome_lsp::handlers::text_document::did_open{params=DidOpenTextDocumentParams { text_document: TextDocumentItem { uri: Url { scheme: "git", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/Users/denis.bezrukov/Projects/my-app/src/lo.ts", query: Some(""), fragment: None }, language_id: "typescript", version: 1, text: "console.log(\"before\");\n" } }}

 │ ├─0ms TRACE rome_lsp::handlers::text_document old document: "console.log(\"before\");\n"
│ │ ├─0ms TRACE rome_lsp::handlers::text_document content changes: [TextDocumentContentChangeEvent { range: Some(Range { start: Position { line: 0, character: 15 }, end: Position { line: 0, character: 15 } }), range_length: Some(0), text: "fore" }]
│ │ ├─0ms TRACE rome_lsp::handlers::text_document new document: "console.log(\"beforefore\");\n"

```

I check how other tools handled their files: 
 - [`rust-analyzer`](https://github.com/rust-lang/rust-analyzer/blob/b218009f46dd012abcd2d9c2656c3dc498075368/editors/code/src/client.ts#L77) 
- [`bash-lsp`](https://github.com/bash-lsp/bash-language-server/blob/main/vscode-client/src/extension.ts)
- [`deno`](https://github.com/denoland/vscode_deno/blob/4b2787824f03879e2cbbff47c9921110ce1f20fb/client/src/extension.ts#L178-L202)


## Test Plan

`???`

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
