### PR TITLE
docs: change "tabs" to "tab" in format help command

### DIFF
--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -51,7 +51,7 @@ const CHECK: Markup = markup! {
 
 const FORMAT_OPTIONS: Markup = markup! {
     "
-    "<Dim>"--indent-style <tabs|space>"</Dim>"              Change the indention character (default: tabs)
+    "<Dim>"--indent-style <tab|space>"</Dim>"               Change the indention character (default: tab)
     "<Dim>"--indent-size <number>"</Dim>"                   If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
     "<Dim>"--line-width <number>"</Dim>"                    Change how many characters the formatter is allowed to print in a single line (default: 80)
     "<Dim>"--quote-style <single|double>"</Dim>"            Changes the quotation character for strings (default: double)

--- a/website/src/pages/formatter/index.mdx
+++ b/website/src/pages/formatter/index.mdx
@@ -49,7 +49,7 @@ OPTIONS:
     --max-diagnostics                        Cap the amount of diagnostics displayed (default: 50)
     --config-path                            Set the filesystem path to the directory of the rome.json configuration file
     --verbose                                Print additional verbose advices on diagnostics
-    --indent-style <tabs|space>              Change the indention character (default: tabs)
+    --indent-style <tab|space>              Change the indention character (default: tab)
     --indent-size <number>                   If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
     --line-width <number>                    Change how many characters the formatter is allowed to print in a single line (default: 80)
     --quote-style <single|double>            Changes the quotation character for strings (default: double)


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

The following PR https://github.com/rome/tools/pull/3657 provided an update to the copy on the website, but did not update the copy in the CLI. 

This update resolves the typo, which is hopefully the last time. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Followed instructions in [CONTRIBUTING.md](https://github.com/rome/tools/blob/fdf2a8ccc1708374ba9156d2faaa49436e574daa/CONTRIBUTING.md)

- `cargo build`
- `cargo test`

The following screenshot shows running the help command and the `--indent-style` option resolved saying `<tab|space>`

![20230418_22h07m50s_grim](https://user-images.githubusercontent.com/97810962/232904920-26c637ae-7d4d-4ff1-999e-d9bfae33161f.png)



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
