### PR TITLE
feat(rome_cli): rome check via stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@
 #### Other changes
 
 - Refactored the underling argument parsing logic. Changed the look and feel of the help
-output. [#4405](https://github.com/rome/tools/pull/4405)
+output. [#4405](https://github.com/rome/tools/pull/4405).
+- The command `rome check` can accept input from `stdin`.
+- Add the argument `--stdin-file-path` to use when running `rome check` via `stdin`.
+- Add the argument `--formatter-enabled` to control the formatter via CLI.
+- Add the argument `--linter-enabled` to control the linter via CLI.
+- Add the argument `--organize-imports-enabled` to control the import sorting via CLI.
 
 ### Linter
 
@@ -24,7 +29,7 @@ output. [#4405](https://github.com/rome/tools/pull/4405)
 when there are breaking changes.
 - Fix [#4348](https://github.com/rome/tools/issues/4348) that caused [`noNonNullAssertion`](https://docs.rome.tools/lint/rules/nononnullassertion/) to emit incorrect code action
 - Fix [#4410](https://github.com/rome/tools/issues/4410) that caused [`useButtonType`](https://docs.rome.tools/lint/rules/usebuttontype/) to miss some cases
-- Fix false positive diagnostics that [`useCamelCase`](https://docs.rome.tools/lint/rules/usecamelcase/) caused to default exported components 
+- Fix false positive diagnostics that [`useCamelCase`](https://docs.rome.tools/lint/rules/usecamelcase/) caused to default exported components
 
 ### Configuration
 ### Editors

--- a/crates/rome_cli/src/commands/mod.rs
+++ b/crates/rome_cli/src/commands/mod.rs
@@ -49,6 +49,9 @@ pub enum RomeCommand {
         configuration: Option<Configuration>,
         #[bpaf(external, hide_usage)]
         cli_options: CliOptions,
+        /// A file name with its extension to pass when reading from standard in, e.g. echo 'let a;' | rome format --stdin-file-path=file.js"
+        #[bpaf(long("stdin-file-path"), argument("PATH"), hide_usage)]
+        stdin_file_path: Option<String>,
         /// Single file, single path or list of paths
         #[bpaf(positional("PATH"), many)]
         paths: Vec<OsString>,

--- a/crates/rome_cli/src/commands/mod.rs
+++ b/crates/rome_cli/src/commands/mod.rs
@@ -45,11 +45,30 @@ pub enum RomeCommand {
         /// Apply safe fixes and unsafe fixes, formatting and import sorting
         #[bpaf(long("apply-unsafe"), switch)]
         apply_unsafe: bool,
+        /// Allow to enable or disable the formatter check.
+        #[bpaf(
+            long("formatter-enabled"),
+            argument("true|false"),
+            optional,
+            hide_usage
+        )]
+        formatter_enabled: Option<bool>,
+        /// Allow to enable or disable the linter check.
+        #[bpaf(long("linter-enabled"), argument("true|false"), optional, hide_usage)]
+        linter_enabled: Option<bool>,
+        /// Allow to enable or disable the organize imports.
+        #[bpaf(
+            long("organize-imports-enabled"),
+            argument("true|false"),
+            optional,
+            hide_usage
+        )]
+        organize_imports_enabled: Option<bool>,
         #[bpaf(external, hide_usage, optional)]
         configuration: Option<Configuration>,
         #[bpaf(external, hide_usage)]
         cli_options: CliOptions,
-        /// A file name with its extension to pass when reading from standard in, e.g. echo 'let a;' | rome format --stdin-file-path=file.js"
+        /// A file name with its extension to pass when reading from standard in, e.g. echo 'let a;' | rome check --stdin-file-path=file.js"
         #[bpaf(long("stdin-file-path"), argument("PATH"), hide_usage)]
         stdin_file_path: Option<String>,
         /// Single file, single path or list of paths

--- a/crates/rome_cli/src/execute/mod.rs
+++ b/crates/rome_cli/src/execute/mod.rs
@@ -42,6 +42,10 @@ pub(crate) enum TraversalMode {
         /// It's [None] if the `check` command is called without `--apply` or `--apply-suggested`
         /// arguments.
         fix_file_mode: Option<FixFileMode>,
+        /// An optional tuple.
+        /// 1. The virtual path to the file
+        /// 2. The content of the file
+        stdin: Option<(PathBuf, String)>,
     },
     /// This mode is enabled when running the command `rome ci`
     CI,
@@ -125,7 +129,8 @@ impl Execution {
         matches!(
             self.traversal_mode,
             TraversalMode::Check {
-                fix_file_mode: Some(FixFileMode::SafeFixes)
+                fix_file_mode: Some(FixFileMode::SafeFixes),
+                ..
             }
         )
     }
@@ -134,7 +139,8 @@ impl Execution {
         matches!(
             self.traversal_mode,
             TraversalMode::Check {
-                fix_file_mode: Some(FixFileMode::SafeAndUnsafeFixes)
+                fix_file_mode: Some(FixFileMode::SafeAndUnsafeFixes),
+                ..
             }
         )
     }
@@ -146,7 +152,7 @@ impl Execution {
     /// Whether the traversal mode requires write access to files
     pub(crate) const fn requires_write_access(&self) -> bool {
         match self.traversal_mode {
-            TraversalMode::Check { fix_file_mode } => fix_file_mode.is_some(),
+            TraversalMode::Check { fix_file_mode, .. } => fix_file_mode.is_some(),
             TraversalMode::CI => false,
             TraversalMode::Format { write, .. } => write,
             TraversalMode::Migrate { write: dry_run, .. } => dry_run,
@@ -156,6 +162,7 @@ impl Execution {
     pub(crate) fn as_stdin_file(&self) -> Option<&(PathBuf, String)> {
         match &self.traversal_mode {
             TraversalMode::Format { stdin, .. } => stdin.as_ref(),
+            TraversalMode::Check { stdin, .. } => stdin.as_ref(),
             _ => None,
         }
     }

--- a/crates/rome_cli/src/execute/process_file.rs
+++ b/crates/rome_cli/src/execute/process_file.rs
@@ -163,23 +163,21 @@ pub(crate) fn process_file(ctx: &TraversalOptions, path: &Path) -> FileResult {
                 category!("organizeImports"),
             )?;
 
-            if let Some(output) = sorted.code {
-                if output != input {
-                    if ctx.execution.is_check_apply_unsafe() {
-                        file.set_content(output.as_bytes())
-                            .with_file_path(path.display().to_string())?;
-                        file_guard.change_file(file.file_version(), output)?;
-                    } else {
-                        errors += 1;
-                        ctx.messages
-                            .send(Message::Diff {
-                                file_name: path.display().to_string(),
-                                old: input.clone(),
-                                new: output,
-                                diff_kind: DiffKind::OrganizeImports,
-                            })
-                            .ok();
-                    }
+            if sorted.code != input {
+                if ctx.execution.is_check_apply_unsafe() {
+                    file.set_content(sorted.code.as_bytes())
+                        .with_file_path(path.display().to_string())?;
+                    file_guard.change_file(file.file_version(), sorted.code)?;
+                } else {
+                    errors += 1;
+                    ctx.messages
+                        .send(Message::Diff {
+                            file_name: path.display().to_string(),
+                            old: input.clone(),
+                            new: sorted.code,
+                            diff_kind: DiffKind::OrganizeImports,
+                        })
+                        .ok();
                 }
             }
         }
@@ -258,17 +256,15 @@ pub(crate) fn process_file(ctx: &TraversalOptions, path: &Path) -> FileResult {
                 category!("organizeImports"),
             )?;
 
-            if let Some(output) = sorted.code {
-                if output != input {
-                    ctx.messages
-                        .send(Message::Diff {
-                            file_name: path.display().to_string(),
-                            old: input.clone(),
-                            new: output,
-                            diff_kind: DiffKind::OrganizeImports,
-                        })
-                        .ok();
-                }
+            if sorted.code != input {
+                ctx.messages
+                    .send(Message::Diff {
+                        file_name: path.display().to_string(),
+                        old: input.clone(),
+                        new: sorted.code,
+                        diff_kind: DiffKind::OrganizeImports,
+                    })
+                    .ok();
             }
         }
 

--- a/crates/rome_cli/src/execute/std_in.rs
+++ b/crates/rome_cli/src/execute/std_in.rs
@@ -71,7 +71,7 @@ pub(crate) fn run<'a>(
                     fix_file_mode: *fix_file_mode,
                     path: rome_path.clone(),
                 })?;
-                if &fix_file_result.code != &new_content {
+                if fix_file_result.code != new_content {
                     version += 1;
                     workspace.change_file(ChangeFileParams {
                         content: fix_file_result.code.clone(),
@@ -94,7 +94,7 @@ pub(crate) fn run<'a>(
                 let result = workspace.organize_imports(OrganizeImportsParams {
                     path: rome_path.clone(),
                 })?;
-                if &result.code != &new_content {
+                if result.code != new_content {
                     version += 1;
                     workspace.change_file(ChangeFileParams {
                         content: result.code.clone(),
@@ -115,7 +115,7 @@ pub(crate) fn run<'a>(
 
         if unsupported_format_reason.is_none() {
             let printed = workspace.format_file(FormatFileParams { path: rome_path })?;
-            if printed.as_code() != &new_content {
+            if printed.as_code() != new_content {
                 new_content = Cow::Owned(printed.into_code());
             }
         }

--- a/crates/rome_cli/src/execute/std_in.rs
+++ b/crates/rome_cli/src/execute/std_in.rs
@@ -5,9 +5,10 @@ use crate::{CliDiagnostic, CliSession};
 use rome_console::{markup, ConsoleExt};
 use rome_fs::RomePath;
 use rome_service::workspace::{
-    FeatureName, FixFileParams, FormatFileParams, Language, OpenFileParams, OrganizeImportsParams,
-    SupportsFeatureParams,
+    ChangeFileParams, FeatureName, FixFileParams, FormatFileParams, Language, OpenFileParams,
+    OrganizeImportsParams, SupportsFeatureParams,
 };
+use std::borrow::Cow;
 
 pub(crate) fn run<'a>(
     session: CliSession,
@@ -17,6 +18,7 @@ pub(crate) fn run<'a>(
 ) -> Result<(), CliDiagnostic> {
     let workspace = &*session.app.workspace;
     let console = &mut *session.app.console;
+    let mut version = 0;
 
     if mode.is_format() {
         let unsupported_format_reason = workspace
@@ -46,14 +48,16 @@ pub(crate) fn run<'a>(
                 })
         }
     } else if mode.is_check() {
-        let content = if let Some(fix_file_mode) = mode.as_fix_file_mode() {
-            workspace.open_file(OpenFileParams {
-                path: rome_path.clone(),
-                version: 0,
-                content: content.into(),
-                language_hint: Language::default(),
-            })?;
+        let mut new_content = Cow::Borrowed(content);
 
+        workspace.open_file(OpenFileParams {
+            path: rome_path.clone(),
+            version: 0,
+            content: content.into(),
+            language_hint: Language::default(),
+        })?;
+
+        if let Some(fix_file_mode) = mode.as_fix_file_mode() {
             // apply fix file of the linter
             let unsupported_lint_reason = workspace
                 .supports_feature(SupportsFeatureParams {
@@ -62,16 +66,21 @@ pub(crate) fn run<'a>(
                 })?
                 .reason;
 
-            let content = if unsupported_lint_reason.is_none() {
+            if unsupported_lint_reason.is_none() {
                 let fix_file_result = workspace.fix_file(FixFileParams {
                     fix_file_mode: *fix_file_mode,
                     path: rome_path.clone(),
                 })?;
-
-                fix_file_result.code
-            } else {
-                content.into()
-            };
+                if &fix_file_result.code != &new_content {
+                    version += 1;
+                    workspace.change_file(ChangeFileParams {
+                        content: fix_file_result.code.clone(),
+                        path: rome_path.clone(),
+                        version,
+                    })?;
+                    new_content = Cow::Owned(fix_file_result.code);
+                }
+            }
 
             // apply organize imports
             let unsupported_organize_imports_reason = workspace
@@ -85,14 +94,17 @@ pub(crate) fn run<'a>(
                 let result = workspace.organize_imports(OrganizeImportsParams {
                     path: rome_path.clone(),
                 })?;
-
-                result.code
-            } else {
-                content
+                if &result.code != &new_content {
+                    version += 1;
+                    workspace.change_file(ChangeFileParams {
+                        content: result.code.clone(),
+                        path: rome_path.clone(),
+                        version,
+                    })?;
+                    new_content = Cow::Owned(result.code);
+                }
             }
-        } else {
-            content.into()
-        };
+        }
 
         let unsupported_format_reason = workspace
             .supports_feature(SupportsFeatureParams {
@@ -101,23 +113,25 @@ pub(crate) fn run<'a>(
             })?
             .reason;
 
-        let content = if unsupported_format_reason.is_none() {
-            workspace.open_file(OpenFileParams {
-                path: rome_path.clone(),
-                version: 0,
-                content,
-                language_hint: Language::default(),
-            })?;
+        if unsupported_format_reason.is_none() {
             let printed = workspace.format_file(FormatFileParams { path: rome_path })?;
+            if printed.as_code() != &new_content {
+                new_content = Cow::Owned(printed.into_code());
+            }
+        }
 
-            printed.into_code()
-        } else {
-            content
-        };
-
-        console.append(markup! {
-            {content}
-        });
+        match new_content {
+            Cow::Borrowed(original) => {
+                console.append(markup! {
+                    {original}
+                });
+            }
+            Cow::Owned(new_content) => {
+                console.append(markup! {
+                    {new_content}
+                });
+            }
+        }
     }
     Ok(())
 }

--- a/crates/rome_cli/src/execute/std_in.rs
+++ b/crates/rome_cli/src/execute/std_in.rs
@@ -5,7 +5,8 @@ use crate::{CliDiagnostic, CliSession};
 use rome_console::{markup, ConsoleExt};
 use rome_fs::RomePath;
 use rome_service::workspace::{
-    FeatureName, FormatFileParams, Language, OpenFileParams, SupportsFeatureParams,
+    FeatureName, FixFileParams, FormatFileParams, Language, OpenFileParams, OrganizeImportsParams,
+    SupportsFeatureParams,
 };
 
 pub(crate) fn run<'a>(
@@ -44,6 +45,79 @@ pub(crate) fn run<'a>(
                     <Warn>"The content was not formatted because the formatter is currently disabled."</Warn>
                 })
         }
+    } else if mode.is_check() {
+        let content = if let Some(fix_file_mode) = mode.as_fix_file_mode() {
+            workspace.open_file(OpenFileParams {
+                path: rome_path.clone(),
+                version: 0,
+                content: content.into(),
+                language_hint: Language::default(),
+            })?;
+
+            // apply fix file of the linter
+            let unsupported_lint_reason = workspace
+                .supports_feature(SupportsFeatureParams {
+                    path: rome_path.clone(),
+                    feature: FeatureName::Lint,
+                })?
+                .reason;
+
+            let content = if unsupported_lint_reason.is_none() {
+                let fix_file_result = workspace.fix_file(FixFileParams {
+                    fix_file_mode: *fix_file_mode,
+                    path: rome_path.clone(),
+                })?;
+
+                fix_file_result.code
+            } else {
+                content.into()
+            };
+
+            // apply organize imports
+            let unsupported_organize_imports_reason = workspace
+                .supports_feature(SupportsFeatureParams {
+                    path: rome_path.clone(),
+                    feature: FeatureName::OrganizeImports,
+                })?
+                .reason;
+
+            if unsupported_organize_imports_reason.is_none() {
+                let result = workspace.organize_imports(OrganizeImportsParams {
+                    path: rome_path.clone(),
+                })?;
+
+                result.code
+            } else {
+                content
+            }
+        } else {
+            content.into()
+        };
+
+        let unsupported_format_reason = workspace
+            .supports_feature(SupportsFeatureParams {
+                path: rome_path.clone(),
+                feature: FeatureName::Format,
+            })?
+            .reason;
+
+        let content = if unsupported_format_reason.is_none() {
+            workspace.open_file(OpenFileParams {
+                path: rome_path.clone(),
+                version: 0,
+                content,
+                language_hint: Language::default(),
+            })?;
+            let printed = workspace.format_file(FormatFileParams { path: rome_path })?;
+
+            printed.into_code()
+        } else {
+            content
+        };
+
+        console.append(markup! {
+            {content}
+        });
     }
     Ok(())
 }

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -81,9 +81,9 @@ impl<'app> CliSession<'app> {
                 configuration: rome_configuration,
                 paths,
                 stdin_file_path,
-				linter_enabled,
-				organize_imports_enabled,
-				formatter_enabled
+                linter_enabled,
+                organize_imports_enabled,
+                formatter_enabled,
             } => commands::check::check(
                 self,
                 CheckCommandPayload {
@@ -93,9 +93,9 @@ impl<'app> CliSession<'app> {
                     configuration: rome_configuration,
                     paths,
                     stdin_file_path,
-					linter_enabled,
-					organize_imports_enabled,
-					formatter_enabled
+                    linter_enabled,
+                    organize_imports_enabled,
+                    formatter_enabled,
                 },
             ),
             RomeCommand::Ci {

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -80,6 +80,7 @@ impl<'app> CliSession<'app> {
                 cli_options,
                 configuration: rome_configuration,
                 paths,
+                stdin_file_path,
             } => commands::check::check(
                 self,
                 CheckCommandPayload {
@@ -88,6 +89,7 @@ impl<'app> CliSession<'app> {
                     cli_options,
                     configuration: rome_configuration,
                     paths,
+                    stdin_file_path,
                 },
             ),
             RomeCommand::Ci {

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -81,6 +81,9 @@ impl<'app> CliSession<'app> {
                 configuration: rome_configuration,
                 paths,
                 stdin_file_path,
+				linter_enabled,
+				organize_imports_enabled,
+				formatter_enabled
             } => commands::check::check(
                 self,
                 CheckCommandPayload {
@@ -90,6 +93,9 @@ impl<'app> CliSession<'app> {
                     configuration: rome_configuration,
                     paths,
                     stdin_file_path,
+					linter_enabled,
+					organize_imports_enabled,
+					formatter_enabled
                 },
             ),
             RomeCommand::Ci {

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -14,9 +14,9 @@ use crate::configs::{
     CONFIG_LINTER_SUPPRESSED_GROUP, CONFIG_LINTER_SUPPRESSED_RULE,
     CONFIG_LINTER_UPGRADE_DIAGNOSTIC, CONFIG_RECOMMENDED_GROUP,
 };
-use crate::snap_test::SnapshotPayload;
+use crate::snap_test::{markup_to_string, SnapshotPayload};
 use crate::{assert_cli_snapshot, run_cli, FORMATTED, LINT_ERROR, PARSE_ERROR};
-use rome_console::{BufferConsole, LogLevel, MarkupBuf};
+use rome_console::{markup, BufferConsole, LogLevel, MarkupBuf};
 use rome_fs::{ErrorEntry, FileSystemExt, MemoryFileSystem, OsFileSystem};
 use rome_service::DynRef;
 
@@ -1893,6 +1893,43 @@ file2.js
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "ignore_vcs_ignored_file_via_cli",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn check_stdin_successfully() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    console
+        .in_buffer
+        .push("function f() {return{}}".to_string());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[("check"), "--apply", ("--stdin-file-path"), ("mock.js")]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let message = console
+        .out_buffer
+        .get(0)
+        .expect("Console should have written a message");
+
+    let content = markup_to_string(markup! {
+        {message.content}
+    });
+
+    assert_eq!(content, "function f() {\n\treturn {};\n}\n");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "check_stdin_successfully",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -15,6 +15,9 @@ Available positional items:
 Available options:
         --apply         Apply safe fixes, formatting
         --apply-unsafe  Apply safe fixes and unsafe fixes, formatting and import sorting
+        --formatter-enabled <true|false>  Allow to enable or disable the formatter check.
+        --linter-enabled <true|false>  Allow to enable or disable the linter check.
+        --organize-imports-enabled <true|false>  Allow to enable or disable the organize imports.
         --vcs-client-kind <git>  The kind of client.
         --vcs-enabled <true|false>  Whether Rome should integrate itself with the VCS client
         --vcs-use-ignore-file <true|false>  Whether Rome should use the VCS ignore file. When [true],
@@ -46,6 +49,8 @@ Available options:
         --skip-errors   Skip over files containing syntax errors instead of emitting an error
                         diagnostic.
         --json          Reports information using the JSON format
+        --stdin-file-path <PATH>  A file name with its extension to pass when reading from standard
+                        in, e.g. echo 'let a;' | rome check --stdin-file-path=file.js"
     -h, --help          Prints help information
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_check/check_stdin_apply_successfully.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/check_stdin_apply_successfully.snap
@@ -1,0 +1,21 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Input messages
+
+```block
+function f() {return{}} class Foo { constructor() {} }
+```
+
+# Emitted Messages
+
+```block
+function f() {
+	return {};
+}
+class Foo {}
+
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_check/check_stdin_apply_unsafe_only_organize_imports.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/check_stdin_apply_unsafe_only_organize_imports.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Input messages
+
+```block
+import 'zod'; import 'lodash'; function f() {return{}} class Foo { constructor() {} }
+```
+
+# Emitted Messages
+
+```block
+import 'lodash'; import 'zod'; function f() {return{}} class Foo { constructor() {} }
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_check/check_stdin_apply_unsafe_successfully.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/check_stdin_apply_unsafe_successfully.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+# Input messages
+
+```block
+import 'zod'; import 'lodash'; function f() {return{}} class Foo { constructor() {} }
+```
+
+# Emitted Messages
+
+```block
+import "lodash";
+import "zod";
+function f() {
+	return {};
+}
+class Foo {}
+
+```
+
+

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -646,10 +646,12 @@ fn organize_imports(parse: AnyParse) -> Result<OrganizeImportsResult, WorkspaceE
         };
 
         Ok(OrganizeImportsResult {
-            code: Some(tree.syntax().to_string()),
+            code: tree.syntax().to_string(),
         })
     } else {
-        Ok(OrganizeImportsResult { code: None })
+        Ok(OrganizeImportsResult {
+            code: tree.syntax().to_string(),
+        })
     }
 }
 

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -233,6 +233,8 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
     })
 }
 
-fn organize_imports(_: AnyParse) -> Result<OrganizeImportsResult, WorkspaceError> {
-    Ok(OrganizeImportsResult { code: None })
+fn organize_imports(parse: AnyParse) -> Result<OrganizeImportsResult, WorkspaceError> {
+    Ok(OrganizeImportsResult {
+        code: parse.syntax::<JsonLanguage>().to_string(),
+    })
 }

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -354,7 +354,7 @@ pub struct OrganizeImportsParams {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct OrganizeImportsResult {
-    pub code: Option<String>,
+    pub code: String,
 }
 
 impl RageEntry {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR allows running the command `rome check` via standard input.

Example:

```shell
cat file.js | rome check --apply-unsafe --organize-imports-enabled=true --stdin-file-path=file.js > file.js
```

In order to make the command `rome check` more ergonomic with `stdin`, I created three new flags:
- `--formatter-enabled`
- `--linter-enabled`
- `--organize-imports-enabled`

By doing so, a user can apply the type of change to the input. These are the same flags that we have in the `rome ci` command, and they behave in the same way.

These new flags can be used even without `stdin`. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new test cases to ensure the changes are applied based on the features enabled/disabled.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
