### PR TITLE
fix(rome_lsp): don't throw error for ignored files in code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,13 @@ when there are breaking changes.
 ### Configuration
 ### Editors
 
- - Fix an issue where the VSCode extension duplicates text when using VSCode git utilities [#4338]
- - Remove code assists from being added to the code actions when apply fixes;
- -
+#### Other changes
+
+- Fix an issue where the VSCode extension duplicates text when using VSCode git utilities [#4338](https://github.com/rome/tools/issues/4338)
+- Remove code assists from being added to the code actions when apply fixes;
+- When requesting code actions, ignored files should not throw errors. Fixes [#4434](https://github.com/rome/tools/issues/4434)
+
+
 ### Formatter
 
 - Fix an issue where formatting of JSX string literals property values were using incorrect quotes [#4054](https://github.com/rome/tools/issues/4054)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+
+[[package]]
 name = "bpaf"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,7 +275,7 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap",
  "textwrap",
@@ -759,7 +765,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "libgit2-sys",
  "log",
@@ -791,7 +797,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -1079,7 +1085,7 @@ version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1384,7 +1390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -1404,7 +1410,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -1570,7 +1576,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1644,7 +1650,7 @@ dependencies = [
 name = "rome_analyze"
 version = "0.0.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.2.1",
  "rome_console",
  "rome_deserialize",
  "rome_diagnostics",
@@ -1770,7 +1776,7 @@ name = "rome_diagnostics"
 version = "0.0.1"
 dependencies = [
  "backtrace",
- "bitflags",
+ "bitflags 1.3.2",
  "bpaf",
  "pico-args",
  "rome_console",
@@ -1939,7 +1945,7 @@ dependencies = [
 name = "rome_js_parser"
 version = "0.0.2"
 dependencies = [
- "bitflags",
+ "bitflags 2.2.1",
  "cfg-if",
  "drop_bomb",
  "expect-test",
@@ -2217,7 +2223,7 @@ version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,6 @@ insta = "1.21.2"
 quote = { version = "1.0.21" }
 lazy_static = "1.4.0"
 bpaf = { version = "0.7.10", features = ["derive"] }
+bitflags = "2.2.1"
+
 

--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -14,7 +14,7 @@ rome_console = { path = "../rome_console" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 rome_json_parser = { path = "../rome_json_parser" }
 rome_deserialize = { path = "../rome_deserialize"}
-bitflags = "1.3.2"
+bitflags.workspace = true
 rustc-hash = { workspace = true }
 serde = { version = "1.0.136", features = ["derive"] }
 schemars = { version = "0.8.10", optional = true }

--- a/crates/rome_analyze/src/categories.rs
+++ b/crates/rome_analyze/src/categories.rs
@@ -170,7 +170,7 @@ bitflags! {
         const SYNTAX = 1 << RuleCategory::Syntax as u8;
         const LINT = 1 << RuleCategory::Lint as u8;
         const ACTION = 1 << RuleCategory::Action as u8;
-    }	
+    }
 }
 
 impl Default for RuleCategories {

--- a/crates/rome_analyze/src/categories.rs
+++ b/crates/rome_analyze/src/categories.rs
@@ -165,11 +165,12 @@ pub enum SourceActionKind {
 }
 
 bitflags! {
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     pub struct RuleCategories: u8 {
         const SYNTAX = 1 << RuleCategory::Syntax as u8;
         const LINT = 1 << RuleCategory::Lint as u8;
         const ACTION = 1 << RuleCategory::Action as u8;
-    }
+    }	
 }
 
 impl Default for RuleCategories {

--- a/crates/rome_cli/src/execute/diagnostics.rs
+++ b/crates/rome_cli/src/execute/diagnostics.rs
@@ -101,7 +101,11 @@ pub(crate) struct PanicDiagnostic {
 }
 
 #[derive(Debug, Diagnostic)]
-#[diagnostic(category = "files/missingHandler", message = "unhandled file type")]
+#[diagnostic(
+    category = "files/missingHandler",
+    message = "Rome doesn't know how to process this file",
+	severity = Warning
+)]
 pub(crate) struct UnhandledDiagnostic;
 
 #[derive(Debug, Diagnostic)]

--- a/crates/rome_formatter_test/src/spec.rs
+++ b/crates/rome_formatter_test/src/spec.rs
@@ -7,7 +7,7 @@ use rome_formatter::{FormatOptions, Printed};
 use rome_fs::RomePath;
 use rome_parser::AnyParse;
 use rome_rowan::{TextRange, TextSize};
-use rome_service::workspace::{FeatureName, SupportsFeatureParams};
+use rome_service::workspace::{FeatureName, FeaturesBuilder, SupportsFeatureParams};
 use rome_service::App;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -41,28 +41,26 @@ impl<'a> SpecTestFile<'a> {
             .workspace
             .file_features(SupportsFeatureParams {
                 path: input_file.clone(),
-                features: FeatureName::Format,
+                feature: FeaturesBuilder::new().with_formatter().build(),
             })
             .unwrap();
 
-        match can_format.reason {
-            None => {
-                let mut input_code = input_file.get_buffer_from_file();
+        if can_format.supports_for(&FeatureName::Format) {
+            let mut input_code = input_file.get_buffer_from_file();
 
-                let (_, range_start_index, range_end_index) =
-                    strip_rome_placeholders(&mut input_code);
+            let (_, range_start_index, range_end_index) = strip_rome_placeholders(&mut input_code);
 
-                Some(SpecTestFile {
-                    input_file,
-                    root_path,
+            Some(SpecTestFile {
+                input_file,
+                root_path,
 
-                    input_code,
+                input_code,
 
-                    range_start_index,
-                    range_end_index,
-                })
-            }
-            Some(_) => None,
+                range_start_index,
+                range_end_index,
+            })
+        } else {
+            None
         }
     }
 

--- a/crates/rome_formatter_test/src/spec.rs
+++ b/crates/rome_formatter_test/src/spec.rs
@@ -39,9 +39,9 @@ impl<'a> SpecTestFile<'a> {
         let mut input_file = RomePath::new(file_path);
         let can_format = app
             .workspace
-            .supports_feature(SupportsFeatureParams {
+            .file_features(SupportsFeatureParams {
                 path: input_file.clone(),
-                feature: FeatureName::Format,
+                features: FeatureName::Format,
             })
             .unwrap();
 

--- a/crates/rome_js_parser/Cargo.toml
+++ b/crates/rome_js_parser/Cargo.toml
@@ -18,7 +18,7 @@ rome_js_unicode_table = { version = "0.0.1", path = "../rome_js_unicode_table" }
 rome_rowan = { version = "0.0.1", path = "../rome_rowan" }
 rome_parser = { version = "0.0.1", path = "../rome_parser" }
 drop_bomb = "0.1.5"
-bitflags = "1.3.2"
+bitflags.workspace = true
 indexmap = { workspace = true }
 cfg-if = "1.0.0"
 smallvec = { version = "1.8.0", features = ["union", "const_new"] }

--- a/crates/rome_js_parser/src/lexer/mod.rs
+++ b/crates/rome_js_parser/src/lexer/mod.rs
@@ -111,6 +111,7 @@ pub enum ReLexContext {
 
 bitflags! {
     /// Flags for a lexed token.
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     pub(crate) struct TokenFlags: u8 {
         /// Indicates that there has been a line break between the last non-trivia token
         const PRECEDING_LINE_BREAK = 1 << 0;

--- a/crates/rome_js_parser/src/state.rs
+++ b/crates/rome_js_parser/src/state.rs
@@ -330,6 +330,8 @@ impl ChangeParserState for EnableStrictMode {
 }
 
 bitflags! {
+    #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+
     /// Flags describing the context of a function.
     pub(crate) struct SignatureFlags: u8 {
         /// Is the function in an async context
@@ -369,7 +371,7 @@ bitflags! {
     /// * It's easier to snapshot the previous state. Individual boolean fields would require that a change
     ///   snapshots each individual boolean field to allow restoring the previous state. With bitflags, all that
     ///   is needed is to copy away the flags field and restore it after.
-    #[derive(Default)]
+    #[derive(Debug, Copy, Default, Clone, Eq, PartialEq)]
     pub(crate) struct ParsingContextFlags: u8 {
         /// Whether the parser is in a generator function like `function* a() {}`
         /// Matches the `Yield` parameter in the ECMA spec
@@ -396,13 +398,13 @@ bitflags! {
         /// Whatever the parser is in a TypeScript ambient context
         const AMBIENT_CONTEXT = 1 << 7;
 
-        const LOOP = Self::BREAK_ALLOWED.bits | Self::CONTINUE_ALLOWED.bits;
+        const LOOP = Self::BREAK_ALLOWED.bits() | Self::CONTINUE_ALLOWED.bits();
 
         /// Bitmask of all the flags that must be reset (shouldn't be inherited) when the parser enters a function
-        const FUNCTION_RESET_MASK = Self::BREAK_ALLOWED.bits | Self::CONTINUE_ALLOWED.bits | Self::IN_CONSTRUCTOR.bits | Self::IN_ASYNC.bits | Self::IN_GENERATOR.bits | Self::TOP_LEVEL.bits;
+        const FUNCTION_RESET_MASK = Self::BREAK_ALLOWED.bits() | Self::CONTINUE_ALLOWED.bits() | Self::IN_CONSTRUCTOR.bits() | Self::IN_ASYNC.bits() | Self::IN_GENERATOR.bits() | Self::TOP_LEVEL.bits();
 
         /// Bitmask of all the flags that must be reset (shouldn't be inherited) when entering parameters.
-        const PARAMETER_RESET_MASK = Self::IN_CONSTRUCTOR.bits | Self::IN_FUNCTION.bits | Self::TOP_LEVEL.bits | Self::IN_GENERATOR.bits | Self::IN_ASYNC.bits;
+        const PARAMETER_RESET_MASK = Self::IN_CONSTRUCTOR.bits() | Self::IN_FUNCTION.bits() | Self::TOP_LEVEL.bits() | Self::IN_GENERATOR.bits() | Self::IN_ASYNC.bits();
     }
 }
 

--- a/crates/rome_js_parser/src/syntax/class.rs
+++ b/crates/rome_js_parser/src/syntax/class.rs
@@ -1793,7 +1793,7 @@ fn parse_modifier(p: &mut JsParser, constructor_parameter: bool) -> Option<Class
 bitflags! {
     /// Bitflag of class member modifiers.
     /// Useful to cheaply track all already seen modifiers of a member (instead of using a HashSet<ModifierKind>).
-    #[derive(Default)]
+    #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
     struct ModifierFlags: u16 {
         const DECLARE       = 1 << 0;
         const PRIVATE       = 1 << 1;
@@ -1807,18 +1807,18 @@ bitflags! {
         const ACCESSOR      = 1 << 9;
         const DECORATOR     = 1 << 10;
 
-        const ACCESSIBILITY = ModifierFlags::PRIVATE.bits | ModifierFlags::PROTECTED.bits | ModifierFlags::PUBLIC.bits;
+        const ACCESSIBILITY = ModifierFlags::PRIVATE.bits() | ModifierFlags::PROTECTED.bits() | ModifierFlags::PUBLIC.bits();
 
-        const ALL_MODIFIERS_EXCEPT_DECORATOR = ModifierFlags::DECLARE.bits
-            | ModifierFlags::PRIVATE.bits
-            | ModifierFlags::PROTECTED.bits
-            | ModifierFlags::PUBLIC.bits
-            | ModifierFlags::STATIC.bits
-            | ModifierFlags::READONLY.bits
-            | ModifierFlags::ABSTRACT.bits
-            | ModifierFlags::OVERRIDE.bits
-            | ModifierFlags::PRIVATE_NAME.bits
-            | ModifierFlags::ACCESSOR.bits;
+        const ALL_MODIFIERS_EXCEPT_DECORATOR = ModifierFlags::DECLARE.bits()
+            | ModifierFlags::PRIVATE.bits()
+            | ModifierFlags::PROTECTED.bits()
+            | ModifierFlags::PUBLIC.bits()
+            | ModifierFlags::STATIC.bits()
+            | ModifierFlags::READONLY.bits()
+            | ModifierFlags::ABSTRACT.bits()
+            | ModifierFlags::OVERRIDE.bits()
+            | ModifierFlags::PRIVATE_NAME.bits()
+            | ModifierFlags::ACCESSOR.bits();
 
     }
 }

--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -43,7 +43,7 @@ pub const EXPR_RECOVERY_SET: TokenSet<JsSyntaxKind> =
 pub(crate) struct ExpressionContext(ExpressionContextFlags);
 
 bitflags! {
-	#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     struct ExpressionContextFlags: u8 {
         /// Whether `in` should be counted in a binary expression.
         /// This is for `for...in` statements to prevent ambiguity.

--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -43,6 +43,7 @@ pub const EXPR_RECOVERY_SET: TokenSet<JsSyntaxKind> =
 pub(crate) struct ExpressionContext(ExpressionContextFlags);
 
 bitflags! {
+	#[derive(Debug, Copy, Clone, Eq, PartialEq)]
     struct ExpressionContextFlags: u8 {
         /// Whether `in` should be counted in a binary expression.
         /// This is for `for...in` statements to prevent ambiguity.

--- a/crates/rome_js_parser/src/syntax/typescript/types.rs
+++ b/crates/rome_js_parser/src/syntax/typescript/types.rs
@@ -40,7 +40,7 @@ use super::{expect_ts_index_signature_member, is_at_ts_index_signature_member, M
 
 bitflags! {
     /// Context tracking state that applies to the parsing of all types
-    #[derive(Default)]
+    #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
     pub(crate) struct TypeContext: u8 {
         /// Whether conditional types `extends string ? string : number` are allowed in the current context.
         ///

--- a/crates/rome_lsp/src/handlers/analysis.rs
+++ b/crates/rome_lsp/src/handlers/analysis.rs
@@ -6,7 +6,8 @@ use anyhow::{Context, Result};
 use rome_analyze::{ActionCategory, SourceActionKind};
 use rome_fs::RomePath;
 use rome_service::workspace::{
-    FeatureName, FixFileMode, FixFileParams, PullActionsParams, SupportsFeatureParams,
+    FeatureName, FeaturesBuilder, FixFileMode, FixFileParams, PullActionsParams, PullActionsResult,
+    SupportsFeatureParams,
 };
 use rome_service::WorkspaceError;
 use std::borrow::Cow;
@@ -35,18 +36,18 @@ pub(crate) fn code_actions(
     let url = params.text_document.uri.clone();
     let rome_path = session.file_path(&url)?;
 
-    let unsupported_lint = &session.workspace.supports_feature(SupportsFeatureParams {
-        path: rome_path.clone(),
-        feature: FeatureName::Lint,
+    let file_features = &session.workspace.file_features(SupportsFeatureParams {
+        path: rome_path,
+        feature: FeaturesBuilder::new()
+            .with_linter()
+            .with_organize_imports()
+            .build(),
     })?;
 
-    let unsupported_organize_imports =
-        &session.workspace.supports_feature(SupportsFeatureParams {
-            path: rome_path,
-            feature: FeatureName::OrganizeImports,
-        })?;
-
-    if unsupported_lint.is_not_supported() && unsupported_organize_imports.is_not_supported() {
+    if !file_features.supports_for(&FeatureName::Lint)
+        && !file_features.supports_for(&FeatureName::OrganizeImports)
+    {
+        debug!("Linter and organize imports are both disabled");
         return Ok(Some(Vec::new()));
     }
 
@@ -78,10 +79,21 @@ pub(crate) fn code_actions(
             )
         })?;
 
-    let result = session.workspace.pull_actions(PullActionsParams {
+    let result = match session.workspace.pull_actions(PullActionsParams {
         path: rome_path.clone(),
         range: cursor_range,
-    })?;
+    }) {
+        Ok(result) => result,
+        Err(err) => {
+            if matches!(err, WorkspaceError::FileIgnored(_)) {
+                return Ok(Some(Vec::new()));
+            } else {
+                return Err(err.into());
+            }
+        }
+    };
+
+    debug!("Pull actions result: {:?}", result);
 
     // Generate an additional code action to apply all safe fixes on the
     // document if the action category "source.fixAll" was explicitly requested
@@ -98,7 +110,7 @@ pub(crate) fn code_actions(
         .into_iter()
         .filter_map(|action| {
             if action.category.matches("source.organizeImports.rome")
-                && unsupported_organize_imports.is_not_supported()
+                && !file_features.supports_for(&FeatureName::OrganizeImports)
             {
                 return None;
             }

--- a/crates/rome_lsp/src/handlers/analysis.rs
+++ b/crates/rome_lsp/src/handlers/analysis.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use rome_analyze::{ActionCategory, SourceActionKind};
 use rome_fs::RomePath;
 use rome_service::workspace::{
-    FeatureName, FeaturesBuilder, FixFileMode, FixFileParams, PullActionsParams, PullActionsResult,
+    FeatureName, FeaturesBuilder, FixFileMode, FixFileParams, PullActionsParams,
     SupportsFeatureParams,
 };
 use rome_service::WorkspaceError;
@@ -85,10 +85,10 @@ pub(crate) fn code_actions(
     }) {
         Ok(result) => result,
         Err(err) => {
-            if matches!(err, WorkspaceError::FileIgnored(_)) {
-                return Ok(Some(Vec::new()));
+            return if matches!(err, WorkspaceError::FileIgnored(_)) {
+                Ok(Some(Vec::new()))
             } else {
-                return Err(err.into());
+                Err(err.into())
             }
         }
     };

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -513,7 +513,7 @@ impl ServerFactory {
 
         builder = builder.custom_method("rome/rage", LSPServer::rage);
 
-        workspace_method!(builder, supports_feature);
+        workspace_method!(builder, file_features);
         workspace_method!(builder, is_path_ignored);
         workspace_method!(builder, update_settings);
         workspace_method!(builder, open_file);

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -18,7 +18,6 @@ use rome_analyze::{
     AnalysisFilter, AnalyzerOptions, ControlFlow, GroupCategory, Never, QueryMatch,
     RegistryVisitor, RuleCategories, RuleCategory, RuleFilter, RuleGroup,
 };
-use rome_diagnostics::panic::catch_unwind;
 use rome_diagnostics::{category, Applicability, Diagnostic, DiagnosticExt, Severity};
 use rome_formatter::{FormatError, Printed};
 use rome_fs::RomePath;

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -18,6 +18,7 @@ use rome_analyze::{
     AnalysisFilter, AnalyzerOptions, ControlFlow, GroupCategory, Never, QueryMatch,
     RegistryVisitor, RuleCategories, RuleCategory, RuleFilter, RuleGroup,
 };
+use rome_diagnostics::panic::catch_unwind;
 use rome_diagnostics::{category, Applicability, Diagnostic, DiagnosticExt, Severity};
 use rome_formatter::{FormatError, Printed};
 use rome_fs::RomePath;
@@ -38,7 +39,7 @@ use rome_rowan::{AstNode, BatchMutationExt, Direction, NodeCache};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use tracing::debug;
+use tracing::{debug, trace};
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -314,6 +315,7 @@ impl RegistryVisitor<JsLanguage> for ActionsVisitor<'_> {
     }
 }
 
+#[tracing::instrument(level = "debug", skip(parse))]
 fn code_actions(
     parse: AnyParse,
     range: TextRange,
@@ -325,27 +327,36 @@ fn code_actions(
 
     let mut actions = Vec::new();
 
-    let enabled_rules: Option<Vec<RuleFilter>> = if let Some(rules) = rules {
-        let enabled_rules = rules.as_enabled_rules().into_iter().collect();
+    let mut enabled_rules = vec![];
+    if settings.as_ref().organize_imports.enabled {
+        enabled_rules.push(RuleFilter::Rule("correctness", "organizeImports"));
+    }
+    if let Some(rules) = rules {
+        let rules = rules.as_enabled_rules().into_iter().collect();
 
         // The rules in the assist category do not have configuration entries,
         // always add them all to the enabled rules list
-        let mut visitor = ActionsVisitor { enabled_rules };
+        let mut visitor = ActionsVisitor {
+            enabled_rules: rules,
+        };
         visit_registry(&mut visitor);
 
-        Some(visitor.enabled_rules)
-    } else {
-        None
-    };
+        enabled_rules.extend(visitor.enabled_rules);
+    }
 
-    let mut filter = match &enabled_rules {
-        Some(rules) => AnalysisFilter::from_enabled_rules(Some(rules.as_slice())),
-        _ => AnalysisFilter::default(),
+    let mut filter = if !enabled_rules.is_empty() {
+        AnalysisFilter::from_enabled_rules(Some(enabled_rules.as_slice()))
+    } else {
+        AnalysisFilter::default()
     };
 
     filter.categories = RuleCategories::SYNTAX | RuleCategories::LINT;
+    if settings.as_ref().organize_imports.enabled {
+        filter.categories |= RuleCategories::ACTION;
+    }
     filter.range = Some(range);
 
+    trace!("Filter applied for code actions: {:?}", &filter);
     let analyzer_options = compute_analyzer_options(&settings, PathBuf::from(path.as_path()));
 
     analyze(

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -152,7 +152,7 @@ pub struct FixAllParams<'a> {
 
 #[derive(Default)]
 /// The list of capabilities that are available for a language
-pub(crate) struct Capabilities {
+pub struct Capabilities {
     pub(crate) parser: ParserCapabilities,
     pub(crate) debug: DebugCapabilities,
     pub(crate) analyzer: AnalyzerCapabilities,
@@ -162,7 +162,7 @@ pub(crate) struct Capabilities {
 type Parse = fn(&RomePath, Language, &str, &mut NodeCache) -> AnyParse;
 
 #[derive(Default)]
-pub(crate) struct ParserCapabilities {
+pub struct ParserCapabilities {
     /// Parse a file
     pub(crate) parse: Option<Parse>,
 }
@@ -172,7 +172,7 @@ type DebugControlFlow = fn(AnyParse, TextSize) -> String;
 type DebugFormatterIR = fn(&RomePath, AnyParse, SettingsHandle) -> Result<String, WorkspaceError>;
 
 #[derive(Default)]
-pub(crate) struct DebugCapabilities {
+pub struct DebugCapabilities {
     /// Prints the syntax tree
     pub(crate) debug_syntax_tree: Option<DebugSyntaxTree>,
     /// Prints the control flow graph
@@ -204,7 +204,7 @@ type Rename = fn(&RomePath, AnyParse, TextSize, String) -> Result<RenameResult, 
 type OrganizeImports = fn(AnyParse) -> Result<OrganizeImportsResult, WorkspaceError>;
 
 #[derive(Default)]
-pub(crate) struct AnalyzerCapabilities {
+pub struct AnalyzerCapabilities {
     /// It lints a file
     pub(crate) lint: Option<Lint>,
     /// It extracts code actions for a file

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -51,6 +51,7 @@
 //! document does not implement the required capability: for instance trying to
 //! format a file with a language that does not have a formatter
 
+use crate::file_handlers::Capabilities;
 use crate::{Configuration, Deserialize, Serialize, WorkspaceError};
 use rome_analyze::ActionCategory;
 pub use rome_analyze::RuleCategories;
@@ -60,10 +61,12 @@ use rome_formatter::Printed;
 use rome_fs::RomePath;
 use rome_js_syntax::{TextRange, TextSize};
 use rome_text_edit::TextEdit;
+use std::collections::HashMap;
 use std::{borrow::Cow, panic::RefUnwindSafe, sync::Arc};
 
 pub use self::client::{TransportRequest, WorkspaceClient, WorkspaceTransport};
 pub use crate::file_handlers::Language;
+use crate::settings::WorkspaceSettings;
 
 mod client;
 mod server;
@@ -72,37 +75,98 @@ mod server;
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SupportsFeatureParams {
     pub path: RomePath,
-    pub feature: FeatureName,
+    pub feature: Vec<FeatureName>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Default)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SupportsFeatureResult {
-    pub reason: Option<UnsupportedReason>,
+    pub reason: Option<SupportKind>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Default)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct FileFeaturesResult {
+    pub features_supported: HashMap<FeatureName, SupportKind>,
+}
+
+impl FileFeaturesResult {
+    /// By default, all features are not supported by a file.
+    const WORKSPACE_FEATURES: [(FeatureName, SupportKind); 3] = [
+        (FeatureName::Lint, SupportKind::FileNotSupported),
+        (FeatureName::Format, SupportKind::FileNotSupported),
+        (FeatureName::OrganizeImports, SupportKind::FileNotSupported),
+    ];
+
+    pub fn new() -> Self {
+        Self {
+            features_supported: HashMap::from(FileFeaturesResult::WORKSPACE_FEATURES),
+        }
+    }
+
+    pub fn with_capabilities(mut self, capabilities: &Capabilities) -> Self {
+        if capabilities.formatter.format.is_some() {
+            self.features_supported
+                .insert(FeatureName::Format, SupportKind::Supported);
+        }
+        if capabilities.analyzer.lint.is_some() {
+            self.features_supported
+                .insert(FeatureName::Lint, SupportKind::Supported);
+        }
+        if capabilities.analyzer.organize_imports.is_some() {
+            self.features_supported
+                .insert(FeatureName::OrganizeImports, SupportKind::Supported);
+        }
+
+        self
+    }
+
+    pub fn with_settings(mut self, settings: &WorkspaceSettings) -> Self {
+        if !settings.formatter().enabled {
+            self.features_supported
+                .insert(FeatureName::Format, SupportKind::FeatureNotEnabled);
+        }
+        if !settings.linter().enabled {
+            self.features_supported
+                .insert(FeatureName::Lint, SupportKind::FeatureNotEnabled);
+        }
+        if !settings.organize_imports().enabled {
+            self.features_supported
+                .insert(FeatureName::OrganizeImports, SupportKind::FeatureNotEnabled);
+        }
+
+        self
+    }
+
+    pub fn ignored(&mut self, feature: FeatureName) {
+        self.features_supported
+            .insert(feature, SupportKind::Ignored);
+    }
+
+    /// Checks whether the file support the given `feature`
+    pub fn supports_for(&self, feature: &FeatureName) -> bool {
+        self.features_supported
+            .get(&feature)
+            .map(|support_kind| matches!(support_kind, SupportKind::Supported))
+            .unwrap_or_default()
+    }
+
+    pub fn is_ignored_for(&self, feature: &FeatureName) -> bool {
+        self.features_supported
+            .get(&feature)
+            .map(|support_kind| matches!(support_kind, SupportKind::Ignored))
+            .unwrap_or_default()
+    }
+
+    pub fn support_kind_for(&self, feature: &FeatureName) -> Option<&SupportKind> {
+        self.features_supported.get(&feature)
+    }
 }
 
 impl SupportsFeatureResult {
-    const fn ignored() -> Self {
-        Self {
-            reason: Some(UnsupportedReason::Ignored),
-        }
-    }
-
-    const fn disabled() -> Self {
-        Self {
-            reason: Some(UnsupportedReason::FeatureNotEnabled),
-        }
-    }
-
-    const fn file_not_supported() -> Self {
-        Self {
-            reason: Some(UnsupportedReason::FileNotSupported),
-        }
-    }
-
     /// Whether the feature is intentionally disabled
     pub const fn is_not_enabled(&self) -> bool {
-        matches!(self.reason, Some(UnsupportedReason::FeatureNotEnabled))
+        matches!(self.reason, Some(SupportKind::FeatureNotEnabled))
     }
 
     /// Whether the feature is supported
@@ -118,24 +182,58 @@ impl SupportsFeatureResult {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub enum UnsupportedReason {
+pub enum SupportKind {
+    /// The feature is enabled for the file
+    Supported,
+    /// The file is ignored (configuration)
     Ignored,
+    /// The feature is not enabled (configuration or the file doesn't need it)
     FeatureNotEnabled,
+    /// The file is not capable of having this feature
     FileNotSupported,
 }
 
-impl UnsupportedReason {
+impl SupportKind {
+    pub const fn is_supported(&self) -> bool {
+        matches!(self, SupportKind::Supported)
+    }
     pub const fn is_not_enabled(&self) -> bool {
-        matches!(self, UnsupportedReason::FeatureNotEnabled)
+        matches!(self, SupportKind::FeatureNotEnabled)
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum FeatureName {
     Format,
     Lint,
     OrganizeImports,
+}
+
+#[derive(Debug, Default)]
+pub struct FeaturesBuilder(Vec<FeatureName>);
+
+impl FeaturesBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_formatter(mut self) -> Self {
+        self.0.push(FeatureName::Format);
+        self
+    }
+    pub fn with_linter(mut self) -> Self {
+        self.0.push(FeatureName::Lint);
+        self
+    }
+    pub fn with_organize_imports(mut self) -> Self {
+        self.0.push(FeatureName::OrganizeImports);
+        self
+    }
+
+    pub fn build(self) -> Vec<FeatureName> {
+        self.0
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -390,10 +488,10 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// - Rome doesn't recognize a file, so it can't provide the feature;
     /// - the feature is disabled inside the configuration;
     /// - the file is ignored
-    fn supports_feature(
+    fn file_features(
         &self,
         params: SupportsFeatureParams,
-    ) -> Result<SupportsFeatureResult, WorkspaceError>;
+    ) -> Result<FileFeaturesResult, WorkspaceError>;
 
     /// Checks if the current path is ignored by the workspace, against a particular feature.
     ///

--- a/crates/rome_service/src/workspace.rs
+++ b/crates/rome_service/src/workspace.rs
@@ -146,20 +146,20 @@ impl FileFeaturesResult {
     /// Checks whether the file support the given `feature`
     pub fn supports_for(&self, feature: &FeatureName) -> bool {
         self.features_supported
-            .get(&feature)
+            .get(feature)
             .map(|support_kind| matches!(support_kind, SupportKind::Supported))
             .unwrap_or_default()
     }
 
     pub fn is_ignored_for(&self, feature: &FeatureName) -> bool {
         self.features_supported
-            .get(&feature)
+            .get(feature)
             .map(|support_kind| matches!(support_kind, SupportKind::Ignored))
             .unwrap_or_default()
     }
 
     pub fn support_kind_for(&self, feature: &FeatureName) -> Option<&SupportKind> {
-        self.features_supported.get(&feature)
+        self.features_supported.get(feature)
     }
 }
 

--- a/crates/rome_service/src/workspace/client.rs
+++ b/crates/rome_service/src/workspace/client.rs
@@ -1,6 +1,6 @@
 use crate::workspace::{
-    GetFileContentParams, IsPathIgnoredParams, OrganizeImportsParams, OrganizeImportsResult,
-    RageParams, RageResult, ServerInfo, SupportsFeatureResult,
+    FileFeaturesResult, GetFileContentParams, IsPathIgnoredParams, OrganizeImportsParams,
+    OrganizeImportsResult, RageParams, RageResult, ServerInfo,
 };
 use crate::{TransportError, Workspace, WorkspaceError};
 use rome_formatter::Printed;
@@ -100,11 +100,11 @@ impl<T> Workspace for WorkspaceClient<T>
 where
     T: WorkspaceTransport + RefUnwindSafe + Send + Sync,
 {
-    fn supports_feature(
+    fn file_features(
         &self,
         params: SupportsFeatureParams,
-    ) -> Result<SupportsFeatureResult, WorkspaceError> {
-        self.request("rome/supports_feature", params)
+    ) -> Result<FileFeaturesResult, WorkspaceError> {
+        self.request("rome/file_features", params)
     }
 
     fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError> {

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::file_handlers::{Capabilities, FixAllParams, Language, LintParams};
 use crate::workspace::{
     FileFeaturesResult, GetFileContentParams, IsPathIgnoredParams, OrganizeImportsParams,
-    OrganizeImportsResult, RageEntry, RageParams, RageResult, ServerInfo, SupportsFeatureResult,
+    OrganizeImportsResult, RageEntry, RageParams, RageResult, ServerInfo,
 };
 use crate::{
     file_handlers::Features,

--- a/crates/rome_service/src/workspace/server.rs
+++ b/crates/rome_service/src/workspace/server.rs
@@ -7,8 +7,8 @@ use super::{
 };
 use crate::file_handlers::{Capabilities, FixAllParams, Language, LintParams};
 use crate::workspace::{
-    GetFileContentParams, IsPathIgnoredParams, OrganizeImportsParams, OrganizeImportsResult,
-    RageEntry, RageParams, RageResult, ServerInfo, SupportsFeatureResult,
+    FileFeaturesResult, GetFileContentParams, IsPathIgnoredParams, OrganizeImportsParams,
+    OrganizeImportsResult, RageEntry, RageParams, RageResult, ServerInfo, SupportsFeatureResult,
 };
 use crate::{
     file_handlers::Features,
@@ -25,6 +25,7 @@ use rome_parser::AnyParse;
 use rome_rowan::NodeCache;
 use std::ffi::OsStr;
 use std::{panic::RefUnwindSafe, sync::RwLock};
+use tracing::trace;
 
 pub(super) struct WorkspaceServer {
     /// features available throughout the application
@@ -189,52 +190,27 @@ impl WorkspaceServer {
 }
 
 impl Workspace for WorkspaceServer {
-    fn supports_feature(
+    fn file_features(
         &self,
         params: SupportsFeatureParams,
-    ) -> Result<SupportsFeatureResult, WorkspaceError> {
+    ) -> Result<FileFeaturesResult, WorkspaceError> {
         let capabilities = self.get_capabilities(&params.path);
         let settings = self.settings.read().unwrap();
-        let is_ignored = self.is_path_ignored(IsPathIgnoredParams {
-            rome_path: params.path,
-            feature: params.feature.clone(),
-        })?;
-        let result = match params.feature {
-            FeatureName::Format => {
-                if is_ignored {
-                    SupportsFeatureResult::ignored()
-                } else if capabilities.formatter.format.is_none() {
-                    SupportsFeatureResult::file_not_supported()
-                } else if !settings.formatter().enabled {
-                    SupportsFeatureResult::disabled()
-                } else {
-                    SupportsFeatureResult { reason: None }
-                }
+        let mut file_features = FileFeaturesResult::new()
+            .with_capabilities(&capabilities)
+            .with_settings(&settings);
+
+        for feature in params.feature {
+            let is_ignored = self.is_path_ignored(IsPathIgnoredParams {
+                rome_path: params.path.clone(),
+                feature: feature.clone(),
+            })?;
+
+            if is_ignored {
+                file_features.ignored(feature);
             }
-            FeatureName::Lint => {
-                if is_ignored {
-                    SupportsFeatureResult::ignored()
-                } else if capabilities.analyzer.lint.is_none() {
-                    SupportsFeatureResult::file_not_supported()
-                } else if !settings.linter().enabled {
-                    SupportsFeatureResult::disabled()
-                } else {
-                    SupportsFeatureResult { reason: None }
-                }
-            }
-            FeatureName::OrganizeImports => {
-                if is_ignored {
-                    SupportsFeatureResult::ignored()
-                } else if capabilities.analyzer.organize_imports.is_none() {
-                    SupportsFeatureResult::file_not_supported()
-                } else if !settings.organize_imports().enabled {
-                    SupportsFeatureResult::disabled()
-                } else {
-                    SupportsFeatureResult { reason: None }
-                }
-            }
-        };
-        Ok(result)
+        }
+        Ok(file_features)
     }
 
     fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError> {
@@ -400,9 +376,14 @@ impl Workspace for WorkspaceServer {
             self.get_capabilities(&params.path).analyzer.lint
         {
             let rules = settings.linter().rules.as_ref();
-            let rule_filter_list = self.build_rule_filter_list(rules);
+            let mut rule_filter_list = self.build_rule_filter_list(rules);
+            if settings.organize_imports.enabled {
+                rule_filter_list.push(RuleFilter::Rule("correctness", "organizeImports"));
+            }
             let mut filter = AnalysisFilter::from_enabled_rules(Some(rule_filter_list.as_slice()));
             filter.categories = params.categories;
+
+            trace!("Analyzer filter to apply to lint: {:?}", &filter);
 
             let results = lint(LintParams {
                 parse,

--- a/crates/rome_service/src/workspace_types.rs
+++ b/crates/rome_service/src/workspace_types.rs
@@ -453,7 +453,7 @@ macro_rules! workspace_method {
 /// Returns a list of signature for all the methods in the [Workspace] trait
 pub fn methods() -> [WorkspaceMethod; 16] {
     [
-        WorkspaceMethod::of::<SupportsFeatureParams, SupportsFeatureResult>("supports_feature"),
+        WorkspaceMethod::of::<SupportsFeatureParams, SupportsFeatureResult>("file_features"),
         workspace_method!(update_settings),
         workspace_method!(open_file),
         workspace_method!(change_file),

--- a/crates/rome_wasm/src/lib.rs
+++ b/crates/rome_wasm/src/lib.rs
@@ -36,14 +36,14 @@ impl Workspace {
         }
     }
 
-    #[wasm_bindgen(js_name = supportsFeature)]
-    pub fn supports_feature(
+    #[wasm_bindgen(js_name = fileFeatures)]
+    pub fn file_features(
         &self,
         params: ISupportsFeatureParams,
     ) -> Result<ISupportsFeatureResult, Error> {
         let params: SupportsFeatureParams =
             serde_wasm_bindgen::from_value(params.into()).map_err(into_error)?;
-        let result = self.inner.supports_feature(params).map_err(into_error)?;
+        let result = self.inner.file_features(params).map_err(into_error)?;
         to_value(&result)
             .map(ISupportsFeatureResult::from)
             .map_err(into_error)

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -92,7 +92,7 @@ export interface JavascriptConfiguration {
 	/**
 	* A list of global bindings that should be ignored by the analyzers
 
-If defined here, they should not emit diagnostics. 
+If defined here, they should not emit diagnostics.
 	 */
 	globals?: StringSet;
 	organize_imports?: JavascriptOrganizeImports;
@@ -136,7 +136,7 @@ export interface VcsConfiguration {
 	/**
 	* The folder where Rome should check for VCS files. By default, Rome will use the same folder where `rome.json` was found.
 
-If Rome can't fine the configuration, it will attempt to use the current working directory. If no current working directory can't be found, Rome won't use the VCS integration. 
+If Rome can't fine the configuration, it will attempt to use the current working directory. If no current working directory can't be found, Rome won't use the VCS integration.
 	 */
 	root?: string;
 	/**
@@ -149,7 +149,7 @@ export type PlainIndentStyle = "tab" | "space";
 /**
 	* Validated value for the `line_width` formatter options
 
-The allowed range of values is 1..=320 
+The allowed range of values is 1..=320
 	 */
 export type LineWidth = number;
 export interface JavascriptFormatter {
@@ -1120,7 +1120,7 @@ export type DiagnosticTags = DiagnosticTag[];
 /**
 	* Serializable representation of a [Diagnostic](super::Diagnostic) advice
 
-See the [Visitor] trait for additional documentation on all the supported advice types. 
+See the [Visitor] trait for additional documentation on all the supported advice types.
 	 */
 export type Advice =
 	| { Log: [LogCategory, MarkupBuf] }
@@ -1208,7 +1208,7 @@ export interface CodeAction {
 /**
 	* The category of a code action, this type maps directly to the [CodeActionKind] type in the Language Server Protocol specification
 
-[CodeActionKind]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind 
+[CodeActionKind]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind
 	 */
 export type ActionCategory =
 	| "QuickFix"
@@ -1353,7 +1353,7 @@ export interface Workspace {
 export function createWorkspace(transport: Transport): Workspace {
 	return {
 		supportsFeature(params) {
-			return transport.request("rome/supports_feature", params);
+			return transport.request("rome/file_features", params);
 		},
 		updateSettings(params) {
 			return transport.request("rome/update_settings", params);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/4434

I also took the opportunity to refactor how "features" are requested from a workspace. So far, requesting a feature was done via `.supports_feature`, and it was possible only to ask for a "feature" per file.

I refactored the code; now it's possible to request multiple features. The result of the function also provides some APIs to ask if a file supports a single "feature".

The concept of `supports_feature` has been renamed to `file_features`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I created a new test for the bug.

The refactor should not have any regression, so the existing tests should all pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
