### PR TITLE
fix(rome_service): treat nursery rules differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - `rome lsp-proxy` should accept the global CLI options [#4505](https://github.com/rome/tools/issues/4505)
 
 ### Configuration
+
+#### Other changes
+
+- Fix an issue where all the `nursery` were enabled when the `"nursery": {}` object
+was defined [#4479](https://github.com/rome/tools/issues/4479)
+
 ### Editors
 ### Formatter
 ### Linter

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -2220,3 +2220,56 @@ array.map((sentence) => sentence.split(" ")).flat();
         result,
     ));
 }
+
+#[test]
+fn should_not_enable_nursery_rules() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"	{
+  "$schema": "https://docs.rome.tools/schemas/12.1.0/schema.json",
+  "organizeImports": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "nursery": {
+        "noAccumulatingSpread": "error"
+      }
+    }
+  }
+}"#;
+
+    let configuration_path = Path::new("rome.json");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let file_path = Path::new("fix.ts");
+    fs.insert(
+        file_path.into(),
+        r#"const bannedType: Boolean = true;
+
+if (true) {
+	const obj = {};
+	obj["useLiteralKey"];
+}
+		"#,
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[("check"), file_path.as_os_str().to_str().unwrap()]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_not_enable_nursery_rules",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/rome_cli/tests/snapshots/main_commands_check/should_not_enable_nursery_rules.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/should_not_enable_nursery_rules.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "$schema": "https://docs.rome.tools/schemas/12.1.0/schema.json",
+  "organizeImports": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "nursery": {
+        "noAccumulatingSpread": "error"
+      }
+    }
+  }
+}
+```
+
+## `fix.ts`
+
+```ts
+const bannedType: Boolean = true;
+
+if (true) {
+	const obj = {};
+	obj["useLiteralKey"];
+}
+		
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -2219,13 +2219,13 @@ impl Nursery {
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
-        parent_is_recommended: bool,
+        _parent_is_recommended: bool,
         enabled_rules: &mut IndexSet<RuleFilter>,
         disabled_rules: &mut IndexSet<RuleFilter>,
     ) {
         if self.is_all() {
             enabled_rules.extend(Self::all_rules_as_filters());
-        } else if parent_is_recommended || self.is_recommended() {
+        } else if self.is_recommended() {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
         if self.is_not_all() {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/4479

We treat nursery rules differently from the rest of the rules. We treated them differently only when using the top `recommended: true` but not when `nursery: {}` was defined.

This PR changes the code generation of the configuration to enable recommended rules **only** when `recommended: true`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added the test case of the issue

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
