### PR TITLE
perf: improve clone speed of benchmark tool with sparse-checkout

### DIFF
--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -53,6 +53,18 @@ const BENCHMARKS = {
 	},
 };
 
+function getDirsToClone(sourceDirs) {
+	if (typeof sourceDirs !== 'object' || sourceDirs === null) {
+		return;
+	}
+
+	if (Array.isArray(sourceDirs)) {
+		return sourceDirs;
+	}
+
+	return Object.keys(sourceDirs);
+}
+
 function benchmarkFormatter(rome) {
 	console.log("");
 	console.log("Benchmark formatter...");
@@ -65,7 +77,7 @@ function benchmarkFormatter(rome) {
 	for (const [name, configuration] of Object.entries(BENCHMARKS.formatter)) {
 		console.log(`[${name}]`);
 
-		let projectDirectory = cloneProject(name, configuration.repository);
+		let projectDirectory = cloneProject(name, configuration.repository, getDirsToClone(configuration.sourceDirectories));
 
 		const prettierPaths = Object.entries(configuration.sourceDirectories)
 			.flatMap(([directory, extensions]) => {
@@ -124,7 +136,7 @@ function benchmarkLinter(rome) {
 	for (const [name, configuration] of Object.entries(BENCHMARKS.linter)) {
 		console.log(`[${name}]`);
 
-		const projectDirectory = cloneProject(name, configuration.repository);
+		const projectDirectory = cloneProject(name, configuration.repository, getDirsToClone(configuration.sourceDirectories));
 
 		deleteFile(path.join(projectDirectory, ".eslintignore"));
 		deleteFile(path.join(projectDirectory, "/eslintrc.js"));
@@ -207,22 +219,27 @@ function deleteFile(path) {
 	}
 }
 
-function cloneProject(name, repository) {
+function cloneProject(name, repository, dirs = []) {
 	let projectDirectory = path.join(TMP_DIRECTORY, name);
 
 	let inProjectDirectory = withDirectory(projectDirectory);
 
 	if (fs.existsSync(projectDirectory)) {
-		console.log("Updating");
+		console.log(`Updating git repository in directory ${projectDirectory}`);
 		inProjectDirectory.run("git reset --hard @{u}");
 		inProjectDirectory.run("git clean -df");
 		inProjectDirectory.run("git pull --depth=1");
 	} else {
 		console.log("Clone project...");
 
-		withDirectory(TMP_DIRECTORY).run(`git clone --depth=1 ${repository}`, {
+		withDirectory(TMP_DIRECTORY).run(`git clone ${dirs.length > 0 ? '--sparse' : ''} --depth=1 ${repository}`, {
 			stdio: "inherit",
 		});
+	}
+
+	if (dirs.length > 0) {
+		console.log(`Adding directories ${dirs.join()} to sparse checkout in ${projectDirectory}`)
+		inProjectDirectory.run(`git sparse-checkout add ${dirs.join(' ')}`);
 	}
 
 	return projectDirectory;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
I noticed that we were cloning whole repositories but only using parts of them to actually perform the benchmark against. This change takes advantage of [`git sparse-checkout`](https://git-scm.com/docs/git-sparse-checkout) to only pull the folders that we define in our configuration. It does not affect benchmark results, but does make the setup faster.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog
I don't believe this requires a changelog entry
<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation
This does not require documentation.
<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
