### PR TITLE
fix(rome_js_analyze): suppress noHeadeScope diagnostics for custom components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ when there are breaking changes.
 - Fix false positive diagnostics that [`useCamelCase`](https://docs.rome.tools/lint/rules/usecamelcase/) caused to default exported components
 - Fix false positive diagnostics that [`useCamelCase`](https://docs.rome.tools/lint/rules/usecamelcase/) caused to private class members
 - Fix false positive diagnostics that [`useHookAtTopLevel`](https://docs.rome.tools/lint/rules/usehookattoplevel/) caused to arrow functions, export default functions and function expressions.
+- Fix false positive diagnostics that [`noHeadeScope`](https://docs.rome.tools/lint/rules/noheaderscope/) caused to custom components
 
 ### Configuration
 ### Editors

--- a/crates/rome_js_analyze/src/analyzers/a11y/no_header_scope.rs
+++ b/crates/rome_js_analyze/src/analyzers/a11y/no_header_scope.rs
@@ -53,10 +53,11 @@ impl Rule for NoHeaderScope {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
 
-        if element.is_element() && element.name_value_token()?.text_trimmed() != "th" {
-            if element.has_truthy_attribute("scope") {
-                return Some(());
-            }
+        if element.is_element()
+            && element.name_value_token()?.text_trimmed() != "th"
+            && element.has_truthy_attribute("scope")
+        {
+            return Some(());
         }
 
         None

--- a/crates/rome_js_analyze/tests/specs/a11y/noHeaderScope/invalid.jsx
+++ b/crates/rome_js_analyze/tests/specs/a11y/noHeaderScope/invalid.jsx
@@ -3,4 +3,5 @@
 	<div scope={scope}></div>
 	<div scope="col" />
 	<div scope="col"></div>
+	<div scope />
 </>

--- a/crates/rome_js_analyze/tests/specs/a11y/noHeaderScope/invalid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/a11y/noHeaderScope/invalid.jsx.snap
@@ -9,6 +9,7 @@ expression: invalid.jsx
 	<div scope={scope}></div>
 	<div scope="col" />
 	<div scope="col"></div>
+	<div scope />
 </>
 
 ```
@@ -61,7 +62,7 @@ invalid.jsx:4:7 lint/a11y/noHeaderScope  FIXABLE  ━━━━━━━━━━
   > 4 │ 	<div scope="col" />
       │ 	     ^^^^^^^^^^^
     5 │ 	<div scope="col"></div>
-    6 │ </>
+    6 │ 	<div scope />
   
   i Suggested fix: Remove the scope attribute.
   
@@ -79,13 +80,32 @@ invalid.jsx:5:7 lint/a11y/noHeaderScope  FIXABLE  ━━━━━━━━━━
     4 │ 	<div scope="col" />
   > 5 │ 	<div scope="col"></div>
       │ 	     ^^^^^^^^^^^
-    6 │ </>
-    7 │ 
+    6 │ 	<div scope />
+    7 │ </>
   
   i Suggested fix: Remove the scope attribute.
   
     5 │ → <div·scope="col"></div>
       │        -----------       
+
+```
+
+```
+invalid.jsx:6:7 lint/a11y/noHeaderScope  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid using the scope attribute on elements other than th elements.
+  
+    4 │ 	<div scope="col" />
+    5 │ 	<div scope="col"></div>
+  > 6 │ 	<div scope />
+      │ 	     ^^^^^
+    7 │ </>
+    8 │ 
+  
+  i Suggested fix: Remove the scope attribute.
+  
+    6 │ → <div·scope·/>
+      │        ------  
 
 ```
 

--- a/crates/rome_js_analyze/tests/specs/a11y/noHeaderScope/valid.jsx
+++ b/crates/rome_js_analyze/tests/specs/a11y/noHeaderScope/valid.jsx
@@ -1,4 +1,8 @@
 <>
+  <th scope />
 	<th scope="col"></th>
 	<th scope={scope}></th>
+	<th scope={"col"} {...props} />
+	<Component scope={scope} />
+	<Component scope={scope} {...props} />
 </>

--- a/crates/rome_js_analyze/tests/specs/a11y/noHeaderScope/valid.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/a11y/noHeaderScope/valid.jsx.snap
@@ -1,13 +1,16 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 73
 expression: valid.jsx
 ---
 # Input
 ```js
 <>
+  <th scope />
 	<th scope="col"></th>
 	<th scope={scope}></th>
+	<th scope={"col"} {...props} />
+	<Component scope={scope} />
+	<Component scope={scope} {...props} />
 </>
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix false positive diagnostics that noHeadeScope caused to custom components.

see: [playground](https://docs.rome.tools/playground/?lintRules=all&code=PABDAG8AbQBwAG8AbgBlAG4AdAAgAHMAYwBvAHAAZQA9AHsAIgB0AGUAcwB0ACIAfQAgAC8APgAKAA%3D%3D)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
