### PR TITLE
feat: suppress warnings flag for check and ci

### DIFF
--- a/crates/rome_cli/src/cli_options.rs
+++ b/crates/rome_cli/src/cli_options.rs
@@ -24,6 +24,10 @@ pub struct CliOptions {
     #[bpaf(long("max-diagnostics"), argument("NUMBER"), optional)]
     pub max_diagnostics: Option<u16>,
 
+    /// Do not emit warning diagnostics
+    #[bpaf(long("suppress-warnings"), switch)]
+    pub suppress_warnings: bool,
+
     /// Skip over files containing syntax errors instead of emitting an error diagnostic.
     #[bpaf(long("skip-errors"), switch)]
     pub skip_errors: bool,

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -32,6 +32,7 @@ for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
 "#;
 
 const NO_DEBUGGER: &str = "debugger;";
+
 const NEW_SYMBOL: &str = "new Symbol(\"\");";
 
 const FIX_BEFORE: &str = "
@@ -1328,6 +1329,68 @@ fn print_verbose() {
     ));
 }
 
+#[test]
+fn suppress_warnings() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let rome_path = Path::new("rome.json");
+    fs.insert(
+        rome_path.into(),
+        CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC.as_bytes(),
+    );
+
+    let file_path = Path::new("file.ts");
+
+    const DEBUG_AND_ANY: &str = "debugger; const a: any = 1;";
+
+    fs.insert(file_path.into(), DEBUG_AND_ANY.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[
+            ("check"),
+            ("--suppress-warnings"),
+            file_path.as_os_str().to_str().unwrap(),
+        ]),
+    );
+    print!("{:?}", console.out_buffer);
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    let messages = &console.out_buffer;
+
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|m| m.level == LogLevel::Error)
+            .filter(|m| {
+                let content = format!("{:#?}", m.content);
+                content.contains("suspicious/noExplicitAny")
+            })
+            .count(),
+        1
+    );
+
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|m| {
+                let content = format!("{:#?}", m.content);
+                content.contains("suspicious/noDebugger")
+            })
+            .count(),
+        0
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "suppress_warnings",
+        fs,
+        console,
+        result,
+    ));
+}
 #[test]
 fn unsupported_file() {
     let mut fs = MemoryFileSystem::default();

--- a/crates/rome_cli/tests/commands/ci.rs
+++ b/crates/rome_cli/tests/commands/ci.rs
@@ -1,11 +1,14 @@
-use crate::configs::{CONFIG_DISABLED_FORMATTER, CONFIG_FILE_SIZE_LIMIT, CONFIG_LINTER_DISABLED};
+use crate::configs::{
+    CONFIG_DISABLED_FORMATTER, CONFIG_FILE_SIZE_LIMIT, CONFIG_LINTER_DISABLED,
+    CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC,
+};
 use crate::snap_test::SnapshotPayload;
 use crate::{
     assert_cli_snapshot, run_cli, CUSTOM_FORMAT_BEFORE, FORMATTED, LINT_ERROR, PARSE_ERROR,
     UNFORMATTED,
 };
 use bpaf::Args;
-use rome_console::{BufferConsole, MarkupBuf};
+use rome_console::{BufferConsole, LogLevel, MarkupBuf};
 use rome_fs::{FileSystemExt, MemoryFileSystem};
 use rome_service::DynRef;
 use std::path::{Path, PathBuf};
@@ -696,6 +699,69 @@ fn print_verbose() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "print_verbose",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn suppress_warnings() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let rome_path = Path::new("rome.json");
+    fs.insert(
+        rome_path.into(),
+        CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC.as_bytes(),
+    );
+
+    let file_path = Path::new("file.ts");
+
+    const DEBUG_AND_ANY: &str = "debugger; const a: any = 1;";
+
+    fs.insert(file_path.into(), DEBUG_AND_ANY.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[
+            ("ci"),
+            ("--suppress-warnings"),
+            file_path.as_os_str().to_str().unwrap(),
+        ]),
+    );
+    print!("{:?}", console.out_buffer);
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    let messages = &console.out_buffer;
+
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|m| m.level == LogLevel::Error)
+            .filter(|m| {
+                let content = format!("{:#?}", m.content);
+                content.contains("suspicious/noExplicitAny")
+            })
+            .count(),
+        1
+    );
+
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|m| {
+                let content = format!("{:#?}", m.content);
+                content.contains("suspicious/noDebugger")
+            })
+            .count(),
+        0
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "suppress_warnings",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -56,6 +56,7 @@ Available options:
         --config-path <PATH>  Set the filesystem path to the directory of the rome.json configuration
                         file
         --max-diagnostics <NUMBER>  Cap the amount of diagnostics displayed (default: 20)
+        --suppress-warnings  Do not emit warning diagnostics
         --skip-errors   Skip over files containing syntax errors instead of emitting an error
                         diagnostic.
         --json          Reports information using the JSON format

--- a/crates/rome_cli/tests/snapshots/main_commands_check/suppress_warnings.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/suppress_warnings.snap
@@ -1,0 +1,61 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noDebugger": "warn"
+      }
+    }
+  }
+}
+```
+
+## `file.ts`
+
+```ts
+debugger; const a: any = 1;
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.ts:1:20 lint/suspicious/noExplicitAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected any. Specify a different type.
+  
+  > 1 │ debugger; const a: any = 1;
+      │                    ^^^
+  
+  i any disables many type checking rules. Its use should be avoided.
+  
+
+```
+
+```block
+The number of diagnostics exceeds the number allowed by Rome.
+Diagnostics not shown: 1.
+```
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -55,6 +55,7 @@ Available options:
         --config-path <PATH>  Set the filesystem path to the directory of the rome.json configuration
                        file
         --max-diagnostics <NUMBER>  Cap the amount of diagnostics displayed (default: 20)
+        --suppress-warnings  Do not emit warning diagnostics
         --skip-errors  Skip over files containing syntax errors instead of emitting an error
                        diagnostic.
         --json         Reports information using the JSON format

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/suppress_warnings.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/suppress_warnings.snap
@@ -1,0 +1,56 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noDebugger": "warn"
+      }
+    }
+  }
+}
+```
+
+## `file.ts`
+
+```ts
+debugger; const a: any = 1;
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.ts:1:20 lint/suspicious/noExplicitAny ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected any. Specify a different type.
+  
+  > 1 │ debugger; const a: any = 1;
+      │                    ^^^
+  
+  i any disables many type checking rules. Its use should be avoided.
+  
+
+```
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -51,6 +51,7 @@ Available options:
         --config-path <PATH>  Set the filesystem path to the directory of the rome.json configuration
                        file
         --max-diagnostics <NUMBER>  Cap the amount of diagnostics displayed (default: 20)
+        --suppress-warnings  Do not emit warning diagnostics
         --skip-errors  Skip over files containing syntax errors instead of emitting an error
                        diagnostic.
         --json         Reports information using the JSON format

--- a/crates/rome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
@@ -8,7 +8,7 @@ expression: content
 Acts as a server for the Language Server Protocol over stdin/stdout
 
 Usage: [--colors off|force] [--use-server] [--verbose] [--config-path PATH] [--max-diagnostics
-NUMBER] [--skip-errors]
+NUMBER] [--suppress-warnings] [--skip-errors]
 
 Available options:
   Global options applied to all commands
@@ -20,6 +20,7 @@ Available options:
         --config-path <PATH>  Set the filesystem path to the directory of the rome.json configuration
                        file
         --max-diagnostics <NUMBER>  Cap the amount of diagnostics displayed (default: 20)
+        --suppress-warnings  Do not emit warning diagnostics
         --skip-errors  Skip over files containing syntax errors instead of emitting an error
                        diagnostic.
         --json         Reports information using the JSON format

--- a/crates/rome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -19,6 +19,7 @@ Available options:
         --config-path <PATH>  Set the filesystem path to the directory of the rome.json configuration
                        file
         --max-diagnostics <NUMBER>  Cap the amount of diagnostics displayed (default: 20)
+        --suppress-warnings  Do not emit warning diagnostics
         --skip-errors  Skip over files containing syntax errors instead of emitting an error
                        diagnostic.
         --json         Reports information using the JSON format


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When linting a large number a files its useful to prioritize the errors in the output. Allowing the user to suppress the warning messages makes it easier to address the higher priority errors first. Similarly on CI the user may not care about seeing the warning messages since they will not lead to a CI failure and thus just add noise to the logs.  

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

https://github.com/rome/tools/discussions/4532

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Added test cases to the check and ci commands in /crates/rome_cli/tests/commands

`cargo test --package rome_cli --test main -- commands::check::suppress_warnings --exact --nocapture`

```running 1 test
[Message { level: Error, content: "file.ts:1:20 "<Hyperlink href="https://docs.rome.tools/lint/rules/noExplicitAny">"lint/suspicious/noExplicitAny"</Hyperlink>" ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n"<Emphasis><Error>"  ✖"</Error></Emphasis>" "<Error>"Unexpected "</Error><Error><Emphasis>"any"</Emphasis></Error><Error>". Specify a different type."</Error>"\n  \n"<Emphasis><Error>"  >"</Error></Emphasis>" "<Emphasis>"1 │ "</Emphasis>"debugger; const a: any = 1;\n   "<Emphasis>"   │ "</Emphasis>"                   "<Emphasis><Error>"^^^"</Error></Emphasis>"\n  \n"<Emphasis><Info>"  ℹ"</Info></Emphasis>" "<Info><Emphasis>"any"</Emphasis></Info><Info>" disables many type checking rules. Its use should be avoided."</Info>"\n  \n" }, Message { level: Log, content: <Warn>"The number of diagnostics exceeds the number allowed by Rome.\n"</Warn><Info>"Diagnostics not shown: "</Info><Emphasis>"1"</Emphasis><Info>"."</Info> }, Message { level: Log, content: <Info>"Checked 1 file(s) in 43"</Info><Info><Dim>"ms"</Dim></Info>"\n"<Error>"Found 1 error(s)"</Error> }]test commands::check::suppress_warnings ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 146 filtered out; finished in 0.20s```



`cargo test --package rome_cli --test main -- commands::ci::suppress_warnings --exact --nocapture`

```running 1 test
[Message { level: Error, content: "file.ts:1:20 "<Hyperlink href="https://docs.rome.tools/lint/rules/noExplicitAny">"lint/suspicious/noExplicitAny"</Hyperlink>" ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n"<Emphasis><Error>"  ✖"</Error></Emphasis>" "<Error>"Unexpected "</Error><Error><Emphasis>"any"</Emphasis></Error><Error>". Specify a different type."</Error>"\n  \n"<Emphasis><Error>"  >"</Error></Emphasis>" "<Emphasis>"1 │ "</Emphasis>"debugger; const a: any = 1;\n   "<Emphasis>"   │ "</Emphasis>"                   "<Emphasis><Error>"^^^"</Error></Emphasis>"\n  \n"<Emphasis><Info>"  ℹ"</Info></Emphasis>" "<Info><Emphasis>"any"</Emphasis></Info><Info>" disables many type checking rules. Its use should be avoided."</Info>"\n  \n" }, Message { level: Log, content: <Info>"Checked 1 file(s) in 4"</Info><Info><Dim>"ms"</Dim></Info>"\n"<Error>"Found 1 error(s)"</Error> }]test commands::ci::suppress_warnings ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 146 filtered out; finished in 0.09s```

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
