### PR TITLE
Accept an environment variable to specify which binary to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `rome lsp-proxy` should accept the global CLI options [#4505](https://github.com/rome/tools/issues/4505)
 - Enhance help descriptions
+- Accept the environment variable 'ROME_BINARY' to override the Rome binary
 
 ### Configuration
 

--- a/npm/rome/bin/rome
+++ b/npm/rome/bin/rome
@@ -16,7 +16,7 @@ const PLATFORMS = {
 	},
 };
 
-const binPath = PLATFORMS?.[platform]?.[arch];
+const binPath = env.ROME_BINARY || PLATFORMS?.[platform]?.[arch];
 if (binPath) {
 	const result = require("child_process").spawnSync(
 		require.resolve(binPath),


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This adds an env var which allow users to override the path to the rome binary.

It's a way to provide a solution for running rome under nix.
See https://github.com/rome/tools/issues/4516#issuecomment-1569095669

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
