### PR TITLE
perf: improve rome benchmark performance in formatting by removing di…

### DIFF
--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -80,7 +80,7 @@ function benchmarkFormatter(rome) {
 
 		const dprintCommand = `${resolveDprint()} fmt --incremental=false --config '${require.resolve("./dprint.json")}' ${Object.keys(configuration.sourceDirectories).map(path => `'${path}/**/*'`).join(" ")}`;
 
-		const romeCommand = `${rome} format ${Object.keys(
+		const romeCommand = `${rome} format --max-diagnostics=0 ${Object.keys(
 			configuration.sourceDirectories,
 		)
 			.map((path) => `'${path}'`)


### PR DESCRIPTION
…agnostics

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

The benchmark tool was not passing `--max-diagnostics=0` when performing the format benchmark for `rome`. It should be set as none of the other tools have any significant output - unlike `rome`, which by default was outputting up to 20 diagnostics per run.

This improved `rome`'s performance in the format benchmark to the x25 speed improvement over Prettier, which is advertised on the homepage of the project. Without this, `rome` performed worse than `dprint`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
N/A
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog
I don't believe this requires a changelog entry
<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation
The documentation was wrong before, this makes the documentation accurate again.
<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
