### PR TITLE
feat(rome_js_parser): EcmaScript @decorators #4252

### DIFF
--- a/crates/rome_js_factory/src/generated/node_factory.rs
+++ b/crates/rome_js_factory/src/generated/node_factory.rs
@@ -918,10 +918,15 @@ pub fn js_empty_statement(semicolon_token: SyntaxToken) -> JsEmptyStatement {
         [Some(SyntaxElement::Token(semicolon_token))],
     ))
 }
-pub fn js_export(export_token: SyntaxToken, export_clause: AnyJsExportClause) -> JsExport {
+pub fn js_export(
+    decorators: JsDecoratorList,
+    export_token: SyntaxToken,
+    export_clause: AnyJsExportClause,
+) -> JsExport {
     JsExport::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JS_EXPORT,
         [
+            Some(SyntaxElement::Node(decorators.into_syntax())),
             Some(SyntaxElement::Token(export_token)),
             Some(SyntaxElement::Node(export_clause.into_syntax())),
         ],

--- a/crates/rome_js_factory/src/generated/syntax_factory.rs
+++ b/crates/rome_js_factory/src/generated/syntax_factory.rs
@@ -1522,8 +1522,15 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_EXPORT => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if JsDecoratorList::can_cast(element.kind()) {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
                 if let Some(element) = &current_element {
                     if element.kind() == T![export] {
                         slots.mark_present();

--- a/crates/rome_js_formatter/src/js/module/export.rs
+++ b/crates/rome_js_formatter/src/js/module/export.rs
@@ -10,10 +10,19 @@ pub(crate) struct FormatJsExport;
 impl FormatNodeRule<JsExport> for FormatJsExport {
     fn fmt_fields(&self, node: &JsExport, f: &mut JsFormatter) -> FormatResult<()> {
         let JsExportFields {
+            decorators,
             export_token,
             export_clause,
         } = node.as_fields();
 
-        write![f, [export_token.format(), space(), export_clause.format()]]
+        write![
+            f,
+            [
+                decorators.format(),
+                export_token.format(),
+                space(),
+                export_clause.format()
+            ]
+        ]
     }
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorators-export/after_export.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorators-export/after_export.js.snap
@@ -26,9 +26,8 @@ export default @decorator class {}
  
 -export default
 -@decorator
--class {}
-+export default (@decorator
-+class {});
++export default @decorator
+ class {}
 ```
 
 # Output
@@ -37,8 +36,8 @@ export default @decorator class {}
 export @decorator
 class Foo {}
 
-export default (@decorator
-class {});
+export default @decorator
+class {}
 ```
 
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorators/classes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorators/classes.js.snap
@@ -82,31 +82,4 @@ class {
 };
 ```
 
-# Errors
-```
-classes.js:3:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Decorators are not valid here.
-  
-    1 │ @deco class Foo {}
-    2 │ 
-  > 3 │ @deco export class Bar {}
-      │ ^^^^^
-    4 │ 
-    5 │ @deco export default class Baz {}
-  
-classes.js:5:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Decorators are not valid here.
-  
-    3 │ @deco export class Bar {}
-    4 │ 
-  > 5 │ @deco export default class Baz {}
-      │ ^^^^^
-    6 │ 
-    7 │ const foo = @deco class {
-  
-
-```
-
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/decorators/redux.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/decorators/redux.js.snap
@@ -39,29 +39,4 @@ export class MyApp extends React.Component {}
 export class Home extends React.Component {}
 ```
 
-# Errors
-```
-redux.js:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Decorators are not valid here.
-  
-  > 1 │ @connect(mapStateToProps, mapDispatchToProps)
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    2 │ export class MyApp extends React.Component {}
-    3 │ 
-  
-redux.js:4:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Decorators are not valid here.
-  
-    2 │ export class MyApp extends React.Component {}
-    3 │ 
-  > 4 │ @connect(state => ({ todos: state.todos }))
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    5 │ export class Home extends React.Component {}
-    6 │ 
-  
-
-```
-
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators-ts/angular.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators-ts/angular.ts.snap
@@ -47,22 +47,4 @@ export class HeroButtonComponent {
 }
 ```
 
-# Errors
-```
-angular.ts:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Decorators are not valid here.
-  
-  > 1 │ @Component({
-      │ ^^^^^^^^^^^^
-  > 2 │   selector: 'toh-hero-button',
-  > 3 │   template: `<button>{{label}}</button>`
-  > 4 │ })
-      │ ^^
-    5 │ export class HeroButtonComponent {
-    6 │   @Output() change = new EventEmitter<any>();
-  
-
-```
-
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators-ts/typeorm.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators-ts/typeorm.ts.snap
@@ -72,18 +72,4 @@ export class Board {
 }
 ```
 
-# Errors
-```
-typeorm.ts:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Decorators are not valid here.
-  
-  > 1 │ @Entity()
-      │ ^^^^^^^^^
-    2 │ export class Board {
-    3 │ 
-  
-
-```
-
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorators.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/decorators/decorators.ts.snap
@@ -221,20 +221,4 @@ class Class6 {
 }
 ```
 
-# Errors
-```
-decorators.ts:8:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Decorators are not valid here.
-  
-     6 │ }
-     7 │ 
-   > 8 │ @commonEditorContribution
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
-     9 │ export class TabCompletionController {
-    10 │ }
-  
-
-```
-
 

--- a/crates/rome_js_parser/src/state.rs
+++ b/crates/rome_js_parser/src/state.rs
@@ -24,7 +24,6 @@ impl LabelledItem {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum ExportDefaultItemKind {
-    Unknown,
     Expression,
     FunctionOverload,
     FunctionDeclaration,

--- a/crates/rome_js_parser/src/syntax/class.rs
+++ b/crates/rome_js_parser/src/syntax/class.rs
@@ -68,6 +68,16 @@ pub(crate) fn is_at_ts_abstract_class_declaration(
     }
 }
 
+pub(crate) fn is_at_export_class_declaration(p: &mut JsParser) -> bool {
+    p.at(T![export]) && (p.nth_at(1, T![class]) || p.nth_at(1, T![@]) || p.nth_at(1, T![abstract]))
+}
+
+pub(crate) fn is_at_export_default_class_declaration(p: &mut JsParser) -> bool {
+    p.at(T![export])
+        && p.nth_at(1, T![default])
+        && (p.nth_at(2, T![class]) || p.nth_at(2, T![@]) || p.nth_at(2, T![abstract]))
+}
+
 /// Parses a class expression, e.g. let a = class {}
 pub(super) fn parse_class_expression(
     p: &mut JsParser,
@@ -2409,6 +2419,14 @@ impl ClassMemberModifiers {
 // export @decorator class Foo {};
 // export @decorator @functionDecorator(1,2,3) class Bar {};
 // export @first @second class Baz {}
+// @decorator
+// export class Foo { }
+// @first.field @second @(() => decorator)()
+// export class Bar {}
+// @before
+// export @after class Foo { }
+// @before.field @before @(() => decorator)()
+// export @after.field @after @(() => decorator)() class Bar {}
 
 // test ts decorator_class_not_top_level
 // if (a) {
@@ -2478,6 +2496,13 @@ fn parse_decorator(p: &mut JsParser) -> ParsedSyntax {
 
     Present(m.complete(p, JS_DECORATOR))
 }
+
+// test ts ts_class_decorator
+// function test() {}
+// @test
+// class Test {}
+// @test.a?.c @test @test
+// class Test2{}
 
 /// Skips over any TypeScript decorator syntax.
 pub(crate) fn skip_ts_decorators(p: &mut JsParser) {

--- a/crates/rome_js_parser/src/syntax/js_parse_error.rs
+++ b/crates/rome_js_parser/src/syntax/js_parse_error.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use crate::span::Span;
 use crate::JsParser;
+use crate::JsSyntaxFeature::TypeScript;
 use rome_js_syntax::TextRange;
 use rome_parser::diagnostic::{expected_any, expected_node};
 
@@ -182,6 +183,26 @@ pub(crate) fn expected_declaration(p: &JsParser, range: TextRange) -> ParseDiagn
         range,
     )
     .into_diagnostic(p)
+}
+
+pub(crate) fn expected_export_default_declaration(
+    p: &JsParser,
+    range: TextRange,
+) -> ParseDiagnostic {
+    let expected = if TypeScript.is_supported(p) {
+        expected_any(
+            &[
+                "class declaration",
+                "function declaration",
+                "interface declaration",
+            ],
+            range,
+        )
+    } else {
+        expected_any(&["class declaration", "function declaration"], range)
+    };
+
+    expected.into_diagnostic(p)
 }
 
 pub(crate) fn unexpected_body_inside_ambient_context(

--- a/crates/rome_js_parser/src/tests.rs
+++ b/crates/rome_js_parser/src/tests.rs
@@ -392,10 +392,13 @@ fn diagnostics_print_correctly() {
 #[ignore]
 #[test]
 pub fn quick_test() {
-    let code = r"@1 + 2 class MyClass {};
+    let code = r"
+@first.field @second @(() => decorator)()
+export default class Bar {}
+
 ";
     let root = parse(code, SourceType::ts());
     let syntax = root.syntax();
 
-    dbg!(syntax);
+    dbg!(syntax, root.diagnostics());
 }

--- a/crates/rome_js_parser/test_data/inline/err/decorator_async_function_export_default_declaration_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_async_function_export_default_declaration_clause.rast
@@ -1,0 +1,106 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsBogusStatement {
+            items: [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..10 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")],
+                declaration: JsFunctionExportDefaultDeclaration {
+                    async_token: ASYNC_KW@26..32 "async" [] [Whitespace(" ")],
+                    function_token: FUNCTION_KW@32..41 "function" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@41..45 "foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    parameters: missing (required),
+                    return_type_annotation: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@45..47 "{" [] [Whitespace(" ")],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@47..48 "}" [] [],
+                    },
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@48..49 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..49
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..48
+    0: JS_BOGUS_STATEMENT@0..10
+      0: JS_DECORATOR@0..10
+        0: AT@0..1 "@" [] []
+        1: JS_IDENTIFIER_EXPRESSION@1..10
+          0: JS_REFERENCE_IDENTIFIER@1..10
+            0: IDENT@1..10 "decorator" [] []
+    1: JS_EXPORT@10..48
+      0: JS_DECORATOR_LIST@10..10
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@18..48
+        0: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")]
+        1: JS_FUNCTION_EXPORT_DEFAULT_DECLARATION@26..48
+          0: ASYNC_KW@26..32 "async" [] [Whitespace(" ")]
+          1: FUNCTION_KW@32..41 "function" [] [Whitespace(" ")]
+          2: (empty)
+          3: JS_IDENTIFIER_BINDING@41..45
+            0: IDENT@41..45 "foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: JS_FUNCTION_BODY@45..48
+            0: L_CURLY@45..47 "{" [] [Whitespace(" ")]
+            1: JS_DIRECTIVE_LIST@47..47
+            2: JS_STATEMENT_LIST@47..47
+            3: R_CURLY@47..48 "}" [] []
+        2: (empty)
+  3: EOF@48..49 "" [Newline("\n")] []
+--
+decorator_async_function_export_default_declaration_clause.ts:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Decorators are not valid here.
+  
+  > 1 │ @decorator
+      │ ^^^^^^^^^^
+    2 │ export default async function foo { }
+    3 │ 
+  
+--
+decorator_async_function_export_default_declaration_clause.ts:2:35 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected a parenthesis '(' but instead found '{'
+  
+    1 │ @decorator
+  > 2 │ export default async function foo { }
+      │                                   ^
+    3 │ 
+  
+  i Expected a parenthesis '(' here
+  
+    1 │ @decorator
+  > 2 │ export default async function foo { }
+      │                                   ^
+    3 │ 
+  
+--
+@decorator
+export default async function foo { }

--- a/crates/rome_js_parser/test_data/inline/err/decorator_async_function_export_default_declaration_clause.ts
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_async_function_export_default_declaration_clause.ts
@@ -1,0 +1,2 @@
+@decorator
+export default async function foo { }

--- a/crates/rome_js_parser/test_data/inline/err/decorator_enum_export_default_declaration_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_enum_export_default_declaration_clause.rast
@@ -1,0 +1,123 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsBogusStatement {
+            items: [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..10 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+        },
+        JsBogusStatement {
+            items: [
+                JsDecoratorList [],
+                EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
+                JsBogus {
+                    items: [
+                        DEFAULT_KW@18..26 "default" [] [Whitespace(" ")],
+                        TsEnumDeclaration {
+                            const_token: missing (optional),
+                            enum_token: ENUM_KW@26..31 "enum" [] [Whitespace(" ")],
+                            id: JsIdentifierBinding {
+                                name_token: IDENT@31..33 "A" [] [Whitespace(" ")],
+                            },
+                            l_curly_token: L_CURLY@33..35 "{" [] [Whitespace(" ")],
+                            members: TsEnumMemberList [
+                                TsEnumMember {
+                                    name: JsLiteralMemberName {
+                                        value: IDENT@35..36 "X" [] [],
+                                    },
+                                    initializer: missing (optional),
+                                },
+                                COMMA@36..38 "," [] [Whitespace(" ")],
+                                TsEnumMember {
+                                    name: JsLiteralMemberName {
+                                        value: IDENT@38..39 "Y" [] [],
+                                    },
+                                    initializer: missing (optional),
+                                },
+                                COMMA@39..41 "," [] [Whitespace(" ")],
+                                TsEnumMember {
+                                    name: JsLiteralMemberName {
+                                        value: IDENT@41..43 "Z" [] [Whitespace(" ")],
+                                    },
+                                    initializer: missing (optional),
+                                },
+                            ],
+                            r_curly_token: R_CURLY@43..44 "}" [] [],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@44..45 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..45
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..44
+    0: JS_BOGUS_STATEMENT@0..10
+      0: JS_DECORATOR@0..10
+        0: AT@0..1 "@" [] []
+        1: JS_IDENTIFIER_EXPRESSION@1..10
+          0: JS_REFERENCE_IDENTIFIER@1..10
+            0: IDENT@1..10 "decorator" [] []
+    1: JS_BOGUS_STATEMENT@10..44
+      0: JS_DECORATOR_LIST@10..10
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@18..44
+        0: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")]
+        1: TS_ENUM_DECLARATION@26..44
+          0: (empty)
+          1: ENUM_KW@26..31 "enum" [] [Whitespace(" ")]
+          2: JS_IDENTIFIER_BINDING@31..33
+            0: IDENT@31..33 "A" [] [Whitespace(" ")]
+          3: L_CURLY@33..35 "{" [] [Whitespace(" ")]
+          4: TS_ENUM_MEMBER_LIST@35..43
+            0: TS_ENUM_MEMBER@35..36
+              0: JS_LITERAL_MEMBER_NAME@35..36
+                0: IDENT@35..36 "X" [] []
+              1: (empty)
+            1: COMMA@36..38 "," [] [Whitespace(" ")]
+            2: TS_ENUM_MEMBER@38..39
+              0: JS_LITERAL_MEMBER_NAME@38..39
+                0: IDENT@38..39 "Y" [] []
+              1: (empty)
+            3: COMMA@39..41 "," [] [Whitespace(" ")]
+            4: TS_ENUM_MEMBER@41..43
+              0: JS_LITERAL_MEMBER_NAME@41..43
+                0: IDENT@41..43 "Z" [] [Whitespace(" ")]
+              1: (empty)
+          5: R_CURLY@43..44 "}" [] []
+  3: EOF@44..45 "" [Newline("\n")] []
+--
+decorator_enum_export_default_declaration_clause.ts:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Decorators are not valid here.
+  
+  > 1 │ @decorator
+      │ ^^^^^^^^^^
+    2 │ export default enum A { X, Y, Z }
+    3 │ 
+  
+--
+decorator_enum_export_default_declaration_clause.ts:2:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'export default' isn't allowed for 'enum's. Move the 'enum' declaration in its own statement and then export the enum's name.
+  
+    1 │ @decorator
+  > 2 │ export default enum A { X, Y, Z }
+      │                ^^^^^^^^^^^^^^^^^^
+    3 │ 
+  
+--
+@decorator
+export default enum A { X, Y, Z }

--- a/crates/rome_js_parser/test_data/inline/err/decorator_enum_export_default_declaration_clause.ts
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_enum_export_default_declaration_clause.ts
@@ -1,0 +1,2 @@
+@decorator
+export default enum A { X, Y, Z }

--- a/crates/rome_js_parser/test_data/inline/err/decorator_export.js
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_export.js
@@ -1,0 +1,6 @@
+function foo() {
+     @decorator
+     export class Foo { }
+     @first.field @second @(() => decorator)()
+     export class Bar {}
+}

--- a/crates/rome_js_parser/test_data/inline/err/decorator_export.rast
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_export.rast
@@ -1,0 +1,267 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@9..12 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameters: JsParameters {
+                l_paren_token: L_PAREN@12..13 "(" [] [],
+                items: JsParameterList [],
+                r_paren_token: R_PAREN@13..15 ")" [] [Whitespace(" ")],
+            },
+            return_type_annotation: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@15..16 "{" [] [],
+                directives: JsDirectiveList [],
+                statements: JsStatementList [
+                    JsBogusStatement {
+                        items: [
+                            JsDecoratorList [
+                                JsDecorator {
+                                    at_token: AT@16..23 "@" [Newline("\n"), Whitespace("     ")] [],
+                                    expression: JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@23..32 "decorator" [] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            EXPORT_KW@32..45 "export" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")],
+                            JsClassDeclaration {
+                                decorators: JsDecoratorList [],
+                                abstract_token: missing (optional),
+                                class_token: CLASS_KW@45..51 "class" [] [Whitespace(" ")],
+                                id: JsIdentifierBinding {
+                                    name_token: IDENT@51..55 "Foo" [] [Whitespace(" ")],
+                                },
+                                type_parameters: missing (optional),
+                                extends_clause: missing (optional),
+                                implements_clause: missing (optional),
+                                l_curly_token: L_CURLY@55..57 "{" [] [Whitespace(" ")],
+                                members: JsClassMemberList [],
+                                r_curly_token: R_CURLY@57..58 "}" [] [],
+                            },
+                        ],
+                    },
+                    JsBogusStatement {
+                        items: [
+                            JsDecoratorList [
+                                JsDecorator {
+                                    at_token: AT@58..65 "@" [Newline("\n"), Whitespace("     ")] [],
+                                    expression: JsStaticMemberExpression {
+                                        object: JsIdentifierExpression {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@65..70 "first" [] [],
+                                            },
+                                        },
+                                        operator_token: DOT@70..71 "." [] [],
+                                        member: JsName {
+                                            value_token: IDENT@71..77 "field" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                                JsDecorator {
+                                    at_token: AT@77..78 "@" [] [],
+                                    expression: JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@78..85 "second" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                                JsDecorator {
+                                    at_token: AT@85..86 "@" [] [],
+                                    expression: JsCallExpression {
+                                        callee: JsParenthesizedExpression {
+                                            l_paren_token: L_PAREN@86..87 "(" [] [],
+                                            expression: JsArrowFunctionExpression {
+                                                async_token: missing (optional),
+                                                type_parameters: missing (optional),
+                                                parameters: JsParameters {
+                                                    l_paren_token: L_PAREN@87..88 "(" [] [],
+                                                    items: JsParameterList [],
+                                                    r_paren_token: R_PAREN@88..90 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type_annotation: missing (optional),
+                                                fat_arrow_token: FAT_ARROW@90..93 "=>" [] [Whitespace(" ")],
+                                                body: JsIdentifierExpression {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@93..102 "decorator" [] [],
+                                                    },
+                                                },
+                                            },
+                                            r_paren_token: R_PAREN@102..103 ")" [] [],
+                                        },
+                                        optional_chain_token: missing (optional),
+                                        type_arguments: missing (optional),
+                                        arguments: JsCallArguments {
+                                            l_paren_token: L_PAREN@103..104 "(" [] [],
+                                            args: JsCallArgumentList [],
+                                            r_paren_token: R_PAREN@104..105 ")" [] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            EXPORT_KW@105..118 "export" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")],
+                            JsClassDeclaration {
+                                decorators: JsDecoratorList [],
+                                abstract_token: missing (optional),
+                                class_token: CLASS_KW@118..124 "class" [] [Whitespace(" ")],
+                                id: JsIdentifierBinding {
+                                    name_token: IDENT@124..128 "Bar" [] [Whitespace(" ")],
+                                },
+                                type_parameters: missing (optional),
+                                extends_clause: missing (optional),
+                                implements_clause: missing (optional),
+                                l_curly_token: L_CURLY@128..129 "{" [] [],
+                                members: JsClassMemberList [],
+                                r_curly_token: R_CURLY@129..130 "}" [] [],
+                            },
+                        ],
+                    },
+                ],
+                r_curly_token: R_CURLY@130..132 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@132..133 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..133
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..132
+    0: JS_FUNCTION_DECLARATION@0..132
+      0: (empty)
+      1: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
+      2: (empty)
+      3: JS_IDENTIFIER_BINDING@9..12
+        0: IDENT@9..12 "foo" [] []
+      4: (empty)
+      5: JS_PARAMETERS@12..15
+        0: L_PAREN@12..13 "(" [] []
+        1: JS_PARAMETER_LIST@13..13
+        2: R_PAREN@13..15 ")" [] [Whitespace(" ")]
+      6: (empty)
+      7: JS_FUNCTION_BODY@15..132
+        0: L_CURLY@15..16 "{" [] []
+        1: JS_DIRECTIVE_LIST@16..16
+        2: JS_STATEMENT_LIST@16..130
+          0: JS_BOGUS_STATEMENT@16..58
+            0: JS_DECORATOR_LIST@16..32
+              0: JS_DECORATOR@16..32
+                0: AT@16..23 "@" [Newline("\n"), Whitespace("     ")] []
+                1: JS_IDENTIFIER_EXPRESSION@23..32
+                  0: JS_REFERENCE_IDENTIFIER@23..32
+                    0: IDENT@23..32 "decorator" [] []
+            1: EXPORT_KW@32..45 "export" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")]
+            2: JS_CLASS_DECLARATION@45..58
+              0: JS_DECORATOR_LIST@45..45
+              1: (empty)
+              2: CLASS_KW@45..51 "class" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@51..55
+                0: IDENT@51..55 "Foo" [] [Whitespace(" ")]
+              4: (empty)
+              5: (empty)
+              6: (empty)
+              7: L_CURLY@55..57 "{" [] [Whitespace(" ")]
+              8: JS_CLASS_MEMBER_LIST@57..57
+              9: R_CURLY@57..58 "}" [] []
+          1: JS_BOGUS_STATEMENT@58..130
+            0: JS_DECORATOR_LIST@58..105
+              0: JS_DECORATOR@58..77
+                0: AT@58..65 "@" [Newline("\n"), Whitespace("     ")] []
+                1: JS_STATIC_MEMBER_EXPRESSION@65..77
+                  0: JS_IDENTIFIER_EXPRESSION@65..70
+                    0: JS_REFERENCE_IDENTIFIER@65..70
+                      0: IDENT@65..70 "first" [] []
+                  1: DOT@70..71 "." [] []
+                  2: JS_NAME@71..77
+                    0: IDENT@71..77 "field" [] [Whitespace(" ")]
+              1: JS_DECORATOR@77..85
+                0: AT@77..78 "@" [] []
+                1: JS_IDENTIFIER_EXPRESSION@78..85
+                  0: JS_REFERENCE_IDENTIFIER@78..85
+                    0: IDENT@78..85 "second" [] [Whitespace(" ")]
+              2: JS_DECORATOR@85..105
+                0: AT@85..86 "@" [] []
+                1: JS_CALL_EXPRESSION@86..105
+                  0: JS_PARENTHESIZED_EXPRESSION@86..103
+                    0: L_PAREN@86..87 "(" [] []
+                    1: JS_ARROW_FUNCTION_EXPRESSION@87..102
+                      0: (empty)
+                      1: (empty)
+                      2: JS_PARAMETERS@87..90
+                        0: L_PAREN@87..88 "(" [] []
+                        1: JS_PARAMETER_LIST@88..88
+                        2: R_PAREN@88..90 ")" [] [Whitespace(" ")]
+                      3: (empty)
+                      4: FAT_ARROW@90..93 "=>" [] [Whitespace(" ")]
+                      5: JS_IDENTIFIER_EXPRESSION@93..102
+                        0: JS_REFERENCE_IDENTIFIER@93..102
+                          0: IDENT@93..102 "decorator" [] []
+                    2: R_PAREN@102..103 ")" [] []
+                  1: (empty)
+                  2: (empty)
+                  3: JS_CALL_ARGUMENTS@103..105
+                    0: L_PAREN@103..104 "(" [] []
+                    1: JS_CALL_ARGUMENT_LIST@104..104
+                    2: R_PAREN@104..105 ")" [] []
+            1: EXPORT_KW@105..118 "export" [Newline("\n"), Whitespace("     ")] [Whitespace(" ")]
+            2: JS_CLASS_DECLARATION@118..130
+              0: JS_DECORATOR_LIST@118..118
+              1: (empty)
+              2: CLASS_KW@118..124 "class" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@124..128
+                0: IDENT@124..128 "Bar" [] [Whitespace(" ")]
+              4: (empty)
+              5: (empty)
+              6: (empty)
+              7: L_CURLY@128..129 "{" [] []
+              8: JS_CLASS_MEMBER_LIST@129..129
+              9: R_CURLY@129..130 "}" [] []
+        3: R_CURLY@130..132 "}" [Newline("\n")] []
+  3: EOF@132..133 "" [Newline("\n")] []
+--
+decorator_export.js:2:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Illegal use of an export declaration not at the top level
+  
+    1 │ function foo() {
+  > 2 │      @decorator
+      │      ^^^^^^^^^^
+  > 3 │      export class Foo { }
+      │      ^^^^^^^^^^^^^^^^^^^^
+    4 │      @first.field @second @(() => decorator)()
+    5 │      export class Bar {}
+  
+  i move this declaration to the top level
+  
+--
+decorator_export.js:4:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Illegal use of an export declaration not at the top level
+  
+    2 │      @decorator
+    3 │      export class Foo { }
+  > 4 │      @first.field @second @(() => decorator)()
+      │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 5 │      export class Bar {}
+      │      ^^^^^^^^^^^^^^^^^^^
+    6 │ }
+    7 │ 
+  
+  i move this declaration to the top level
+  
+--
+function foo() {
+     @decorator
+     export class Foo { }
+     @first.field @second @(() => decorator)()
+     export class Bar {}
+}

--- a/crates/rome_js_parser/test_data/inline/err/decorator_export_class_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_export_class_clause.rast
@@ -15,6 +15,7 @@ JsModule {
             ],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsVariableDeclarationClause {
                 declaration: JsVariableDeclaration {
@@ -53,6 +54,7 @@ JsModule {
             ],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@48..56 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsFunctionDeclaration {
                 async_token: missing (optional),
@@ -91,8 +93,9 @@ JsModule {
           0: JS_REFERENCE_IDENTIFIER@1..10
             0: IDENT@1..10 "decorator" [] []
     1: JS_EXPORT@10..24
-      0: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_VARIABLE_DECLARATION_CLAUSE@18..24
+      0: JS_DECORATOR_LIST@10..10
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_VARIABLE_DECLARATION_CLAUSE@18..24
         0: JS_VARIABLE_DECLARATION@18..23
           0: LET_KW@18..22 "let" [] [Whitespace(" ")]
           1: JS_VARIABLE_DECLARATOR_LIST@22..23
@@ -114,8 +117,9 @@ JsModule {
           0: JS_REFERENCE_IDENTIFIER@38..48
             0: IDENT@38..48 "decorator2" [] []
     3: JS_EXPORT@48..74
-      0: EXPORT_KW@48..56 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_FUNCTION_DECLARATION@56..74
+      0: JS_DECORATOR_LIST@48..48
+      1: EXPORT_KW@48..56 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_FUNCTION_DECLARATION@56..74
         0: (empty)
         1: FUNCTION_KW@56..65 "function" [] [Whitespace(" ")]
         2: (empty)

--- a/crates/rome_js_parser/test_data/inline/err/decorator_export_default_expression_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_export_default_expression_clause.rast
@@ -1,0 +1,66 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsBogusStatement {
+            items: [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..10 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultExpressionClause {
+                default_token: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")],
+                expression: JsIdentifierExpression {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@26..27 "a" [] [],
+                    },
+                },
+                semicolon_token: SEMICOLON@27..28 ";" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@28..29 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..29
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..28
+    0: JS_BOGUS_STATEMENT@0..10
+      0: JS_DECORATOR@0..10
+        0: AT@0..1 "@" [] []
+        1: JS_IDENTIFIER_EXPRESSION@1..10
+          0: JS_REFERENCE_IDENTIFIER@1..10
+            0: IDENT@1..10 "decorator" [] []
+    1: JS_EXPORT@10..28
+      0: JS_DECORATOR_LIST@10..10
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE@18..28
+        0: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")]
+        1: JS_IDENTIFIER_EXPRESSION@26..27
+          0: JS_REFERENCE_IDENTIFIER@26..27
+            0: IDENT@26..27 "a" [] []
+        2: SEMICOLON@27..28 ";" [] []
+  3: EOF@28..29 "" [Newline("\n")] []
+--
+decorator_export_default_expression_clause.ts:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Decorators are not valid here.
+  
+  > 1 │ @decorator
+      │ ^^^^^^^^^^
+    2 │ export default a;
+    3 │ 
+  
+--
+@decorator
+export default a;

--- a/crates/rome_js_parser/test_data/inline/err/decorator_export_default_expression_clause.ts
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_export_default_expression_clause.ts
@@ -1,0 +1,2 @@
+@decorator
+export default a;

--- a/crates/rome_js_parser/test_data/inline/err/decorator_function_export_default_declaration_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_function_export_default_declaration_clause.rast
@@ -1,0 +1,106 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsBogusStatement {
+            items: [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..10 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")],
+                declaration: JsFunctionExportDefaultDeclaration {
+                    async_token: missing (optional),
+                    function_token: FUNCTION_KW@26..35 "function" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@35..39 "foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    parameters: missing (required),
+                    return_type_annotation: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@39..41 "{" [] [Whitespace(" ")],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@41..42 "}" [] [],
+                    },
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..43
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..42
+    0: JS_BOGUS_STATEMENT@0..10
+      0: JS_DECORATOR@0..10
+        0: AT@0..1 "@" [] []
+        1: JS_IDENTIFIER_EXPRESSION@1..10
+          0: JS_REFERENCE_IDENTIFIER@1..10
+            0: IDENT@1..10 "decorator" [] []
+    1: JS_EXPORT@10..42
+      0: JS_DECORATOR_LIST@10..10
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@18..42
+        0: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")]
+        1: JS_FUNCTION_EXPORT_DEFAULT_DECLARATION@26..42
+          0: (empty)
+          1: FUNCTION_KW@26..35 "function" [] [Whitespace(" ")]
+          2: (empty)
+          3: JS_IDENTIFIER_BINDING@35..39
+            0: IDENT@35..39 "foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: JS_FUNCTION_BODY@39..42
+            0: L_CURLY@39..41 "{" [] [Whitespace(" ")]
+            1: JS_DIRECTIVE_LIST@41..41
+            2: JS_STATEMENT_LIST@41..41
+            3: R_CURLY@41..42 "}" [] []
+        2: (empty)
+  3: EOF@42..43 "" [Newline("\n")] []
+--
+decorator_function_export_default_declaration_clause.ts:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Decorators are not valid here.
+  
+  > 1 │ @decorator
+      │ ^^^^^^^^^^
+    2 │ export default function foo { }
+    3 │ 
+  
+--
+decorator_function_export_default_declaration_clause.ts:2:29 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected a parenthesis '(' but instead found '{'
+  
+    1 │ @decorator
+  > 2 │ export default function foo { }
+      │                             ^
+    3 │ 
+  
+  i Expected a parenthesis '(' here
+  
+    1 │ @decorator
+  > 2 │ export default function foo { }
+      │                             ^
+    3 │ 
+  
+--
+@decorator
+export default function foo { }

--- a/crates/rome_js_parser/test_data/inline/err/decorator_function_export_default_declaration_clause.ts
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_function_export_default_declaration_clause.ts
@@ -1,0 +1,2 @@
+@decorator
+export default function foo { }

--- a/crates/rome_js_parser/test_data/inline/err/decorator_interface_export_default_declaration_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_interface_export_default_declaration_clause.rast
@@ -1,0 +1,78 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsBogusStatement {
+            items: [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..10 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")],
+                declaration: TsInterfaceDeclaration {
+                    interface_token: INTERFACE_KW@26..36 "interface" [] [Whitespace(" ")],
+                    id: TsIdentifierBinding {
+                        name_token: IDENT@36..38 "A" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    l_curly_token: L_CURLY@38..40 "{" [] [Whitespace(" ")],
+                    members: TsTypeMemberList [],
+                    r_curly_token: R_CURLY@40..41 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@41..42 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..42
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..41
+    0: JS_BOGUS_STATEMENT@0..10
+      0: JS_DECORATOR@0..10
+        0: AT@0..1 "@" [] []
+        1: JS_IDENTIFIER_EXPRESSION@1..10
+          0: JS_REFERENCE_IDENTIFIER@1..10
+            0: IDENT@1..10 "decorator" [] []
+    1: JS_EXPORT@10..41
+      0: JS_DECORATOR_LIST@10..10
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@18..41
+        0: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")]
+        1: TS_INTERFACE_DECLARATION@26..41
+          0: INTERFACE_KW@26..36 "interface" [] [Whitespace(" ")]
+          1: TS_IDENTIFIER_BINDING@36..38
+            0: IDENT@36..38 "A" [] [Whitespace(" ")]
+          2: (empty)
+          3: (empty)
+          4: L_CURLY@38..40 "{" [] [Whitespace(" ")]
+          5: TS_TYPE_MEMBER_LIST@40..40
+          6: R_CURLY@40..41 "}" [] []
+        2: (empty)
+  3: EOF@41..42 "" [Newline("\n")] []
+--
+decorator_interface_export_default_declaration_clause.ts:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Decorators are not valid here.
+  
+  > 1 │ @decorator
+      │ ^^^^^^^^^^
+    2 │ export default interface A { }
+    3 │ 
+  
+--
+@decorator
+export default interface A { }

--- a/crates/rome_js_parser/test_data/inline/err/decorator_interface_export_default_declaration_clause.ts
+++ b/crates/rome_js_parser/test_data/inline/err/decorator_interface_export_default_declaration_clause.ts
@@ -1,0 +1,2 @@
+@decorator
+export default interface A { }

--- a/crates/rome_js_parser/test_data/inline/err/escaped_from.rast
+++ b/crates/rome_js_parser/test_data/inline/err/escaped_from.rast
@@ -4,6 +4,7 @@ JsModule {
     items: JsModuleItemList [
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -28,8 +29,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..40
     0: JS_BOGUS_STATEMENT@0..40
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_BOGUS@7..40
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_BOGUS@7..40
         0: L_CURLY@7..8 "{" [] []
         1: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@8..8
         2: R_CURLY@8..10 "}" [] [Whitespace(" ")]

--- a/crates/rome_js_parser/test_data/inline/err/export_as_identifier_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_as_identifier_err.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -30,8 +31,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..15
     0: JS_EXPORT@0..15
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@7..15
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@7..15
         0: (empty)
         1: L_CURLY@7..9 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@9..14

--- a/crates/rome_js_parser/test_data/inline/err/export_decl_not_top_level.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_decl_not_top_level.rast
@@ -7,6 +7,7 @@ JsModule {
             statements: JsStatementList [
                 JsBogusStatement {
                     items: [
+                        JsDecoratorList [],
                         EXPORT_KW@1..10 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                         JsExportNamedFromClause {
                             type_token: missing (optional),
@@ -45,8 +46,9 @@ JsModule {
       0: L_CURLY@0..1 "{" [] []
       1: JS_STATEMENT_LIST@1..31
         0: JS_BOGUS_STATEMENT@1..31
-          0: EXPORT_KW@1..10 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
-          1: JS_EXPORT_NAMED_FROM_CLAUSE@10..31
+          0: JS_DECORATOR_LIST@1..1
+          1: EXPORT_KW@1..10 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
+          2: JS_EXPORT_NAMED_FROM_CLAUSE@10..31
             0: (empty)
             1: L_CURLY@10..12 "{" [] [Whitespace(" ")]
             2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@12..17

--- a/crates/rome_js_parser/test_data/inline/err/export_default_expression_clause_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_default_expression_clause_err.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportDefaultExpressionClause {
                 default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
@@ -32,8 +33,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..20
     0: JS_EXPORT@0..16
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE@7..16
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE@7..16
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: JS_IDENTIFIER_EXPRESSION@15..16
           0: JS_REFERENCE_IDENTIFIER@15..16

--- a/crates/rome_js_parser/test_data/inline/err/export_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_err.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..6 "export" [] [],
             export_clause: missing (required),
         },
@@ -15,8 +16,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..6
     0: JS_EXPORT@0..6
-      0: EXPORT_KW@0..6 "export" [] []
-      1: (empty)
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..6 "export" [] []
+      2: (empty)
   3: EOF@6..7 "" [Newline("\n")] []
 --
 export_err.js:2:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/crates/rome_js_parser/test_data/inline/err/export_from_clause_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_from_clause_err.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: missing (optional),
@@ -15,6 +16,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@9..17 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: missing (optional),
@@ -33,6 +35,7 @@ JsModule {
             semicolon_token: SEMICOLON@25..26 ";" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: missing (optional),
@@ -52,6 +55,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@49..57 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: missing (optional),
@@ -66,6 +70,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@69..77 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: TYPE_KW@77..82 "type" [] [Whitespace(" ")],
@@ -78,6 +83,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@84..92 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: TYPE_KW@92..97 "type" [] [Whitespace(" ")],
@@ -90,6 +96,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@104..112 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: TYPE_KW@112..117 "type" [] [Whitespace(" ")],
@@ -107,6 +114,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@127..135 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: TYPE_KW@135..140 "type" [] [Whitespace(" ")],
@@ -132,8 +140,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..153
     0: JS_EXPORT@0..9
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@7..9
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@7..9
         0: (empty)
         1: STAR@7..8 "*" [] []
         2: (empty)
@@ -142,8 +151,9 @@ JsModule {
         5: (empty)
         6: SEMICOLON@8..9 ";" [] []
     1: JS_EXPORT@9..24
-      0: EXPORT_KW@9..17 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@17..24
+      0: JS_DECORATOR_LIST@9..9
+      1: EXPORT_KW@9..17 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@17..24
         0: (empty)
         1: STAR@17..19 "*" [] [Whitespace(" ")]
         2: (empty)
@@ -156,8 +166,9 @@ JsModule {
         0: JS_NUMBER_LITERAL@24..25 "5" [] []
       1: SEMICOLON@25..26 ";" [] []
     3: JS_EXPORT@26..49
-      0: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@34..49
+      0: JS_DECORATOR_LIST@26..26
+      1: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@34..49
         0: (empty)
         1: (empty)
         2: JS_EXPORT_AS_CLAUSE@34..42
@@ -170,8 +181,9 @@ JsModule {
         5: (empty)
         6: SEMICOLON@48..49 ";" [] []
     4: JS_EXPORT@49..69
-      0: EXPORT_KW@49..57 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@57..69
+      0: JS_DECORATOR_LIST@49..49
+      1: EXPORT_KW@49..57 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@57..69
         0: (empty)
         1: (empty)
         2: (empty)
@@ -181,8 +193,9 @@ JsModule {
         5: (empty)
         6: SEMICOLON@68..69 ";" [] []
     5: JS_EXPORT@69..84
-      0: EXPORT_KW@69..77 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@77..84
+      0: JS_DECORATOR_LIST@69..69
+      1: EXPORT_KW@69..77 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@77..84
         0: TYPE_KW@77..82 "type" [] [Whitespace(" ")]
         1: STAR@82..83 "*" [] []
         2: (empty)
@@ -191,8 +204,9 @@ JsModule {
         5: (empty)
         6: SEMICOLON@83..84 ";" [] []
     6: JS_EXPORT@84..104
-      0: EXPORT_KW@84..92 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@92..104
+      0: JS_DECORATOR_LIST@84..84
+      1: EXPORT_KW@84..92 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@92..104
         0: TYPE_KW@92..97 "type" [] [Whitespace(" ")]
         1: STAR@97..99 "*" [] [Whitespace(" ")]
         2: (empty)
@@ -201,8 +215,9 @@ JsModule {
         5: (empty)
         6: SEMICOLON@103..104 ";" [] []
     7: JS_EXPORT@104..127
-      0: EXPORT_KW@104..112 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@112..127
+      0: JS_DECORATOR_LIST@104..104
+      1: EXPORT_KW@104..112 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@112..127
         0: TYPE_KW@112..117 "type" [] [Whitespace(" ")]
         1: STAR@117..119 "*" [] [Whitespace(" ")]
         2: JS_EXPORT_AS_CLAUSE@119..126
@@ -214,8 +229,9 @@ JsModule {
         5: (empty)
         6: SEMICOLON@126..127 ";" [] []
     8: JS_EXPORT@127..153
-      0: EXPORT_KW@127..135 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@135..153
+      0: JS_DECORATOR_LIST@127..127
+      1: EXPORT_KW@127..135 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@135..153
         0: TYPE_KW@135..140 "type" [] [Whitespace(" ")]
         1: STAR@140..142 "*" [] [Whitespace(" ")]
         2: JS_EXPORT_AS_CLAUSE@142..148

--- a/crates/rome_js_parser/test_data/inline/err/export_huge_function_in_script.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_huge_function_in_script.rast
@@ -4,6 +4,7 @@ JsScript {
     statements: JsStatementList [
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@0..17 "export" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
                 JsFunctionDeclaration {
                     async_token: missing (optional),
@@ -45,8 +46,9 @@ JsScript {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_STATEMENT_LIST@0..1441
     0: JS_BOGUS_STATEMENT@0..1441
-      0: EXPORT_KW@0..17 "export" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
-      1: JS_FUNCTION_DECLARATION@17..1441
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..17 "export" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
+      2: JS_FUNCTION_DECLARATION@17..1441
         0: (empty)
         1: FUNCTION_KW@17..26 "function" [] [Whitespace(" ")]
         2: (empty)

--- a/crates/rome_js_parser/test_data/inline/err/export_named_clause_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_named_clause_err.rast
@@ -4,6 +4,7 @@ JsModule {
     items: JsModuleItemList [
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -31,6 +32,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -57,6 +59,7 @@ JsModule {
             ],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -77,6 +80,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@64..72 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -105,6 +109,7 @@ JsModule {
             ],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@83..91 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -144,8 +149,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..101
     0: JS_BOGUS_STATEMENT@0..26
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_BOGUS@7..26
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_BOGUS@7..26
         0: L_CURLY@7..9 "{" [] [Whitespace(" ")]
         1: JS_BOGUS@9..24
           0: JS_BOGUS@9..24
@@ -157,8 +163,9 @@ JsModule {
         2: R_CURLY@24..25 "}" [] []
         3: SEMICOLON@25..26 ";" [] []
     1: JS_BOGUS_STATEMENT@26..47
-      0: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@34..47
+      0: JS_DECORATOR_LIST@26..26
+      1: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@34..47
         0: L_CURLY@34..36 "{" [] [Whitespace(" ")]
         1: JS_BOGUS@36..45
           0: JS_BOGUS@36..45
@@ -170,8 +177,9 @@ JsModule {
         2: R_CURLY@45..46 "}" [] []
         3: SEMICOLON@46..47 ";" [] []
     2: JS_EXPORT@47..64
-      0: EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@55..64
+      0: JS_DECORATOR_LIST@47..47
+      1: EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@55..64
         0: (empty)
         1: L_CURLY@55..57 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@57..62
@@ -184,8 +192,9 @@ JsModule {
         3: R_CURLY@62..63 "}" [] []
         4: SEMICOLON@63..64 ";" [] []
     3: JS_BOGUS_STATEMENT@64..83
-      0: EXPORT_KW@64..72 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@72..83
+      0: JS_DECORATOR_LIST@64..64
+      1: EXPORT_KW@64..72 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@72..83
         0: L_CURLY@72..74 "{" [] [Whitespace(" ")]
         1: JS_BOGUS@74..81
           0: JS_EXPORT_NAMED_SPECIFIER@74..79
@@ -199,8 +208,9 @@ JsModule {
         2: R_CURLY@81..82 "}" [] []
         3: SEMICOLON@82..83 ";" [] []
     4: JS_EXPORT@83..101
-      0: EXPORT_KW@83..91 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@91..101
+      0: JS_DECORATOR_LIST@83..83
+      1: EXPORT_KW@83..91 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@91..101
         0: (empty)
         1: L_CURLY@91..93 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@93..99

--- a/crates/rome_js_parser/test_data/inline/err/export_named_from_clause_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_named_from_clause_err.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -30,6 +31,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@27..35 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -64,6 +66,7 @@ JsModule {
             ],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@57..65 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -104,6 +107,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -138,8 +142,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..116
     0: JS_EXPORT@0..27
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@7..27
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@7..27
         0: (empty)
         1: L_CURLY@7..9 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@9..14
@@ -157,8 +162,9 @@ JsModule {
         6: (empty)
         7: SEMICOLON@26..27 ";" [] []
     1: JS_BOGUS_STATEMENT@27..57
-      0: EXPORT_KW@27..35 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@35..57
+      0: JS_DECORATOR_LIST@27..27
+      1: EXPORT_KW@27..35 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@35..57
         0: L_CURLY@35..37 "{" [] [Whitespace(" ")]
         1: JS_BOGUS@37..44
           0: JS_EXPORT_NAMED_FROM_SPECIFIER@37..42
@@ -176,8 +182,9 @@ JsModule {
           0: JS_STRING_LITERAL@51..56 "\"mod\"" [] []
         5: SEMICOLON@56..57 ";" [] []
     2: JS_EXPORT@57..86
-      0: EXPORT_KW@57..65 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@65..86
+      0: JS_DECORATOR_LIST@57..57
+      1: EXPORT_KW@57..65 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@65..86
         0: (empty)
         1: L_CURLY@65..67 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@67..73
@@ -205,8 +212,9 @@ JsModule {
         6: (empty)
         7: SEMICOLON@85..86 ";" [] []
     3: JS_BOGUS_STATEMENT@86..116
-      0: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@94..116
+      0: JS_DECORATOR_LIST@86..86
+      1: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@94..116
         0: L_CURLY@94..96 "{" [] [Whitespace(" ")]
         1: JS_BOGUS@96..103
           0: JS_BOGUS@96..103

--- a/crates/rome_js_parser/test_data/inline/err/export_variable_clause_error.rast
+++ b/crates/rome_js_parser/test_data/inline/err/export_variable_clause_error.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsVariableDeclarationClause {
                 declaration: JsVariableDeclaration {
@@ -24,6 +25,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@16..24 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsVariableDeclarationClause {
                 declaration: JsVariableDeclaration {
@@ -42,6 +44,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@32..40 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsVariableDeclarationClause {
                 declaration: JsVariableDeclaration {
@@ -76,8 +79,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..49
     0: JS_EXPORT@0..16
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_VARIABLE_DECLARATION_CLAUSE@7..16
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_VARIABLE_DECLARATION_CLAUSE@7..16
         0: JS_VARIABLE_DECLARATION@7..15
           0: LET_KW@7..11 "let" [] [Whitespace(" ")]
           1: JS_VARIABLE_DECLARATOR_LIST@11..15
@@ -90,8 +94,9 @@ JsModule {
                 1: (empty)
         1: SEMICOLON@15..16 ";" [] []
     1: JS_EXPORT@16..32
-      0: EXPORT_KW@16..24 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_VARIABLE_DECLARATION_CLAUSE@24..32
+      0: JS_DECORATOR_LIST@16..16
+      1: EXPORT_KW@16..24 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_VARIABLE_DECLARATION_CLAUSE@24..32
         0: JS_VARIABLE_DECLARATION@24..31
           0: CONST_KW@24..30 "const" [] [Whitespace(" ")]
           1: JS_VARIABLE_DECLARATOR_LIST@30..31
@@ -102,8 +107,9 @@ JsModule {
               2: (empty)
         1: SEMICOLON@31..32 ";" [] []
     2: JS_EXPORT@32..49
-      0: EXPORT_KW@32..40 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_VARIABLE_DECLARATION_CLAUSE@40..49
+      0: JS_DECORATOR_LIST@32..32
+      1: EXPORT_KW@32..40 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_VARIABLE_DECLARATION_CLAUSE@40..49
         0: JS_VARIABLE_DECLARATION@40..48
           0: LET_KW@40..44 "let" [] [Whitespace(" ")]
           1: JS_VARIABLE_DECLARATOR_LIST@44..48

--- a/crates/rome_js_parser/test_data/inline/err/multiple_default_exports_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/multiple_default_exports_err.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportDefaultExpressionClause {
                 default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
@@ -26,6 +27,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@25..33 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -50,6 +52,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -92,8 +95,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..80
     0: JS_EXPORT@0..25
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE@7..25
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE@7..25
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: JS_PARENTHESIZED_EXPRESSION@15..25
           0: L_PAREN@15..16 "(" [] []
@@ -110,8 +114,9 @@ JsModule {
           2: R_PAREN@24..25 ")" [] []
         2: (empty)
     1: JS_BOGUS_STATEMENT@25..47
-      0: EXPORT_KW@25..33 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@33..47
+      0: JS_DECORATOR_LIST@25..25
+      1: EXPORT_KW@25..33 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@33..47
         0: DEFAULT_KW@33..41 "default" [] [Whitespace(" ")]
         1: JS_BINARY_EXPRESSION@41..46
           0: JS_IDENTIFIER_EXPRESSION@41..43
@@ -123,8 +128,9 @@ JsModule {
               0: IDENT@45..46 "b" [] []
         2: SEMICOLON@46..47 ";" [] []
     2: JS_BOGUS_STATEMENT@47..80
-      0: EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@55..80
+      0: JS_DECORATOR_LIST@47..47
+      1: EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@55..80
         0: DEFAULT_KW@55..63 "default" [] [Whitespace(" ")]
         1: JS_PARENTHESIZED_EXPRESSION@63..80
           0: L_PAREN@63..64 "(" [] []

--- a/crates/rome_js_parser/test_data/inline/err/ts_declare_function_export_declaration_missing_id.rast
+++ b/crates/rome_js_parser/test_data/inline/err/ts_declare_function_export_declaration_missing_id.rast
@@ -13,6 +13,7 @@ JsModule {
                     l_curly_token: L_CURLY@19..20 "{" [] [],
                     items: JsModuleItemList [
                         JsExport {
+                            decorators: JsDecoratorList [],
                             export_token: EXPORT_KW@20..30 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             export_clause: TsDeclareFunctionDeclaration {
                                 async_token: missing (optional),
@@ -70,8 +71,9 @@ JsModule {
           0: L_CURLY@19..20 "{" [] []
           1: JS_MODULE_ITEM_LIST@20..57
             0: JS_EXPORT@20..57
-              0: EXPORT_KW@20..30 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-              1: TS_DECLARE_FUNCTION_DECLARATION@30..57
+              0: JS_DECORATOR_LIST@20..20
+              1: EXPORT_KW@20..30 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+              2: TS_DECLARE_FUNCTION_DECLARATION@30..57
                 0: (empty)
                 1: FUNCTION_KW@30..38 "function" [] []
                 2: (empty)

--- a/crates/rome_js_parser/test_data/inline/err/ts_declare_generator_function.rast
+++ b/crates/rome_js_parser/test_data/inline/err/ts_declare_generator_function.rast
@@ -40,6 +40,7 @@ JsModule {
                     items: JsModuleItemList [
                         JsBogusStatement {
                             items: [
+                                JsDecoratorList [],
                                 EXPORT_KW@52..62 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                 JsBogus {
                                     items: [
@@ -107,8 +108,9 @@ JsModule {
           0: L_CURLY@51..52 "{" [] []
           1: JS_MODULE_ITEM_LIST@52..92
             0: JS_BOGUS_STATEMENT@52..92
-              0: EXPORT_KW@52..62 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-              1: JS_BOGUS@62..92
+              0: JS_DECORATOR_LIST@52..52
+              1: EXPORT_KW@52..62 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+              2: JS_BOGUS@62..92
                 0: DEFAULT_KW@62..70 "default" [] [Whitespace(" ")]
                 1: JS_BOGUS@70..92
                   0: FUNCTION_KW@70..78 "function" [] []

--- a/crates/rome_js_parser/test_data/inline/err/ts_export_declare.rast
+++ b/crates/rome_js_parser/test_data/inline/err/ts_export_declare.rast
@@ -4,6 +4,7 @@ JsModule {
     items: JsModuleItemList [
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -40,6 +41,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@36..44 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -83,8 +85,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..82
     0: JS_BOGUS_STATEMENT@0..36
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_BOGUS@7..36
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_BOGUS@7..36
         0: DECLARE_KW@7..15 "declare" [] [Whitespace(" ")]
         1: JS_BOGUS_STATEMENT@15..26
           0: JS_DECORATOR@15..26
@@ -105,8 +108,9 @@ JsModule {
           8: JS_CLASS_MEMBER_LIST@35..35
           9: R_CURLY@35..36 "}" [] []
     1: JS_BOGUS_STATEMENT@36..82
-      0: EXPORT_KW@36..44 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@44..82
+      0: JS_DECORATOR_LIST@36..36
+      1: EXPORT_KW@36..44 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@44..82
         0: DECLARE_KW@44..52 "declare" [] [Whitespace(" ")]
         1: JS_BOGUS_STATEMENT@52..63
           0: JS_DECORATOR@52..63

--- a/crates/rome_js_parser/test_data/inline/err/ts_export_default_enum.rast
+++ b/crates/rome_js_parser/test_data/inline/err/ts_export_default_enum.rast
@@ -4,6 +4,7 @@ JsModule {
     items: JsModuleItemList [
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -52,8 +53,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..33
     0: JS_BOGUS_STATEMENT@0..33
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_BOGUS@7..33
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_BOGUS@7..33
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: TS_ENUM_DECLARATION@15..33
           0: (empty)

--- a/crates/rome_js_parser/test_data/inline/err/ts_export_syntax_in_js.rast
+++ b/crates/rome_js_parser/test_data/inline/err/ts_export_syntax_in_js.rast
@@ -35,6 +35,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@12..20 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -56,6 +57,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@31..39 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -80,6 +82,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@50..58 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -108,6 +111,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@75..83 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -134,6 +138,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@105..113 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -162,6 +167,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@135..143 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -225,8 +231,9 @@ JsModule {
             2: (empty)
       1: SEMICOLON@11..12 ";" [] []
     1: JS_BOGUS_STATEMENT@12..31
-      0: EXPORT_KW@12..20 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@20..31
+      0: JS_DECORATOR_LIST@12..12
+      1: EXPORT_KW@12..20 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@20..31
         0: TYPE_KW@20..25 "type" [] [Whitespace(" ")]
         1: L_CURLY@25..27 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@27..29
@@ -237,8 +244,9 @@ JsModule {
         3: R_CURLY@29..30 "}" [] []
         4: SEMICOLON@30..31 ";" [] []
     2: JS_BOGUS_STATEMENT@31..50
-      0: EXPORT_KW@31..39 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@39..50
+      0: JS_DECORATOR_LIST@31..31
+      1: EXPORT_KW@31..39 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@39..50
         0: L_CURLY@39..41 "{" [] [Whitespace(" ")]
         1: JS_BOGUS@41..48
           0: JS_BOGUS@41..48
@@ -248,8 +256,9 @@ JsModule {
         2: R_CURLY@48..49 "}" [] []
         3: SEMICOLON@49..50 ";" [] []
     3: JS_BOGUS_STATEMENT@50..75
-      0: EXPORT_KW@50..58 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@58..75
+      0: JS_DECORATOR_LIST@50..50
+      1: EXPORT_KW@50..58 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@58..75
         0: L_CURLY@58..60 "{" [] [Whitespace(" ")]
         1: JS_BOGUS@60..73
           0: JS_BOGUS@60..73
@@ -262,8 +271,9 @@ JsModule {
         2: R_CURLY@73..74 "}" [] []
         3: SEMICOLON@74..75 ";" [] []
     4: JS_BOGUS_STATEMENT@75..105
-      0: EXPORT_KW@75..83 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@83..105
+      0: JS_DECORATOR_LIST@75..75
+      1: EXPORT_KW@75..83 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@83..105
         0: TYPE_KW@83..88 "type" [] [Whitespace(" ")]
         1: L_CURLY@88..90 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@90..92
@@ -278,8 +288,9 @@ JsModule {
           0: JS_STRING_LITERAL@99..104 "\"./d\"" [] []
         6: SEMICOLON@104..105 ";" [] []
     5: JS_BOGUS_STATEMENT@105..135
-      0: EXPORT_KW@105..113 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@113..135
+      0: JS_DECORATOR_LIST@105..105
+      1: EXPORT_KW@105..113 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@113..135
         0: L_CURLY@113..115 "{" [] [Whitespace(" ")]
         1: JS_BOGUS@115..122
           0: JS_BOGUS@115..122
@@ -292,8 +303,9 @@ JsModule {
           0: JS_STRING_LITERAL@129..134 "\"./e\"" [] []
         5: SEMICOLON@134..135 ";" [] []
     6: JS_BOGUS_STATEMENT@135..171
-      0: EXPORT_KW@135..143 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS@143..171
+      0: JS_DECORATOR_LIST@135..135
+      1: EXPORT_KW@135..143 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS@143..171
         0: L_CURLY@143..145 "{" [] [Whitespace(" ")]
         1: JS_BOGUS@145..158
           0: JS_BOGUS@145..158

--- a/crates/rome_js_parser/test_data/inline/err/ts_export_type.rast
+++ b/crates/rome_js_parser/test_data/inline/err/ts_export_type.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: missing (required),
         },
@@ -23,8 +24,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..11
     0: JS_EXPORT@0..7
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: (empty)
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: (empty)
     1: JS_EXPRESSION_STATEMENT@7..11
       0: JS_IDENTIFIER_EXPRESSION@7..11
         0: JS_REFERENCE_IDENTIFIER@7..11

--- a/crates/rome_js_parser/test_data/inline/err/type_parameter_modifier.rast
+++ b/crates/rome_js_parser/test_data/inline/err/type_parameter_modifier.rast
@@ -4,6 +4,7 @@ JsModule {
     items: JsModuleItemList [
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
                 JsBogus {
                     items: [
@@ -55,6 +56,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@38..46 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogusStatement {
                     items: [
@@ -101,6 +103,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@70..78 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogusStatement {
                     items: [
@@ -147,6 +150,7 @@ JsModule {
         },
         JsBogusStatement {
             items: [
+                JsDecoratorList [],
                 EXPORT_KW@102..110 "export" [Newline("\n")] [Whitespace(" ")],
                 JsBogusStatement {
                     items: [
@@ -2001,8 +2005,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..1072
     0: JS_BOGUS_STATEMENT@0..38
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_BOGUS@7..38
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_BOGUS@7..38
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: JS_BOGUS@15..38
           0: FUNCTION_KW@15..24 "function" [] [Whitespace(" ")]
@@ -2027,8 +2032,9 @@ JsModule {
             2: JS_STATEMENT_LIST@37..37
             3: R_CURLY@37..38 "}" [] []
     1: JS_BOGUS_STATEMENT@38..70
-      0: EXPORT_KW@38..46 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS_STATEMENT@46..70
+      0: JS_DECORATOR_LIST@38..38
+      1: EXPORT_KW@38..46 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS_STATEMENT@46..70
         0: FUNCTION_KW@46..55 "function" [] [Whitespace(" ")]
         1: JS_IDENTIFIER_BINDING@55..58
           0: IDENT@55..58 "foo" [] []
@@ -2051,8 +2057,9 @@ JsModule {
           2: JS_STATEMENT_LIST@69..69
           3: R_CURLY@69..70 "}" [] []
     2: JS_BOGUS_STATEMENT@70..102
-      0: EXPORT_KW@70..78 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS_STATEMENT@78..102
+      0: JS_DECORATOR_LIST@70..70
+      1: EXPORT_KW@70..78 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS_STATEMENT@78..102
         0: FUNCTION_KW@78..87 "function" [] [Whitespace(" ")]
         1: JS_IDENTIFIER_BINDING@87..91
           0: IDENT@87..91 "foo1" [] []
@@ -2075,8 +2082,9 @@ JsModule {
           2: JS_STATEMENT_LIST@101..101
           3: R_CURLY@101..102 "}" [] []
     3: JS_BOGUS_STATEMENT@102..135
-      0: EXPORT_KW@102..110 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_BOGUS_STATEMENT@110..135
+      0: JS_DECORATOR_LIST@102..102
+      1: EXPORT_KW@102..110 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_BOGUS_STATEMENT@110..135
         0: FUNCTION_KW@110..119 "function" [] [Whitespace(" ")]
         1: JS_IDENTIFIER_BINDING@119..123
           0: IDENT@119..123 "foo2" [] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator.rast
@@ -377,6 +377,7 @@ JsModule {
             r_curly_token: R_CURLY@427..428 "}" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@428..467 "export" [Newline("\n"), Comments("// exported class dec ..."), Newline("\n")] [Whitespace(" ")],
             export_clause: JsClassDeclaration {
                 decorators: JsDecoratorList [
@@ -406,6 +407,7 @@ JsModule {
             semicolon_token: SEMICOLON@490..491 ";" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@491..499 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsClassDeclaration {
                 decorators: JsDecoratorList [
@@ -464,6 +466,7 @@ JsModule {
             semicolon_token: SEMICOLON@548..549 ";" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@549..557 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsClassDeclaration {
                 decorators: JsDecoratorList [
@@ -497,14 +500,278 @@ JsModule {
                 r_curly_token: R_CURLY@583..584 "}" [] [],
             },
         },
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@584..586 "@" [Newline("\n")] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@586..595 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@595..603 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                decorators: JsDecoratorList [],
+                abstract_token: missing (optional),
+                class_token: CLASS_KW@603..609 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@609..613 "Foo" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@613..615 "{" [] [Whitespace(" ")],
+                members: JsClassMemberList [],
+                r_curly_token: R_CURLY@615..616 "}" [] [],
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@616..618 "@" [Newline("\n")] [],
+                    expression: JsStaticMemberExpression {
+                        object: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@618..623 "first" [] [],
+                            },
+                        },
+                        operator_token: DOT@623..624 "." [] [],
+                        member: JsName {
+                            value_token: IDENT@624..630 "field" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+                JsDecorator {
+                    at_token: AT@630..631 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@631..638 "second" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+                JsDecorator {
+                    at_token: AT@638..639 "@" [] [],
+                    expression: JsCallExpression {
+                        callee: JsParenthesizedExpression {
+                            l_paren_token: L_PAREN@639..640 "(" [] [],
+                            expression: JsArrowFunctionExpression {
+                                async_token: missing (optional),
+                                type_parameters: missing (optional),
+                                parameters: JsParameters {
+                                    l_paren_token: L_PAREN@640..641 "(" [] [],
+                                    items: JsParameterList [],
+                                    r_paren_token: R_PAREN@641..643 ")" [] [Whitespace(" ")],
+                                },
+                                return_type_annotation: missing (optional),
+                                fat_arrow_token: FAT_ARROW@643..646 "=>" [] [Whitespace(" ")],
+                                body: JsIdentifierExpression {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@646..655 "decorator" [] [],
+                                    },
+                                },
+                            },
+                            r_paren_token: R_PAREN@655..656 ")" [] [],
+                        },
+                        optional_chain_token: missing (optional),
+                        type_arguments: missing (optional),
+                        arguments: JsCallArguments {
+                            l_paren_token: L_PAREN@656..657 "(" [] [],
+                            args: JsCallArgumentList [],
+                            r_paren_token: R_PAREN@657..658 ")" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@658..666 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                decorators: JsDecoratorList [],
+                abstract_token: missing (optional),
+                class_token: CLASS_KW@666..672 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@672..676 "Bar" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@676..677 "{" [] [],
+                members: JsClassMemberList [],
+                r_curly_token: R_CURLY@677..678 "}" [] [],
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@678..680 "@" [Newline("\n")] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@680..686 "before" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@686..694 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                decorators: JsDecoratorList [
+                    JsDecorator {
+                        at_token: AT@694..695 "@" [] [],
+                        expression: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@695..701 "after" [] [Whitespace(" ")],
+                            },
+                        },
+                    },
+                ],
+                abstract_token: missing (optional),
+                class_token: CLASS_KW@701..707 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@707..711 "Foo" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@711..713 "{" [] [Whitespace(" ")],
+                members: JsClassMemberList [],
+                r_curly_token: R_CURLY@713..714 "}" [] [],
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@714..716 "@" [Newline("\n")] [],
+                    expression: JsStaticMemberExpression {
+                        object: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@716..722 "before" [] [],
+                            },
+                        },
+                        operator_token: DOT@722..723 "." [] [],
+                        member: JsName {
+                            value_token: IDENT@723..729 "field" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+                JsDecorator {
+                    at_token: AT@729..730 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@730..737 "before" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+                JsDecorator {
+                    at_token: AT@737..738 "@" [] [],
+                    expression: JsCallExpression {
+                        callee: JsParenthesizedExpression {
+                            l_paren_token: L_PAREN@738..739 "(" [] [],
+                            expression: JsArrowFunctionExpression {
+                                async_token: missing (optional),
+                                type_parameters: missing (optional),
+                                parameters: JsParameters {
+                                    l_paren_token: L_PAREN@739..740 "(" [] [],
+                                    items: JsParameterList [],
+                                    r_paren_token: R_PAREN@740..742 ")" [] [Whitespace(" ")],
+                                },
+                                return_type_annotation: missing (optional),
+                                fat_arrow_token: FAT_ARROW@742..745 "=>" [] [Whitespace(" ")],
+                                body: JsIdentifierExpression {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@745..754 "decorator" [] [],
+                                    },
+                                },
+                            },
+                            r_paren_token: R_PAREN@754..755 ")" [] [],
+                        },
+                        optional_chain_token: missing (optional),
+                        type_arguments: missing (optional),
+                        arguments: JsCallArguments {
+                            l_paren_token: L_PAREN@755..756 "(" [] [],
+                            args: JsCallArgumentList [],
+                            r_paren_token: R_PAREN@756..757 ")" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@757..765 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                decorators: JsDecoratorList [
+                    JsDecorator {
+                        at_token: AT@765..766 "@" [] [],
+                        expression: JsStaticMemberExpression {
+                            object: JsIdentifierExpression {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@766..771 "after" [] [],
+                                },
+                            },
+                            operator_token: DOT@771..772 "." [] [],
+                            member: JsName {
+                                value_token: IDENT@772..778 "field" [] [Whitespace(" ")],
+                            },
+                        },
+                    },
+                    JsDecorator {
+                        at_token: AT@778..779 "@" [] [],
+                        expression: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@779..785 "after" [] [Whitespace(" ")],
+                            },
+                        },
+                    },
+                    JsDecorator {
+                        at_token: AT@785..786 "@" [] [],
+                        expression: JsCallExpression {
+                            callee: JsParenthesizedExpression {
+                                l_paren_token: L_PAREN@786..787 "(" [] [],
+                                expression: JsArrowFunctionExpression {
+                                    async_token: missing (optional),
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameters {
+                                        l_paren_token: L_PAREN@787..788 "(" [] [],
+                                        items: JsParameterList [],
+                                        r_paren_token: R_PAREN@788..790 ")" [] [Whitespace(" ")],
+                                    },
+                                    return_type_annotation: missing (optional),
+                                    fat_arrow_token: FAT_ARROW@790..793 "=>" [] [Whitespace(" ")],
+                                    body: JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@793..802 "decorator" [] [],
+                                        },
+                                    },
+                                },
+                                r_paren_token: R_PAREN@802..803 ")" [] [],
+                            },
+                            optional_chain_token: missing (optional),
+                            type_arguments: missing (optional),
+                            arguments: JsCallArguments {
+                                l_paren_token: L_PAREN@803..804 "(" [] [],
+                                args: JsCallArgumentList [],
+                                r_paren_token: R_PAREN@804..806 ")" [] [Whitespace(" ")],
+                            },
+                        },
+                    },
+                ],
+                abstract_token: missing (optional),
+                class_token: CLASS_KW@806..812 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@812..816 "Bar" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@816..817 "{" [] [],
+                members: JsClassMemberList [],
+                r_curly_token: R_CURLY@817..818 "}" [] [],
+            },
+        },
     ],
-    eof_token: EOF@584..585 "" [Newline("\n")] [],
+    eof_token: EOF@818..819 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..585
+0: JS_MODULE@0..819
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..584
+  2: JS_MODULE_ITEM_LIST@0..818
     0: JS_VARIABLE_STATEMENT@0..49
       0: JS_VARIABLE_DECLARATION@0..48
         0: LET_KW@0..25 "let" [Comments("// class expressions"), Newline("\n")] [Whitespace(" ")]
@@ -770,8 +1037,9 @@ JsModule {
       8: JS_CLASS_MEMBER_LIST@427..427
       9: R_CURLY@427..428 "}" [] []
     13: JS_EXPORT@428..490
-      0: EXPORT_KW@428..467 "export" [Newline("\n"), Comments("// exported class dec ..."), Newline("\n")] [Whitespace(" ")]
-      1: JS_CLASS_DECLARATION@467..490
+      0: JS_DECORATOR_LIST@428..428
+      1: EXPORT_KW@428..467 "export" [Newline("\n"), Comments("// exported class dec ..."), Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@467..490
         0: JS_DECORATOR_LIST@467..478
           0: JS_DECORATOR@467..478
             0: AT@467..468 "@" [] []
@@ -791,8 +1059,9 @@ JsModule {
     14: JS_EMPTY_STATEMENT@490..491
       0: SEMICOLON@490..491 ";" [] []
     15: JS_EXPORT@491..548
-      0: EXPORT_KW@491..499 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_CLASS_DECLARATION@499..548
+      0: JS_DECORATOR_LIST@491..491
+      1: EXPORT_KW@491..499 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@499..548
         0: JS_DECORATOR_LIST@499..536
           0: JS_DECORATOR@499..510
             0: AT@499..500 "@" [] []
@@ -832,8 +1101,9 @@ JsModule {
     16: JS_EMPTY_STATEMENT@548..549
       0: SEMICOLON@548..549 ";" [] []
     17: JS_EXPORT@549..584
-      0: EXPORT_KW@549..557 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_CLASS_DECLARATION@557..584
+      0: JS_DECORATOR_LIST@549..549
+      1: EXPORT_KW@549..557 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@557..584
         0: JS_DECORATOR_LIST@557..572
           0: JS_DECORATOR@557..564
             0: AT@557..558 "@" [] []
@@ -855,4 +1125,193 @@ JsModule {
         7: L_CURLY@582..583 "{" [] []
         8: JS_CLASS_MEMBER_LIST@583..583
         9: R_CURLY@583..584 "}" [] []
-  3: EOF@584..585 "" [Newline("\n")] []
+    18: JS_EXPORT@584..616
+      0: JS_DECORATOR_LIST@584..595
+        0: JS_DECORATOR@584..595
+          0: AT@584..586 "@" [Newline("\n")] []
+          1: JS_IDENTIFIER_EXPRESSION@586..595
+            0: JS_REFERENCE_IDENTIFIER@586..595
+              0: IDENT@586..595 "decorator" [] []
+      1: EXPORT_KW@595..603 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@603..616
+        0: JS_DECORATOR_LIST@603..603
+        1: (empty)
+        2: CLASS_KW@603..609 "class" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@609..613
+          0: IDENT@609..613 "Foo" [] [Whitespace(" ")]
+        4: (empty)
+        5: (empty)
+        6: (empty)
+        7: L_CURLY@613..615 "{" [] [Whitespace(" ")]
+        8: JS_CLASS_MEMBER_LIST@615..615
+        9: R_CURLY@615..616 "}" [] []
+    19: JS_EXPORT@616..678
+      0: JS_DECORATOR_LIST@616..658
+        0: JS_DECORATOR@616..630
+          0: AT@616..618 "@" [Newline("\n")] []
+          1: JS_STATIC_MEMBER_EXPRESSION@618..630
+            0: JS_IDENTIFIER_EXPRESSION@618..623
+              0: JS_REFERENCE_IDENTIFIER@618..623
+                0: IDENT@618..623 "first" [] []
+            1: DOT@623..624 "." [] []
+            2: JS_NAME@624..630
+              0: IDENT@624..630 "field" [] [Whitespace(" ")]
+        1: JS_DECORATOR@630..638
+          0: AT@630..631 "@" [] []
+          1: JS_IDENTIFIER_EXPRESSION@631..638
+            0: JS_REFERENCE_IDENTIFIER@631..638
+              0: IDENT@631..638 "second" [] [Whitespace(" ")]
+        2: JS_DECORATOR@638..658
+          0: AT@638..639 "@" [] []
+          1: JS_CALL_EXPRESSION@639..658
+            0: JS_PARENTHESIZED_EXPRESSION@639..656
+              0: L_PAREN@639..640 "(" [] []
+              1: JS_ARROW_FUNCTION_EXPRESSION@640..655
+                0: (empty)
+                1: (empty)
+                2: JS_PARAMETERS@640..643
+                  0: L_PAREN@640..641 "(" [] []
+                  1: JS_PARAMETER_LIST@641..641
+                  2: R_PAREN@641..643 ")" [] [Whitespace(" ")]
+                3: (empty)
+                4: FAT_ARROW@643..646 "=>" [] [Whitespace(" ")]
+                5: JS_IDENTIFIER_EXPRESSION@646..655
+                  0: JS_REFERENCE_IDENTIFIER@646..655
+                    0: IDENT@646..655 "decorator" [] []
+              2: R_PAREN@655..656 ")" [] []
+            1: (empty)
+            2: (empty)
+            3: JS_CALL_ARGUMENTS@656..658
+              0: L_PAREN@656..657 "(" [] []
+              1: JS_CALL_ARGUMENT_LIST@657..657
+              2: R_PAREN@657..658 ")" [] []
+      1: EXPORT_KW@658..666 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@666..678
+        0: JS_DECORATOR_LIST@666..666
+        1: (empty)
+        2: CLASS_KW@666..672 "class" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@672..676
+          0: IDENT@672..676 "Bar" [] [Whitespace(" ")]
+        4: (empty)
+        5: (empty)
+        6: (empty)
+        7: L_CURLY@676..677 "{" [] []
+        8: JS_CLASS_MEMBER_LIST@677..677
+        9: R_CURLY@677..678 "}" [] []
+    20: JS_EXPORT@678..714
+      0: JS_DECORATOR_LIST@678..686
+        0: JS_DECORATOR@678..686
+          0: AT@678..680 "@" [Newline("\n")] []
+          1: JS_IDENTIFIER_EXPRESSION@680..686
+            0: JS_REFERENCE_IDENTIFIER@680..686
+              0: IDENT@680..686 "before" [] []
+      1: EXPORT_KW@686..694 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@694..714
+        0: JS_DECORATOR_LIST@694..701
+          0: JS_DECORATOR@694..701
+            0: AT@694..695 "@" [] []
+            1: JS_IDENTIFIER_EXPRESSION@695..701
+              0: JS_REFERENCE_IDENTIFIER@695..701
+                0: IDENT@695..701 "after" [] [Whitespace(" ")]
+        1: (empty)
+        2: CLASS_KW@701..707 "class" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@707..711
+          0: IDENT@707..711 "Foo" [] [Whitespace(" ")]
+        4: (empty)
+        5: (empty)
+        6: (empty)
+        7: L_CURLY@711..713 "{" [] [Whitespace(" ")]
+        8: JS_CLASS_MEMBER_LIST@713..713
+        9: R_CURLY@713..714 "}" [] []
+    21: JS_EXPORT@714..818
+      0: JS_DECORATOR_LIST@714..757
+        0: JS_DECORATOR@714..729
+          0: AT@714..716 "@" [Newline("\n")] []
+          1: JS_STATIC_MEMBER_EXPRESSION@716..729
+            0: JS_IDENTIFIER_EXPRESSION@716..722
+              0: JS_REFERENCE_IDENTIFIER@716..722
+                0: IDENT@716..722 "before" [] []
+            1: DOT@722..723 "." [] []
+            2: JS_NAME@723..729
+              0: IDENT@723..729 "field" [] [Whitespace(" ")]
+        1: JS_DECORATOR@729..737
+          0: AT@729..730 "@" [] []
+          1: JS_IDENTIFIER_EXPRESSION@730..737
+            0: JS_REFERENCE_IDENTIFIER@730..737
+              0: IDENT@730..737 "before" [] [Whitespace(" ")]
+        2: JS_DECORATOR@737..757
+          0: AT@737..738 "@" [] []
+          1: JS_CALL_EXPRESSION@738..757
+            0: JS_PARENTHESIZED_EXPRESSION@738..755
+              0: L_PAREN@738..739 "(" [] []
+              1: JS_ARROW_FUNCTION_EXPRESSION@739..754
+                0: (empty)
+                1: (empty)
+                2: JS_PARAMETERS@739..742
+                  0: L_PAREN@739..740 "(" [] []
+                  1: JS_PARAMETER_LIST@740..740
+                  2: R_PAREN@740..742 ")" [] [Whitespace(" ")]
+                3: (empty)
+                4: FAT_ARROW@742..745 "=>" [] [Whitespace(" ")]
+                5: JS_IDENTIFIER_EXPRESSION@745..754
+                  0: JS_REFERENCE_IDENTIFIER@745..754
+                    0: IDENT@745..754 "decorator" [] []
+              2: R_PAREN@754..755 ")" [] []
+            1: (empty)
+            2: (empty)
+            3: JS_CALL_ARGUMENTS@755..757
+              0: L_PAREN@755..756 "(" [] []
+              1: JS_CALL_ARGUMENT_LIST@756..756
+              2: R_PAREN@756..757 ")" [] []
+      1: EXPORT_KW@757..765 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@765..818
+        0: JS_DECORATOR_LIST@765..806
+          0: JS_DECORATOR@765..778
+            0: AT@765..766 "@" [] []
+            1: JS_STATIC_MEMBER_EXPRESSION@766..778
+              0: JS_IDENTIFIER_EXPRESSION@766..771
+                0: JS_REFERENCE_IDENTIFIER@766..771
+                  0: IDENT@766..771 "after" [] []
+              1: DOT@771..772 "." [] []
+              2: JS_NAME@772..778
+                0: IDENT@772..778 "field" [] [Whitespace(" ")]
+          1: JS_DECORATOR@778..785
+            0: AT@778..779 "@" [] []
+            1: JS_IDENTIFIER_EXPRESSION@779..785
+              0: JS_REFERENCE_IDENTIFIER@779..785
+                0: IDENT@779..785 "after" [] [Whitespace(" ")]
+          2: JS_DECORATOR@785..806
+            0: AT@785..786 "@" [] []
+            1: JS_CALL_EXPRESSION@786..806
+              0: JS_PARENTHESIZED_EXPRESSION@786..803
+                0: L_PAREN@786..787 "(" [] []
+                1: JS_ARROW_FUNCTION_EXPRESSION@787..802
+                  0: (empty)
+                  1: (empty)
+                  2: JS_PARAMETERS@787..790
+                    0: L_PAREN@787..788 "(" [] []
+                    1: JS_PARAMETER_LIST@788..788
+                    2: R_PAREN@788..790 ")" [] [Whitespace(" ")]
+                  3: (empty)
+                  4: FAT_ARROW@790..793 "=>" [] [Whitespace(" ")]
+                  5: JS_IDENTIFIER_EXPRESSION@793..802
+                    0: JS_REFERENCE_IDENTIFIER@793..802
+                      0: IDENT@793..802 "decorator" [] []
+                2: R_PAREN@802..803 ")" [] []
+              1: (empty)
+              2: (empty)
+              3: JS_CALL_ARGUMENTS@803..806
+                0: L_PAREN@803..804 "(" [] []
+                1: JS_CALL_ARGUMENT_LIST@804..804
+                2: R_PAREN@804..806 ")" [] [Whitespace(" ")]
+        1: (empty)
+        2: CLASS_KW@806..812 "class" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@812..816
+          0: IDENT@812..816 "Bar" [] [Whitespace(" ")]
+        4: (empty)
+        5: (empty)
+        6: (empty)
+        7: L_CURLY@816..817 "{" [] []
+        8: JS_CLASS_MEMBER_LIST@817..817
+        9: R_CURLY@817..818 "}" [] []
+  3: EOF@818..819 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator.ts
@@ -14,3 +14,11 @@ let c = @first @second class Foo {}
 export @decorator class Foo {};
 export @decorator @functionDecorator(1,2,3) class Bar {};
 export @first @second class Baz {}
+@decorator
+export class Foo { }
+@first.field @second @(() => decorator)()
+export class Bar {}
+@before
+export @after class Foo { }
+@before.field @before @(() => decorator)()
+export @after.field @after @(() => decorator)() class Bar {}

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_abstract_class_export_default_declaration_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_abstract_class_export_default_declaration_clause.rast
@@ -1,0 +1,67 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..10 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")],
+                declaration: JsClassExportDefaultDeclaration {
+                    decorators: JsDecoratorList [],
+                    abstract_token: ABSTRACT_KW@26..35 "abstract" [] [Whitespace(" ")],
+                    class_token: CLASS_KW@35..41 "class" [] [Whitespace(" ")],
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@41..45 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    implements_clause: missing (optional),
+                    l_curly_token: L_CURLY@45..47 "{" [] [Whitespace(" ")],
+                    members: JsClassMemberList [],
+                    r_curly_token: R_CURLY@47..48 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@48..49 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..49
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..48
+    0: JS_EXPORT@0..48
+      0: JS_DECORATOR_LIST@0..10
+        0: JS_DECORATOR@0..10
+          0: AT@0..1 "@" [] []
+          1: JS_IDENTIFIER_EXPRESSION@1..10
+            0: JS_REFERENCE_IDENTIFIER@1..10
+              0: IDENT@1..10 "decorator" [] []
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@18..48
+        0: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")]
+        1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@26..48
+          0: JS_DECORATOR_LIST@26..26
+          1: ABSTRACT_KW@26..35 "abstract" [] [Whitespace(" ")]
+          2: CLASS_KW@35..41 "class" [] [Whitespace(" ")]
+          3: JS_IDENTIFIER_BINDING@41..45
+            0: IDENT@41..45 "Foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: L_CURLY@45..47 "{" [] [Whitespace(" ")]
+          8: JS_CLASS_MEMBER_LIST@47..47
+          9: R_CURLY@47..48 "}" [] []
+        2: (empty)
+  3: EOF@48..49 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_abstract_class_export_default_declaration_clause.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_abstract_class_export_default_declaration_clause.ts
@@ -1,0 +1,2 @@
+@decorator
+export default abstract class Foo { }

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_class_export_default_declaration_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_class_export_default_declaration_clause.rast
@@ -1,0 +1,67 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..10 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")],
+                declaration: JsClassExportDefaultDeclaration {
+                    decorators: JsDecoratorList [],
+                    abstract_token: missing (optional),
+                    class_token: CLASS_KW@26..32 "class" [] [Whitespace(" ")],
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@32..36 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    implements_clause: missing (optional),
+                    l_curly_token: L_CURLY@36..38 "{" [] [Whitespace(" ")],
+                    members: JsClassMemberList [],
+                    r_curly_token: R_CURLY@38..39 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@39..40 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..40
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..39
+    0: JS_EXPORT@0..39
+      0: JS_DECORATOR_LIST@0..10
+        0: JS_DECORATOR@0..10
+          0: AT@0..1 "@" [] []
+          1: JS_IDENTIFIER_EXPRESSION@1..10
+            0: JS_REFERENCE_IDENTIFIER@1..10
+              0: IDENT@1..10 "decorator" [] []
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@18..39
+        0: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")]
+        1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@26..39
+          0: JS_DECORATOR_LIST@26..26
+          1: (empty)
+          2: CLASS_KW@26..32 "class" [] [Whitespace(" ")]
+          3: JS_IDENTIFIER_BINDING@32..36
+            0: IDENT@32..36 "Foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: L_CURLY@36..38 "{" [] [Whitespace(" ")]
+          8: JS_CLASS_MEMBER_LIST@38..38
+          9: R_CURLY@38..39 "}" [] []
+        2: (empty)
+  3: EOF@39..40 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_class_export_default_declaration_clause.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_class_export_default_declaration_clause.ts
@@ -1,0 +1,2 @@
+@decorator
+export default class Foo { }

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_class_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_class_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsClassDeclaration {
                 decorators: JsDecoratorList [
@@ -32,6 +33,7 @@ JsModule {
             semicolon_token: SEMICOLON@30..31 ";" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@31..39 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsClassDeclaration {
                 decorators: JsDecoratorList [
@@ -92,8 +94,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..88
     0: JS_EXPORT@0..30
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_CLASS_DECLARATION@7..30
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@7..30
         0: JS_DECORATOR_LIST@7..18
           0: JS_DECORATOR@7..18
             0: AT@7..8 "@" [] []
@@ -113,8 +116,9 @@ JsModule {
     1: JS_EMPTY_STATEMENT@30..31
       0: SEMICOLON@30..31 ";" [] []
     2: JS_EXPORT@31..88
-      0: EXPORT_KW@31..39 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_CLASS_DECLARATION@39..88
+      0: JS_DECORATOR_LIST@31..31
+      1: EXPORT_KW@31..39 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@39..88
         0: JS_DECORATOR_LIST@39..54
           0: JS_DECORATOR@39..46
             0: AT@39..40 "@" [] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_1.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_1.rast
@@ -1,0 +1,67 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..10 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")],
+                declaration: JsClassExportDefaultDeclaration {
+                    decorators: JsDecoratorList [],
+                    abstract_token: missing (optional),
+                    class_token: CLASS_KW@26..32 "class" [] [Whitespace(" ")],
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@32..36 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    implements_clause: missing (optional),
+                    l_curly_token: L_CURLY@36..38 "{" [] [Whitespace(" ")],
+                    members: JsClassMemberList [],
+                    r_curly_token: R_CURLY@38..39 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@39..40 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..40
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..39
+    0: JS_EXPORT@0..39
+      0: JS_DECORATOR_LIST@0..10
+        0: JS_DECORATOR@0..10
+          0: AT@0..1 "@" [] []
+          1: JS_IDENTIFIER_EXPRESSION@1..10
+            0: JS_REFERENCE_IDENTIFIER@1..10
+              0: IDENT@1..10 "decorator" [] []
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@18..39
+        0: DEFAULT_KW@18..26 "default" [] [Whitespace(" ")]
+        1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@26..39
+          0: JS_DECORATOR_LIST@26..26
+          1: (empty)
+          2: CLASS_KW@26..32 "class" [] [Whitespace(" ")]
+          3: JS_IDENTIFIER_BINDING@32..36
+            0: IDENT@32..36 "Foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: L_CURLY@36..38 "{" [] [Whitespace(" ")]
+          8: JS_CLASS_MEMBER_LIST@38..38
+          9: R_CURLY@38..39 "}" [] []
+        2: (empty)
+  3: EOF@39..40 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_1.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_1.ts
@@ -1,0 +1,2 @@
+@decorator
+export default class Foo { }

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_2.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_2.rast
@@ -1,0 +1,146 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsStaticMemberExpression {
+                        object: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@1..6 "first" [] [],
+                            },
+                        },
+                        operator_token: DOT@6..7 "." [] [],
+                        member: JsName {
+                            value_token: IDENT@7..13 "field" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+                JsDecorator {
+                    at_token: AT@13..14 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@14..21 "second" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+                JsDecorator {
+                    at_token: AT@21..22 "@" [] [],
+                    expression: JsCallExpression {
+                        callee: JsParenthesizedExpression {
+                            l_paren_token: L_PAREN@22..23 "(" [] [],
+                            expression: JsArrowFunctionExpression {
+                                async_token: missing (optional),
+                                type_parameters: missing (optional),
+                                parameters: JsParameters {
+                                    l_paren_token: L_PAREN@23..24 "(" [] [],
+                                    items: JsParameterList [],
+                                    r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                                },
+                                return_type_annotation: missing (optional),
+                                fat_arrow_token: FAT_ARROW@26..29 "=>" [] [Whitespace(" ")],
+                                body: JsIdentifierExpression {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@29..38 "decorator" [] [],
+                                    },
+                                },
+                            },
+                            r_paren_token: R_PAREN@38..39 ")" [] [],
+                        },
+                        optional_chain_token: missing (optional),
+                        type_arguments: missing (optional),
+                        arguments: JsCallArguments {
+                            l_paren_token: L_PAREN@39..40 "(" [] [],
+                            args: JsCallArgumentList [],
+                            r_paren_token: R_PAREN@40..41 ")" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@41..49 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@49..57 "default" [] [Whitespace(" ")],
+                declaration: JsClassExportDefaultDeclaration {
+                    decorators: JsDecoratorList [],
+                    abstract_token: missing (optional),
+                    class_token: CLASS_KW@57..63 "class" [] [Whitespace(" ")],
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@63..67 "Bar" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    implements_clause: missing (optional),
+                    l_curly_token: L_CURLY@67..68 "{" [] [],
+                    members: JsClassMemberList [],
+                    r_curly_token: R_CURLY@68..69 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@69..70 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..70
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..69
+    0: JS_EXPORT@0..69
+      0: JS_DECORATOR_LIST@0..41
+        0: JS_DECORATOR@0..13
+          0: AT@0..1 "@" [] []
+          1: JS_STATIC_MEMBER_EXPRESSION@1..13
+            0: JS_IDENTIFIER_EXPRESSION@1..6
+              0: JS_REFERENCE_IDENTIFIER@1..6
+                0: IDENT@1..6 "first" [] []
+            1: DOT@6..7 "." [] []
+            2: JS_NAME@7..13
+              0: IDENT@7..13 "field" [] [Whitespace(" ")]
+        1: JS_DECORATOR@13..21
+          0: AT@13..14 "@" [] []
+          1: JS_IDENTIFIER_EXPRESSION@14..21
+            0: JS_REFERENCE_IDENTIFIER@14..21
+              0: IDENT@14..21 "second" [] [Whitespace(" ")]
+        2: JS_DECORATOR@21..41
+          0: AT@21..22 "@" [] []
+          1: JS_CALL_EXPRESSION@22..41
+            0: JS_PARENTHESIZED_EXPRESSION@22..39
+              0: L_PAREN@22..23 "(" [] []
+              1: JS_ARROW_FUNCTION_EXPRESSION@23..38
+                0: (empty)
+                1: (empty)
+                2: JS_PARAMETERS@23..26
+                  0: L_PAREN@23..24 "(" [] []
+                  1: JS_PARAMETER_LIST@24..24
+                  2: R_PAREN@24..26 ")" [] [Whitespace(" ")]
+                3: (empty)
+                4: FAT_ARROW@26..29 "=>" [] [Whitespace(" ")]
+                5: JS_IDENTIFIER_EXPRESSION@29..38
+                  0: JS_REFERENCE_IDENTIFIER@29..38
+                    0: IDENT@29..38 "decorator" [] []
+              2: R_PAREN@38..39 ")" [] []
+            1: (empty)
+            2: (empty)
+            3: JS_CALL_ARGUMENTS@39..41
+              0: L_PAREN@39..40 "(" [] []
+              1: JS_CALL_ARGUMENT_LIST@40..40
+              2: R_PAREN@40..41 ")" [] []
+      1: EXPORT_KW@41..49 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@49..69
+        0: DEFAULT_KW@49..57 "default" [] [Whitespace(" ")]
+        1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@57..69
+          0: JS_DECORATOR_LIST@57..57
+          1: (empty)
+          2: CLASS_KW@57..63 "class" [] [Whitespace(" ")]
+          3: JS_IDENTIFIER_BINDING@63..67
+            0: IDENT@63..67 "Bar" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: L_CURLY@67..68 "{" [] []
+          8: JS_CLASS_MEMBER_LIST@68..68
+          9: R_CURLY@68..69 "}" [] []
+        2: (empty)
+  3: EOF@69..70 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_2.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_2.ts
@@ -1,0 +1,2 @@
+@first.field @second @(() => decorator)()
+export default class Bar {}

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_3.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_3.rast
@@ -1,0 +1,81 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..7 "before" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@7..15 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@15..23 "default" [] [Whitespace(" ")],
+                declaration: JsClassExportDefaultDeclaration {
+                    decorators: JsDecoratorList [
+                        JsDecorator {
+                            at_token: AT@23..24 "@" [] [],
+                            expression: JsIdentifierExpression {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@24..30 "after" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                    ],
+                    abstract_token: missing (optional),
+                    class_token: CLASS_KW@30..36 "class" [] [Whitespace(" ")],
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@36..40 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    implements_clause: missing (optional),
+                    l_curly_token: L_CURLY@40..42 "{" [] [Whitespace(" ")],
+                    members: JsClassMemberList [],
+                    r_curly_token: R_CURLY@42..43 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@43..44 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..44
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..43
+    0: JS_EXPORT@0..43
+      0: JS_DECORATOR_LIST@0..7
+        0: JS_DECORATOR@0..7
+          0: AT@0..1 "@" [] []
+          1: JS_IDENTIFIER_EXPRESSION@1..7
+            0: JS_REFERENCE_IDENTIFIER@1..7
+              0: IDENT@1..7 "before" [] []
+      1: EXPORT_KW@7..15 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@15..43
+        0: DEFAULT_KW@15..23 "default" [] [Whitespace(" ")]
+        1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@23..43
+          0: JS_DECORATOR_LIST@23..30
+            0: JS_DECORATOR@23..30
+              0: AT@23..24 "@" [] []
+              1: JS_IDENTIFIER_EXPRESSION@24..30
+                0: JS_REFERENCE_IDENTIFIER@24..30
+                  0: IDENT@24..30 "after" [] [Whitespace(" ")]
+          1: (empty)
+          2: CLASS_KW@30..36 "class" [] [Whitespace(" ")]
+          3: JS_IDENTIFIER_BINDING@36..40
+            0: IDENT@36..40 "Foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: L_CURLY@40..42 "{" [] [Whitespace(" ")]
+          8: JS_CLASS_MEMBER_LIST@42..42
+          9: R_CURLY@42..43 "}" [] []
+        2: (empty)
+  3: EOF@43..44 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_3.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_3.ts
@@ -1,0 +1,2 @@
+@before
+export default @after class Foo { }

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_4.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_4.rast
@@ -1,0 +1,67 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@0..2 "@" [Whitespace(" ")] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@2..8 "before" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@8..17 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@17..25 "default" [] [Whitespace(" ")],
+                declaration: JsClassExportDefaultDeclaration {
+                    decorators: JsDecoratorList [],
+                    abstract_token: ABSTRACT_KW@25..34 "abstract" [] [Whitespace(" ")],
+                    class_token: CLASS_KW@34..40 "class" [] [Whitespace(" ")],
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@40..44 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    implements_clause: missing (optional),
+                    l_curly_token: L_CURLY@44..46 "{" [] [Whitespace(" ")],
+                    members: JsClassMemberList [],
+                    r_curly_token: R_CURLY@46..47 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@47..48 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..48
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..47
+    0: JS_EXPORT@0..47
+      0: JS_DECORATOR_LIST@0..8
+        0: JS_DECORATOR@0..8
+          0: AT@0..2 "@" [Whitespace(" ")] []
+          1: JS_IDENTIFIER_EXPRESSION@2..8
+            0: JS_REFERENCE_IDENTIFIER@2..8
+              0: IDENT@2..8 "before" [] []
+      1: EXPORT_KW@8..17 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@17..47
+        0: DEFAULT_KW@17..25 "default" [] [Whitespace(" ")]
+        1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@25..47
+          0: JS_DECORATOR_LIST@25..25
+          1: ABSTRACT_KW@25..34 "abstract" [] [Whitespace(" ")]
+          2: CLASS_KW@34..40 "class" [] [Whitespace(" ")]
+          3: JS_IDENTIFIER_BINDING@40..44
+            0: IDENT@40..44 "Foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: L_CURLY@44..46 "{" [] [Whitespace(" ")]
+          8: JS_CLASS_MEMBER_LIST@46..46
+          9: R_CURLY@46..47 "}" [] []
+        2: (empty)
+  3: EOF@47..48 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_4.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_4.ts
@@ -1,0 +1,2 @@
+ @before
+ export default abstract class Foo { }

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_5.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_5.rast
@@ -1,0 +1,81 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@0..2 "@" [Whitespace(" ")] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@2..8 "before" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@8..17 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
+            export_clause: JsExportDefaultDeclarationClause {
+                default_token: DEFAULT_KW@17..25 "default" [] [Whitespace(" ")],
+                declaration: JsClassExportDefaultDeclaration {
+                    decorators: JsDecoratorList [
+                        JsDecorator {
+                            at_token: AT@25..26 "@" [] [],
+                            expression: JsIdentifierExpression {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@26..32 "after" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                    ],
+                    abstract_token: ABSTRACT_KW@32..41 "abstract" [] [Whitespace(" ")],
+                    class_token: CLASS_KW@41..47 "class" [] [Whitespace(" ")],
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@47..51 "Foo" [] [Whitespace(" ")],
+                    },
+                    type_parameters: missing (optional),
+                    extends_clause: missing (optional),
+                    implements_clause: missing (optional),
+                    l_curly_token: L_CURLY@51..53 "{" [] [Whitespace(" ")],
+                    members: JsClassMemberList [],
+                    r_curly_token: R_CURLY@53..54 "}" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@54..55 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..55
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..54
+    0: JS_EXPORT@0..54
+      0: JS_DECORATOR_LIST@0..8
+        0: JS_DECORATOR@0..8
+          0: AT@0..2 "@" [Whitespace(" ")] []
+          1: JS_IDENTIFIER_EXPRESSION@2..8
+            0: JS_REFERENCE_IDENTIFIER@2..8
+              0: IDENT@2..8 "before" [] []
+      1: EXPORT_KW@8..17 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@17..54
+        0: DEFAULT_KW@17..25 "default" [] [Whitespace(" ")]
+        1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@25..54
+          0: JS_DECORATOR_LIST@25..32
+            0: JS_DECORATOR@25..32
+              0: AT@25..26 "@" [] []
+              1: JS_IDENTIFIER_EXPRESSION@26..32
+                0: JS_REFERENCE_IDENTIFIER@26..32
+                  0: IDENT@26..32 "after" [] [Whitespace(" ")]
+          1: ABSTRACT_KW@32..41 "abstract" [] [Whitespace(" ")]
+          2: CLASS_KW@41..47 "class" [] [Whitespace(" ")]
+          3: JS_IDENTIFIER_BINDING@47..51
+            0: IDENT@47..51 "Foo" [] [Whitespace(" ")]
+          4: (empty)
+          5: (empty)
+          6: (empty)
+          7: L_CURLY@51..53 "{" [] [Whitespace(" ")]
+          8: JS_CLASS_MEMBER_LIST@53..53
+          9: R_CURLY@53..54 "}" [] []
+        2: (empty)
+  3: EOF@54..55 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_5.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_default_top_level_5.ts
@@ -1,0 +1,2 @@
+ @before
+ export default @after abstract class Foo { }

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_top_level.js
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_top_level.js
@@ -1,0 +1,10 @@
+@decorator
+export class Foo { }
+@first.field @second @(() => decorator)()
+export class Bar {}
+@before
+export @after class Foo { }
+ @before
+ export abstract class Foo { }
+ @before
+ export @after abstract class Foo { }

--- a/crates/rome_js_parser/test_data/inline/ok/decorator_export_top_level.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/decorator_export_top_level.rast
@@ -1,0 +1,355 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@0..1 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@1..10 "decorator" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                decorators: JsDecoratorList [],
+                abstract_token: missing (optional),
+                class_token: CLASS_KW@18..24 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@24..28 "Foo" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@28..30 "{" [] [Whitespace(" ")],
+                members: JsClassMemberList [],
+                r_curly_token: R_CURLY@30..31 "}" [] [],
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@31..33 "@" [Newline("\n")] [],
+                    expression: JsStaticMemberExpression {
+                        object: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@33..38 "first" [] [],
+                            },
+                        },
+                        operator_token: DOT@38..39 "." [] [],
+                        member: JsName {
+                            value_token: IDENT@39..45 "field" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+                JsDecorator {
+                    at_token: AT@45..46 "@" [] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@46..53 "second" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+                JsDecorator {
+                    at_token: AT@53..54 "@" [] [],
+                    expression: JsCallExpression {
+                        callee: JsParenthesizedExpression {
+                            l_paren_token: L_PAREN@54..55 "(" [] [],
+                            expression: JsArrowFunctionExpression {
+                                async_token: missing (optional),
+                                type_parameters: missing (optional),
+                                parameters: JsParameters {
+                                    l_paren_token: L_PAREN@55..56 "(" [] [],
+                                    items: JsParameterList [],
+                                    r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                },
+                                return_type_annotation: missing (optional),
+                                fat_arrow_token: FAT_ARROW@58..61 "=>" [] [Whitespace(" ")],
+                                body: JsIdentifierExpression {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@61..70 "decorator" [] [],
+                                    },
+                                },
+                            },
+                            r_paren_token: R_PAREN@70..71 ")" [] [],
+                        },
+                        optional_chain_token: missing (optional),
+                        type_arguments: missing (optional),
+                        arguments: JsCallArguments {
+                            l_paren_token: L_PAREN@71..72 "(" [] [],
+                            args: JsCallArgumentList [],
+                            r_paren_token: R_PAREN@72..73 ")" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@73..81 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                decorators: JsDecoratorList [],
+                abstract_token: missing (optional),
+                class_token: CLASS_KW@81..87 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@87..91 "Bar" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@91..92 "{" [] [],
+                members: JsClassMemberList [],
+                r_curly_token: R_CURLY@92..93 "}" [] [],
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@93..95 "@" [Newline("\n")] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@95..101 "before" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@101..109 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                decorators: JsDecoratorList [
+                    JsDecorator {
+                        at_token: AT@109..110 "@" [] [],
+                        expression: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@110..116 "after" [] [Whitespace(" ")],
+                            },
+                        },
+                    },
+                ],
+                abstract_token: missing (optional),
+                class_token: CLASS_KW@116..122 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@122..126 "Foo" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@126..128 "{" [] [Whitespace(" ")],
+                members: JsClassMemberList [],
+                r_curly_token: R_CURLY@128..129 "}" [] [],
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@129..132 "@" [Newline("\n"), Whitespace(" ")] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@132..138 "before" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@138..147 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                decorators: JsDecoratorList [],
+                abstract_token: ABSTRACT_KW@147..156 "abstract" [] [Whitespace(" ")],
+                class_token: CLASS_KW@156..162 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@162..166 "Foo" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@166..168 "{" [] [Whitespace(" ")],
+                members: JsClassMemberList [],
+                r_curly_token: R_CURLY@168..169 "}" [] [],
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [
+                JsDecorator {
+                    at_token: AT@169..172 "@" [Newline("\n"), Whitespace(" ")] [],
+                    expression: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@172..178 "before" [] [],
+                        },
+                    },
+                },
+            ],
+            export_token: EXPORT_KW@178..187 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                decorators: JsDecoratorList [
+                    JsDecorator {
+                        at_token: AT@187..188 "@" [] [],
+                        expression: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@188..194 "after" [] [Whitespace(" ")],
+                            },
+                        },
+                    },
+                ],
+                abstract_token: ABSTRACT_KW@194..203 "abstract" [] [Whitespace(" ")],
+                class_token: CLASS_KW@203..209 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@209..213 "Foo" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@213..215 "{" [] [Whitespace(" ")],
+                members: JsClassMemberList [],
+                r_curly_token: R_CURLY@215..216 "}" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@216..217 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..217
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..216
+    0: JS_EXPORT@0..31
+      0: JS_DECORATOR_LIST@0..10
+        0: JS_DECORATOR@0..10
+          0: AT@0..1 "@" [] []
+          1: JS_IDENTIFIER_EXPRESSION@1..10
+            0: JS_REFERENCE_IDENTIFIER@1..10
+              0: IDENT@1..10 "decorator" [] []
+      1: EXPORT_KW@10..18 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@18..31
+        0: JS_DECORATOR_LIST@18..18
+        1: (empty)
+        2: CLASS_KW@18..24 "class" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@24..28
+          0: IDENT@24..28 "Foo" [] [Whitespace(" ")]
+        4: (empty)
+        5: (empty)
+        6: (empty)
+        7: L_CURLY@28..30 "{" [] [Whitespace(" ")]
+        8: JS_CLASS_MEMBER_LIST@30..30
+        9: R_CURLY@30..31 "}" [] []
+    1: JS_EXPORT@31..93
+      0: JS_DECORATOR_LIST@31..73
+        0: JS_DECORATOR@31..45
+          0: AT@31..33 "@" [Newline("\n")] []
+          1: JS_STATIC_MEMBER_EXPRESSION@33..45
+            0: JS_IDENTIFIER_EXPRESSION@33..38
+              0: JS_REFERENCE_IDENTIFIER@33..38
+                0: IDENT@33..38 "first" [] []
+            1: DOT@38..39 "." [] []
+            2: JS_NAME@39..45
+              0: IDENT@39..45 "field" [] [Whitespace(" ")]
+        1: JS_DECORATOR@45..53
+          0: AT@45..46 "@" [] []
+          1: JS_IDENTIFIER_EXPRESSION@46..53
+            0: JS_REFERENCE_IDENTIFIER@46..53
+              0: IDENT@46..53 "second" [] [Whitespace(" ")]
+        2: JS_DECORATOR@53..73
+          0: AT@53..54 "@" [] []
+          1: JS_CALL_EXPRESSION@54..73
+            0: JS_PARENTHESIZED_EXPRESSION@54..71
+              0: L_PAREN@54..55 "(" [] []
+              1: JS_ARROW_FUNCTION_EXPRESSION@55..70
+                0: (empty)
+                1: (empty)
+                2: JS_PARAMETERS@55..58
+                  0: L_PAREN@55..56 "(" [] []
+                  1: JS_PARAMETER_LIST@56..56
+                  2: R_PAREN@56..58 ")" [] [Whitespace(" ")]
+                3: (empty)
+                4: FAT_ARROW@58..61 "=>" [] [Whitespace(" ")]
+                5: JS_IDENTIFIER_EXPRESSION@61..70
+                  0: JS_REFERENCE_IDENTIFIER@61..70
+                    0: IDENT@61..70 "decorator" [] []
+              2: R_PAREN@70..71 ")" [] []
+            1: (empty)
+            2: (empty)
+            3: JS_CALL_ARGUMENTS@71..73
+              0: L_PAREN@71..72 "(" [] []
+              1: JS_CALL_ARGUMENT_LIST@72..72
+              2: R_PAREN@72..73 ")" [] []
+      1: EXPORT_KW@73..81 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@81..93
+        0: JS_DECORATOR_LIST@81..81
+        1: (empty)
+        2: CLASS_KW@81..87 "class" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@87..91
+          0: IDENT@87..91 "Bar" [] [Whitespace(" ")]
+        4: (empty)
+        5: (empty)
+        6: (empty)
+        7: L_CURLY@91..92 "{" [] []
+        8: JS_CLASS_MEMBER_LIST@92..92
+        9: R_CURLY@92..93 "}" [] []
+    2: JS_EXPORT@93..129
+      0: JS_DECORATOR_LIST@93..101
+        0: JS_DECORATOR@93..101
+          0: AT@93..95 "@" [Newline("\n")] []
+          1: JS_IDENTIFIER_EXPRESSION@95..101
+            0: JS_REFERENCE_IDENTIFIER@95..101
+              0: IDENT@95..101 "before" [] []
+      1: EXPORT_KW@101..109 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@109..129
+        0: JS_DECORATOR_LIST@109..116
+          0: JS_DECORATOR@109..116
+            0: AT@109..110 "@" [] []
+            1: JS_IDENTIFIER_EXPRESSION@110..116
+              0: JS_REFERENCE_IDENTIFIER@110..116
+                0: IDENT@110..116 "after" [] [Whitespace(" ")]
+        1: (empty)
+        2: CLASS_KW@116..122 "class" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@122..126
+          0: IDENT@122..126 "Foo" [] [Whitespace(" ")]
+        4: (empty)
+        5: (empty)
+        6: (empty)
+        7: L_CURLY@126..128 "{" [] [Whitespace(" ")]
+        8: JS_CLASS_MEMBER_LIST@128..128
+        9: R_CURLY@128..129 "}" [] []
+    3: JS_EXPORT@129..169
+      0: JS_DECORATOR_LIST@129..138
+        0: JS_DECORATOR@129..138
+          0: AT@129..132 "@" [Newline("\n"), Whitespace(" ")] []
+          1: JS_IDENTIFIER_EXPRESSION@132..138
+            0: JS_REFERENCE_IDENTIFIER@132..138
+              0: IDENT@132..138 "before" [] []
+      1: EXPORT_KW@138..147 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@147..169
+        0: JS_DECORATOR_LIST@147..147
+        1: ABSTRACT_KW@147..156 "abstract" [] [Whitespace(" ")]
+        2: CLASS_KW@156..162 "class" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@162..166
+          0: IDENT@162..166 "Foo" [] [Whitespace(" ")]
+        4: (empty)
+        5: (empty)
+        6: (empty)
+        7: L_CURLY@166..168 "{" [] [Whitespace(" ")]
+        8: JS_CLASS_MEMBER_LIST@168..168
+        9: R_CURLY@168..169 "}" [] []
+    4: JS_EXPORT@169..216
+      0: JS_DECORATOR_LIST@169..178
+        0: JS_DECORATOR@169..178
+          0: AT@169..172 "@" [Newline("\n"), Whitespace(" ")] []
+          1: JS_IDENTIFIER_EXPRESSION@172..178
+            0: JS_REFERENCE_IDENTIFIER@172..178
+              0: IDENT@172..178 "before" [] []
+      1: EXPORT_KW@178..187 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@187..216
+        0: JS_DECORATOR_LIST@187..194
+          0: JS_DECORATOR@187..194
+            0: AT@187..188 "@" [] []
+            1: JS_IDENTIFIER_EXPRESSION@188..194
+              0: JS_REFERENCE_IDENTIFIER@188..194
+                0: IDENT@188..194 "after" [] [Whitespace(" ")]
+        1: ABSTRACT_KW@194..203 "abstract" [] [Whitespace(" ")]
+        2: CLASS_KW@203..209 "class" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@209..213
+          0: IDENT@209..213 "Foo" [] [Whitespace(" ")]
+        4: (empty)
+        5: (empty)
+        6: (empty)
+        7: L_CURLY@213..215 "{" [] [Whitespace(" ")]
+        8: JS_CLASS_MEMBER_LIST@215..215
+        9: R_CURLY@215..216 "}" [] []
+  3: EOF@216..217 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/export_as_identifier.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_as_identifier.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -20,6 +21,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@14..22 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -49,8 +51,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..34
     0: JS_EXPORT@0..14
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@7..14
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@7..14
         0: (empty)
         1: L_CURLY@7..9 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@9..12
@@ -61,8 +64,9 @@ JsModule {
         3: R_CURLY@12..13 "}" [] []
         4: SEMICOLON@13..14 ";" [] []
     1: JS_EXPORT@14..34
-      0: EXPORT_KW@14..22 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@22..34
+      0: JS_DECORATOR_LIST@14..14
+      1: EXPORT_KW@14..22 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@22..34
         0: (empty)
         1: L_CURLY@22..24 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@24..33

--- a/crates/rome_js_parser/test_data/inline/ok/export_class_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_class_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsClassDeclaration {
                 decorators: JsDecoratorList [],
@@ -20,6 +21,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@17..25 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsClassDeclaration {
                 decorators: JsDecoratorList [],
@@ -53,8 +55,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..45
     0: JS_EXPORT@0..17
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_CLASS_DECLARATION@7..17
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@7..17
         0: JS_DECORATOR_LIST@7..7
         1: (empty)
         2: CLASS_KW@7..13 "class" [] [Whitespace(" ")]
@@ -67,8 +70,9 @@ JsModule {
         8: JS_CLASS_MEMBER_LIST@16..16
         9: R_CURLY@16..17 "}" [] []
     1: JS_EXPORT@17..45
-      0: EXPORT_KW@17..25 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_CLASS_DECLARATION@25..45
+      0: JS_DECORATOR_LIST@17..17
+      1: EXPORT_KW@17..25 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@25..45
         0: JS_DECORATOR_LIST@25..25
         1: (empty)
         2: CLASS_KW@25..31 "class" [] [Whitespace(" ")]

--- a/crates/rome_js_parser/test_data/inline/ok/export_default_class_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_default_class_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
@@ -30,8 +31,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..23
     0: JS_EXPORT@0..23
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..23
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..23
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@15..23
           0: JS_DECORATOR_LIST@15..15

--- a/crates/rome_js_parser/test_data/inline/ok/export_default_expression_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_default_expression_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportDefaultExpressionClause {
                 default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
@@ -23,8 +24,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..17
     0: JS_EXPORT@0..17
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE@7..17
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE@7..17
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: JS_IDENTIFIER_EXPRESSION@15..16
           0: JS_REFERENCE_IDENTIFIER@15..16

--- a/crates/rome_js_parser/test_data/inline/ok/export_default_function_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_default_function_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
@@ -57,8 +58,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..37
     0: JS_EXPORT@0..37
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..37
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..37
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: JS_FUNCTION_EXPORT_DEFAULT_DECLARATION@15..37
           0: (empty)

--- a/crates/rome_js_parser/test_data/inline/ok/export_from_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_from_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -31,6 +32,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@37..45 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -59,6 +61,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@71..79 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: missing (optional),
@@ -73,6 +76,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@90..98 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: missing (optional),
@@ -92,6 +96,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@114..122 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: missing (optional),
@@ -111,6 +116,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@143..151 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: missing (optional),
@@ -136,6 +142,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@185..193 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: TYPE_KW@193..198 "type" [] [Whitespace(" ")],
@@ -150,6 +157,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@213..221 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 type_token: TYPE_KW@221..226 "type" [] [Whitespace(" ")],
@@ -177,8 +185,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..250
     0: JS_EXPORT@0..37
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@7..37
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@7..37
         0: (empty)
         1: L_CURLY@7..8 "{" [] []
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@8..26
@@ -197,8 +206,9 @@ JsModule {
         6: (empty)
         7: SEMICOLON@36..37 ";" [] []
     1: JS_EXPORT@37..71
-      0: EXPORT_KW@37..45 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@45..71
+      0: JS_DECORATOR_LIST@37..37
+      1: EXPORT_KW@37..45 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@45..71
         0: (empty)
         1: L_CURLY@45..47 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@47..60
@@ -217,8 +227,9 @@ JsModule {
         6: (empty)
         7: SEMICOLON@70..71 ";" [] []
     2: JS_EXPORT@71..90
-      0: EXPORT_KW@71..79 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@79..90
+      0: JS_DECORATOR_LIST@71..71
+      1: EXPORT_KW@71..79 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@79..90
         0: (empty)
         1: STAR@79..81 "*" [] [Whitespace(" ")]
         2: (empty)
@@ -228,8 +239,9 @@ JsModule {
         5: (empty)
         6: SEMICOLON@89..90 ";" [] []
     3: JS_EXPORT@90..114
-      0: EXPORT_KW@90..98 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@98..114
+      0: JS_DECORATOR_LIST@90..90
+      1: EXPORT_KW@90..98 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@98..114
         0: (empty)
         1: STAR@98..100 "*" [] [Whitespace(" ")]
         2: JS_EXPORT_AS_CLAUSE@100..105
@@ -242,8 +254,9 @@ JsModule {
         5: (empty)
         6: SEMICOLON@113..114 ";" [] []
     4: JS_EXPORT@114..143
-      0: EXPORT_KW@114..122 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@122..143
+      0: JS_DECORATOR_LIST@114..114
+      1: EXPORT_KW@114..122 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@122..143
         0: (empty)
         1: STAR@122..124 "*" [] [Whitespace(" ")]
         2: JS_EXPORT_AS_CLAUSE@124..135
@@ -256,8 +269,9 @@ JsModule {
         5: (empty)
         6: (empty)
     5: JS_EXPORT@143..185
-      0: EXPORT_KW@143..151 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@151..185
+      0: JS_DECORATOR_LIST@143..143
+      1: EXPORT_KW@143..151 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@151..185
         0: (empty)
         1: STAR@151..153 "*" [] [Whitespace(" ")]
         2: (empty)
@@ -275,8 +289,9 @@ JsModule {
           3: R_CURLY@184..185 "}" [] []
         6: (empty)
     6: JS_EXPORT@185..213
-      0: EXPORT_KW@185..193 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@193..213
+      0: JS_DECORATOR_LIST@185..185
+      1: EXPORT_KW@185..193 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@193..213
         0: TYPE_KW@193..198 "type" [] [Whitespace(" ")]
         1: STAR@198..200 "*" [] [Whitespace(" ")]
         2: (empty)
@@ -286,8 +301,9 @@ JsModule {
         5: (empty)
         6: SEMICOLON@212..213 ";" [] []
     7: JS_EXPORT@213..250
-      0: EXPORT_KW@213..221 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_FROM_CLAUSE@221..250
+      0: JS_DECORATOR_LIST@213..213
+      1: EXPORT_KW@213..221 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_FROM_CLAUSE@221..250
         0: TYPE_KW@221..226 "type" [] [Whitespace(" ")]
         1: STAR@226..228 "*" [] [Whitespace(" ")]
         2: JS_EXPORT_AS_CLAUSE@228..237

--- a/crates/rome_js_parser/test_data/inline/ok/export_function_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_function_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsFunctionDeclaration {
                 async_token: missing (optional),
@@ -45,6 +46,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@29..37 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsFunctionDeclaration {
                 async_token: missing (optional),
@@ -87,6 +89,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@61..69 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsFunctionDeclaration {
                 async_token: ASYNC_KW@69..75 "async" [] [Whitespace(" ")],
@@ -138,8 +141,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..100
     0: JS_EXPORT@0..29
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_FUNCTION_DECLARATION@7..29
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_FUNCTION_DECLARATION@7..29
         0: (empty)
         1: FUNCTION_KW@7..16 "function" [] [Whitespace(" ")]
         2: (empty)
@@ -170,8 +174,9 @@ JsModule {
           2: JS_STATEMENT_LIST@28..28
           3: R_CURLY@28..29 "}" [] []
     1: JS_EXPORT@29..61
-      0: EXPORT_KW@29..37 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_FUNCTION_DECLARATION@37..61
+      0: JS_DECORATOR_LIST@29..29
+      1: EXPORT_KW@29..37 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_FUNCTION_DECLARATION@37..61
         0: (empty)
         1: FUNCTION_KW@37..45 "function" [] []
         2: STAR@45..47 "*" [] [Whitespace(" ")]
@@ -202,8 +207,9 @@ JsModule {
           2: JS_STATEMENT_LIST@60..60
           3: R_CURLY@60..61 "}" [] []
     2: JS_EXPORT@61..100
-      0: EXPORT_KW@61..69 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_FUNCTION_DECLARATION@69..100
+      0: JS_DECORATOR_LIST@61..61
+      1: EXPORT_KW@61..69 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_FUNCTION_DECLARATION@69..100
         0: ASYNC_KW@69..75 "async" [] [Whitespace(" ")]
         1: FUNCTION_KW@75..84 "function" [] [Whitespace(" ")]
         2: (empty)

--- a/crates/rome_js_parser/test_data/inline/ok/export_named_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_named_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -20,6 +21,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -63,6 +65,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@55..63 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -88,8 +91,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..70
     0: JS_EXPORT@0..13
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@7..13
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@7..13
         0: (empty)
         1: L_CURLY@7..9 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@9..11
@@ -100,8 +104,9 @@ JsModule {
         3: R_CURLY@11..12 "}" [] []
         4: SEMICOLON@12..13 ";" [] []
     1: JS_EXPORT@13..55
-      0: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@21..55
+      0: JS_DECORATOR_LIST@13..13
+      1: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@21..55
         0: (empty)
         1: L_CURLY@21..23 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@23..54
@@ -131,8 +136,9 @@ JsModule {
         3: R_CURLY@54..55 "}" [] []
         4: (empty)
     2: JS_EXPORT@55..70
-      0: EXPORT_KW@55..63 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@63..70
+      0: JS_DECORATOR_LIST@55..55
+      1: EXPORT_KW@55..63 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@63..70
         0: (empty)
         1: L_CURLY@63..65 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@65..68

--- a/crates/rome_js_parser/test_data/inline/ok/export_named_from_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_named_from_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -34,6 +35,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -88,6 +90,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -111,6 +114,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@112..120 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -139,6 +143,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@150..158 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -167,6 +172,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@182..190 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -201,6 +207,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@228..236 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -224,6 +231,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@257..265 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -255,8 +263,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..291
     0: JS_EXPORT@0..33
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@7..33
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@7..33
         0: (empty)
         1: L_CURLY@7..9 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@9..20
@@ -278,8 +287,9 @@ JsModule {
         6: (empty)
         7: SEMICOLON@32..33 ";" [] []
     1: JS_EXPORT@33..86
-      0: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@41..86
+      0: JS_DECORATOR_LIST@33..33
+      1: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@41..86
         0: (empty)
         1: L_CURLY@41..43 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@43..74
@@ -316,8 +326,9 @@ JsModule {
         6: (empty)
         7: (empty)
     2: JS_EXPORT@86..112
-      0: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@94..112
+      0: JS_DECORATOR_LIST@86..86
+      1: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@94..112
         0: (empty)
         1: L_CURLY@94..96 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@96..99
@@ -333,8 +344,9 @@ JsModule {
         6: (empty)
         7: SEMICOLON@111..112 ";" [] []
     3: JS_EXPORT@112..150
-      0: EXPORT_KW@112..120 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@120..150
+      0: JS_DECORATOR_LIST@112..112
+      1: EXPORT_KW@112..120 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@120..150
         0: (empty)
         1: L_CURLY@120..122 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@122..137
@@ -353,8 +365,9 @@ JsModule {
         6: (empty)
         7: SEMICOLON@149..150 ";" [] []
     4: JS_EXPORT@150..182
-      0: EXPORT_KW@150..158 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@158..182
+      0: JS_DECORATOR_LIST@150..150
+      1: EXPORT_KW@150..158 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@158..182
         0: (empty)
         1: L_CURLY@158..160 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@160..169
@@ -373,8 +386,9 @@ JsModule {
         6: (empty)
         7: SEMICOLON@181..182 ";" [] []
     5: JS_EXPORT@182..228
-      0: EXPORT_KW@182..190 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@190..228
+      0: JS_DECORATOR_LIST@182..182
+      1: EXPORT_KW@182..190 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@190..228
         0: (empty)
         1: L_CURLY@190..192 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@192..194
@@ -398,8 +412,9 @@ JsModule {
           3: R_CURLY@227..228 "}" [] []
         7: (empty)
     6: JS_EXPORT@228..257
-      0: EXPORT_KW@228..236 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@236..257
+      0: JS_DECORATOR_LIST@228..228
+      1: EXPORT_KW@228..236 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@236..257
         0: (empty)
         1: L_CURLY@236..238 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@238..242
@@ -415,8 +430,9 @@ JsModule {
         6: (empty)
         7: SEMICOLON@256..257 ";" [] []
     7: JS_EXPORT@257..291
-      0: EXPORT_KW@257..265 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@265..291
+      0: JS_DECORATOR_LIST@257..257
+      1: EXPORT_KW@257..265 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@265..291
         0: (empty)
         1: L_CURLY@265..266 "{" [] []
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@266..275

--- a/crates/rome_js_parser/test_data/inline/ok/export_variable_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/export_variable_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsVariableDeclarationClause {
                 declaration: JsVariableDeclaration {
@@ -21,6 +22,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsVariableDeclarationClause {
                 declaration: JsVariableDeclaration {
@@ -44,6 +46,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsVariableDeclarationClause {
                 declaration: JsVariableDeclaration {
@@ -91,8 +94,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..57
     0: JS_EXPORT@0..13
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_VARIABLE_DECLARATION_CLAUSE@7..13
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_VARIABLE_DECLARATION_CLAUSE@7..13
         0: JS_VARIABLE_DECLARATION@7..12
           0: LET_KW@7..11 "let" [] [Whitespace(" ")]
           1: JS_VARIABLE_DECLARATOR_LIST@11..12
@@ -103,8 +107,9 @@ JsModule {
               2: (empty)
         1: SEMICOLON@12..13 ";" [] []
     1: JS_EXPORT@13..33
-      0: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_VARIABLE_DECLARATION_CLAUSE@21..33
+      0: JS_DECORATOR_LIST@13..13
+      1: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_VARIABLE_DECLARATION_CLAUSE@21..33
         0: JS_VARIABLE_DECLARATION@21..32
           0: CONST_KW@21..27 "const" [] [Whitespace(" ")]
           1: JS_VARIABLE_DECLARATOR_LIST@27..32
@@ -118,8 +123,9 @@ JsModule {
                   0: JS_NUMBER_LITERAL@31..32 "3" [] []
         1: SEMICOLON@32..33 ";" [] []
     2: JS_EXPORT@33..57
-      0: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_VARIABLE_DECLARATION_CLAUSE@41..57
+      0: JS_DECORATOR_LIST@33..33
+      1: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_VARIABLE_DECLARATION_CLAUSE@41..57
         0: JS_VARIABLE_DECLARATION@41..56
           0: VAR_KW@41..45 "var" [] [Whitespace(" ")]
           1: JS_VARIABLE_DECLARATOR_LIST@45..56

--- a/crates/rome_js_parser/test_data/inline/ok/module.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/module.rast
@@ -18,6 +18,7 @@ JsModule {
             semicolon_token: SEMICOLON@17..18 ";" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@18..26 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -96,8 +97,9 @@ JsModule {
         4: (empty)
       2: SEMICOLON@17..18 ";" [] []
     1: JS_EXPORT@18..32
-      0: EXPORT_KW@18..26 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@26..32
+      0: JS_DECORATOR_LIST@18..18
+      1: EXPORT_KW@18..26 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@26..32
         0: (empty)
         1: L_CURLY@26..28 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@28..30

--- a/crates/rome_js_parser/test_data/inline/ok/ts_declare_function_export_declaration.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_declare_function_export_declaration.rast
@@ -13,6 +13,7 @@ JsModule {
                     l_curly_token: L_CURLY@19..20 "{" [] [],
                     items: JsModuleItemList [
                         JsExport {
+                            decorators: JsDecoratorList [],
                             export_token: EXPORT_KW@20..30 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             export_clause: TsDeclareFunctionDeclaration {
                                 async_token: missing (optional),
@@ -72,8 +73,9 @@ JsModule {
           0: L_CURLY@19..20 "{" [] []
           1: JS_MODULE_ITEM_LIST@20..62
             0: JS_EXPORT@20..62
-              0: EXPORT_KW@20..30 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-              1: TS_DECLARE_FUNCTION_DECLARATION@30..62
+              0: JS_DECORATOR_LIST@20..20
+              1: EXPORT_KW@20..30 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+              2: TS_DECLARE_FUNCTION_DECLARATION@30..62
                 0: (empty)
                 1: FUNCTION_KW@30..39 "function" [] [Whitespace(" ")]
                 2: JS_IDENTIFIER_BINDING@39..43

--- a/crates/rome_js_parser/test_data/inline/ok/ts_declare_function_export_default_declaration.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_declare_function_export_default_declaration.rast
@@ -13,6 +13,7 @@ JsModule {
                     l_curly_token: L_CURLY@19..20 "{" [] [],
                     items: JsModuleItemList [
                         JsExport {
+                            decorators: JsDecoratorList [],
                             export_token: EXPORT_KW@20..30 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             export_clause: JsExportDefaultDeclarationClause {
                                 default_token: DEFAULT_KW@30..38 "default" [] [Whitespace(" ")],
@@ -67,6 +68,7 @@ JsModule {
                     l_curly_token: L_CURLY@87..88 "{" [] [],
                     items: JsModuleItemList [
                         JsExport {
+                            decorators: JsDecoratorList [],
                             export_token: EXPORT_KW@88..98 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             export_clause: JsExportDefaultDeclarationClause {
                                 default_token: DEFAULT_KW@98..106 "default" [] [Whitespace(" ")],
@@ -130,8 +132,9 @@ JsModule {
           0: L_CURLY@19..20 "{" [] []
           1: JS_MODULE_ITEM_LIST@20..65
             0: JS_EXPORT@20..65
-              0: EXPORT_KW@20..30 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-              1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@30..65
+              0: JS_DECORATOR_LIST@20..20
+              1: EXPORT_KW@20..30 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+              2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@30..65
                 0: DEFAULT_KW@30..38 "default" [] [Whitespace(" ")]
                 1: TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION@38..65
                   0: (empty)
@@ -168,8 +171,9 @@ JsModule {
           0: L_CURLY@87..88 "{" [] []
           1: JS_MODULE_ITEM_LIST@88..138
             0: JS_EXPORT@88..138
-              0: EXPORT_KW@88..98 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-              1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@98..138
+              0: JS_DECORATOR_LIST@88..88
+              1: EXPORT_KW@88..98 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+              2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@98..138
                 0: DEFAULT_KW@98..106 "default" [] [Whitespace(" ")]
                 1: TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION@106..138
                   0: (empty)

--- a/crates/rome_js_parser/test_data/inline/ok/ts_decorator_call_expression_with_arrow.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_decorator_call_expression_with_arrow.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsClassDeclaration {
                 decorators: JsDecoratorList [],
@@ -46,8 +47,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..65
     0: JS_EXPORT@0..65
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_CLASS_DECLARATION@7..65
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_CLASS_DECLARATION@7..65
         0: JS_DECORATOR_LIST@7..7
         1: (empty)
         2: CLASS_KW@7..13 "class" [] [Whitespace(" ")]

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_assignment_identifier.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_assignment_identifier.rast
@@ -43,6 +43,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@30..38 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportAssignmentClause {
                 eq_token: EQ@38..40 "=" [] [Whitespace(" ")],
@@ -55,6 +56,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@42..50 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportAssignmentClause {
                 eq_token: EQ@50..52 "=" [] [Whitespace(" ")],
@@ -73,6 +75,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@60..68 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportAssignmentClause {
                 eq_token: EQ@68..70 "=" [] [Whitespace(" ")],
@@ -99,6 +102,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@84..92 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportAssignmentClause {
                 eq_token: EQ@92..94 "=" [] [Whitespace(" ")],
@@ -158,16 +162,18 @@ JsModule {
               2: (empty)
         1: (empty)
     1: JS_EXPORT@30..42
-      0: EXPORT_KW@30..38 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_ASSIGNMENT_CLAUSE@38..42
+      0: JS_DECORATOR_LIST@30..30
+      1: EXPORT_KW@30..38 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_ASSIGNMENT_CLAUSE@38..42
         0: EQ@38..40 "=" [] [Whitespace(" ")]
         1: JS_IDENTIFIER_EXPRESSION@40..41
           0: JS_REFERENCE_IDENTIFIER@40..41
             0: IDENT@40..41 "a" [] []
         2: SEMICOLON@41..42 ";" [] []
     2: JS_EXPORT@42..60
-      0: EXPORT_KW@42..50 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_ASSIGNMENT_CLAUSE@50..60
+      0: JS_DECORATOR_LIST@42..42
+      1: EXPORT_KW@42..50 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_ASSIGNMENT_CLAUSE@50..60
         0: EQ@50..52 "=" [] [Whitespace(" ")]
         1: JS_CLASS_EXPRESSION@52..60
           0: JS_DECORATOR_LIST@52..52
@@ -181,8 +187,9 @@ JsModule {
           8: R_CURLY@59..60 "}" [] []
         2: (empty)
     3: JS_EXPORT@60..84
-      0: EXPORT_KW@60..68 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_ASSIGNMENT_CLAUSE@68..84
+      0: JS_DECORATOR_LIST@60..60
+      1: EXPORT_KW@60..68 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_ASSIGNMENT_CLAUSE@68..84
         0: EQ@68..70 "=" [] [Whitespace(" ")]
         1: JS_FUNCTION_EXPRESSION@70..84
           0: (empty)
@@ -202,8 +209,9 @@ JsModule {
             3: R_CURLY@83..84 "}" [] []
         2: (empty)
     4: JS_EXPORT@84..104
-      0: EXPORT_KW@84..92 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_ASSIGNMENT_CLAUSE@92..104
+      0: JS_DECORATOR_LIST@84..84
+      1: EXPORT_KW@84..92 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_ASSIGNMENT_CLAUSE@92..104
         0: EQ@92..94 "=" [] [Whitespace(" ")]
         1: JS_BINARY_EXPRESSION@94..103
           0: JS_BINARY_EXPRESSION@94..100

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_assignment_qualified_name.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_assignment_qualified_name.rast
@@ -43,6 +43,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@30..38 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportAssignmentClause {
                 eq_token: EQ@38..40 "=" [] [Whitespace(" ")],
@@ -96,8 +97,9 @@ JsModule {
               2: (empty)
         1: (empty)
     1: JS_EXPORT@30..44
-      0: EXPORT_KW@30..38 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_ASSIGNMENT_CLAUSE@38..44
+      0: JS_DECORATOR_LIST@30..30
+      1: EXPORT_KW@30..38 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_ASSIGNMENT_CLAUSE@38..44
         0: EQ@38..40 "=" [] [Whitespace(" ")]
         1: JS_STATIC_MEMBER_EXPRESSION@40..43
           0: JS_IDENTIFIER_EXPRESSION@40..41

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_declare.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_declare.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: TsExportDeclareClause {
                 declare_token: DECLARE_KW@7..15 "declare" [] [Whitespace(" ")],
@@ -29,6 +30,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@31..39 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportDeclareClause {
                 declare_token: DECLARE_KW@39..47 "declare" [] [Whitespace(" ")],
@@ -46,6 +48,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@61..69 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportDeclareClause {
                 declare_token: DECLARE_KW@69..77 "declare" [] [Whitespace(" ")],
@@ -62,6 +65,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportDeclareClause {
                 declare_token: DECLARE_KW@94..102 "declare" [] [Whitespace(" ")],
@@ -80,6 +84,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@118..126 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportDeclareClause {
                 declare_token: DECLARE_KW@126..134 "declare" [] [Whitespace(" ")],
@@ -100,6 +105,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@144..152 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportDeclareClause {
                 declare_token: DECLARE_KW@152..160 "declare" [] [Whitespace(" ")],
@@ -129,8 +135,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..172
     0: JS_EXPORT@0..31
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: TS_EXPORT_DECLARE_CLAUSE@7..31
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: TS_EXPORT_DECLARE_CLAUSE@7..31
         0: DECLARE_KW@7..15 "declare" [] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_CLAUSE@15..31
           0: JS_VARIABLE_DECLARATION@15..30
@@ -146,8 +153,9 @@ JsModule {
                 2: (empty)
           1: SEMICOLON@30..31 ";" [] []
     1: JS_EXPORT@31..61
-      0: EXPORT_KW@31..39 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_DECLARE_CLAUSE@39..61
+      0: JS_DECORATOR_LIST@31..31
+      1: EXPORT_KW@31..39 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_DECLARE_CLAUSE@39..61
         0: DECLARE_KW@39..47 "declare" [] [Whitespace(" ")]
         1: TS_INTERFACE_DECLARATION@47..61
           0: INTERFACE_KW@47..57 "interface" [] [Whitespace(" ")]
@@ -159,8 +167,9 @@ JsModule {
           5: TS_TYPE_MEMBER_LIST@60..60
           6: R_CURLY@60..61 "}" [] []
     2: JS_EXPORT@61..86
-      0: EXPORT_KW@61..69 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_DECLARE_CLAUSE@69..86
+      0: JS_DECORATOR_LIST@61..61
+      1: EXPORT_KW@61..69 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_DECLARE_CLAUSE@69..86
         0: DECLARE_KW@69..77 "declare" [] [Whitespace(" ")]
         1: TS_ENUM_DECLARATION@77..86
           0: (empty)
@@ -171,8 +180,9 @@ JsModule {
           4: TS_ENUM_MEMBER_LIST@85..85
           5: R_CURLY@85..86 "}" [] []
     3: JS_EXPORT@86..118
-      0: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_DECLARE_CLAUSE@94..118
+      0: JS_DECORATOR_LIST@86..86
+      1: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_DECLARE_CLAUSE@94..118
         0: DECLARE_KW@94..102 "declare" [] [Whitespace(" ")]
         1: TS_TYPE_ALIAS_DECLARATION@102..118
           0: TYPE_KW@102..107 "type" [] [Whitespace(" ")]
@@ -184,8 +194,9 @@ JsModule {
             0: STRING_KW@111..117 "string" [] []
           5: SEMICOLON@117..118 ";" [] []
     4: JS_EXPORT@118..144
-      0: EXPORT_KW@118..126 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_DECLARE_CLAUSE@126..144
+      0: JS_DECORATOR_LIST@118..118
+      1: EXPORT_KW@118..126 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_DECLARE_CLAUSE@126..144
         0: DECLARE_KW@126..134 "declare" [] [Whitespace(" ")]
         1: JS_CLASS_DECLARATION@134..144
           0: JS_DECORATOR_LIST@134..134
@@ -200,8 +211,9 @@ JsModule {
           8: JS_CLASS_MEMBER_LIST@143..143
           9: R_CURLY@143..144 "}" [] []
     5: JS_EXPORT@144..172
-      0: EXPORT_KW@144..152 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_DECLARE_CLAUSE@152..172
+      0: JS_DECORATOR_LIST@144..144
+      1: EXPORT_KW@144..152 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_DECLARE_CLAUSE@152..172
         0: DECLARE_KW@152..160 "declare" [] [Whitespace(" ")]
         1: TS_DECLARE_FUNCTION_DECLARATION@160..172
           0: (empty)

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_default_function_overload.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_default_function_overload.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
@@ -44,6 +45,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@48..56 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@56..64 "default" [] [Whitespace(" ")],
@@ -116,8 +118,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..127
     0: JS_EXPORT@0..48
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..48
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..48
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION@15..48
           0: (empty)
@@ -145,8 +148,9 @@ JsModule {
           6: SEMICOLON@47..48 ";" [] []
         2: (empty)
     1: JS_EXPORT@48..127
-      0: EXPORT_KW@48..56 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@56..127
+      0: JS_DECORATOR_LIST@48..48
+      1: EXPORT_KW@48..56 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@56..127
         0: DEFAULT_KW@56..64 "default" [] [Whitespace(" ")]
         1: JS_FUNCTION_EXPORT_DEFAULT_DECLARATION@64..127
           0: (empty)

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_default_interface.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_default_interface.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
@@ -29,8 +30,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..30
     0: JS_EXPORT@0..30
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..30
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..30
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: TS_INTERFACE_DECLARATION@15..30
           0: INTERFACE_KW@15..25 "interface" [] [Whitespace(" ")]

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_default_multiple_interfaces.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_default_multiple_interfaces.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
@@ -36,6 +37,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@41..49 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@49..57 "default" [] [Whitespace(" ")],
@@ -69,6 +71,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@82..90 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@90..98 "default" [] [Whitespace(" ")],
@@ -105,8 +108,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..116
     0: JS_EXPORT@0..41
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..41
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..41
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: TS_INTERFACE_DECLARATION@15..41
           0: INTERFACE_KW@15..25 "interface" [] [Whitespace(" ")]
@@ -129,8 +133,9 @@ JsModule {
           6: R_CURLY@40..41 "}" [] []
         2: (empty)
     1: JS_EXPORT@41..82
-      0: EXPORT_KW@41..49 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@49..82
+      0: JS_DECORATOR_LIST@41..41
+      1: EXPORT_KW@41..49 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@49..82
         0: DEFAULT_KW@49..57 "default" [] [Whitespace(" ")]
         1: TS_INTERFACE_DECLARATION@57..82
           0: INTERFACE_KW@57..67 "interface" [] [Whitespace(" ")]
@@ -153,8 +158,9 @@ JsModule {
           6: R_CURLY@81..82 "}" [] []
         2: (empty)
     2: JS_EXPORT@82..116
-      0: EXPORT_KW@82..90 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@90..116
+      0: JS_DECORATOR_LIST@82..82
+      1: EXPORT_KW@82..90 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@90..116
         0: DEFAULT_KW@90..98 "default" [] [Whitespace(" ")]
         1: JS_FUNCTION_EXPORT_DEFAULT_DECLARATION@98..116
           0: (empty)

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_enum_declaration.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_enum_declaration.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: TsEnumDeclaration {
                 const_token: missing (optional),
@@ -30,6 +31,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@22..30 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsEnumDeclaration {
                 const_token: CONST_KW@30..36 "const" [] [Whitespace(" ")],
@@ -65,8 +67,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..51
     0: JS_EXPORT@0..22
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: TS_ENUM_DECLARATION@7..22
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: TS_ENUM_DECLARATION@7..22
         0: (empty)
         1: ENUM_KW@7..12 "enum" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_BINDING@12..14
@@ -84,8 +87,9 @@ JsModule {
             1: (empty)
         5: R_CURLY@21..22 "}" [] []
     1: JS_EXPORT@22..51
-      0: EXPORT_KW@22..30 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_ENUM_DECLARATION@30..51
+      0: JS_DECORATOR_LIST@22..22
+      1: EXPORT_KW@22..30 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_ENUM_DECLARATION@30..51
         0: CONST_KW@30..36 "const" [] [Whitespace(" ")]
         1: ENUM_KW@36..41 "enum" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_BINDING@41..43

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_function_overload.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_function_overload.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: TsDeclareFunctionDeclaration {
                 async_token: missing (optional),
@@ -40,6 +41,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@40..48 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsFunctionDeclaration {
                 async_token: missing (optional),
@@ -108,8 +110,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..111
     0: JS_EXPORT@0..40
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: TS_DECLARE_FUNCTION_DECLARATION@7..40
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: TS_DECLARE_FUNCTION_DECLARATION@7..40
         0: (empty)
         1: FUNCTION_KW@7..16 "function" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_BINDING@16..20
@@ -134,8 +137,9 @@ JsModule {
             0: STRING_KW@33..39 "string" [] []
         6: SEMICOLON@39..40 ";" [] []
     1: JS_EXPORT@40..111
-      0: EXPORT_KW@40..48 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_FUNCTION_DECLARATION@48..111
+      0: JS_DECORATOR_LIST@40..40
+      1: EXPORT_KW@40..48 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_FUNCTION_DECLARATION@48..111
         0: (empty)
         1: FUNCTION_KW@48..57 "function" [] [Whitespace(" ")]
         2: (empty)

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_interface_declaration.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_interface_declaration.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: TsInterfaceDeclaration {
                 interface_token: INTERFACE_KW@7..17 "interface" [] [Whitespace(" ")],
@@ -25,8 +26,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..21
     0: JS_EXPORT@0..21
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: TS_INTERFACE_DECLARATION@7..21
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: TS_INTERFACE_DECLARATION@7..21
         0: INTERFACE_KW@7..17 "interface" [] [Whitespace(" ")]
         1: TS_IDENTIFIER_BINDING@17..19
           0: IDENT@17..19 "A" [] [Whitespace(" ")]

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_named_from_specifier_with_type.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_named_from_specifier_with_type.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -26,6 +27,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: missing (optional),
@@ -57,8 +59,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..57
     0: JS_EXPORT@0..26
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@7..26
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@7..26
         0: (empty)
         1: L_CURLY@7..9 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@9..16
@@ -74,8 +77,9 @@ JsModule {
         6: (empty)
         7: (empty)
     1: JS_EXPORT@26..57
-      0: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@34..57
+      0: JS_DECORATOR_LIST@26..26
+      1: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@34..57
         0: (empty)
         1: L_CURLY@34..36 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@36..41

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_named_type_specifier.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_named_type_specifier.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -20,6 +21,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@15..23 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -37,6 +39,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@36..44 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -66,8 +69,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..69
     0: JS_EXPORT@0..15
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@7..15
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@7..15
         0: (empty)
         1: L_CURLY@7..9 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@9..14
@@ -78,8 +82,9 @@ JsModule {
         3: R_CURLY@14..15 "}" [] []
         4: (empty)
     1: JS_EXPORT@15..36
-      0: EXPORT_KW@15..23 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@23..36
+      0: JS_DECORATOR_LIST@15..15
+      1: EXPORT_KW@15..23 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@23..36
         0: (empty)
         1: L_CURLY@23..25 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@25..35
@@ -90,8 +95,9 @@ JsModule {
         3: R_CURLY@35..36 "}" [] []
         4: (empty)
     2: JS_EXPORT@36..69
-      0: EXPORT_KW@36..44 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@44..69
+      0: JS_DECORATOR_LIST@36..36
+      1: EXPORT_KW@36..44 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@44..69
         0: (empty)
         1: L_CURLY@44..46 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@46..68

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_namespace_clause.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_namespace_clause.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: TsDeclareFunctionDeclaration {
                 async_token: missing (optional),
@@ -40,6 +41,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@44..52 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsExportAsNamespaceClause {
                 as_token: AS_KW@52..55 "as" [] [Whitespace(" ")],
@@ -59,8 +61,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..73
     0: JS_EXPORT@0..44
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: TS_DECLARE_FUNCTION_DECLARATION@7..44
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: TS_DECLARE_FUNCTION_DECLARATION@7..44
         0: (empty)
         1: FUNCTION_KW@7..16 "function" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_BINDING@16..23
@@ -85,8 +88,9 @@ JsModule {
             0: BOOLEAN_KW@36..43 "boolean" [] []
         6: SEMICOLON@43..44 ";" [] []
     1: JS_EXPORT@44..73
-      0: EXPORT_KW@44..52 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_EXPORT_AS_NAMESPACE_CLAUSE@52..73
+      0: JS_DECORATOR_LIST@44..44
+      1: EXPORT_KW@44..52 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_EXPORT_AS_NAMESPACE_CLAUSE@52..73
         0: AS_KW@52..55 "as" [] [Whitespace(" ")]
         1: NAMESPACE_KW@55..65 "namespace" [] [Whitespace(" ")]
         2: JS_NAME@65..72

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_type_named.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_type_named.rast
@@ -15,6 +15,7 @@ JsModule {
             semicolon_token: SEMICOLON@15..16 ";" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@16..24 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: TYPE_KW@24..29 "type" [] [Whitespace(" ")],
@@ -49,8 +50,9 @@ JsModule {
         0: STRING_KW@9..15 "string" [] []
       5: SEMICOLON@15..16 ";" [] []
     1: JS_EXPORT@16..35
-      0: EXPORT_KW@16..24 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@24..35
+      0: JS_DECORATOR_LIST@16..16
+      1: EXPORT_KW@16..24 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@24..35
         0: TYPE_KW@24..29 "type" [] [Whitespace(" ")]
         1: L_CURLY@29..31 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@31..33

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_type_named_from.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_type_named_from.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 type_token: TYPE_KW@7..12 "type" [] [Whitespace(" ")],
@@ -34,8 +35,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..27
     0: JS_EXPORT@0..27
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_FROM_CLAUSE@7..27
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_FROM_CLAUSE@7..27
         0: TYPE_KW@7..12 "type" [] [Whitespace(" ")]
         1: L_CURLY@12..14 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@14..16

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_type_specifier.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_type_specifier.rast
@@ -48,6 +48,7 @@ JsModule {
             semicolon_token: SEMICOLON@23..24 ";" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@24..32 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -65,6 +66,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@41..49 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -86,6 +88,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@64..72 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -107,6 +110,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@85..93 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -128,6 +132,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@110..118 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -145,6 +150,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@132..140 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -162,6 +168,7 @@ JsModule {
             },
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@152..160 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 type_token: missing (optional),
@@ -221,8 +228,9 @@ JsModule {
             2: (empty)
       1: SEMICOLON@23..24 ";" [] []
     3: JS_EXPORT@24..41
-      0: EXPORT_KW@24..32 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@32..41
+      0: JS_DECORATOR_LIST@24..24
+      1: EXPORT_KW@24..32 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@32..41
         0: (empty)
         1: L_CURLY@32..34 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@34..39
@@ -233,8 +241,9 @@ JsModule {
         3: R_CURLY@39..40 "}" [] []
         4: SEMICOLON@40..41 ";" [] []
     4: JS_EXPORT@41..64
-      0: EXPORT_KW@41..49 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@49..64
+      0: JS_DECORATOR_LIST@41..41
+      1: EXPORT_KW@41..49 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@49..64
         0: (empty)
         1: L_CURLY@49..51 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@51..62
@@ -248,8 +257,9 @@ JsModule {
         3: R_CURLY@62..63 "}" [] []
         4: SEMICOLON@63..64 ";" [] []
     5: JS_EXPORT@64..85
-      0: EXPORT_KW@64..72 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@72..85
+      0: JS_DECORATOR_LIST@64..64
+      1: EXPORT_KW@64..72 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@72..85
         0: (empty)
         1: L_CURLY@72..74 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@74..83
@@ -263,8 +273,9 @@ JsModule {
         3: R_CURLY@83..84 "}" [] []
         4: SEMICOLON@84..85 ";" [] []
     6: JS_EXPORT@85..110
-      0: EXPORT_KW@85..93 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@93..110
+      0: JS_DECORATOR_LIST@85..85
+      1: EXPORT_KW@85..93 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@93..110
         0: (empty)
         1: L_CURLY@93..95 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@95..109
@@ -278,8 +289,9 @@ JsModule {
         3: R_CURLY@109..110 "}" [] []
         4: (empty)
     7: JS_EXPORT@110..132
-      0: EXPORT_KW@110..118 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@118..132
+      0: JS_DECORATOR_LIST@110..110
+      1: EXPORT_KW@110..118 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@118..132
         0: (empty)
         1: L_CURLY@118..120 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@120..130
@@ -290,8 +302,9 @@ JsModule {
         3: R_CURLY@130..131 "}" [] []
         4: SEMICOLON@131..132 ";" [] []
     8: JS_EXPORT@132..152
-      0: EXPORT_KW@132..140 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@140..152
+      0: JS_DECORATOR_LIST@132..132
+      1: EXPORT_KW@132..140 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@140..152
         0: (empty)
         1: L_CURLY@140..142 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@142..150
@@ -302,8 +315,9 @@ JsModule {
         3: R_CURLY@150..151 "}" [] []
         4: SEMICOLON@151..152 ";" [] []
     9: JS_EXPORT@152..177
-      0: EXPORT_KW@152..160 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_NAMED_CLAUSE@160..177
+      0: JS_DECORATOR_LIST@152..152
+      1: EXPORT_KW@152..160 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_NAMED_CLAUSE@160..177
         0: (empty)
         1: L_CURLY@160..162 "{" [] [Whitespace(" ")]
         2: JS_EXPORT_NAMED_SPECIFIER_LIST@162..175

--- a/crates/rome_js_parser/test_data/inline/ok/ts_import_equals_declaration.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_import_equals_declaration.rast
@@ -84,6 +84,7 @@ JsModule {
             semicolon_token: SEMICOLON@107..108 ";" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@108..116 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: TsImportEqualsDeclaration {
                 import_token: IMPORT_KW@116..123 "import" [] [Whitespace(" ")],
@@ -167,8 +168,9 @@ JsModule {
         3: R_PAREN@106..107 ")" [] []
       5: SEMICOLON@107..108 ";" [] []
     5: JS_EXPORT@108..129
-      0: EXPORT_KW@108..116 "export" [Newline("\n")] [Whitespace(" ")]
-      1: TS_IMPORT_EQUALS_DECLARATION@116..129
+      0: JS_DECORATOR_LIST@108..108
+      1: EXPORT_KW@108..116 "export" [Newline("\n")] [Whitespace(" ")]
+      2: TS_IMPORT_EQUALS_DECLARATION@116..129
         0: IMPORT_KW@116..123 "import" [] [Whitespace(" ")]
         1: (empty)
         2: JS_IDENTIFIER_BINDING@123..125

--- a/crates/rome_js_parser/test_data/inline/ok/ts_parameter_option_binding_pattern.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_parameter_option_binding_pattern.rast
@@ -13,6 +13,7 @@ JsModule {
                     l_curly_token: L_CURLY@20..21 "{" [] [],
                     items: JsModuleItemList [
                         JsExport {
+                            decorators: JsDecoratorList [],
                             export_token: EXPORT_KW@21..31 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             export_clause: JsClassDeclaration {
                                 decorators: JsDecoratorList [],
@@ -138,8 +139,9 @@ JsModule {
           0: L_CURLY@20..21 "{" [] []
           1: JS_MODULE_ITEM_LIST@21..152
             0: JS_EXPORT@21..152
-              0: EXPORT_KW@21..31 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-              1: JS_CLASS_DECLARATION@31..152
+              0: JS_DECORATOR_LIST@21..21
+              1: EXPORT_KW@21..31 "export" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+              2: JS_CLASS_DECLARATION@31..152
                 0: JS_DECORATOR_LIST@31..31
                 1: (empty)
                 2: CLASS_KW@31..37 "class" [] [Whitespace(" ")]

--- a/crates/rome_js_parser/test_data/inline/ok/type_parameter_modifier.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/type_parameter_modifier.rast
@@ -393,6 +393,7 @@ JsModule {
             r_curly_token: R_CURLY@266..267 "}" [] [],
         },
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@267..275 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@275..283 "default" [] [Whitespace(" ")],
@@ -2029,8 +2030,9 @@ JsModule {
       8: JS_CLASS_MEMBER_LIST@266..266
       9: R_CURLY@266..267 "}" [] []
     11: JS_EXPORT@267..301
-      0: EXPORT_KW@267..275 "export" [Newline("\n")] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@275..301
+      0: JS_DECORATOR_LIST@267..267
+      1: EXPORT_KW@267..275 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@275..301
         0: DEFAULT_KW@275..283 "default" [] [Whitespace(" ")]
         1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@283..301
           0: JS_DECORATOR_LIST@283..283

--- a/crates/rome_js_parser/test_data/inline/ok/typescript_export_default_abstract_class_case.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/typescript_export_default_abstract_class_case.rast
@@ -3,6 +3,7 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExport {
+            decorators: JsDecoratorList [],
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
             export_clause: JsExportDefaultDeclarationClause {
                 default_token: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")],
@@ -30,8 +31,9 @@ JsModule {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..32
     0: JS_EXPORT@0..32
-      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..32
+      0: JS_DECORATOR_LIST@0..0
+      1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      2: JS_EXPORT_DEFAULT_DECLARATION_CLAUSE@7..32
         0: DEFAULT_KW@7..15 "default" [] [Whitespace(" ")]
         1: JS_CLASS_EXPORT_DEFAULT_DECLARATION@15..32
           0: JS_DECORATOR_LIST@15..15

--- a/crates/rome_js_syntax/src/generated/nodes.rs
+++ b/crates/rome_js_syntax/src/generated/nodes.rs
@@ -1846,15 +1846,17 @@ impl JsExport {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn as_fields(&self) -> JsExportFields {
         JsExportFields {
+            decorators: self.decorators(),
             export_token: self.export_token(),
             export_clause: self.export_clause(),
         }
     }
+    pub fn decorators(&self) -> JsDecoratorList { support::list(&self.syntax, 0usize) }
     pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 0usize)
+        support::required_token(&self.syntax, 1usize)
     }
     pub fn export_clause(&self) -> SyntaxResult<AnyJsExportClause> {
-        support::required_node(&self.syntax, 1usize)
+        support::required_node(&self.syntax, 2usize)
     }
 }
 #[cfg(feature = "serde")]
@@ -1868,6 +1870,7 @@ impl Serialize for JsExport {
 }
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct JsExportFields {
+    pub decorators: JsDecoratorList,
     pub export_token: SyntaxResult<SyntaxToken>,
     pub export_clause: SyntaxResult<AnyJsExportClause>,
 }
@@ -16732,6 +16735,7 @@ impl AstNode for JsExport {
 impl std::fmt::Debug for JsExport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsExport")
+            .field("decorators", &self.decorators())
             .field(
                 "export_token",
                 &support::DebugSyntaxResult(self.export_token()),

--- a/crates/rome_js_syntax/src/generated/nodes_mut.rs
+++ b/crates/rome_js_syntax/src/generated/nodes_mut.rs
@@ -913,16 +913,22 @@ impl JsEmptyStatement {
     }
 }
 impl JsExport {
+    pub fn with_decorators(self, element: JsDecoratorList) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
+        )
+    }
     pub fn with_export_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(0usize..=0usize, once(Some(element.into()))),
+                .splice_slots(1usize..=1usize, once(Some(element.into()))),
         )
     }
     pub fn with_export_clause(self, element: AnyJsExportClause) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
+                .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),
         )
     }
 }

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -1347,6 +1347,7 @@ JsModuleSource = value: 'js_string_literal'
 
 
 JsExport =
+	decorators: JsDecoratorList
 	'export'
 	export_clause: AnyJsExportClause
 

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -201,6 +201,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
             export = export.with_leading_trivia(trivia);
         }
         AnyJsModuleItem::JsExport(make::js_export(
+            make::js_decorator_list(std::iter::empty()),
             export,
             AnyJsExportClause::AnyJsDeclarationClause(match decl {
                 AnyJsDeclaration::JsClassDeclaration(decl) => {
@@ -306,6 +307,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
     ));
 
     items.push(AnyJsModuleItem::JsExport(make::js_export(
+        make::js_decorator_list(std::iter::empty()),
         make::token(T![export]),
         AnyJsExportClause::AnyJsDeclarationClause(AnyJsDeclarationClause::TsInterfaceDeclaration(
             make::ts_interface_declaration(
@@ -322,6 +324,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
     let member_separators = (0..member_declarations.len()).map(|_| make::token(T![,]));
 
     items.push(AnyJsModuleItem::JsExport(make::js_export(
+        make::js_decorator_list(std::iter::empty()),
         make::token(T![export]),
         AnyJsExportClause::AnyJsDeclarationClause(AnyJsDeclarationClause::JsFunctionDeclaration(
             make::js_function_declaration(


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Implement decorators before `export` and `export default`.

ECMA spec page of the decorators:
https://arai-a.github.io/ecma262-compare/?pr=2417
https://github.com/tc39/proposal-decorators

```
@decorator
export class Foo { }

@first.field @second @(() => decorator)()
export class Bar {}

@before
export @after class Foo { }

@before
export abstract class Foo { }

@before
export @after abstract class Foo { }

@decorator
export default class Foo { }

@first.field @second @(() => decorator)()
export default class Bar {}

@before
export default @after class Foo { }

@before
export default abstract class Foo { }

@before
export default @after abstract class Foo { }
```

## Test Plan

`cargo test`

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
