### PR TITLE
fix(rome_js_analyzer): ignore default exported function in useCamelCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ output. [#4405](https://github.com/rome/tools/pull/4405)
 when there are breaking changes.
 - Fix [#4348](https://github.com/rome/tools/issues/4348) that caused [`noNonNullAssertion`](https://docs.rome.tools/lint/rules/nononnullassertion/) to emit incorrect code action
 - Fix [#4410](https://github.com/rome/tools/issues/4410) that caused [`useButtonType`](https://docs.rome.tools/lint/rules/usebuttontype/) to miss some cases
+- Fix false positive diagnostics that [`useCamelCase`](https://docs.rome.tools/lint/rules/usecamelcase/) caused to default exported components 
 
 ### Configuration
 ### Editors

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_camel_case.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_camel_case.rs
@@ -76,7 +76,7 @@ fn is_non_camel_ok(binding: &JsIdentifierBinding, model: &SemanticModel) -> Opti
             };
             Some(is_ok)
         }
-        JS_FUNCTION_DECLARATION => {
+        JS_FUNCTION_DECLARATION | JS_FUNCTION_EXPORT_DEFAULT_DECLARATION => {
             if binding.is_exported(model) {
                 return Some(true);
             }

--- a/crates/rome_js_analyze/tests/specs/nursery/useCamelCase/useCamelCase.jsx
+++ b/crates/rome_js_analyze/tests/specs/nursery/useCamelCase/useCamelCase.jsx
@@ -1,3 +1,5 @@
 // valid
 function Component() {}
 <Component>foo</Component>
+export function ExportComponent() {}
+export default function ExportDefaultComponent() {}

--- a/crates/rome_js_analyze/tests/specs/nursery/useCamelCase/useCamelCase.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useCamelCase/useCamelCase.jsx.snap
@@ -7,6 +7,9 @@ expression: useCamelCase.jsx
 // valid
 function Component() {}
 <Component>foo</Component>
+export function ExportComponent() {}
+export default function ExportDefaultComponent() {}
+
 ```
 
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This is related to #3262
`useCamelCase`emits a false positive diagnostic for default exported components.

see: [playground](https://docs.rome.tools/playground/?lintRules=all&code=ZQB4AHAAbwByAHQAIABkAGUAZgBhAHUAbAB0ACAAZgB1AG4AYwB0AGkAbwBuACAASABvAGcAZQAoACkAIAB7AAoAIAAgAHIAZQB0AHUAcgBuACAAKAA8AFQAZQB4AHQAPgB0AGUAcwB0ADwALwBUAGUAeAB0AD4AKQAKAH0ACgAKAGUAeABwAG8AcgB0ACAAZgB1AG4AYwB0AGkAbwBuACAARgBvAG8AKAApACAAewAKACAAIAByAGUAdAB1AHIAbgAgADwAZABpAHYAPgBoAG8AZwBlADwALwBkAGkAdgA%2BAAoAfQAKAA%3D%3D)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I add new test cases. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
