### PR TITLE
fix(rome_service): correctly send file source to workspace

### DIFF
--- a/crates/rome_cli/tests/snapshots/main_commands_check/should_apply_correct_file_source.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/should_apply_correct_file_source.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUndeclaredVariables": "error"
+      }
+    }
+  }
+}
+```
+
+## `file.ts`
+
+```ts
+type A = { a: string }; type B = Partial<A>
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_js_analyze/src/lib.rs
+++ b/crates/rome_js_analyze/src/lib.rs
@@ -7,7 +7,7 @@ use rome_analyze::{
 use rome_aria::{AriaProperties, AriaRoles};
 use rome_diagnostics::{category, Diagnostic, Error as DiagnosticError};
 use rome_js_syntax::suppression::SuppressionDiagnostic;
-use rome_js_syntax::{suppression::parse_suppression_comment, JsLanguage, SourceType};
+use rome_js_syntax::{suppression::parse_suppression_comment, JsFileSource, JsLanguage};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::{borrow::Cow, error::Error};
@@ -56,7 +56,7 @@ pub fn analyze_with_inspect_matcher<'a, V, F, B>(
     filter: AnalysisFilter,
     inspect_matcher: V,
     options: &'a AnalyzerOptions,
-    source_type: SourceType,
+    source_type: JsFileSource,
     mut emit_signal: F,
 ) -> (Option<B>, Vec<DiagnosticError>)
 where
@@ -147,7 +147,7 @@ pub fn analyze<'a, F, B>(
     root: &LanguageRoot<JsLanguage>,
     filter: AnalysisFilter,
     options: &'a AnalyzerOptions,
-    source_type: SourceType,
+    source_type: JsFileSource,
     emit_signal: F,
 ) -> (Option<B>, Vec<DiagnosticError>)
 where
@@ -166,7 +166,7 @@ mod tests {
     use rome_diagnostics::termcolor::NoColor;
     use rome_diagnostics::{Diagnostic, DiagnosticExt, PrintDiagnostic, Severity};
     use rome_js_parser::parse;
-    use rome_js_syntax::{SourceType, TextRange, TextSize};
+    use rome_js_syntax::{JsFileSource, TextRange, TextSize};
     use std::slice;
 
     use crate::{analyze, AnalysisFilter, ControlFlow};
@@ -185,7 +185,7 @@ mod tests {
 
         const SOURCE: &str = r#"a.b["c"];"#;
 
-        let parsed = parse(SOURCE, SourceType::tsx());
+        let parsed = parse(SOURCE, JsFileSource::tsx());
 
         let mut error_ranges: Vec<TextRange> = Vec::new();
         let options = AnalyzerOptions::default();
@@ -197,7 +197,7 @@ mod tests {
                 ..AnalysisFilter::default()
             },
             &options,
-            SourceType::tsx(),
+            JsFileSource::tsx(),
             |signal| {
                 if let Some(diag) = signal.diagnostic() {
                     error_ranges.push(diag.location().span.unwrap());
@@ -272,7 +272,7 @@ mod tests {
             }
         ";
 
-        let parsed = parse(SOURCE, SourceType::js_module());
+        let parsed = parse(SOURCE, JsFileSource::js_module());
 
         let mut lint_ranges: Vec<TextRange> = Vec::new();
         let mut parse_ranges: Vec<TextRange> = Vec::new();
@@ -283,7 +283,7 @@ mod tests {
             &parsed.tree(),
             AnalysisFilter::default(),
             &options,
-            SourceType::js_module(),
+            JsFileSource::js_module(),
             |signal| {
                 if let Some(diag) = signal.diagnostic() {
                     let span = diag.get_span();
@@ -354,7 +354,7 @@ mod tests {
             a == b;
         ";
 
-        let parsed = parse(SOURCE, SourceType::js_module());
+        let parsed = parse(SOURCE, JsFileSource::js_module());
 
         let filter = AnalysisFilter {
             categories: RuleCategories::SYNTAX,
@@ -366,7 +366,7 @@ mod tests {
             &parsed.tree(),
             filter,
             &options,
-            SourceType::js_module(),
+            JsFileSource::js_module(),
             |signal| {
                 if let Some(diag) = signal.diagnostic() {
                     let code = diag.category().unwrap();

--- a/crates/rome_js_analyze/src/react/hooks.rs
+++ b/crates/rome_js_analyze/src/react/hooks.rs
@@ -208,11 +208,11 @@ pub fn is_binding_react_stable(
 #[cfg(test)]
 mod test {
     use super::*;
-    use rome_js_syntax::SourceType;
+    use rome_js_syntax::JsFileSource;
 
     #[test]
     pub fn ok_react_stable_captures() {
-        let r = rome_js_parser::parse("const ref = useRef();", SourceType::js_module());
+        let r = rome_js_parser::parse("const ref = useRef();", JsFileSource::js_module());
         let node = r
             .syntax()
             .descendants()

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
@@ -6,7 +6,7 @@ use crate::semantic_services::SemanticServices;
 use rome_analyze::context::RuleContext;
 use rome_analyze::{declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
-use rome_js_syntax::{Language, SourceType, TextRange, TsAsExpression, TsReferenceType};
+use rome_js_syntax::{JsFileSource, Language, TextRange, TsAsExpression, TsReferenceType};
 use rome_rowan::AstNode;
 
 declare_rule! {
@@ -55,7 +55,7 @@ impl Rule for NoUndeclaredVariables {
                 let token = identifier.value_token().ok()?;
                 let text = token.text_trimmed();
 
-                let source_type = ctx.source_type::<SourceType>();
+                let source_type = ctx.source_type::<JsFileSource>();
 
                 if ctx.is_global(text) {
                     return None;
@@ -88,7 +88,7 @@ impl Rule for NoUndeclaredVariables {
     }
 }
 
-fn is_global(reference_name: &str, source_type: &SourceType) -> bool {
+fn is_global(reference_name: &str, source_type: &JsFileSource) -> bool {
     ES_2021.binary_search(&reference_name).is_ok()
         || BROWSER.binary_search(&reference_name).is_ok()
         || NODE.binary_search(&reference_name).is_ok()

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_constant_condition.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_constant_condition.rs
@@ -461,13 +461,13 @@ fn get_boolean_value(node: AnyJsLiteralExpression) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use rome_js_syntax::{AnyJsLiteralExpression, SourceType};
+    use rome_js_syntax::{AnyJsLiteralExpression, JsFileSource};
     use rome_rowan::SyntaxNodeCast;
 
     use super::get_boolean_value;
 
     fn assert_boolean_value(code: &str, value: bool) {
-        let source = rome_js_parser::parse(code, SourceType::tsx());
+        let source = rome_js_parser::parse(code, JsFileSource::tsx());
 
         if source.has_errors() {
             panic!("syntax error")

--- a/crates/rome_js_analyze/src/utils/tests.rs
+++ b/crates/rome_js_analyze/src/utils/tests.rs
@@ -3,8 +3,8 @@ use crate::utils::batch::JsBatchMutation;
 use rome_js_semantic::{semantic_model, SemanticModelOptions};
 use rome_js_syntax::JsSyntaxNode;
 use rome_js_syntax::{
-    AnyJsObjectMember, JsFormalParameter, JsIdentifierBinding, JsLanguage, JsVariableDeclarator,
-    SourceType,
+    AnyJsObjectMember, JsFileSource, JsFormalParameter, JsIdentifierBinding, JsLanguage,
+    JsVariableDeclarator,
 };
 use rome_rowan::{AstNode, BatchMutationExt, SyntaxNodeCast};
 use std::{any::type_name, fmt::Debug};
@@ -12,7 +12,7 @@ use std::{any::type_name, fmt::Debug};
 /// Search and renames alls bindings where the name contains "a" replacing it to "b".
 /// Asserts the renaming worked.
 pub fn assert_rename_binding_a_to_b_ok(before: &str, expected: &str) {
-    let r = rome_js_parser::parse(before, SourceType::js_module());
+    let r = rome_js_parser::parse(before, JsFileSource::js_module());
     let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
     let bindings: Vec<JsIdentifierBinding> = r
@@ -44,7 +44,7 @@ pub fn assert_rename_binding_a_to_b_ok(before: &str, expected: &str) {
 /// Search and renames one binding named "a" to "b".
 /// Asserts the renaming fails.
 pub fn assert_rename_binding_a_to_b_nok(before: &str) {
-    let r = rome_js_parser::parse(before, SourceType::js_module());
+    let r = rome_js_parser::parse(before, JsFileSource::js_module());
     let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
     let binding_a = r
@@ -64,7 +64,7 @@ pub fn assert_remove_identifier_a_ok<Anc: AstNode<Language = JsLanguage> + Debug
     before: &str,
     expected: &str,
 ) {
-    let r = rome_js_parser::parse(before, SourceType::js_module());
+    let r = rome_js_parser::parse(before, JsFileSource::js_module());
 
     let identifiers_a: Vec<JsSyntaxNode> = r
         .syntax()
@@ -147,7 +147,7 @@ macro_rules! assert_remove_ok {
 
 #[test]
 pub fn ok_find_attributes_by_name() {
-    let r = rome_js_parser::parse(r#"<a a="A" c="C" b="B" />"#, SourceType::jsx());
+    let r = rome_js_parser::parse(r#"<a a="A" c="C" b="B" />"#, JsFileSource::jsx());
     let list = r
         .syntax()
         .descendants()

--- a/crates/rome_js_analyze/tests/spec_tests.rs
+++ b/crates/rome_js_analyze/tests/spec_tests.rs
@@ -13,7 +13,7 @@ use rome_js_parser::{
     parse,
     test_utils::{assert_errors_are_absent, has_bogus_nodes_or_empty_slots},
 };
-use rome_js_syntax::{JsLanguage, SourceType};
+use rome_js_syntax::{JsFileSource, JsLanguage};
 use similar::TextDiff;
 use std::{
     ffi::OsStr, fmt::Write, fs::read_to_string, os::raw::c_int, path::Path, slice, sync::Once,
@@ -65,7 +65,7 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
             write_analysis_to_snapshot(
                 &mut snapshot,
                 &script,
-                SourceType::js_script(),
+                JsFileSource::js_script(),
                 filter,
                 file_name,
                 input_file,
@@ -115,7 +115,7 @@ impl CheckActionType {
 pub(crate) fn write_analysis_to_snapshot(
     snapshot: &mut String,
     input_code: &str,
-    source_type: SourceType,
+    source_type: JsFileSource,
     filter: AnalysisFilter,
     file_name: &str,
     input_file: &Path,
@@ -251,7 +251,7 @@ fn diagnostic_to_string(name: &str, source: &str, diag: Error) -> String {
 fn check_code_action(
     path: &Path,
     source: &str,
-    source_type: SourceType,
+    source_type: JsFileSource,
     action: &AnalyzerAction<JsLanguage>,
 ) {
     let (_, text_edit) = action.mutation.as_text_edits().unwrap_or_default();
@@ -335,7 +335,7 @@ pub(crate) fn run_suppression_test(input: &'static str, _: &str, _: &str, _: &st
     write_analysis_to_snapshot(
         &mut snapshot,
         &input_code,
-        SourceType::jsx(),
+        JsFileSource::jsx(),
         filter,
         file_name,
         input_file,

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -8,7 +8,7 @@ use rome_formatter::{
     CstFormatContext, FormatContext, FormatElement, FormatOptions, IndentStyle, LineWidth,
     TransformSourceMap,
 };
-use rome_js_syntax::{AnyJsFunctionBody, JsLanguage, SourceType};
+use rome_js_syntax::{AnyJsFunctionBody, JsFileSource, JsLanguage};
 use rome_json_syntax::JsonLanguage;
 use rome_rowan::SyntaxNode;
 use std::fmt;
@@ -154,11 +154,11 @@ pub struct JsFormatOptions {
     semicolons: Semicolons,
 
     /// Information related to the current file
-    source_type: SourceType,
+    source_type: JsFileSource,
 }
 
 impl JsFormatOptions {
-    pub fn new(source_type: SourceType) -> Self {
+    pub fn new(source_type: JsFileSource) -> Self {
         Self {
             source_type,
             indent_style: IndentStyle::default(),
@@ -208,7 +208,7 @@ impl JsFormatOptions {
         self.quote_properties
     }
 
-    pub fn source_type(&self) -> SourceType {
+    pub fn source_type(&self) -> JsFileSource {
         self.source_type
     }
 

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -647,7 +647,7 @@ pub(crate) fn is_multiline_template_starting_on_same_line(template: &JsTemplateE
 mod tests {
 
     use crate::{assert_needs_parentheses, assert_not_needs_parentheses};
-    use rome_js_syntax::{JsArrowFunctionExpression, SourceType};
+    use rome_js_syntax::{JsArrowFunctionExpression, JsFileSource};
 
     #[test]
     fn needs_parentheses() {
@@ -668,7 +668,7 @@ mod tests {
         assert_needs_parentheses!(
             "<Function>(a => a)",
             JsArrowFunctionExpression,
-            SourceType::ts()
+            JsFileSource::ts()
         );
         assert_needs_parentheses!("(a => a) ? b : c", JsArrowFunctionExpression);
         assert_not_needs_parentheses!("a ? b => b : c", JsArrowFunctionExpression);

--- a/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
@@ -30,7 +30,7 @@ impl NeedsParentheses for JsBinaryExpression {
 #[cfg(test)]
 mod tests {
     use crate::{assert_needs_parentheses, assert_not_needs_parentheses};
-    use rome_js_syntax::{JsBinaryExpression, SourceType};
+    use rome_js_syntax::{JsBinaryExpression, JsFileSource};
 
     #[test]
     fn needs_parentheses() {
@@ -51,12 +51,12 @@ mod tests {
         assert_needs_parentheses!(
             "<test {...(4 + 4)} />",
             JsBinaryExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
         assert_needs_parentheses!(
             "<test>{...(4 + 4)}</test>",
             JsBinaryExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
 
         assert_needs_parentheses!("(4 + 4).member", JsBinaryExpression);

--- a/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/conditional_expression.rs
@@ -62,7 +62,7 @@ impl NeedsParentheses for JsConditionalExpression {
 mod tests {
 
     use crate::{assert_needs_parentheses, assert_not_needs_parentheses};
-    use rome_js_syntax::{JsConditionalExpression, SourceType};
+    use rome_js_syntax::{JsConditionalExpression, JsFileSource};
 
     #[test]
     fn needs_parentheses() {
@@ -105,7 +105,7 @@ mod tests {
         assert_needs_parentheses!(
             "<a {...(a ? b : c)} />",
             JsConditionalExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
 
         assert_needs_parentheses!("(a ? b : c) as number;", JsConditionalExpression);

--- a/crates/rome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/in_expression.rs
@@ -59,7 +59,7 @@ fn is_in_for_initializer(expression: &JsInExpression) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::{assert_needs_parentheses, assert_not_needs_parentheses};
-    use rome_js_syntax::{JsInExpression, SourceType};
+    use rome_js_syntax::{JsFileSource, JsInExpression};
 
     #[test]
     fn needs_parentheses() {
@@ -77,11 +77,15 @@ mod tests {
         assert_needs_parentheses!("(a in b)`template`", JsInExpression);
         assert_needs_parentheses!("[...(a in b)]", JsInExpression);
         assert_needs_parentheses!("({...(a in b)})", JsInExpression);
-        assert_needs_parentheses!("<test {...(a in b)} />", JsInExpression, SourceType::tsx());
+        assert_needs_parentheses!(
+            "<test {...(a in b)} />",
+            JsInExpression,
+            JsFileSource::tsx()
+        );
         assert_needs_parentheses!(
             "<test>{...(a in b)}</test>",
             JsInExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
 
         assert_needs_parentheses!("(a in b).member", JsInExpression);

--- a/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -30,7 +30,7 @@ impl NeedsParentheses for JsInstanceofExpression {
 #[cfg(test)]
 mod tests {
     use crate::{assert_needs_parentheses, assert_not_needs_parentheses};
-    use rome_js_syntax::{JsInstanceofExpression, SourceType};
+    use rome_js_syntax::{JsFileSource, JsInstanceofExpression};
 
     #[test]
     fn needs_parentheses() {
@@ -54,12 +54,12 @@ mod tests {
         assert_needs_parentheses!(
             "<test {...(a instanceof B)} />",
             JsInstanceofExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
         assert_needs_parentheses!(
             "<test>{...(a instanceof B)}</test>",
             JsInstanceofExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
 
         assert_needs_parentheses!("(a instanceof B).member", JsInstanceofExpression);

--- a/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
@@ -36,7 +36,7 @@ impl NeedsParentheses for JsLogicalExpression {
 mod tests {
 
     use crate::{assert_needs_parentheses, assert_not_needs_parentheses};
-    use rome_js_syntax::{JsLogicalExpression, SourceType};
+    use rome_js_syntax::{JsFileSource, JsLogicalExpression};
 
     #[test]
     fn needs_parentheses() {
@@ -57,12 +57,12 @@ mod tests {
         assert_needs_parentheses!(
             "<test {...(a && b)} />",
             JsLogicalExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
         assert_needs_parentheses!(
             "<test>{...(a && b)}</test>",
             JsLogicalExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
 
         assert_needs_parentheses!("(a && b).member", JsLogicalExpression);

--- a/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/string_literal_expression.rs
@@ -53,7 +53,7 @@ impl NeedsParentheses for JsStringLiteralExpression {
 mod tests {
 
     use crate::{assert_needs_parentheses, assert_not_needs_parentheses};
-    use rome_js_syntax::{JsStringLiteralExpression, ModuleKind, SourceType};
+    use rome_js_syntax::{JsFileSource, JsStringLiteralExpression, ModuleKind};
 
     #[test]
     fn needs_parentheses() {
@@ -88,7 +88,7 @@ mod tests {
         assert_needs_parentheses!(
             "('test');",
             JsStringLiteralExpression,
-            SourceType::ts().with_module_kind(ModuleKind::Module)
+            JsFileSource::ts().with_module_kind(ModuleKind::Module)
         );
 
         assert_not_needs_parentheses!("console.log('a')", JsStringLiteralExpression);

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -545,7 +545,7 @@ mod tests {
     use crate::context::JsFormatOptions;
     use rome_formatter::IndentStyle;
     use rome_js_parser::{parse, parse_script};
-    use rome_js_syntax::SourceType;
+    use rome_js_syntax::JsFileSource;
     use rome_rowan::{TextRange, TextSize};
 
     #[test]
@@ -580,7 +580,8 @@ while(
 
         let tree = parse_script(input);
         let result = format_range(
-            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(JsFileSource::js_script())
+                .with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -612,7 +613,8 @@ function() {
 
         let tree = parse_script(input);
         let result = format_range(
-            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(JsFileSource::js_script())
+                .with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -639,7 +641,8 @@ function() {
 
         let tree = parse_script(input);
         let result = format_range(
-            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(JsFileSource::js_script())
+                .with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
@@ -667,7 +670,8 @@ function() {
 
         let tree = parse_script(input);
         let result = format_range(
-            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(JsFileSource::js_script())
+                .with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             range,
         )
@@ -698,7 +702,8 @@ function() {
 
         let tree = parse_script(input);
         let result = format_range(
-            JsFormatOptions::new(SourceType::js_script()).with_indent_style(IndentStyle::Space(4)),
+            JsFormatOptions::new(JsFileSource::js_script())
+                .with_indent_style(IndentStyle::Space(4)),
             &tree.syntax(),
             range,
         )
@@ -715,7 +720,7 @@ function() {
     fn format_range_out_of_bounds() {
         let src = "statement();";
 
-        let syntax = SourceType::js_module();
+        let syntax = JsFileSource::js_module();
         let tree = parse(src, syntax);
 
         let result = format_range(

--- a/crates/rome_js_formatter/src/parentheses.rs
+++ b/crates/rome_js_formatter/src/parentheses.rs
@@ -1040,7 +1040,7 @@ pub(crate) fn debug_assert_is_parent(node: &JsSyntaxNode, parent: &JsSyntaxNode)
 pub(crate) mod tests {
     use super::NeedsParentheses;
     use crate::transform;
-    use rome_js_syntax::{JsLanguage, SourceType};
+    use rome_js_syntax::{JsFileSource, JsLanguage};
     use rome_rowan::AstNode;
 
     pub(crate) fn assert_needs_parentheses_impl<
@@ -1048,7 +1048,7 @@ pub(crate) mod tests {
     >(
         input: &'static str,
         index: Option<usize>,
-        source_type: SourceType,
+        source_type: JsFileSource,
     ) {
         let parse = rome_js_parser::parse(input, source_type);
 
@@ -1089,7 +1089,7 @@ pub(crate) mod tests {
     >(
         input: &'static str,
         index: Option<usize>,
-        source_type: SourceType,
+        source_type: JsFileSource,
     ) {
         let parse = rome_js_parser::parse(input, source_type);
 

--- a/crates/rome_js_formatter/src/parentheses.rs
+++ b/crates/rome_js_formatter/src/parentheses.rs
@@ -1150,14 +1150,14 @@ pub(crate) mod tests {
     #[macro_export]
     macro_rules! assert_needs_parentheses {
         ($input:expr, $Node:ident) => {{
-            $crate::assert_needs_parentheses!($input, $Node, rome_js_syntax::SourceType::ts())
+            $crate::assert_needs_parentheses!($input, $Node, rome_js_syntax::JsFileSource::ts())
         }};
 
         ($input:expr, $Node:ident[$index:expr]) => {{
             $crate::assert_needs_parentheses!(
                 $input,
                 $Node[$index],
-                rome_js_syntax::SourceType::ts()
+                rome_js_syntax::JsFileSource::ts()
             )
         }};
 
@@ -1203,14 +1203,14 @@ pub(crate) mod tests {
     #[macro_export]
     macro_rules! assert_not_needs_parentheses {
         ($input:expr, $Node:ident) => {{
-            $crate::assert_not_needs_parentheses!($input, $Node, rome_js_syntax::SourceType::ts())
+            $crate::assert_not_needs_parentheses!($input, $Node, rome_js_syntax::JsFileSource::ts())
         }};
 
         ($input:expr, $Node:ident[$index:expr]) => {{
             $crate::assert_not_needs_parentheses!(
                 $input,
                 $Node[$index],
-                rome_js_syntax::SourceType::ts()
+                rome_js_syntax::JsFileSource::ts()
             )
         }};
 

--- a/crates/rome_js_formatter/src/syntax_rewriter.rs
+++ b/crates/rome_js_formatter/src/syntax_rewriter.rs
@@ -448,9 +448,9 @@ mod tests {
     use rome_formatter::{SourceMarker, TransformSourceMap};
     use rome_js_parser::{parse, parse_module};
     use rome_js_syntax::{
-        JsArrayExpression, JsBinaryExpression, JsExpressionStatement, JsIdentifierExpression,
-        JsLogicalExpression, JsSequenceExpression, JsStringLiteralExpression, JsSyntaxNode,
-        JsUnaryExpression, JsxTagExpression, SourceType,
+        JsArrayExpression, JsBinaryExpression, JsExpressionStatement, JsFileSource,
+        JsIdentifierExpression, JsLogicalExpression, JsSequenceExpression,
+        JsStringLiteralExpression, JsSyntaxNode, JsUnaryExpression, JsxTagExpression,
     };
     use rome_rowan::{AstNode, SyntaxRewriter, TextSize};
 
@@ -809,7 +809,7 @@ mod tests {
     }
 
     fn source_map_test(input: &str) -> (JsSyntaxNode, TransformSourceMap) {
-        let tree = parse(input, SourceType::jsx()).syntax();
+        let tree = parse(input, JsFileSource::jsx()).syntax();
 
         let mut rewriter = JsFormatSyntaxRewriter::default();
         let transformed = rewriter.transform(tree);
@@ -823,7 +823,7 @@ mod tests {
         let (transformed, source_map) = source_map_test("(((a * b) * c)) / 3");
 
         let formatted =
-            format_node(JsFormatOptions::new(SourceType::default()), &transformed).unwrap();
+            format_node(JsFormatOptions::new(JsFileSource::default()), &transformed).unwrap();
         let printed = formatted.print().unwrap();
 
         assert_eq!(printed.as_code(), "(a * b * c) / 3;\n");

--- a/crates/rome_js_formatter/src/ts/expressions/as_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/as_expression.rs
@@ -104,7 +104,7 @@ impl NeedsParentheses for TsAsOrSatisfiesExpression {
 mod tests {
 
     use crate::{assert_needs_parentheses, assert_not_needs_parentheses};
-    use rome_js_syntax::{SourceType, TsAsExpression};
+    use rome_js_syntax::{JsFileSource, TsAsExpression};
 
     #[test]
     fn needs_parentheses() {
@@ -126,12 +126,12 @@ mod tests {
         assert_needs_parentheses!(
             "<test {...(x as any)} />",
             TsAsExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
         assert_needs_parentheses!(
             "<test>{...(x as any)}</test>",
             TsAsExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
         assert_needs_parentheses!("await (x as any)", TsAsExpression);
         assert_needs_parentheses!("(x as any)!", TsAsExpression);

--- a/crates/rome_js_formatter/src/ts/expressions/satisfies_expression.rs
+++ b/crates/rome_js_formatter/src/ts/expressions/satisfies_expression.rs
@@ -27,7 +27,7 @@ impl NeedsParentheses for TsSatisfiesExpression {
 mod tests {
 
     use crate::{assert_needs_parentheses, assert_not_needs_parentheses};
-    use rome_js_syntax::{SourceType, TsSatisfiesExpression};
+    use rome_js_syntax::{JsFileSource, TsSatisfiesExpression};
 
     #[test]
     fn needs_parentheses() {
@@ -52,12 +52,12 @@ mod tests {
         assert_needs_parentheses!(
             "<test {...(x satisfies any)} />",
             TsSatisfiesExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
         assert_needs_parentheses!(
             "<test>{...(x satisfies any)}</test>",
             TsSatisfiesExpression,
-            SourceType::tsx()
+            JsFileSource::tsx()
         );
         assert_needs_parentheses!("await (x satisfies any)", TsSatisfiesExpression);
         assert_needs_parentheses!("(x satisfies any)!", TsSatisfiesExpression);

--- a/crates/rome_js_formatter/src/utils/conditional.rs
+++ b/crates/rome_js_formatter/src/utils/conditional.rs
@@ -7,9 +7,9 @@ use rome_formatter::{
 use crate::{AsFormat, IntoFormat};
 use rome_js_syntax::{
     AnyJsExpression, AnyTsType, JsAssignmentExpression, JsCallExpression,
-    JsComputedMemberExpression, JsConditionalExpression, JsInitializerClause, JsNewExpression,
-    JsReturnStatement, JsStaticMemberExpression, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
-    JsThrowStatement, JsUnaryExpression, JsYieldArgument, SourceType, TsAsExpression,
+    JsComputedMemberExpression, JsConditionalExpression, JsFileSource, JsInitializerClause,
+    JsNewExpression, JsReturnStatement, JsStaticMemberExpression, JsSyntaxKind, JsSyntaxNode,
+    JsSyntaxToken, JsThrowStatement, JsUnaryExpression, JsYieldArgument, TsAsExpression,
     TsConditionalType, TsNonNullAssertionExpression, TsSatisfiesExpression,
 };
 use rome_rowan::{declare_node_union, match_ast, AstNode, SyntaxResult};
@@ -238,7 +238,11 @@ impl FormatRule<AnyJsConditional> for FormatJsAnyConditionalRule {
 }
 
 impl FormatJsAnyConditionalRule {
-    fn layout(&self, conditional: &AnyJsConditional, source_type: SourceType) -> ConditionalLayout {
+    fn layout(
+        &self,
+        conditional: &AnyJsConditional,
+        source_type: JsFileSource,
+    ) -> ConditionalLayout {
         match conditional.syntax().parent() {
             Some(parent) if parent.kind() == conditional.syntax().kind() => {
                 let conditional_parent = AnyJsConditional::unwrap_cast(parent);

--- a/crates/rome_js_formatter/src/utils/jsx.rs
+++ b/crates/rome_js_formatter/src/utils/jsx.rs
@@ -565,7 +565,7 @@ mod tests {
     };
     use rome_formatter::comments::Comments;
     use rome_js_parser::parse;
-    use rome_js_syntax::{JsxChildList, JsxText, SourceType};
+    use rome_js_syntax::{JsFileSource, JsxChildList, JsxText};
     use rome_rowan::{AstNode, TextSize};
 
     #[test]
@@ -589,7 +589,7 @@ mod tests {
     }
 
     fn assert_jsx_text_chunks(text: &str, expected_chunks: Vec<(TextSize, JsxTextChunk)>) {
-        let parse = parse(&std::format!("<>{text}</>"), SourceType::jsx());
+        let parse = parse(&std::format!("<>{text}</>"), JsFileSource::jsx());
         assert!(
             !parse.has_errors(),
             "Source should not have any errors {:?}",
@@ -660,7 +660,7 @@ mod tests {
     }
 
     fn parse_jsx_children(children: &str) -> JsxChildList {
-        let parse = parse(&std::format!("<div>{children}</div>"), SourceType::jsx());
+        let parse = parse(&std::format!("<div>{children}</div>"), JsFileSource::jsx());
 
         assert!(
             !parse.has_errors(),

--- a/crates/rome_js_formatter/src/utils/string_utils.rs
+++ b/crates/rome_js_formatter/src/utils/string_utils.rs
@@ -2,7 +2,7 @@ use crate::context::{JsFormatOptions, QuoteProperties, QuoteStyle};
 use crate::prelude::*;
 use rome_formatter::token::string::normalize_string;
 use rome_js_syntax::JsSyntaxKind::{JSX_STRING_LITERAL, JS_STRING_LITERAL};
-use rome_js_syntax::{JsSyntaxToken, SourceType};
+use rome_js_syntax::{JsFileSource, JsSyntaxToken};
 use std::borrow::Cow;
 use unicode_width::UnicodeWidthStr;
 
@@ -173,7 +173,7 @@ struct LiteralStringNormaliser<'token> {
     chosen_quote_properties: QuoteProperties,
 }
 
-/// Convenience enum to map [rome_js_syntax::SourceType] by just reading
+/// Convenience enum to map [rome_js_syntax::JsFileSource] by just reading
 /// the type of file
 #[derive(Eq, PartialEq)]
 pub(crate) enum SourceFileKind {
@@ -181,8 +181,8 @@ pub(crate) enum SourceFileKind {
     JavaScript,
 }
 
-impl From<SourceType> for SourceFileKind {
-    fn from(st: SourceType) -> Self {
+impl From<JsFileSource> for SourceFileKind {
+    fn from(st: JsFileSource) -> Self {
         if st.language().is_typescript() {
             Self::TypeScript
         } else {

--- a/crates/rome_js_formatter/src/utils/test_call.rs
+++ b/crates/rome_js_formatter/src/utils/test_call.rs
@@ -430,11 +430,11 @@ impl Iterator for CalleeNamesIterator {
 mod test {
     use super::{contains_a_test_pattern, is_test_each_pattern_callee};
     use rome_js_parser::parse;
-    use rome_js_syntax::{JsCallExpression, JsTemplateExpression, SourceType};
+    use rome_js_syntax::{JsCallExpression, JsFileSource, JsTemplateExpression};
     use rome_rowan::AstNodeList;
 
     fn extract_call_expression(src: &str) -> JsCallExpression {
-        let source_type = SourceType::js_module();
+        let source_type = JsFileSource::js_module();
         let result = parse(src, source_type);
         let module = result
             .tree()
@@ -457,7 +457,7 @@ mod test {
     }
 
     fn extract_template(src: &str) -> JsTemplateExpression {
-        let source_type = SourceType::js_module();
+        let source_type = JsFileSource::js_module();
         let result = parse(src, source_type);
         let module = result
             .tree()

--- a/crates/rome_js_formatter/tests/language.rs
+++ b/crates/rome_js_formatter/tests/language.rs
@@ -8,7 +8,7 @@ use rome_js_formatter::{format_node, format_range, JsFormatLanguage};
 use rome_js_parser::parse;
 use rome_js_syntax::{JsFileSource, JsLanguage};
 use rome_parser::AnyParse;
-use rome_rowan::SyntaxNode;
+use rome_rowan::{FileSource, SyntaxNode};
 use rome_text_size::TextRange;
 use serde::{Deserialize, Serialize};
 
@@ -29,7 +29,13 @@ impl TestFormatLanguage for JsTestFormatLanguage {
     type FormatLanguage = JsFormatLanguage;
 
     fn parse(&self, text: &str) -> AnyParse {
-        parse(text, self.source_type).into()
+        let parse = parse(text, self.source_type);
+
+        AnyParse::new(
+            parse.syntax().as_send().unwrap(),
+            parse.into_diagnostics(),
+            self.source_type.as_any_file_source(),
+        )
     }
 
     fn deserialize_format_options(

--- a/crates/rome_js_formatter/tests/language.rs
+++ b/crates/rome_js_formatter/tests/language.rs
@@ -6,18 +6,18 @@ use rome_js_formatter::context::{
 };
 use rome_js_formatter::{format_node, format_range, JsFormatLanguage};
 use rome_js_parser::parse;
-use rome_js_syntax::{JsLanguage, SourceType};
+use rome_js_syntax::{JsFileSource, JsLanguage};
 use rome_parser::AnyParse;
 use rome_rowan::SyntaxNode;
 use rome_text_size::TextRange;
 use serde::{Deserialize, Serialize};
 
 pub struct JsTestFormatLanguage {
-    source_type: SourceType,
+    source_type: JsFileSource,
 }
 
 impl JsTestFormatLanguage {
-    pub fn new(source_type: SourceType) -> Self {
+    pub fn new(source_type: JsFileSource) -> Self {
         JsTestFormatLanguage { source_type }
     }
 }
@@ -163,7 +163,7 @@ pub struct JsSerializableFormatOptions {
 }
 
 impl JsSerializableFormatOptions {
-    fn into_format_options(self, source_type: SourceType) -> JsFormatOptions {
+    fn into_format_options(self, source_type: JsFileSource) -> JsFormatOptions {
         JsFormatOptions::new(source_type)
             .with_indent_style(
                 self.indent_style

--- a/crates/rome_js_formatter/tests/prettier_tests.rs
+++ b/crates/rome_js_formatter/tests/prettier_tests.rs
@@ -3,7 +3,7 @@ use std::{env, path::Path};
 use rome_formatter::IndentStyle;
 use rome_formatter_test::test_prettier_snapshot::{PrettierSnapshot, PrettierTestFile};
 use rome_js_formatter::context::JsFormatOptions;
-use rome_js_syntax::SourceType;
+use rome_js_syntax::JsFileSource;
 
 mod language;
 
@@ -23,9 +23,9 @@ fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
         // As there's no way to know in advance which files have JSX syntax, we
         // change the source type only here
         if test_file.file_extension() == "js" {
-            SourceType::jsx()
+            JsFileSource::jsx()
         } else if test_file.file_name().contains("jsx") && test_file.file_extension() == "ts" {
-            SourceType::tsx()
+            JsFileSource::tsx()
         } else {
             test_file.input_file().try_into().unwrap()
         }

--- a/crates/rome_js_formatter/tests/quick_test.rs
+++ b/crates/rome_js_formatter/tests/quick_test.rs
@@ -2,7 +2,7 @@ use rome_formatter_test::check_reformat::CheckReformat;
 use rome_js_formatter::context::{JsFormatOptions, Semicolons};
 use rome_js_formatter::format_node;
 use rome_js_parser::parse;
-use rome_js_syntax::SourceType;
+use rome_js_syntax::JsFileSource;
 
 mod language {
     include!("language.rs");
@@ -17,7 +17,7 @@ const foo = @deco class {
   //
 };
 "#;
-    let syntax = SourceType::tsx();
+    let syntax = JsFileSource::tsx();
     let tree = parse(src, syntax);
     let options = JsFormatOptions::new(syntax).with_semicolons(Semicolons::AsNeeded);
     let result = format_node(options.clone(), &tree.syntax())
@@ -26,7 +26,7 @@ const foo = @deco class {
         .unwrap();
 
     let root = &tree.syntax();
-    let language = language::JsTestFormatLanguage::new(SourceType::tsx());
+    let language = language::JsTestFormatLanguage::new(JsFileSource::tsx());
     let check_reformat =
         CheckReformat::new(root, result.as_code(), "quick_test", &language, options);
     check_reformat.check_reformat();

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -1,6 +1,6 @@
 use rome_formatter_test::spec::{SpecSnapshot, SpecTestFile};
 use rome_js_formatter::context::JsFormatOptions;
-use rome_js_syntax::{ModuleKind, SourceType};
+use rome_js_syntax::{JsFileSource, ModuleKind};
 use std::path::Path;
 
 mod language {
@@ -29,7 +29,7 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
 
     let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path) else { return; };
 
-    let mut source_type: SourceType = test_file.input_file().as_path().try_into().unwrap();
+    let mut source_type: JsFileSource = test_file.input_file().as_path().try_into().unwrap();
     if file_type != "module" {
         source_type = source_type.with_module_kind(ModuleKind::Script);
     }

--- a/crates/rome_js_parser/src/parser.rs
+++ b/crates/rome_js_parser/src/parser.rs
@@ -18,8 +18,8 @@ use crate::{
 };
 pub(crate) use parsed_syntax::ParsedSyntax;
 use rome_js_syntax::{
+    JsFileSource,
     JsSyntaxKind::{self},
-    SourceType,
 };
 use rome_parser::diagnostic::merge_diagnostics;
 use rome_parser::event::Event;
@@ -32,14 +32,14 @@ use rome_parser::{ParserContext, ParserContextCheckpoint};
 /// These events are then processed into a syntax tree through a [`TreeSink`] implementation.
 pub struct JsParser<'source> {
     pub(super) state: ParserState,
-    pub source_type: SourceType,
+    pub source_type: JsFileSource,
     context: ParserContext<JsSyntaxKind>,
     source: JsTokenSource<'source>,
 }
 
 impl<'source> JsParser<'source> {
     /// Creates a new parser that parses the `source`.
-    pub fn new(source: &'source str, source_type: SourceType) -> Self {
+    pub fn new(source: &'source str, source_type: JsFileSource) -> Self {
         let source = JsTokenSource::from_str(source);
 
         JsParser {
@@ -58,7 +58,7 @@ impl<'source> JsParser<'source> {
         &mut self.state
     }
 
-    pub fn source_type(&self) -> SourceType {
+    pub fn source_type(&self) -> JsFileSource {
         self.source_type
     }
 
@@ -212,14 +212,14 @@ pub struct JsParserCheckpoint {
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
-    use rome_js_syntax::{JsSyntaxKind, SourceType};
+    use rome_js_syntax::{JsFileSource, JsSyntaxKind};
 
     #[test]
     #[should_panic(
         expected = "Marker must either be `completed` or `abandoned` to avoid that children are implicitly attached to a marker's parent."
     )]
     fn uncompleted_markers_panic() {
-        let mut parser = JsParser::new("'use strict'", SourceType::default());
+        let mut parser = JsParser::new("'use strict'", JsFileSource::default());
 
         let _ = parser.start();
         // drop the marker without calling complete or abandon
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn completed_marker_doesnt_panic() {
-        let mut p = JsParser::new("'use strict'", SourceType::default());
+        let mut p = JsParser::new("'use strict'", JsFileSource::default());
 
         let m = p.start();
         p.expect(JsSyntaxKind::JS_STRING_LITERAL);
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn abandoned_marker_doesnt_panic() {
-        let mut p = JsParser::new("'use strict'", SourceType::default());
+        let mut p = JsParser::new("'use strict'", JsFileSource::default());
 
         let m = p.start();
         m.abandon(&mut p);

--- a/crates/rome_js_parser/src/state.rs
+++ b/crates/rome_js_parser/src/state.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use bitflags::bitflags;
 use indexmap::IndexMap;
-use rome_js_syntax::SourceType;
+use rome_js_syntax::JsFileSource;
 use rome_rowan::{TextRange, TextSize};
 use std::collections::HashSet;
 use std::ops::{Deref, DerefMut, Range};
@@ -97,7 +97,7 @@ pub(crate) enum StrictMode {
 }
 
 impl ParserState {
-    pub fn new(source_type: &SourceType) -> Self {
+    pub fn new(source_type: &JsFileSource) -> Self {
         let mut state = ParserState {
             parsing_context: ParsingContextFlags::TOP_LEVEL,
             label_set: IndexMap::new(),

--- a/crates/rome_js_parser/src/tests.rs
+++ b/crates/rome_js_parser/src/tests.rs
@@ -4,7 +4,7 @@ use rome_console::fmt::{Formatter, Termcolor};
 use rome_console::markup;
 use rome_diagnostics::DiagnosticExt;
 use rome_diagnostics::PrintDiagnostic;
-use rome_js_syntax::{AnyJsRoot, JsSyntaxKind, SourceType};
+use rome_js_syntax::{AnyJsRoot, JsFileSource, JsSyntaxKind};
 use rome_js_syntax::{JsCallArguments, JsLogicalExpression, JsSyntaxToken};
 use rome_rowan::{AstNode, Direction, TextSize};
 use std::fmt::Write;
@@ -19,7 +19,7 @@ let
 a;
 "#;
 
-    let module = parse(src, SourceType::tsx());
+    let module = parse(src, JsFileSource::tsx());
     assert_errors_are_absent(&module, Path::new("parser_smoke_test"));
 }
 
@@ -55,7 +55,7 @@ fn try_parse(path: &str, text: &str) -> Parse<AnyJsRoot> {
         // Files containing a // SCRIPT comment are parsed as script and not as module
         // This is needed to test features that are restricted in strict mode.
         let source_type = if text.contains("// SCRIPT") {
-            SourceType::js_script()
+            JsFileSource::js_script()
         } else {
             path.try_into().unwrap()
         };
@@ -300,7 +300,7 @@ pub fn node_contains_comments() {
 #[test]
 fn parser_regexp_after_operator() {
     fn assert_no_errors(src: &str) {
-        let module = parse(src, SourceType::js_script());
+        let module = parse(src, JsFileSource::js_script());
         assert_errors_are_absent(&module, Path::new("parser_regexp_after_operator"));
     }
     assert_no_errors(r#"a=/a/"#);
@@ -398,7 +398,7 @@ class Foo {
     @decorator declare [b]: number;
 }
     "#;
-    let root = parse(code, SourceType::ts());
+    let root = parse(code, JsFileSource::ts());
     let syntax = root.syntax();
 
     dbg!(syntax, root.diagnostics());

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -140,7 +140,7 @@ impl SemanticEvent {
 /// use rome_js_parser::*;
 /// use rome_js_syntax::*;
 /// use rome_js_semantic::*;
-/// let tree = parse("let a = 1", SourceType::js_script());
+/// let tree = parse("let a = 1", JsFileSource::js_script());
 /// let mut extractor = SemanticEventExtractor::new();
 /// for e in tree.syntax().preorder() {
 ///     match e {
@@ -1010,7 +1010,7 @@ impl Iterator for SemanticEventIterator {
 /// use rome_js_parser::*;
 /// use rome_js_syntax::*;
 /// use rome_js_semantic::*;
-/// let tree = parse("let a = 1", SourceType::js_script());
+/// let tree = parse("let a = 1", JsFileSource::js_script());
 /// for e in semantic_events(tree.syntax()) {
 ///     dbg!(e);
 /// }

--- a/crates/rome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/rome_js_semantic/src/semantic_model/closure.rs
@@ -359,11 +359,11 @@ impl<T: HasClosureAstNode> ClosureExtensions for T {}
 #[cfg(test)]
 mod test {
     use super::*;
-    use rome_js_syntax::{JsArrowFunctionExpression, JsSyntaxKind, SourceType};
+    use rome_js_syntax::{JsArrowFunctionExpression, JsFileSource, JsSyntaxKind};
     use rome_rowan::SyntaxNodeCast;
 
     fn assert_closure(code: &str, name: &str, captures: &[&str]) {
-        let r = rome_js_parser::parse(code, SourceType::tsx());
+        let r = rome_js_parser::parse(code, JsFileSource::tsx());
         let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
         let closure = if name != "ARROWFUNCTION" {
@@ -405,7 +405,7 @@ mod test {
     }
 
     fn get_closure_children(code: &str, name: &str) -> Vec<Closure> {
-        let r = rome_js_parser::parse(code, SourceType::tsx());
+        let r = rome_js_parser::parse(code, JsFileSource::tsx());
         let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
         let closure = if name != "ARROWFUNCTION" {

--- a/crates/rome_js_semantic/src/semantic_model/is_constant.rs
+++ b/crates/rome_js_semantic/src/semantic_model/is_constant.rs
@@ -12,14 +12,14 @@ pub fn is_constant(expr: &AnyJsExpression) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use rome_js_syntax::{JsIdentifierBinding, JsVariableDeclarator, SourceType};
+    use rome_js_syntax::{JsFileSource, JsIdentifierBinding, JsVariableDeclarator};
 
     use crate::{semantic_model, SemanticModelOptions};
 
     fn assert_is_const(code: &str, is_const: bool) {
         use rome_rowan::AstNode;
         use rome_rowan::SyntaxNodeCast;
-        let r = rome_js_parser::parse(code, SourceType::js_module());
+        let r = rome_js_parser::parse(code, JsFileSource::js_module());
         let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
         let a_reference = r

--- a/crates/rome_js_semantic/src/semantic_model/model.rs
+++ b/crates/rome_js_semantic/src/semantic_model/model.rs
@@ -139,10 +139,10 @@ impl SemanticModel {
     ///
     /// ```rust
     /// use rome_rowan::{AstNode, SyntaxNodeCast};
-    /// use rome_js_syntax::{SourceType, JsReferenceIdentifier};
+    /// use rome_js_syntax::{JsFileSource, JsReferenceIdentifier};
     /// use rome_js_semantic::{semantic_model, SemanticModelOptions, SemanticScopeExtensions};
     ///
-    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", SourceType::js_module());
+    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", JsFileSource::js_module());
     /// let model = semantic_model(&r.tree(), SemanticModelOptions::default());
     ///
     /// let arguments_reference = r
@@ -188,10 +188,10 @@ impl SemanticModel {
     ///
     /// ```rust
     /// use rome_rowan::{AstNode, SyntaxNodeCast};
-    /// use rome_js_syntax::{SourceType, JsReferenceIdentifier};
+    /// use rome_js_syntax::{JsFileSource, JsReferenceIdentifier};
     /// use rome_js_semantic::{semantic_model, BindingExtensions, SemanticModelOptions};
     ///
-    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", SourceType::js_module());
+    /// let r = rome_js_parser::parse("function f(){let a = arguments[0]; let b = a + 1;}", JsFileSource::js_module());
     /// let model = semantic_model(&r.tree(), SemanticModelOptions::default());
     ///
     /// let arguments_reference = r
@@ -340,10 +340,10 @@ impl SemanticModel {
     ///
     /// ```rust
     /// use rome_rowan::{AstNode, SyntaxNodeCast};
-    /// use rome_js_syntax::{SourceType, AnyJsFunction};
+    /// use rome_js_syntax::{JsFileSource, AnyJsFunction};
     /// use rome_js_semantic::{semantic_model, CallsExtensions, SemanticModelOptions};
     ///
-    /// let r = rome_js_parser::parse("function f(){} f() f()", SourceType::js_module());
+    /// let r = rome_js_parser::parse("function f(){} f() f()", JsFileSource::js_module());
     /// let model = semantic_model(&r.tree(), SemanticModelOptions::default());
     ///
     /// let f_declaration = r

--- a/crates/rome_js_semantic/src/semantic_model/tests.rs
+++ b/crates/rome_js_semantic/src/semantic_model/tests.rs
@@ -5,8 +5,8 @@ mod test {
         SemanticScopeExtensions,
     };
     use rome_js_syntax::{
-        JsIdentifierAssignment, JsIdentifierBinding, JsReferenceIdentifier, JsSyntaxKind,
-        SourceType, TsIdentifierBinding,
+        JsFileSource, JsIdentifierAssignment, JsIdentifierBinding, JsReferenceIdentifier,
+        JsSyntaxKind, TsIdentifierBinding,
     };
     use rome_rowan::{AstNode, SyntaxNodeCast};
 
@@ -14,7 +14,7 @@ mod test {
     pub fn ok_semantic_model() {
         let r = rome_js_parser::parse(
             "function f(){let a = arguments[0]; let b = a + 1; b = 2; console.log(b)}",
-            SourceType::js_module(),
+            JsFileSource::js_module(),
         );
         let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
@@ -115,7 +115,7 @@ mod test {
 
     #[test]
     pub fn ok_semantic_model_function_scope() {
-        let r = rome_js_parser::parse("function f() {} function g() {}", SourceType::js_module());
+        let r = rome_js_parser::parse("function f() {} function g() {}", JsFileSource::js_module());
         let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
         let function_f = r
@@ -153,7 +153,7 @@ mod test {
 
     /// Finds the last time a token named "name" is used and see if its node is marked as exported
     fn assert_is_exported(is_exported: bool, name: &str, code: &str) {
-        let r = rome_js_parser::parse(code, SourceType::tsx());
+        let r = rome_js_parser::parse(code, JsFileSource::tsx());
         let model = semantic_model(&r.tree(), SemanticModelOptions::default());
 
         let node = r
@@ -286,7 +286,7 @@ mod test {
 
     #[test]
     pub fn ok_semantic_model_globals() {
-        let r = rome_js_parser::parse("console.log()", SourceType::js_module());
+        let r = rome_js_parser::parse("console.log()", JsFileSource::js_module());
 
         let mut options = SemanticModelOptions::default();
         options.globals.insert("console".into());

--- a/crates/rome_js_semantic/src/tests/assertions.rs
+++ b/crates/rome_js_semantic/src/tests/assertions.rs
@@ -4,7 +4,7 @@ use rome_diagnostics::location::AsSpan;
 use rome_diagnostics::{
     Advices, Diagnostic, DiagnosticExt, Location, LogCategory, PrintDiagnostic, Visit,
 };
-use rome_js_syntax::{AnyJsRoot, JsSyntaxToken, SourceType, TextRange, TextSize, WalkEvent};
+use rome_js_syntax::{AnyJsRoot, JsFileSource, JsSyntaxToken, TextRange, TextSize, WalkEvent};
 use rome_rowan::{AstNode, NodeOrToken};
 use std::collections::{BTreeMap, HashMap};
 
@@ -104,7 +104,7 @@ use std::collections::{BTreeMap, HashMap};
 /// if(true) ;/*NOEVENT*/;
 /// ```
 pub fn assert(code: &str, test_name: &str) {
-    let r = rome_js_parser::parse(code, SourceType::tsx());
+    let r = rome_js_parser::parse(code, JsFileSource::tsx());
 
     if r.has_errors() {
         let mut console = EnvConsole::default();

--- a/crates/rome_js_syntax/src/lib.rs
+++ b/crates/rome_js_syntax/src/lib.rs
@@ -7,12 +7,12 @@ mod generated;
 pub mod binding_ext;
 pub mod directive_ext;
 pub mod expr_ext;
+pub mod file_source;
 pub mod identifier_ext;
 pub mod import_ext;
 pub mod jsx_ext;
 pub mod modifier_ext;
 pub mod numbers;
-pub mod source_type;
 pub mod static_value;
 pub mod stmt_ext;
 pub mod suppression;
@@ -22,12 +22,12 @@ mod union_ext;
 
 pub use self::generated::*;
 pub use expr_ext::*;
+pub use file_source::*;
 pub use identifier_ext::*;
 pub use modifier_ext::*;
 pub use rome_rowan::{
     SyntaxNodeText, TextLen, TextRange, TextSize, TokenAtOffset, TriviaPieceKind, WalkEvent,
 };
-pub use source_type::*;
 pub use stmt_ext::*;
 pub use syntax_node::*;
 pub use type_ext::*;

--- a/crates/rome_json_formatter/tests/language.rs
+++ b/crates/rome_json_formatter/tests/language.rs
@@ -3,9 +3,9 @@ use rome_formatter_test::TestFormatLanguage;
 use rome_json_formatter::context::{JsonFormatContext, JsonFormatOptions};
 use rome_json_formatter::{format_node, format_range, JsonFormatLanguage};
 use rome_json_parser::parse_json;
-use rome_json_syntax::JsonLanguage;
+use rome_json_syntax::{JsonFileSource, JsonLanguage};
 use rome_parser::AnyParse;
-use rome_rowan::{SyntaxNode, TextRange};
+use rome_rowan::{FileSource, SyntaxNode, TextRange};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default)]
@@ -18,7 +18,12 @@ impl TestFormatLanguage for JsonTestFormatLanguage {
     type FormatLanguage = JsonFormatLanguage;
 
     fn parse(&self, text: &str) -> AnyParse {
-        parse_json(text).into()
+        let parse = parse_json(text);
+        AnyParse::new(
+            parse.syntax().as_send().unwrap(),
+            parse.into_diagnostics(),
+            JsonFileSource::json().as_any_file_source(),
+        )
     }
 
     fn deserialize_format_options(

--- a/crates/rome_json_parser/src/lib.rs
+++ b/crates/rome_json_parser/src/lib.rs
@@ -6,7 +6,6 @@ use rome_json_factory::JsonSyntaxFactory;
 use rome_json_syntax::{JsonLanguage, JsonRoot, JsonSyntaxNode};
 pub use rome_parser::prelude::*;
 use rome_parser::tree_sink::LosslessTreeSink;
-use rome_parser::AnyParse;
 use rome_rowan::{AstNode, NodeCache};
 
 mod lexer;
@@ -98,18 +97,5 @@ impl JsonParse {
     /// Panics if the node represented by this parse result mismatches.
     pub fn tree(&self) -> JsonRoot {
         JsonRoot::unwrap_cast(self.syntax())
-    }
-}
-
-impl From<JsonParse> for AnyParse {
-    fn from(parse: JsonParse) -> Self {
-        let root = parse.syntax();
-        let diagnostics = parse.into_diagnostics();
-
-        AnyParse::new(
-            // SAFETY: the parser should always return a root node
-            root.as_send().unwrap(),
-            diagnostics,
-        )
     }
 }

--- a/crates/rome_json_syntax/src/file_source.rs
+++ b/crates/rome_json_syntax/src/file_source.rs
@@ -1,0 +1,75 @@
+use crate::JsonLanguage;
+use rome_rowan::{FileSource, FileSourceError};
+use std::path::Path;
+
+#[derive(Debug, Default)]
+pub struct JsonFileSource {
+    #[allow(dead_code)]
+    variant: JsonVariant,
+}
+
+#[derive(Debug, Default)]
+enum JsonVariant {
+    #[default]
+    Standard,
+    #[allow(dead_code)]
+    Jsonc,
+}
+
+impl JsonFileSource {
+    pub fn json() -> Self {
+        Self {
+            variant: JsonVariant::Standard,
+        }
+    }
+
+    pub fn jsonc() -> Self {
+        Self {
+            variant: JsonVariant::Jsonc,
+        }
+    }
+}
+
+impl<'a> FileSource<'a, JsonLanguage> for JsonFileSource {}
+
+impl TryFrom<&Path> for JsonFileSource {
+    type Error = FileSourceError;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?
+            .to_str()
+            .ok_or_else(|| FileSourceError::MissingFileName(path.into()))?;
+
+        let extension = path
+            .extension()
+            .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?
+            .to_str()
+            .ok_or_else(|| FileSourceError::MissingFileExtension(path.into()))?;
+
+        compute_source_type_from_path_or_extension(file_name, extension)
+    }
+}
+
+/// It deduce the [JsonFileSource] from the file name and its extension
+fn compute_source_type_from_path_or_extension(
+    file_name: &str,
+    extension: &str,
+) -> Result<JsonFileSource, FileSourceError> {
+    let source_type = if file_name.ends_with(".json") {
+        JsonFileSource::json()
+    } else {
+        match extension {
+            "json" => JsonFileSource::json(),
+            "jsonc" => JsonFileSource::jsonc(),
+            _ => {
+                return Err(FileSourceError::UnknownExtension(
+                    file_name.into(),
+                    extension.into(),
+                ))
+            }
+        }
+    };
+    Ok(source_type)
+}

--- a/crates/rome_json_syntax/src/lib.rs
+++ b/crates/rome_json_syntax/src/lib.rs
@@ -1,10 +1,12 @@
 #[macro_use]
 mod generated;
+mod file_source;
 pub mod member_ext;
 pub mod string_ext;
 mod syntax_node;
 
 pub use self::generated::*;
+pub use file_source::JsonFileSource;
 pub use rome_rowan::{TextLen, TextRange, TextSize, TokenAtOffset, TriviaPieceKind, WalkEvent};
 pub use syntax_node::*;
 

--- a/crates/rome_parser/src/lib.rs
+++ b/crates/rome_parser/src/lib.rs
@@ -247,8 +247,12 @@ use crate::event::Event::Token;
 use crate::token_source::{BumpWithContext, NthToken, TokenSource};
 use rome_console::fmt::Display;
 use rome_diagnostics::location::AsSpan;
-use rome_rowan::{AstNode, Language, SendNode, SyntaxKind, SyntaxNode, TextRange, TextSize};
+use rome_rowan::{
+	AnyFileSource, AstNode, FileSource, Language, SendNode, FileSourceError, SyntaxKind,
+	SyntaxNode, TextRange, TextSize,
+};
 use std::any::type_name;
+use std::path::Path;
 
 pub mod diagnostic;
 pub mod event;
@@ -793,11 +797,20 @@ pub trait SyntaxFeature: Sized {
 pub struct AnyParse {
     pub(crate) root: SendNode,
     pub(crate) diagnostics: Vec<ParseDiagnostic>,
+    pub(crate) file_source: AnyFileSource,
 }
 
 impl AnyParse {
-    pub fn new(root: SendNode, diagnostics: Vec<ParseDiagnostic>) -> AnyParse {
-        AnyParse { root, diagnostics }
+    pub fn new(
+        root: SendNode,
+        diagnostics: Vec<ParseDiagnostic>,
+        file_source: AnyFileSource,
+    ) -> AnyParse {
+        AnyParse {
+            root,
+            diagnostics,
+            file_source,
+        }
     }
 
     pub fn syntax<L>(&self) -> SyntaxNode<L>
@@ -810,6 +823,14 @@ impl AnyParse {
                 type_name::<L>()
             )
         })
+    }
+
+    pub fn file_source<'a, F, L>(&self, path: &'a Path) -> Result<F, FileSourceError>
+    where
+        F: FileSource<'a, L> + 'static,
+        L: Language + 'static,
+    {
+        self.file_source.unwrap_cast(path)
     }
 
     pub fn tree<N>(&self) -> N

--- a/crates/rome_parser/src/lib.rs
+++ b/crates/rome_parser/src/lib.rs
@@ -248,8 +248,8 @@ use crate::token_source::{BumpWithContext, NthToken, TokenSource};
 use rome_console::fmt::Display;
 use rome_diagnostics::location::AsSpan;
 use rome_rowan::{
-	AnyFileSource, AstNode, FileSource, Language, SendNode, FileSourceError, SyntaxKind,
-	SyntaxNode, TextRange, TextSize,
+    AnyFileSource, AstNode, FileSource, FileSourceError, Language, SendNode, SyntaxKind,
+    SyntaxNode, TextRange, TextSize,
 };
 use std::any::type_name;
 use std::path::Path;

--- a/crates/rome_rowan/src/file_source.rs
+++ b/crates/rome_rowan/src/file_source.rs
@@ -70,6 +70,12 @@ pub struct AnyFileSource {
 
 impl AnyFileSource {
     /// Attempts to retrieve the original file source of the file
+    ///
+    /// ## Errors
+    ///
+    /// The function will panic if:
+    /// - the original type and given type mismatch
+    /// - it's possible to retrieve the correct [FileSource] from the given [Path]
     pub fn unwrap_cast<'a, F, L>(&self, path: &'a Path) -> Result<F, FileSourceError>
     where
         F: FileSource<'a, L> + 'static,

--- a/crates/rome_rowan/src/file_source.rs
+++ b/crates/rome_rowan/src/file_source.rs
@@ -44,11 +44,11 @@ impl Display for FileSourceError {
 /// struct UnknownFileSource {}
 ///
 /// impl TryFrom<&Path> for UnknownFileSource {
-/// 	type Error = FileSourceError;
+///  type Error = FileSourceError;
 ///
-/// 	fn try_from(value: &Path) -> Result<Self, Self::Error> {
-///         Ok(UnknownFileSource {})
-///     }
+///  fn try_from(value: &Path) -> Result<Self, Self::Error> {
+///    Ok(UnknownFileSource {})
+///   }
 /// }
 /// impl<'a> FileSource<'a, RawLanguage> for UnknownFileSource {}
 /// ```

--- a/crates/rome_rowan/src/file_source.rs
+++ b/crates/rome_rowan/src/file_source.rs
@@ -1,0 +1,127 @@
+use crate::Language;
+use std::any::TypeId;
+use std::fmt::Display;
+use std::path::{Path, PathBuf};
+
+/// Errors around the construct of the source type
+#[derive(Debug)]
+pub enum FileSourceError {
+    /// The path has no file name
+    MissingFileName(PathBuf),
+    /// The path has no file extension
+    MissingFileExtension(PathBuf),
+    /// The source type is unknown
+    UnknownExtension(String, String),
+}
+
+impl std::error::Error for FileSourceError {}
+
+impl Display for FileSourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FileSourceError::MissingFileName(path) => {
+                write!(f, "The path {path:?} has no file name")
+            }
+            FileSourceError::MissingFileExtension(path) => {
+                write!(f, "The path {path:?} has no file extension")
+            }
+            FileSourceError::UnknownExtension(_, extension) => {
+                write!(f, "The parser can't parse the extension '{extension}' yet")
+            }
+        }
+    }
+}
+
+/// Generic trait that provides a method to safely create
+/// a file source that can be send across thread boundaries.
+///
+/// When applying this trait, the [TryFrom] trait for [Path] must be implemented.
+///
+/// ```
+/// use std::path::Path;
+/// use rome_rowan::{FileSource, FileSourceError};
+/// use rome_rowan::raw_language::RawLanguage;
+/// struct UnknownFileSource {}
+///
+/// impl TryFrom<&Path> for UnknownFileSource {
+/// 	type Error = FileSourceError;
+///
+/// 	fn try_from(value: &Path) -> Result<Self, Self::Error> {
+///         Ok(UnknownFileSource {})
+///     }
+/// }
+/// impl<'a> FileSource<'a, RawLanguage> for UnknownFileSource {}
+/// ```
+pub trait FileSource<'a, L: Language + 'static>:
+    TryFrom<&'a Path, Error = FileSourceError>
+{
+    fn as_any_file_source(&self) -> AnyFileSource {
+        AnyFileSource {
+            file_source: TypeId::of::<L>(),
+        }
+    }
+}
+
+/// Generic file source that can be send across thread boundaries
+#[derive(Clone)]
+pub struct AnyFileSource {
+    pub(crate) file_source: TypeId,
+}
+
+impl AnyFileSource {
+    /// Attempts to retrieve the original file source of the file
+    pub fn unwrap_cast<'a, F, L>(&self, path: &'a Path) -> Result<F, FileSourceError>
+    where
+        F: FileSource<'a, L> + 'static,
+        L: Language + 'static,
+    {
+        let file_source = TypeId::of::<L>();
+        if file_source == self.file_source {
+            F::try_from(path)
+        } else {
+            Err(FileSourceError::MissingFileExtension(PathBuf::from(path)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::file_source::FileSourceError;
+    use crate::raw_language::RawLanguage;
+    use crate::FileSource;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn should_cast_file_source() {
+        #[derive(Debug, Eq, PartialEq)]
+        struct Test {
+            path: String,
+        }
+
+        impl TryFrom<&Path> for Test {
+            type Error = FileSourceError;
+
+            fn try_from(value: &Path) -> Result<Self, Self::Error> {
+                Ok(Test {
+                    path: value.display().to_string(),
+                })
+            }
+        }
+
+        impl<'a> FileSource<'a, RawLanguage> for Test {}
+
+        let path = PathBuf::from("test");
+        let first_test = Test {
+            path: path.display().to_string(),
+        };
+        let send_first = first_test.as_any_file_source();
+
+        let cast = send_first.unwrap_cast::<Test, RawLanguage>(path.as_path());
+
+        assert!(cast.is_ok());
+
+        let cast = cast.unwrap();
+
+        assert_eq!(cast, first_test)
+    }
+}

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -25,6 +25,7 @@ mod utility_types;
 mod arc;
 mod ast;
 mod cow_mut;
+mod file_source;
 pub mod raw_language;
 #[cfg(feature = "serde")]
 mod serde_impls;
@@ -35,19 +36,20 @@ mod tree_builder;
 pub use rome_text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
-    ast::*,
-    green::{NodeCache, RawSyntaxKind},
-    syntax::{
+	ast::*,
+	file_source::{AnyFileSource, FileSource, FileSourceError},
+	green::{NodeCache, RawSyntaxKind},
+	syntax::{
         chain_trivia_pieces, ChainTriviaPiecesIterator, Language, SendNode, SyntaxElement,
         SyntaxElementChildren, SyntaxKind, SyntaxList, SyntaxNode, SyntaxNodeChildren,
         SyntaxNodeOptionExt, SyntaxRewriter, SyntaxSlot, SyntaxToken, SyntaxTriviaPiece,
         SyntaxTriviaPieceComments, TriviaPiece, TriviaPieceKind, VisitNodeSignal,
     },
-    syntax_factory::*,
-    syntax_node_text::SyntaxNodeText,
-    syntax_token_text::SyntaxTokenText,
-    tree_builder::{Checkpoint, TreeBuilder},
-    utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
+	syntax_factory::*,
+	syntax_node_text::SyntaxNodeText,
+	syntax_token_text::SyntaxTokenText,
+	tree_builder::{Checkpoint, TreeBuilder},
+	utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };
 
 pub(crate) use crate::green::{GreenNode, GreenNodeData, GreenToken, GreenTokenData};

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -36,20 +36,20 @@ mod tree_builder;
 pub use rome_text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
-	ast::*,
-	file_source::{AnyFileSource, FileSource, FileSourceError},
-	green::{NodeCache, RawSyntaxKind},
-	syntax::{
+    ast::*,
+    file_source::{AnyFileSource, FileSource, FileSourceError},
+    green::{NodeCache, RawSyntaxKind},
+    syntax::{
         chain_trivia_pieces, ChainTriviaPiecesIterator, Language, SendNode, SyntaxElement,
         SyntaxElementChildren, SyntaxKind, SyntaxList, SyntaxNode, SyntaxNodeChildren,
         SyntaxNodeOptionExt, SyntaxRewriter, SyntaxSlot, SyntaxToken, SyntaxTriviaPiece,
         SyntaxTriviaPieceComments, TriviaPiece, TriviaPieceKind, VisitNodeSignal,
     },
-	syntax_factory::*,
-	syntax_node_text::SyntaxNodeText,
-	syntax_token_text::SyntaxTokenText,
-	tree_builder::{Checkpoint, TreeBuilder},
-	utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
+    syntax_factory::*,
+    syntax_node_text::SyntaxNodeText,
+    syntax_token_text::SyntaxTokenText,
+    tree_builder::{Checkpoint, TreeBuilder},
+    utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };
 
 pub(crate) use crate::green::{GreenNode, GreenNodeData, GreenToken, GreenTokenData};

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -216,7 +216,7 @@ fn debug_formatter_ir(
 }
 
 fn lint(params: LintParams) -> LintResults {
-    let file_source = params.parse.file_source(&params.path).unwrap();
+    let file_source = params.parse.file_source(params.path).unwrap();
     let tree = params.parse.tree();
     let mut diagnostics = params.parse.into_diagnostics();
 
@@ -396,7 +396,7 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
         rome_path,
     } = params;
 
-    let file_source = parse.file_source(&rome_path).unwrap();
+    let file_source = parse.file_source(rome_path).unwrap();
     let mut tree: AnyJsRoot = parse.tree();
     let mut actions = Vec::new();
 

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -31,10 +31,10 @@ use rome_js_formatter::context::{
 use rome_js_formatter::{context::JsFormatOptions, format_node};
 use rome_js_semantic::{semantic_model, SemanticModelOptions};
 use rome_js_syntax::{
-    AnyJsRoot, JsLanguage, JsSyntaxNode, SourceType, TextRange, TextSize, TokenAtOffset,
+    AnyJsRoot, JsFileSource, JsLanguage, JsSyntaxNode, TextRange, TextSize, TokenAtOffset,
 };
 use rome_parser::AnyParse;
-use rome_rowan::{AstNode, BatchMutationExt, Direction, NodeCache};
+use rome_rowan::{AstNode, BatchMutationExt, Direction, FileSource, NodeCache};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::path::PathBuf;
@@ -131,15 +131,22 @@ fn parse(
     cache: &mut NodeCache,
 ) -> AnyParse {
     let source_type =
-        SourceType::try_from(rome_path.as_path()).unwrap_or_else(|_| match language_hint {
-            LanguageId::JavaScriptReact => SourceType::jsx(),
-            LanguageId::TypeScript => SourceType::ts(),
-            LanguageId::TypeScriptReact => SourceType::tsx(),
-            _ => SourceType::js_module(),
+        JsFileSource::try_from(rome_path.as_path()).unwrap_or_else(|_| match language_hint {
+            LanguageId::JavaScriptReact => JsFileSource::jsx(),
+            LanguageId::TypeScript => JsFileSource::ts(),
+            LanguageId::TypeScriptReact => JsFileSource::tsx(),
+            _ => JsFileSource::js_module(),
         });
 
     let parse = rome_js_parser::parse_js_with_cache(text, source_type, cache);
-    AnyParse::from(parse)
+    let root = parse.syntax();
+    let diagnostics = parse.into_diagnostics();
+    AnyParse::new(
+        // SAFETY: the parser should always return a root node
+        root.as_send().unwrap(),
+        diagnostics,
+        source_type.as_any_file_source(),
+    )
 }
 
 fn debug_syntax_tree(_rome_path: &RomePath, parse: AnyParse) -> GetSyntaxTreeResult {
@@ -187,7 +194,7 @@ fn debug_control_flow(parse: AnyParse, cursor: TextSize) -> String {
             }
         },
         &options,
-        SourceType::default(),
+        JsFileSource::default(),
         |_| ControlFlow::<Never>::Continue(()),
     );
 
@@ -209,6 +216,7 @@ fn debug_formatter_ir(
 }
 
 fn lint(params: LintParams) -> LintResults {
+    let file_source = params.parse.file_source(&params.path).unwrap();
     let tree = params.parse.tree();
     let mut diagnostics = params.parse.into_diagnostics();
 
@@ -227,7 +235,7 @@ fn lint(params: LintParams) -> LintResults {
         &tree,
         params.filter,
         &analyzer_options,
-        SourceType::default(),
+        file_source,
         |signal| {
             if let Some(mut diagnostic) = signal.diagnostic() {
                 // Do not report unused suppression comment diagnostics if this is a syntax-only analyzer pass
@@ -357,26 +365,20 @@ fn code_actions(
 
     trace!("Filter applied for code actions: {:?}", &filter);
     let analyzer_options = compute_analyzer_options(&settings, PathBuf::from(path.as_path()));
+    let source_type = parse.file_source(path).unwrap();
+    analyze(&tree, filter, &analyzer_options, source_type, |signal| {
+        actions.extend(signal.actions().into_code_action_iter().map(|item| {
+            CodeAction {
+                category: item.category.clone(),
+                rule_name: item
+                    .rule_name
+                    .map(|(group, name)| (Cow::Borrowed(group), Cow::Borrowed(name))),
+                suggestion: item.suggestion,
+            }
+        }));
 
-    analyze(
-        &tree,
-        filter,
-        &analyzer_options,
-        SourceType::default(),
-        |signal| {
-            actions.extend(signal.actions().into_code_action_iter().map(|item| {
-                CodeAction {
-                    category: item.category.clone(),
-                    rule_name: item
-                        .rule_name
-                        .map(|(group, name)| (Cow::Borrowed(group), Cow::Borrowed(name))),
-                    suggestion: item.suggestion,
-                }
-            }));
-
-            ControlFlow::<Never>::Continue(())
-        },
-    );
+        ControlFlow::<Never>::Continue(())
+    });
 
     PullActionsResult { actions }
 }
@@ -394,6 +396,7 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
         rome_path,
     } = params;
 
+    let file_source = parse.file_source(&rome_path).unwrap();
     let mut tree: AnyJsRoot = parse.tree();
     let mut actions = Vec::new();
 
@@ -415,51 +418,45 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
     let mut errors: u16 = 0;
     let analyzer_options = compute_analyzer_options(&settings, PathBuf::from(rome_path.as_path()));
     loop {
-        let (action, _) = analyze(
-            &tree,
-            filter,
-            &analyzer_options,
-            SourceType::default(),
-            |signal| {
-                let current_diagnostic = signal.diagnostic();
+        let (action, _) = analyze(&tree, filter, &analyzer_options, file_source, |signal| {
+            let current_diagnostic = signal.diagnostic();
 
-                if let Some(diagnostic) = current_diagnostic.as_ref() {
-                    if is_diagnostic_error(diagnostic, params.rules) {
-                        errors += 1;
-                    }
+            if let Some(diagnostic) = current_diagnostic.as_ref() {
+                if is_diagnostic_error(diagnostic, params.rules) {
+                    errors += 1;
+                }
+            }
+
+            for action in signal.actions() {
+                // suppression actions should not be part of the fixes (safe or suggested)
+                if action.is_suppression() {
+                    continue;
                 }
 
-                for action in signal.actions() {
-                    // suppression actions should not be part of the fixes (safe or suggested)
-                    if action.is_suppression() {
-                        continue;
-                    }
-
-                    match fix_file_mode {
-                        FixFileMode::SafeFixes => {
-                            if action.applicability == Applicability::MaybeIncorrect {
-                                skipped_suggested_fixes += 1;
-                            }
-                            if action.applicability == Applicability::Always {
-                                errors = errors.saturating_sub(1);
-                                return ControlFlow::Break(action);
-                            }
+                match fix_file_mode {
+                    FixFileMode::SafeFixes => {
+                        if action.applicability == Applicability::MaybeIncorrect {
+                            skipped_suggested_fixes += 1;
                         }
-                        FixFileMode::SafeAndUnsafeFixes => {
-                            if matches!(
-                                action.applicability,
-                                Applicability::Always | Applicability::MaybeIncorrect
-                            ) {
-                                errors = errors.saturating_sub(1);
-                                return ControlFlow::Break(action);
-                            }
+                        if action.applicability == Applicability::Always {
+                            errors = errors.saturating_sub(1);
+                            return ControlFlow::Break(action);
+                        }
+                    }
+                    FixFileMode::SafeAndUnsafeFixes => {
+                        if matches!(
+                            action.applicability,
+                            Applicability::Always | Applicability::MaybeIncorrect
+                        ) {
+                            errors = errors.saturating_sub(1);
+                            return ControlFlow::Break(action);
                         }
                     }
                 }
+            }
 
-                ControlFlow::Continue(())
-            },
-        );
+            ControlFlow::Continue(())
+        });
 
         match action {
             Some(action) => {
@@ -628,7 +625,7 @@ fn organize_imports(parse: AnyParse) -> Result<OrganizeImportsResult, WorkspaceE
         &tree,
         filter,
         &AnalyzerOptions::default(),
-        SourceType::default(),
+        JsFileSource::default(),
         |signal| {
             for action in signal.actions() {
                 if action.is_suppression() {

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -16,6 +16,7 @@ use rome_js_syntax::{TextRange, TextSize};
 use rome_parser::AnyParse;
 use rome_rowan::NodeCache;
 use std::ffi::OsStr;
+use std::path::Path;
 
 mod javascript;
 mod json;
@@ -51,6 +52,14 @@ impl Language {
             "json" => Language::Json,
             _ => Language::Unknown,
         }
+    }
+
+    /// Returns the language corresponding to the file path
+    pub fn from_path(path: &Path) -> Self {
+        path.extension()
+            .and_then(|path| path.to_str())
+            .map(Language::from_extension)
+            .unwrap_or(Language::Unknown)
     }
 
     /// Returns the language corresponding to this language ID

--- a/crates/rome_wasm/build.rs
+++ b/crates/rome_wasm/build.rs
@@ -2,7 +2,7 @@ use std::{env, fs, io, path::PathBuf};
 
 use quote::{format_ident, quote};
 
-use rome_js_factory::syntax::SourceType;
+use rome_js_factory::syntax::JsFileSource;
 use rome_js_factory::{
     make,
     syntax::{AnyJsDeclaration, AnyJsModuleItem, AnyJsStatement},
@@ -67,7 +67,7 @@ fn main() -> io::Result<()> {
 
     // Wasm-bindgen will paste the generated TS code as-is into the final .d.ts file,
     // ensure it looks good by running it through the formatter
-    let formatted = format_node(JsFormatOptions::new(SourceType::ts()), module.syntax()).unwrap();
+    let formatted = format_node(JsFormatOptions::new(JsFileSource::ts()), module.syntax()).unwrap();
     let printed = formatted.print().unwrap();
     let definitions = printed.into_code();
 

--- a/xtask/bench/src/language.rs
+++ b/xtask/bench/src/language.rs
@@ -4,20 +4,20 @@ use rome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, Never, RuleCate
 use rome_formatter::{FormatResult, Formatted, PrintResult, Printed};
 use rome_js_analyze::analyze;
 use rome_js_formatter::context::{JsFormatContext, JsFormatOptions};
-use rome_js_syntax::{AnyJsRoot, JsSyntaxNode, SourceType};
+use rome_js_syntax::{AnyJsRoot, JsFileSource, JsSyntaxNode};
 use rome_json_formatter::context::{JsonFormatContext, JsonFormatOptions};
 use rome_json_syntax::JsonSyntaxNode;
 use rome_parser::prelude::ParseDiagnostic;
 use rome_rowan::NodeCache;
 
 pub enum Parse<'a> {
-    JavaScript(SourceType, &'a str),
+    JavaScript(JsFileSource, &'a str),
     Json(&'a str),
 }
 
 impl<'a> Parse<'a> {
     pub fn try_from_case(case: &TestCase) -> Option<Parse> {
-        match SourceType::try_from(case.path()) {
+        match JsFileSource::try_from(case.path()) {
             Ok(source_type) => Some(Parse::JavaScript(source_type, case.code())),
             Err(_) => match case.extension() {
                 "json" => Some(Parse::Json(case.code())),
@@ -47,7 +47,7 @@ impl<'a> Parse<'a> {
 }
 
 pub enum Parsed {
-    JavaScript(rome_js_parser::Parse<AnyJsRoot>, SourceType),
+    JavaScript(rome_js_parser::Parse<AnyJsRoot>, JsFileSource),
     Json(rome_json_parser::JsonParse),
 }
 
@@ -77,7 +77,7 @@ impl Parsed {
 }
 
 pub enum FormatNode {
-    JavaScript(JsSyntaxNode, SourceType),
+    JavaScript(JsSyntaxNode, JsFileSource),
     Json(JsonSyntaxNode),
 }
 
@@ -123,7 +123,7 @@ impl Analyze {
                     ..AnalysisFilter::default()
                 };
                 let options = AnalyzerOptions::default();
-                analyze(root, filter, &options, SourceType::default(), |event| {
+                analyze(root, filter, &options, JsFileSource::default(), |event| {
                     black_box(event.diagnostic());
                     black_box(event.actions());
                     ControlFlow::<Never>::Continue(())

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -5,7 +5,7 @@ use rome_js_syntax::{
     AnyJsExportClause, AnyJsExpression, AnyJsFormalParameter, AnyJsImportClause,
     AnyJsLiteralExpression, AnyJsModuleItem, AnyJsName, AnyJsNamedImport,
     AnyJsNamedImportSpecifier, AnyJsObjectMember, AnyJsObjectMemberName, AnyJsParameter,
-    AnyJsStatement, AnyTsName, AnyTsReturnType, AnyTsType, AnyTsTypeMember, SourceType,
+    AnyJsStatement, AnyTsName, AnyTsReturnType, AnyTsType, AnyTsTypeMember, JsFileSource,
     TriviaPieceKind, T,
 };
 use rome_rowan::AstNode;
@@ -398,7 +398,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
     )
     .build();
 
-    let formatted = format_node(JsFormatOptions::new(SourceType::ts()), module.syntax()).unwrap();
+    let formatted = format_node(JsFormatOptions::new(JsFileSource::ts()), module.syntax()).unwrap();
     let printed = formatted.print().unwrap();
     let code = printed.into_code();
 

--- a/xtask/coverage/src/js/test262.rs
+++ b/xtask/coverage/src/js/test262.rs
@@ -3,7 +3,7 @@ use crate::runner::{
 };
 use regex::Regex;
 use rome_js_parser::parse;
-use rome_js_syntax::SourceType;
+use rome_js_syntax::JsFileSource;
 use rome_rowan::syntax::SyntaxKind;
 use rome_rowan::AstNode;
 use serde::Deserialize;
@@ -83,7 +83,7 @@ impl Test262TestCase {
         Self { name, code, meta }
     }
 
-    fn execute_test(&self, append_use_strict: bool, source_type: SourceType) -> TestRunOutcome {
+    fn execute_test(&self, append_use_strict: bool, source_type: JsFileSource) -> TestRunOutcome {
         let code = if append_use_strict {
             format!("\"use strict\";\n{}", self.code)
         } else {
@@ -130,14 +130,14 @@ impl TestCase for Test262TestCase {
     fn run(&self) -> TestRunOutcome {
         let meta = &self.meta;
         if meta.flags.contains(&TestFlag::OnlyStrict) {
-            self.execute_test(true, SourceType::js_script())
+            self.execute_test(true, JsFileSource::js_script())
         } else if meta.flags.contains(&TestFlag::Module) {
-            self.execute_test(false, SourceType::js_module())
+            self.execute_test(false, JsFileSource::js_module())
         } else if meta.flags.contains(&TestFlag::NoStrict) || meta.flags.contains(&TestFlag::Raw) {
-            self.execute_test(false, SourceType::js_script())
+            self.execute_test(false, JsFileSource::js_script())
         } else {
-            let l = self.execute_test(false, SourceType::js_script());
-            let r = self.execute_test(true, SourceType::js_script());
+            let l = self.execute_test(false, JsFileSource::js_script());
+            let r = self.execute_test(true, JsFileSource::js_script());
             merge_outcomes(l, r)
         }
     }

--- a/xtask/coverage/src/jsx/jsx_babel.rs
+++ b/xtask/coverage/src/jsx/jsx_babel.rs
@@ -4,7 +4,7 @@ use crate::{
     runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite},
 };
 use rome_js_parser::parse;
-use rome_js_syntax::{ModuleKind, SourceType};
+use rome_js_syntax::{JsFileSource, ModuleKind};
 use rome_rowan::SyntaxKind;
 use std::path::Path;
 
@@ -35,7 +35,7 @@ impl TestCase for BabelJsxTestCase {
     }
 
     fn run(&self) -> TestRunOutcome {
-        let source_type = SourceType::jsx().with_module_kind(ModuleKind::Script);
+        let source_type = JsFileSource::jsx().with_module_kind(ModuleKind::Script);
         let files = TestCaseFiles::single(self.name().to_string(), self.code.clone(), source_type);
         let result = parse(&self.code, source_type);
 

--- a/xtask/coverage/src/runner.rs
+++ b/xtask/coverage/src/runner.rs
@@ -6,7 +6,7 @@ use rome_diagnostics::termcolor::Buffer;
 use rome_diagnostics::Error;
 use rome_diagnostics::PrintDiagnostic;
 use rome_js_parser::{parse, Parse};
-use rome_js_syntax::{AnyJsRoot, JsSyntaxNode, SourceType};
+use rome_js_syntax::{AnyJsRoot, JsFileSource, JsSyntaxNode};
 use rome_rowan::SyntaxKind;
 use std::fmt::Debug;
 use std::panic::RefUnwindSafe;
@@ -77,7 +77,7 @@ pub(crate) struct TestCaseFile {
     code: String,
 
     /// The source type used to parse the file
-    source_type: SourceType,
+    source_type: JsFileSource,
 }
 
 impl TestCaseFile {
@@ -109,7 +109,7 @@ pub(crate) struct TestCaseFiles {
 }
 
 impl TestCaseFiles {
-    pub(crate) fn single(name: String, code: String, source_type: SourceType) -> Self {
+    pub(crate) fn single(name: String, code: String, source_type: JsFileSource) -> Self {
         Self {
             files: vec![TestCaseFile {
                 name,
@@ -123,7 +123,7 @@ impl TestCaseFiles {
         Self { files: vec![] }
     }
 
-    pub(crate) fn add(&mut self, name: String, code: String, source_type: SourceType) {
+    pub(crate) fn add(&mut self, name: String, code: String, source_type: JsFileSource) {
         self.files.push(TestCaseFile {
             name,
             code,

--- a/xtask/coverage/src/symbols/msts.rs
+++ b/xtask/coverage/src/symbols/msts.rs
@@ -1,5 +1,5 @@
 use rome_js_semantic::SemanticEvent;
-use rome_js_syntax::SourceType;
+use rome_js_syntax::JsFileSource;
 
 use super::utils::{parse_separated_list, parse_str, parse_until_chr, parse_whitespace0};
 use crate::check_file_encoding;
@@ -61,7 +61,7 @@ impl TestCase for SymbolsMicrosoftTestCase {
                         files: TestCaseFiles::single(
                             self.name.clone(),
                             "".to_string(),
-                            SourceType::tsx(),
+                            JsFileSource::tsx(),
                         ),
                         errors: vec![],
                     }
@@ -69,9 +69,9 @@ impl TestCase for SymbolsMicrosoftTestCase {
             }
         };
 
-        let t = TestCaseFiles::single(self.name.clone(), code.clone(), SourceType::tsx());
+        let t = TestCaseFiles::single(self.name.clone(), code.clone(), JsFileSource::tsx());
 
-        let r = rome_js_parser::parse(&code, SourceType::tsx());
+        let r = rome_js_parser::parse(&code, JsFileSource::tsx());
         let mut actual: Vec<_> = rome_js_semantic::semantic_events(r.syntax())
             .into_iter()
             .filter(|x| {

--- a/xtask/coverage/src/ts/ts_babel.rs
+++ b/xtask/coverage/src/ts/ts_babel.rs
@@ -3,7 +3,7 @@ use crate::{
     check_file_encoding,
     runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite},
 };
-use rome_js_syntax::{LanguageVariant, SourceType};
+use rome_js_syntax::{JsFileSource, LanguageVariant};
 use rome_rowan::SyntaxKind;
 use std::path::Path;
 
@@ -41,7 +41,7 @@ impl TestCase for BabelTypescriptTestCase {
     }
 
     fn run(&self) -> TestRunOutcome {
-        let source_type = SourceType::ts().with_variant(self.variant);
+        let source_type = JsFileSource::ts().with_variant(self.variant);
         let files = TestCaseFiles::single(self.name().to_string(), self.code.clone(), source_type);
 
         let result = rome_js_parser::parse(&self.code, source_type);

--- a/xtask/coverage/src/ts/ts_microsoft.rs
+++ b/xtask/coverage/src/ts/ts_microsoft.rs
@@ -3,7 +3,7 @@ use crate::runner::{
     create_bogus_node_in_tree_diagnostic, TestCase, TestCaseFiles, TestRunOutcome, TestSuite,
 };
 use regex::Regex;
-use rome_js_syntax::{ModuleKind, SourceType};
+use rome_js_syntax::{JsFileSource, ModuleKind};
 use rome_rowan::{AstNode, SyntaxKind};
 use std::convert::TryFrom;
 use std::fmt::Write;
@@ -171,7 +171,7 @@ fn extract_metadata(code: &str, path: &str) -> TestCaseMetadata {
 fn add_file_if_supported(files: &mut TestCaseFiles, name: String, content: String) {
     let path = Path::new(&name);
     // Skip files that aren't JS/TS files (JSON, CSS...)
-    if let Ok(mut source_type) = SourceType::try_from(path) {
+    if let Ok(mut source_type) = JsFileSource::try_from(path) {
         let is_module_regex = Regex::new("(import|export)\\s").unwrap();
         // A very basic heuristic to determine if a module is a `Script` or a `Module`.
         // The TypeScript parser automatically detects whatever a file is a module or a script

--- a/xtask/lintdoc/src/main.rs
+++ b/xtask/lintdoc/src/main.rs
@@ -11,7 +11,7 @@ use rome_console::{
 use rome_diagnostics::termcolor::NoColor;
 use rome_diagnostics::{Diagnostic, DiagnosticExt, PrintDiagnostic};
 use rome_js_analyze::{analyze, visit_registry};
-use rome_js_syntax::{JsLanguage, Language, LanguageVariant, ModuleKind, SourceType};
+use rome_js_syntax::{JsFileSource, JsLanguage, Language, LanguageVariant, ModuleKind};
 use rome_service::settings::WorkspaceSettings;
 use std::{
     collections::BTreeMap,
@@ -401,7 +401,7 @@ fn parse_documentation(
 }
 
 enum BlockType {
-    Js(SourceType),
+    Js(JsFileSource),
     Json,
 }
 
@@ -422,7 +422,7 @@ impl FromStr for CodeBlockTest {
             .filter(|token| !token.is_empty());
 
         let mut test = CodeBlockTest {
-            block_type: BlockType::Js(SourceType::default()),
+            block_type: BlockType::Js(JsFileSource::default()),
             expect_diagnostic: false,
         };
 
@@ -430,17 +430,18 @@ impl FromStr for CodeBlockTest {
             match token {
                 // Determine the language, using the same list of extensions as `compute_source_type_from_path_or_extension`
                 "cjs" => {
-                    test.block_type =
-                        BlockType::Js(SourceType::js_module().with_module_kind(ModuleKind::Script));
+                    test.block_type = BlockType::Js(
+                        JsFileSource::js_module().with_module_kind(ModuleKind::Script),
+                    );
                 }
                 "js" | "mjs" | "jsx" => {
-                    test.block_type = BlockType::Js(SourceType::jsx());
+                    test.block_type = BlockType::Js(JsFileSource::jsx());
                 }
                 "ts" | "mts" | "cts" => {
-                    test.block_type = BlockType::Js(SourceType::ts());
+                    test.block_type = BlockType::Js(JsFileSource::ts());
                 }
                 "tsx" => {
-                    test.block_type = BlockType::Js(SourceType::tsx());
+                    test.block_type = BlockType::Js(JsFileSource::tsx());
                 }
 
                 // Other attributes


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/4458

The previous PR was send the default `SourceType`, which wasn't the correct way.

This PR fixes the issue by doing the following:
- renaming "source type" to "file source";
- creating a tiny trait called `FileSource`, which will be used to share behaviour for those file sources that need to be sent across thread boundaries;
- creating a new type called `AnyFileSource`, a language-agnostic data structure that will be used when using the `Workspace`. This type has a method called `try_from`, which will attempt to recreate the file source based on the path of the file


I renamed `SouceType` to `JsFileSource`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current tests should pass. I created a new test case to fix the issue

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

(I will create changelog line in `next-release` branch, to avoid too many conflicts)

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
