### PR TITLE
fix(rome_js_analyze): Fix false positive diagnostics that `useHookAtTopLevel` caused to `as` or `satisfies` expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ when there are breaking changes.
 - Fix false positive diagnostics that [`useCamelCase`](https://docs.rome.tools/lint/rules/usecamelcase/) caused to default exported components
 - Fix false positive diagnostics that [`useCamelCase`](https://docs.rome.tools/lint/rules/usecamelcase/) caused to private class members
 - Fix false positive diagnostics that [`useHookAtTopLevel`](https://docs.rome.tools/lint/rules/usehookattoplevel/) caused to arrow functions, export default functions and function expressions.
+- Fix false positive diagnostics that [`useHookAtTopLevel`](https://docs.rome.tools/lint/rules/usehookattoplevel/) caused to `as` or `satisfies` expression.
 - Fix false positive diagnostics that [`noHeadeScope`](https://docs.rome.tools/lint/rules/noheaderscope/) caused to custom components
 - Fix false negative diagnostics that [`noNoninteractiveElementToInteractiveRole`](https://docs.rome.tools/lint/rules/nononinteractiveelementtointeractiverole/) and [`noNoninteractiveTabindex`](https://docs.rome.tools/lint/rules/nononinteractivetabindex/) caused to non-interactive elements.
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_hook_at_top_level.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_hook_at_top_level.rs
@@ -62,6 +62,8 @@ fn enclosing_function_if_call_is_at_top_level(call: &JsCallExpression) -> Option
                 | JsSyntaxKind::JS_VARIABLE_DECLARATOR
                 | JsSyntaxKind::JS_VARIABLE_DECLARATOR_LIST
                 | JsSyntaxKind::JS_VARIABLE_DECLARATION
+                | JsSyntaxKind::TS_AS_EXPRESSION
+                | JsSyntaxKind::TS_SATISFIES_EXPRESSION
         )
     });
 

--- a/crates/rome_js_analyze/tests/specs/nursery/useHookAtTopLevel/invalid.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/useHookAtTopLevel/invalid.ts
@@ -1,0 +1,9 @@
+const Component1 = () => {
+  useEffect() as [];
+};
+
+const Component2 = () => {
+  if (a == 1) {
+      Component1();
+  }
+};

--- a/crates/rome_js_analyze/tests/specs/nursery/useHookAtTopLevel/invalid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useHookAtTopLevel/invalid.ts.snap
@@ -1,0 +1,48 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```js
+const Component1 = () => {
+  useEffect() as [];
+};
+
+const Component2 = () => {
+  if (a == 1) {
+      Component1();
+  }
+};
+
+```
+
+# Diagnostics
+```
+invalid.ts:2:3 lint/nursery/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook is being called indirectly and conditionally, but all hooks must be called in the exact same order in every component render.
+  
+    1 │ const Component1 = () => {
+  > 2 │   useEffect() as [];
+      │   ^^^^^^^^^
+    3 │ };
+    4 │ 
+  
+  i This is the call path until the hook.
+  
+    5 │ const Component2 = () => {
+  > 6 │   if (a == 1) {
+      │                
+  > 7 │       Component1();
+      │       ^^^^^^^^^^^^
+    8 │   }
+    9 │ };
+  
+  i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
+  
+  i See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/useHookAtTopLevel/valid.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/useHookAtTopLevel/valid.ts
@@ -1,0 +1,9 @@
+/* does not generate diagnostics */
+
+const Component1 = () => {
+  useEffect() as [];
+};
+
+const Component2 = () => {
+  useEffect() satisfies [];
+};

--- a/crates/rome_js_analyze/tests/specs/nursery/useHookAtTopLevel/valid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useHookAtTopLevel/valid.ts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```js
+/* does not generate diagnostics */
+
+const Component1 = () => {
+  useEffect() as [];
+};
+
+const Component2 = () => {
+  useEffect() satisfies [];
+};
+
+```
+
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix #4463 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I add some snapshot tests

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
