### PR TITLE
fix(rome_lsp): remove code assists from code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ when there are breaking changes.
 
 ### Configuration
 ### Editors
- - Fixed an issue where the VSCode extension duplicates text when using VSCode git utilities [#4338]
+
+ - Fix an issue where the VSCode extension duplicates text when using VSCode git utilities [#4338]
+ - Remove code assists from being added to the code actions when apply fixes;
+ -
 ### Formatter
 
 - Fix an issue where formatting of JSX string literals property values were using incorrect quotes [#4054](https://github.com/rome/tools/issues/4054)

--- a/crates/rome_lsp/tests/server.rs
+++ b/crates/rome_lsp/tests/server.rs
@@ -928,7 +928,7 @@ async fn pull_refactors() -> Result<()> {
         ],
     );
 
-    let expected_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+    let _expected_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
         title: String::from("Inline variable"),
         kind: Some(lsp::CodeActionKind::new(
             "refactor.inline.rome.correctness.inlineVariable",
@@ -945,7 +945,7 @@ async fn pull_refactors() -> Result<()> {
         data: None,
     });
 
-    assert_eq!(res, vec![expected_action]);
+    assert_eq!(res, vec![]);
 
     server.close_document().await?;
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -343,7 +343,7 @@ fn code_actions(
         _ => AnalysisFilter::default(),
     };
 
-    filter.categories = RuleCategories::default();
+    filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
     filter.range = Some(range);
 
     let analyzer_options = compute_analyzer_options(&settings, PathBuf::from(path.as_path()));


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR removes the `RuleCategories::ACTION` from being executed during code actions. 

The reason why I removed them from code actions is because:
- they are hidden from the user;
- some of those actions are taking a toll to big files, causing huge delays in saving a file; [relevant discussion](https://discord.com/channels/678763474494423051/1026860476749062154/1099388658336936078)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I updated a test case

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
