### PR TITLE
chore: Bump `pnpm/action-setup` and `jetli/wasm-pack-action` to latest

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -108,7 +108,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
       - name: Install wasm-pack

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           version: 7
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.3.0
+        uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: 'latest'
       - name: Build TypeScript code

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -45,7 +45,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
       - name: Install toolchain

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: false
-      - uses: jetli/wasm-pack-action@v0.3.0
+      - uses: jetli/wasm-pack-action@v0.4.0
       - name: Cache pnpm modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -145,7 +145,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.3.0
+        uses: jetli/wasm-pack-action@v0.4.0
 
       - name: Build WASM module for bundlers
         run: wasm-pack build --out-dir ../../npm/wasm-bundler --target bundler --release --scope rometools crates/rome_wasm

--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -79,7 +79,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
 

--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -68,7 +68,7 @@ jobs:
           node-version: 14.x
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.3.0
+        uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: 'latest'
 

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           submodules: false
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.3.0
+        uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: 'latest'
       - name: Cache pnpm modules

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
       - name: Install toolchain


### PR DESCRIPTION
## Summary
CI gives this warning:
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16:
jetli/wasm-pack-action@v0.3.0, pnpm/action-setup@v2.1.0.
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

Latest `pnpm/action-setup` and `jetli/wasm-pack-action` don't use Node.js 12 any more while not having breaking changes.

## Test Plan


## Changelog
- [ ] The PR requires a changelog line

## Documentation
- [ ] The PR requires documentation
