### PR TITLE
fix: benchmark tooling failing calling node modules bin dir directly

### DIFF
--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -31,7 +31,7 @@ const BENCHMARKS = {
 			repository: "https://github.com/prettier/prettier.git",
 			sourceDirectories: {
 				src: ["js"],
-				scripts: ["js", "mjs"],
+				scripts: ["js"],
 			},
 		},
 	},
@@ -93,7 +93,7 @@ function benchmarkFormatter(rome) {
 		);
 
 		// Run 2 warmups to make sure the files are formatted correctly
-		const hyperfineCommand = `hyperfine -w 2 -n Prettier "${prettierCommand}" -n "Parallel-Prettier" "${parallelPrettierCommand}" -n dprint "${dprintCommand}" -n Rome "${romeCommand}" --shell=${shellOption()} -n "Rome (1 thread)" "${romeSingleCoreCommand}"`;
+		const hyperfineCommand = `hyperfine --show-output -w 2 -n Prettier "${prettierCommand}" -n "Parallel-Prettier" "${parallelPrettierCommand}" -n dprint "${dprintCommand}" -n Rome "${romeCommand}" --shell=${shellOption()} -n "Rome (1 thread)" "${romeSingleCoreCommand}"`;
 		console.log(hyperfineCommand);
 
 		child_process.execSync(hyperfineCommand, {
@@ -108,7 +108,7 @@ function resolvePrettier() {
 }
 
 function resolveParallelPrettier() {
-	return path.resolve("node_modules/.bin/pprettier");
+	return path.resolve("node_modules/@mixer/parallel-prettier/dist/index.js");
 }
 
 function resolveDprint() {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

The benchmarking tool was not working on Windows or the `rust` docker image. This was due to calling the `node_modules` `.bin` directory directly. Which should be avoided. I did try using `npx`  however as the child process that runs `hyperfine` is ran in the working directory of the cloned repositories that did not work as anticipated.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
N/A
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog
I don't believe this requires a changelog entry

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation
This is a transparent fix and the documentation for the benchmark tool should not need updating.

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
