### PR TITLE
feat(rome_js_formatter) support prettier-style jsx quotes #4486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 
 ### Editors
 ### Formatter
+
+- Added a new option called `--jsx-quote-style` to the formatter. This option allows you to choose between single and double quotes for JSX attributes. [#4486](https://github.com/rome/tools/issues/4486)
+
 ### Linter
 
 #### Other changes

--- a/crates/rome_cli/tests/configs.rs
+++ b/crates/rome_cli/tests/configs.rs
@@ -76,6 +76,7 @@ pub const CONFIG_ALL_FIELDS: &str = r#"{
     "globals": ["$"],
     "formatter": {
       "quoteStyle": "double",
+      "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded"
     }
   }

--- a/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -42,6 +42,7 @@ Available options:
         --line-width <NUMBER>  What's the max width of a line. Defaults to 80.
 
         --quote-style <double|single>  The style for quotes. Defaults to double.
+        --jsx-quote-style <double|single>  The style for JSX quotes. Defaults to double.
         --quote-properties <preserve|as-needed>  When properties in objects are quoted. Defaults to
                         asNeeded.
         --trailing-comma <all|es5|none>  Print trailing commas wherever possible in multi-line

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -41,6 +41,7 @@ Available options:
         --line-width <NUMBER>  What's the max width of a line. Defaults to 80.
 
         --quote-style <double|single>  The style for quotes. Defaults to double.
+        --jsx-quote-style <double|single>  The style for JSX quotes. Defaults to double.
         --quote-properties <preserve|as-needed>  When properties in objects are quoted. Defaults to
                        asNeeded.
         --trailing-comma <all|es5|none>  Print trailing commas wherever possible in multi-line

--- a/crates/rome_cli/tests/snapshots/main_commands_format/applies_custom_jsx_quote_style.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/applies_custom_jsx_quote_style.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+<div bar='foo' baz={"foo"} />;
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -19,6 +19,7 @@ Available options:
         --line-width <NUMBER>  What's the max width of a line. Defaults to 80.
 
         --quote-style <double|single>  The style for quotes. Defaults to double.
+        --jsx-quote-style <double|single>  The style for JSX quotes. Defaults to double.
         --quote-properties <preserve|as-needed>  When properties in objects are quoted. Defaults to
                        asNeeded.
         --trailing-comma <all|es5|none>  Print trailing commas wherever possible in multi-line

--- a/crates/rome_cli/tests/snapshots/main_configuration/correct_root.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/correct_root.snap
@@ -39,6 +39,7 @@ expression: content
     "globals": ["$"],
     "formatter": {
       "quoteStyle": "double",
+      "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded"
     }
   }

--- a/crates/rome_js_formatter/src/context.rs
+++ b/crates/rome_js_formatter/src/context.rs
@@ -144,6 +144,9 @@ pub struct JsFormatOptions {
     /// The style for quotes. Defaults to double.
     quote_style: QuoteStyle,
 
+    /// The style for JSX quotes. Defaults to double.
+    jsx_quote_style: QuoteStyle,
+
     /// When properties in objects are quoted. Defaults to as-needed.
     quote_properties: QuoteProperties,
 
@@ -164,6 +167,7 @@ impl JsFormatOptions {
             indent_style: IndentStyle::default(),
             line_width: LineWidth::default(),
             quote_style: QuoteStyle::default(),
+            jsx_quote_style: QuoteStyle::default(),
             quote_properties: QuoteProperties::default(),
             trailing_comma: TrailingComma::default(),
             semicolons: Semicolons::default(),
@@ -185,6 +189,11 @@ impl JsFormatOptions {
         self
     }
 
+    pub fn with_jsx_quote_style(mut self, jsx_quote_style: QuoteStyle) -> Self {
+        self.jsx_quote_style = jsx_quote_style;
+        self
+    }
+
     pub fn with_quote_properties(mut self, quote_properties: QuoteProperties) -> Self {
         self.quote_properties = quote_properties;
         self
@@ -202,6 +211,10 @@ impl JsFormatOptions {
 
     pub fn quote_style(&self) -> QuoteStyle {
         self.quote_style
+    }
+
+    pub fn jsx_quote_style(&self) -> QuoteStyle {
+        self.jsx_quote_style
     }
 
     pub fn quote_properties(&self) -> QuoteProperties {
@@ -247,6 +260,7 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Indent style: {}", self.indent_style)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
         writeln!(f, "Quote style: {}", self.quote_style)?;
+        writeln!(f, "JSX quote style: {}", self.jsx_quote_style)?;
         writeln!(f, "Quote properties: {}", self.quote_properties)?;
         writeln!(f, "Trailing comma: {}", self.trailing_comma)?;
         writeln!(f, "Semicolons: {}", self.semicolons)

--- a/crates/rome_js_formatter/src/utils/string_utils.rs
+++ b/crates/rome_js_formatter/src/utils/string_utils.rs
@@ -42,7 +42,10 @@ impl<'token> FormatLiteralStringToken<'token> {
             JS_STRING_LITERAL | JSX_STRING_LITERAL
         ));
 
-        let chosen_quote_style = options.quote_style();
+        let chosen_quote_style = match token.kind() {
+            JSX_STRING_LITERAL => options.jsx_quote_style(),
+            _ => options.quote_style(),
+        };
         let chosen_quote_properties = options.quote_properties();
 
         let mut string_cleaner =

--- a/crates/rome_js_formatter/tests/language.rs
+++ b/crates/rome_js_formatter/tests/language.rs
@@ -159,6 +159,9 @@ pub struct JsSerializableFormatOptions {
     /// The style for quotes. Defaults to double.
     pub quote_style: Option<JsSerializableQuoteStyle>,
 
+    /// The style for JSX quotes. Defaults to double.
+    pub jsx_quote_style: Option<JsSerializableQuoteStyle>,
+
     /// When properties in objects are quoted. Defaults to as-needed.
     pub quote_properties: Option<JsSerializableQuoteProperties>,
 
@@ -179,6 +182,10 @@ impl JsSerializableFormatOptions {
                 self.line_width
                     .and_then(|width| LineWidth::try_from(width).ok())
                     .unwrap_or_default(),
+            )
+            .with_jsx_quote_style(
+                self.jsx_quote_style
+                    .map_or_else(|| QuoteStyle::Double, |value| value.into()),
             )
             .with_quote_style(
                 self.quote_style

--- a/crates/rome_js_formatter/tests/quick_test.rs
+++ b/crates/rome_js_formatter/tests/quick_test.rs
@@ -1,5 +1,5 @@
 use rome_formatter_test::check_reformat::CheckReformat;
-use rome_js_formatter::context::{JsFormatOptions, Semicolons};
+use rome_js_formatter::context::{JsFormatOptions, QuoteStyle, Semicolons};
 use rome_js_formatter::format_node;
 use rome_js_parser::parse;
 use rome_js_syntax::JsFileSource;
@@ -13,13 +13,19 @@ mod language {
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-const foo = @deco class {
-  //
-};
+(
+  <div
+    attr=''
+    atrr={''}
+    />
+)
 "#;
     let syntax = JsFileSource::tsx();
     let tree = parse(src, syntax);
-    let options = JsFormatOptions::new(syntax).with_semicolons(Semicolons::AsNeeded);
+    let options = JsFormatOptions::new(syntax)
+        .with_semicolons(Semicolons::AsNeeded)
+        .with_quote_style(QuoteStyle::Double)
+        .with_jsx_quote_style(QuoteStyle::Single);
     let result = format_node(options.clone(), &tree.syntax())
         .unwrap()
         .print()

--- a/crates/rome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/array/array_nested.js
+info: js/module/array/array_nested.js
 ---
 
 # Input
@@ -62,6 +61,7 @@ let o1 = [{ a, b }, { a, b, c }];
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/array/binding_pattern.js
+info: js/module/array/binding_pattern.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ let [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,...cccccccccc
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/array/empty_lines.js
+info: js/module/array/empty_lines.js
 ---
 
 # Input
@@ -33,6 +32,7 @@ let a = [
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/array/spaces.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/spaces.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/array/spaces.js
+info: js/module/array/spaces.js
 ---
 
 # Input
@@ -26,6 +25,7 @@ let e = [2,2,1,3];
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/array/spread.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/spread.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/array/spread.js
+info: js/module/array/spread.js
 ---
 
 # Input
@@ -26,6 +25,7 @@ let a = [...baaaaaaaaaaaaaaaaaaaaaaaaaaaaa,...bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,...
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/array/trailing-comma/array_trailing_comma.js
+info: js/module/array/trailing-comma/array_trailing_comma.js
 ---
 
 # Input
@@ -31,6 +30,7 @@ const a = [
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -57,6 +57,7 @@ const a = [
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
@@ -83,6 +84,7 @@ const a = [
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/arrow/arrow-comments.js
+info: js/module/arrow/arrow-comments.js
 ---
 
 # Input
@@ -42,6 +41,7 @@ multiline`;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/arrow/arrow_chain_comments.js
+info: js/module/arrow/arrow_chain_comments.js
 ---
 
 # Input
@@ -30,6 +29,7 @@ x2 = (a) => ((askTrovenaBeenaDependsRowans1, askTrovenaBeenaDependsRowans2, askT
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/arrow/arrow_function.js
+info: js/module/arrow/arrow_function.js
 ---
 
 # Input
@@ -27,6 +26,7 @@ async () => {}
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/arrow/arrow_nested.js
+info: js/module/arrow/arrow_nested.js
 ---
 
 # Input
@@ -48,6 +47,7 @@ runtimeAgent.getProperties(
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/arrow/arrow_test_callback.js
+info: js/module/arrow/arrow_test_callback.js
 ---
 
 # Input
@@ -25,6 +24,7 @@ it('should have the default duration when using the onClose arguments', done => 
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -41,4 +41,5 @@ it("should have the default duration when using the onClose arguments", (done) =
 ```
     1: it("should have the default duration when using the onClose arguments", (done) => {
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/arrow/call.js
+info: js/module/arrow/call.js
 ---
 
 # Input
@@ -65,6 +64,7 @@ romise.then(result => result.veryLongVariable.veryLongPropertyName > someOtherVa
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/arrow/currying.js
+info: js/module/arrow/currying.js
 ---
 
 # Input
@@ -38,6 +37,7 @@ const middleware = options => (req, res, next) => {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/arrow/params.js
+info: js/module/arrow/params.js
 ---
 
 # Input
@@ -342,6 +341,7 @@ foo(
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/assignment/array-assignment-holes.js
+info: js/module/assignment/array-assignment-holes.js
 ---
 
 # Input
@@ -23,6 +22,7 @@ let a, b;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/assignment/assignment.js
+info: js/module/assignment/assignment.js
 ---
 
 # Input
@@ -175,6 +174,7 @@ a =
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -422,4 +422,5 @@ a = {
    64: 	"12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
    66: 	"12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/assignment/assignment_ignore.js
+info: js/module/assignment/assignment_ignore.js
 ---
 
 # Input
@@ -25,6 +24,7 @@ let {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/binding/array-binding-holes.js
+info: js/module/binding/array-binding-holes.js
 ---
 
 # Input
@@ -22,6 +21,7 @@ function foo([foo, /* not used */, /* not used */]) {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/binding/array_binding.js
+info: js/module/binding/array_binding.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ let [aaaaaaaaaaaaaaaaaaaa=bbbbbbbbbbbbbbbbbbbb,cccccccccccccccccccc=dddddddddddd
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/binding/identifier_binding.js
+info: js/module/binding/identifier_binding.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ let abcde = "very long value that will cause a line break", fghij = "this should
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/binding/object_binding.js
+info: js/module/binding/object_binding.js
 ---
 
 # Input
@@ -25,6 +24,7 @@ let {aaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbb=cccccccccccccccccccc,dddddddddddd
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/call_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/call_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/call_expression.js
+info: js/module/call_expression.js
 ---
 
 # Input
@@ -68,6 +67,7 @@ test.expect(t => {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/class/class.js
+info: js/module/class/class.js
 ---
 
 # Input
@@ -91,6 +90,7 @@ export class Task {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/class/class_comments.js
+info: js/module/class/class_comments.js
 ---
 
 # Input
@@ -27,6 +26,7 @@ class A extends B { // leading comment
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/class/private_method.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/private_method.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/class/private_method.js
+info: js/module/class/private_method.js
 ---
 
 # Input
@@ -37,6 +36,7 @@ class Foo {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/comments.js
+info: js/module/comments.js
 ---
 
 # Input
@@ -99,6 +98,7 @@ statement /* comment */;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/declarations/variable_declaration.js
+info: js/module/declarations/variable_declaration.js
 ---
 
 # Input
@@ -286,6 +285,7 @@ const a
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -810,4 +810,5 @@ const a
   442: var loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 =
   444: let loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2 =
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
@@ -112,6 +112,7 @@ class Foo {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
@@ -112,6 +112,7 @@ class Foo {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
@@ -112,6 +112,7 @@ class Foo {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
@@ -68,6 +68,7 @@ export @dec1 @dec2  @dec3 @dec4 class My {}
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
@@ -68,6 +68,7 @@ export @decorator.method(value) @decorator2.method(value)  @decorator3.method(va
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
@@ -21,6 +21,7 @@ info: js/module/decorators/export_default_1.js
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
@@ -21,6 +21,7 @@ info: js/module/decorators/export_default_2.js
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
@@ -21,6 +21,7 @@ info: js/module/decorators/export_default_3.js
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
@@ -21,6 +21,7 @@ info: js/module/decorators/export_default_4.js
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
@@ -41,6 +41,7 @@ class Foo extends (@deco class {}){}
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
@@ -36,6 +36,7 @@ class Foo {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/each/each.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/each/each.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/each/each.js
+info: js/module/each/each.js
 ---
 
 # Input
@@ -87,6 +86,7 @@ ${2} | ${1} | ${3}`
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -172,4 +172,5 @@ ${2} | ${1} | ${3}`;
    54: 	${1} | ${[{ start: 5, end: 15 }]}                        | ${[1, 2, 3, 4, 5, 6, 7, 8]}
    55: 	${1} | ${[{ start: 5, end: 15 }]}                        | ${["test", "string", "for", "prettier"]}
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/export/class_clause.js
+info: js/module/export/class_clause.js
 ---
 
 # Input
@@ -30,6 +29,7 @@ B {}
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/export/expression_clause.js
+info: js/module/export/expression_clause.js
 ---
 
 # Input
@@ -21,6 +20,7 @@ export default (1 - 43);
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/export/from_clause.js
+info: js/module/export/from_clause.js
 ---
 
 # Input
@@ -25,6 +24,7 @@ export * as something_bad_will_happen from "something_bad_might_not_happen" asse
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -45,4 +45,5 @@ export * as something_bad_will_happen from "something_bad_might_not_happen" asse
 ```
     5: export * as something_bad_will_happen from "something_bad_might_not_happen" assert {
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/export/function_clause.js
+info: js/module/export/function_clause.js
 ---
 
 # Input
@@ -29,6 +28,7 @@ export default function ff() {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/export/named_clause.js
+info: js/module/export/named_clause.js
 ---
 
 # Input
@@ -27,6 +26,7 @@ export {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/export/named_from_clause.js
+info: js/module/export/named_from_clause.js
 ---
 
 # Input
@@ -40,6 +39,7 @@ export { a as b } from "looooooooooooooooooooooooooooooooooooooooooooooooooooooo
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/export/trailing-comma/export_trailing_comma.js
+info: js/module/export/trailing-comma/export_trailing_comma.js
 ---
 
 # Input
@@ -26,6 +25,7 @@ export {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -45,6 +45,7 @@ export {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
@@ -64,6 +65,7 @@ export {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/export/variable_declaration.js
+info: js/module/export/variable_declaration.js
 ---
 
 # Input
@@ -23,6 +22,7 @@ export const foofoofoofoofoofoofoo = "ahah", barbarbarbarbarbarbar = {}, loremlo
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/binary_expression.js
+info: js/module/expression/binary_expression.js
 ---
 
 # Input
@@ -55,6 +54,7 @@ a + b + 4 +
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
@@ -21,6 +21,7 @@ info: js/module/expression/binary_range_expression.js
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/binaryish_expression.js
+info: js/module/expression/binaryish_expression.js
 ---
 
 # Input
@@ -21,6 +20,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/computed-member-expression.js
+info: js/module/expression/computed-member-expression.js
 ---
 
 # Input
@@ -22,6 +21,7 @@ a["test"][5 + 5][call()];
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/conditional_expression.js
+info: js/module/expression/conditional_expression.js
 ---
 
 # Input
@@ -30,6 +29,7 @@ somethingThatsAReallyLongPropName ? somethingThatsAReallyLongPropName : somethin
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/import_meta_expression/import_meta_expression.js
+info: js/module/expression/import_meta_expression/import_meta_expression.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ import.meta.aReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherR
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -48,6 +48,7 @@ import.meta.aReallyLongVariableName.andAnotherReallyLongVariableName
 Indent style: Spaces, size: 4
 Line width: 120
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/literal_expression.js
+info: js/module/expression/literal_expression.js
 ---
 
 # Input
@@ -27,6 +26,7 @@ null
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/logical_expression.js
+info: js/module/expression/logical_expression.js
 ---
 
 # Input
@@ -133,6 +132,7 @@ veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo instanceof String && ver
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/member-chain/complex_arguments.js
+info: js/module/expression/member-chain/complex_arguments.js
 ---
 
 # Input
@@ -26,6 +25,7 @@ client.execute(
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/member-chain/computed.js
+info: js/module/expression/member-chain/computed.js
 ---
 
 # Input
@@ -26,6 +25,7 @@ nock(/test/)
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/member-chain/inline-merge.js
+info: js/module/expression/member-chain/inline-merge.js
 ---
 
 # Input
@@ -33,6 +32,7 @@ Object
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/new_expression.js
+info: js/module/expression/new_expression.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ new c(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,cccccccccccc
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/post_update_expression.js
+info: js/module/expression/post_update_expression.js
 ---
 
 # Input
@@ -25,6 +24,7 @@ x = y--
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/pre_update_expression.js
+info: js/module/expression/pre_update_expression.js
 ---
 
 # Input
@@ -25,6 +24,7 @@ x = --y
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/sequence_expression.js
+info: js/module/expression/sequence_expression.js
 ---
 
 # Input
@@ -54,6 +53,7 @@ aLongIdentifierName,
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/static_member_expression.js
+info: js/module/expression/static_member_expression.js
 ---
 
 # Input
@@ -41,6 +40,7 @@ some.member.with.
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/this_expression.js
+info: js/module/expression/this_expression.js
 ---
 
 # Input
@@ -22,6 +21,7 @@ this
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/unary_expression.js
+info: js/module/expression/unary_expression.js
 ---
 
 # Input
@@ -35,6 +34,7 @@ x = !aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -71,4 +71,5 @@ x =
    16: 	~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
    18: 	!aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/expression/unary_expression_verbatim_argument.js
+info: js/module/expression/unary_expression_verbatim_argument.js
 ---
 
 # Input
@@ -29,6 +28,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/function/function.js
+info: js/module/function/function.js
 ---
 
 # Input
@@ -53,6 +52,7 @@ function directives() {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function_args.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function_args.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/function/function_args.js
+info: js/module/function/function_args.js
 ---
 
 # Input
@@ -23,6 +22,7 @@ function foo(someotherlongvariableshould1, someotherlongvariableshould2, someoth
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/function/function_comments.js
+info: js/module/function/function_comments.js
 ---
 
 # Input
@@ -37,6 +36,7 @@ function c( //some comment
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/ident.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/ident.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/ident.js
+info: js/module/ident.js
 ---
 
 # Input
@@ -22,6 +21,7 @@ x
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/import/bare_import.js
+info: js/module/import/bare_import.js
 ---
 
 # Input
@@ -44,6 +43,7 @@ import "very_long_import_very_long_import_very" assert {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -79,4 +79,5 @@ import "very_long_import_very_long_import_very" assert {
     2: import "very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_very_long" assert {
    20: 	"typetypetypetypetypetypetypetypetypetypetype": /****/ "typetypetypetypetypetypetypetypetypetypetypetypetypetype",
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/import/default_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/default_import.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/import/default_import.js
+info: js/module/import/default_import.js
 ---
 
 # Input
@@ -32,6 +31,7 @@ import a, * as b from "foo"
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_call.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/import/import_call.js
+info: js/module/import/import_call.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ import(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -42,4 +42,5 @@ import(
 ```
     4: 	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/import/import_specifiers.js
+info: js/module/import/import_specifiers.js
 ---
 
 # Input
@@ -53,6 +52,7 @@ import a, { loooooooooooooooooooooong } from "looooooooooooooooooooooooooooooooo
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/import/namespace_import.js
+info: js/module/import/namespace_import.js
 ---
 
 # Input
@@ -21,6 +20,7 @@ import * as all from "all"
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/import/trailing-comma/import_trailing_comma.js
+info: js/module/import/trailing-comma/import_trailing_comma.js
 ---
 
 # Input
@@ -51,6 +50,7 @@ wrap(import(/* Hello */ "something"));
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -105,6 +105,7 @@ wrap(import(/* Hello */ "something"));
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
@@ -159,6 +160,7 @@ wrap(import(/* Hello */ "something"));
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/interpreter.js
+info: js/module/interpreter.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ console.log(1)
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/interpreter_with_empty_line.js
+info: js/module/interpreter_with_empty_line.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ console.log(1)
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/invalid/block_stmt_err.js
+info: js/module/invalid/block_stmt_err.js
 ---
 
 # Input
@@ -31,6 +30,7 @@ let recovered     = "no"
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/invalid/if_stmt_err.js
+info: js/module/invalid/if_stmt_err.js
 ---
 
 # Input
@@ -37,6 +36,7 @@ if (false) {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/newlines.js
+info: js/module/newlines.js
 ---
 
 # Input
@@ -99,6 +98,7 @@ const object = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/no-semi/class.js
+info: js/module/no-semi/class.js
 ---
 
 # Input
@@ -139,6 +138,7 @@ class G4 {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -269,6 +269,7 @@ class G4 {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/no-semi/issue2006.js
+info: js/module/no-semi/issue2006.js
 ---
 
 # Input
@@ -29,6 +28,7 @@ var c = a.e;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -51,6 +51,7 @@ var c = a.e;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/no-semi/no-semi.js
+info: js/module/no-semi/no-semi.js
 ---
 
 # Input
@@ -101,6 +100,7 @@ aReallyLongLine012345678901234567890123456789012345678901234567890123456789 *
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -206,6 +206,7 @@ aReallyLongLine012345678901234567890123456789012345678901234567890123456789 *
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/no-semi/private-field.js
+info: js/module/no-semi/private-field.js
 ---
 
 # Input
@@ -25,6 +24,7 @@ class C {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -43,6 +43,7 @@ class C {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/no-semi/semicolons-asi.js
+info: js/module/no-semi/semicolons-asi.js
 ---
 
 # Input
@@ -22,6 +21,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -37,6 +37,7 @@ Semicolons: Always
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
@@ -23,6 +23,7 @@ statement_3()
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -40,6 +41,7 @@ statement_3()
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/number/number.js
+info: js/module/number/number.js
 ---
 
 # Input
@@ -23,6 +22,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/number/number_with_space.js
+info: js/module/number/number_with_space.js
 ---
 
 # Input
@@ -27,6 +26,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/object/computed_member.js
+info: js/module/object/computed_member.js
 ---
 
 # Input
@@ -40,6 +39,7 @@ a[("test")]
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/object/getter_setter.js
+info: js/module/object/getter_setter.js
 ---
 
 # Input
@@ -27,6 +26,7 @@ let b = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/object/object.js
+info: js/module/object/object.js
 ---
 
 # Input
@@ -53,6 +52,7 @@ const y = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/object/object_comments.js
+info: js/module/object/object_comments.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ let a = { // leading comment
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
@@ -26,6 +26,7 @@ const x = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/object/property_key.js
+info: js/module/object/property_key.js
 ---
 
 # Input
@@ -29,6 +28,7 @@ const foo = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/object/property_object_member.js
+info: js/module/object/property_object_member.js
 ---
 
 # Input
@@ -109,6 +108,7 @@ const fluidObject = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -291,4 +291,5 @@ const fluidObject = {
    75: 			.longLongLongLongLongLlongLongLongLongLongLongLongLongLongTooLongPropongLongLongLongTooLongProp ===
    78: 		longLongLongLongLongLongLongLongLonlongLongLongLongLongLongLongLongLongTooLongPropgLongLongLongLongTooLongVar ||
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/object/trailing-comma/object_trailing_comma.js
+info: js/module/object/trailing-comma/object_trailing_comma.js
 ---
 
 # Input
@@ -30,6 +29,7 @@ const {  	adsadasdasdasdasdasdasdasdasdasdas,
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -55,6 +55,7 @@ const {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
@@ -80,6 +81,7 @@ const {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/parentheses/parentheses.js
+info: js/module/parentheses/parentheses.js
 ---
 
 # Input
@@ -44,6 +43,7 @@ const a = () => ({}?.() && a);
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -80,4 +80,5 @@ const a = () => ({})?.() && a;
 ```
    11: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
@@ -21,6 +21,7 @@ import React from 'react'; function test() { const AppShelled = () => (1 + 2) } 
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/prettier-differences/fill-array-comments.js
+info: js/module/prettier-differences/fill-array-comments.js
 ---
 
 # Input
@@ -29,6 +28,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -51,4 +51,5 @@ Semicolons: Always
     4: 	// encounters the first hard line break. As it happens, this line comment contains a hard line break, making
     5: 	// Prettier believe that the `-3` with this leading comment all fits on the line, which, obviously, isn't the case.
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
@@ -30,6 +30,7 @@ console.log("🚀".length);
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info: js/module/range_parenthesis_after_semicol_1.js
+info: js/module/range/range_parenthesis_after_semicol_1.js
 ---
 
 # Input
@@ -28,6 +28,7 @@ console.log("🚀".length);("Jan 1, 2018 – Jan 1, 2019");
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/script.js
+info: js/module/script.js
 ---
 
 # Input
@@ -25,6 +24,7 @@ var express = require("express")
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/block_statement.js
+info: js/module/statement/block_statement.js
 ---
 
 # Input
@@ -30,6 +29,7 @@ if (true) {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/do_while.js
+info: js/module/statement/do_while.js
 ---
 
 # Input
@@ -35,6 +34,7 @@ do; while(true);
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/empty_blocks.js
+info: js/module/statement/empty_blocks.js
 ---
 
 # Input
@@ -50,6 +49,7 @@ do {} while (true);
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/for_in.js
+info: js/module/statement/for_in.js
 ---
 
 # Input
@@ -27,6 +26,7 @@ for (a in b) { // trailing
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -48,4 +48,5 @@ for (a in b) {
 ```
     4: for (aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks in aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks) {
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/for_loop.js
+info: js/module/statement/for_loop.js
 ---
 
 # Input
@@ -38,6 +37,7 @@ for(let aVeryLongVariableNameToEnforceLineBreaks = 0; aVeryLongVariableNameToEnf
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/for_of.js
+info: js/module/statement/for_of.js
 ---
 
 # Input
@@ -29,6 +28,7 @@ for await ( const a of b ) {}
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -52,4 +52,5 @@ for await (const a of b) {
 ```
     7: for (const aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks of aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks) {
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/if_chain.js
+info: js/module/statement/if_chain.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ if(very_long_condition_1) very_long_statement_1(); else if (very_long_condition_
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/if_else.js
+info: js/module/statement/if_else.js
 ---
 
 # Input
@@ -90,6 +89,7 @@ true &&  false
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/return.js
+info: js/module/statement/return.js
 ---
 
 # Input
@@ -27,6 +26,7 @@ function f2() {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/return_verbatim_argument.js
+info: js/module/statement/return_verbatim_argument.js
 ---
 
 # Input
@@ -46,6 +45,7 @@ function supported3(){
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -84,4 +84,5 @@ function supported3() {
     6: 		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
    14: 		// rome-ignore lint/style/useOptionalChain: Optional chaining creates more complicated ES2019 code
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/statement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/statement.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/statement.js
+info: js/module/statement/statement.js
 ---
 
 # Input
@@ -23,6 +22,7 @@ debugger
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/switch.js
+info: js/module/statement/switch.js
 ---
 
 # Input
@@ -40,6 +39,7 @@ switch ("test") {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/throw.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/throw.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/throw.js
+info: js/module/statement/throw.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ throw false
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/try_catch_finally.js
+info: js/module/statement/try_catch_finally.js
 ---
 
 # Input
@@ -47,6 +46,7 @@ try {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/statement/while_loop.js
+info: js/module/statement/while_loop.js
 ---
 
 # Input
@@ -47,6 +46,7 @@ tour: while (true) {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/string/directives.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/directives.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/string/directives.js
+info: js/module/string/directives.js
 ---
 
 # Input
@@ -24,6 +23,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -42,6 +42,7 @@ Semicolons: Always
 Indent style: Tab
 Line width: 80
 Quote style: Single Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -60,6 +61,7 @@ Semicolons: Always
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
@@ -21,6 +21,7 @@ info: js/module/string/parentheses_token.js
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -36,6 +37,7 @@ Semicolons: Always
 Indent style: Tab
 Line width: 80
 Quote style: Single Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -51,6 +53,7 @@ Semicolons: Always
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
@@ -63,6 +63,7 @@ const x = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -121,6 +122,7 @@ const x = {
 Indent style: Tab
 Line width: 80
 Quote style: Single Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -179,6 +181,7 @@ const x = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/string/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/string.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/string/string.js
+info: js/module/string/string.js
 ---
 
 # Input
@@ -78,6 +77,7 @@ export * as something_bad_will_happen from "something_bad_might_not_happen" asse
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -160,6 +160,7 @@ export * as something_bad_will_happen from "something_bad_might_not_happen" asse
 Indent style: Tab
 Line width: 80
 Quote style: Single Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -242,6 +243,7 @@ export * as something_bad_will_happen from 'something_bad_might_not_happen' asse
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/suppression.js
+info: js/module/suppression.js
 ---
 
 # Input
@@ -49,6 +48,7 @@ function () {}
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/template/template.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/template/template.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/template/template.js
+info: js/module/template/template.js
 ---
 
 # Input
@@ -68,6 +67,7 @@ ExampleStory.getFragment('story')}
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/module/with.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/with.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/module/with.js
+info: js/module/with.js
 ---
 
 # Input
@@ -26,6 +25,7 @@ with (   b)
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/script/script.js
+info: js/script/script.js
 ---
 
 # Input
@@ -25,6 +24,7 @@ var express = require("express")
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/js/script/with.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/script/with.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: js/script/with.js
+info: js/script/with.js
 ---
 
 # Input
@@ -27,6 +26,7 @@ with({}) {}
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: jsx/arrow_function.jsx
+info: jsx/arrow_function.jsx
 ---
 
 # Input
@@ -50,6 +49,7 @@ function ArrowBodyIsJsxWithComment({ action }) {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: jsx/attributes.jsx
+info: jsx/attributes.jsx
 ---
 
 # Input
@@ -97,6 +96,7 @@ const a = <Popconfirm
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -205,4 +205,5 @@ const a = (
    30: 			"ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace",
    85: 			veryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzzveryLongConditionZzzzzzzzzzzzzzzzz,
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/jsx/comments.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/comments.jsx.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-assertion_line: 212
 info: jsx/comments.jsx
 ---
 
@@ -25,6 +24,7 @@ a>;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/jsx/conditional.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/conditional.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: jsx/conditional.jsx
+info: jsx/conditional.jsx
 ---
 
 # Input
@@ -70,6 +69,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/jsx/element.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/element.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: jsx/element.jsx
+info: jsx/element.jsx
 ---
 
 # Input
@@ -351,6 +350,7 @@ function Component() {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -767,4 +767,5 @@ function Component() {
   238: 				<pre className="h-screen overflow-y-scroll whitespace-pre-wrap text-red-500 text-xs">
   287: 		Uncle Boonmee Who Can Recall His Past Lives dir. Apichatpong Weerasethakul{" "}
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/jsx/fragment.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/fragment.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: jsx/fragment.jsx
+info: jsx/fragment.jsx
 ---
 
 # Input
@@ -23,6 +22,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: jsx/new-lines.jsx
+info: jsx/new-lines.jsx
 ---
 
 # Input
@@ -71,6 +70,7 @@ let myDiv3 = ReactTestUtils.renderIntoDocument(
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
@@ -21,6 +21,7 @@ import React from 'react'; function test() { const AppShelled = () => (<Componen
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/jsx/quote_style/options.json
+++ b/crates/rome_js_formatter/tests/specs/jsx/quote_style/options.json
@@ -1,0 +1,20 @@
+{
+	"cases": [
+		{
+			"jsx_quote_style": "Double",
+			"quote_style": "Double"
+		},
+		{
+			"jsx_quote_style": "Single",
+			"quote_style": "Single"
+		},
+		{
+			"jsx_quote_style": "Double",
+			"quote_style": "Single"
+		},
+		{
+			"jsx_quote_style": "Single",
+			"quote_style": "Double"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx
+++ b/crates/rome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx
@@ -1,0 +1,8 @@
+(
+	<div
+		bar='foo'
+		baz={"foo"}
+	>
+		"123"
+	</div>
+)

--- a/crates/rome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx.snap
@@ -1,0 +1,115 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+info: jsx/quote_style/quote_style.jsx
+---
+
+# Input
+
+```jsx
+(
+	<div
+		bar='foo'
+		baz={"foo"}
+	>
+		"123"
+	</div>
+)
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```jsx
+<div bar="foo" baz={"foo"}>
+	"123"
+</div>;
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```jsx
+<div bar="foo" baz={"foo"}>
+	"123"
+</div>;
+```
+
+## Output 3
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Single Quotes
+JSX quote style: Single Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```jsx
+<div bar='foo' baz={'foo'}>
+	"123"
+</div>;
+```
+
+## Output 4
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Single Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```jsx
+<div bar="foo" baz={'foo'}>
+	"123"
+</div>;
+```
+
+## Output 5
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Single Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+-----
+
+```jsx
+<div bar='foo' baz={"foo"}>
+	"123"
+</div>;
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: jsx/self_closing.jsx
+info: jsx/self_closing.jsx
 ---
 
 # Input
@@ -36,6 +35,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/jsx/smoke.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/smoke.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: jsx/smoke.jsx
+info: jsx/smoke.jsx
 ---
 
 # Input
@@ -21,6 +20,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/arrow_chain.ts
+info: ts/arrow_chain.ts
 ---
 
 # Input
@@ -32,6 +31,7 @@ const x =  a => b => (aLongSequenceExpression, thatContinuesFurtherOnUntilItBrea
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/assignment/as_assignment.ts
+info: ts/assignment/as_assignment.ts
 ---
 
 # Input
@@ -26,6 +25,7 @@ let binding;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/assignment/assignment.ts
+info: ts/assignment/assignment.ts
 ---
 
 # Input
@@ -34,6 +33,7 @@ const gitBaseExtension = extensions.getExtension<GitBaseExtension>(
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/assignment/assignment_comments.ts
+info: ts/assignment/assignment_comments.ts
 ---
 
 # Input
@@ -42,6 +41,7 @@ const e: string // 1
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/assignment/property_assignment_comments.ts
+info: ts/assignment/property_assignment_comments.ts
 ---
 
 # Input
@@ -54,6 +53,7 @@ class Test {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/assignment/type_assertion_assignment.ts
+info: ts/assignment/type_assertion_assignment.ts
 ---
 
 # Input
@@ -35,6 +34,7 @@ for (<boolean> x of []) {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/binding/definite_variable.ts
+info: ts/binding/definite_variable.ts
 ---
 
 # Input
@@ -22,6 +21,7 @@ let definiteVariable!: TypeName;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/call_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/call_expression.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/call_expression.ts
+info: ts/call_expression.ts
 ---
 
 # Input
@@ -44,6 +43,7 @@ export class Task {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/class/accessor.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/accessor.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-assertion_line: 212
 info: ts/class/accessor.ts
 ---
 
@@ -23,6 +22,7 @@ export abstract class C {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/class/assigment_layout.ts
+info: ts/class/assigment_layout.ts
 ---
 
 # Input
@@ -28,6 +27,7 @@ class SourceRemoveUnused extends SourceAction {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/class/constructor_parameter.ts
+info: ts/class/constructor_parameter.ts
 ---
 
 # Input
@@ -56,6 +55,7 @@ class C {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/class/implements_clause.ts
+info: ts/class/implements_clause.ts
 ---
 
 # Input
@@ -23,6 +22,7 @@ class LongClassName implements Interface1, Interface2, Interface3, Interface4, I
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-assertion_line: 212
 info: ts/class/readonly_ambient_property.ts
 ---
 
@@ -31,6 +30,7 @@ export class B {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/class/trailing_comma/class_trailing_comma.ts
+info: ts/class/trailing_comma/class_trailing_comma.ts
 ---
 
 # Input
@@ -32,6 +31,7 @@ class C<    	longlonglonglonglonglonglongT1,
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -71,6 +71,7 @@ class C<
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
@@ -110,6 +111,7 @@ class C<
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/class.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/class.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/declaration/class.ts
+info: ts/declaration/class.ts
 ---
 
 # Input
@@ -80,6 +79,7 @@ abstract class Test1 {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/declaration/declare_function.ts
+info: ts/declaration/declare_function.ts
 ---
 
 # Input
@@ -24,6 +23,7 @@ declare function looooooooooooooooooooooooooooong_naaaaaame<FirstType, SecondTyp
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/declaration/global_declaration.ts
+info: ts/declaration/global_declaration.ts
 ---
 
 # Input
@@ -27,6 +26,7 @@ declare module "./test"
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -65,6 +65,7 @@ x.y(() => {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/declaration/variable_declaration.ts
+info: ts/declaration/variable_declaration.ts
 ---
 
 # Input
@@ -108,6 +107,7 @@ let looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -252,4 +252,5 @@ let looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
   120: let loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2 =
   122: let loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3 =
 ```
+
 

--- a/crates/rome_js_formatter/tests/specs/ts/declare.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declare.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/declare.ts
+info: ts/declare.ts
 ---
 
 # Input
@@ -27,6 +26,7 @@ declare module 'remark-html' {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
@@ -66,6 +66,7 @@ class Test2 {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
@@ -112,6 +112,7 @@ class Foo {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/enum/enum_trailing_comma.ts
+info: ts/enum/enum_trailing_comma.ts
 ---
 
 # Input
@@ -26,6 +25,7 @@ enum A {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -45,6 +45,7 @@ enum A {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
@@ -64,6 +65,7 @@ enum A {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/expression/as_expression.ts
+info: ts/expression/as_expression.ts
 ---
 
 # Input
@@ -24,6 +23,7 @@ let b =
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/expression/non_null_expression.ts
+info: ts/expression/non_null_expression.ts
 ---
 
 # Input
@@ -22,6 +21,7 @@ let  b  =   a   !;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/expression/type_assertion_expression.ts
+info: ts/expression/type_assertion_expression.ts
 ---
 
 # Input
@@ -27,6 +26,7 @@ var d = <Error>
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/expression/type_expression.ts
+info: ts/expression/type_expression.ts
 ---
 
 # Input
@@ -125,6 +124,7 @@ type Type01 = 0 extends
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/expression/type_member.ts
+info: ts/expression/type_member.ts
 ---
 
 # Input
@@ -67,6 +66,7 @@ type K = { set     something( something_with_long_name: string ) }
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/function/parameters/function_parameters.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/function/parameters/function_parameters.ts.snap
@@ -53,6 +53,7 @@ export const queryAuditLog = async ({
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -102,6 +103,7 @@ export const queryAuditLog = async ({
 Indent style: Tab
 Line width: 100
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -148,6 +150,7 @@ export const queryAuditLog = async ({
 Indent style: Tab
 Line width: 120
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/function/trailing_comma/function_trailing_comma.ts
+info: ts/function/trailing_comma/function_trailing_comma.ts
 ---
 
 # Input
@@ -58,6 +57,7 @@ connect(
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -111,6 +111,7 @@ connect(
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
@@ -164,6 +165,7 @@ connect(
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-assertion_line: 212
 info: ts/module/export_clause.ts
 ---
 
@@ -43,6 +42,7 @@ export  type  *  as  types   from  "types";
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/module/external_module_reference.ts
+info: ts/module/external_module_reference.ts
 ---
 
 # Input
@@ -24,6 +23,7 @@ import name2 = require('other_source')
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/module/module_declaration.ts
+info: ts/module/module_declaration.ts
 ---
 
 # Input
@@ -25,6 +24,7 @@ module qualified.name { }
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/module/qualified_module_name.ts
+info: ts/module/qualified_module_name.ts
 ---
 
 # Input
@@ -22,6 +21,7 @@ module a . b . c { }
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/no-semi/class.ts
+info: ts/no-semi/class.ts
 ---
 
 # Input
@@ -72,6 +71,7 @@ declare module test {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -137,6 +137,7 @@ declare module test {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/no-semi/non-null.ts
+info: ts/no-semi/non-null.ts
 ---
 
 # Input
@@ -24,6 +23,7 @@ const el = ReactDOM.findDOMNode(ref)
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -41,6 +41,7 @@ const el = ReactDOM.findDOMNode(ref);
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/no-semi/statements.ts
+info: ts/no-semi/statements.ts
 ---
 
 # Input
@@ -35,6 +34,7 @@ declare let a;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -62,6 +62,7 @@ declare let a;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/no-semi/types.ts
+info: ts/no-semi/types.ts
 ---
 
 # Input
@@ -34,6 +33,7 @@ type OptionsFlags<Type> = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -65,6 +65,7 @@ type OptionsFlags<Type> = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed

--- a/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/object/object_trailing_comma.ts
+info: ts/object/object_trailing_comma.ts
 ---
 
 # Input
@@ -43,6 +42,7 @@ const obj = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -78,6 +78,7 @@ const obj = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
@@ -113,6 +114,7 @@ const obj = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/parameters/parameters.ts
+info: ts/parameters/parameters.ts
 ---
 
 # Input
@@ -23,6 +22,7 @@ function a(
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/parenthesis.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/parenthesis.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/parenthesis.ts
+info: ts/parenthesis.ts
 ---
 
 # Input
@@ -23,6 +22,7 @@ const a = !(c && b) as boolean;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/statement/empty_block.ts
+info: ts/statement/empty_block.ts
 ---
 
 # Input
@@ -22,6 +21,7 @@ type X = {};
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/statement/enum_statement.ts
+info: ts/statement/enum_statement.ts
 ---
 
 # Input
@@ -33,6 +32,7 @@ const enum C {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/string/parameter_quotes.ts
+info: ts/string/parameter_quotes.ts
 ---
 
 # Input
@@ -56,6 +55,7 @@ const Y = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -105,6 +105,7 @@ const Y = {
 Indent style: Tab
 Line width: 80
 Quote style: Single Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -154,6 +155,7 @@ const Y = {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/suppressions.ts
+info: ts/suppressions.ts
 ---
 
 # Input
@@ -27,6 +26,7 @@ interface Suppressions {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/type/conditional.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/conditional.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/type/conditional.ts
+info: ts/type/conditional.ts
 ---
 
 # Input
@@ -37,6 +36,7 @@ type T4 = test extends string
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/type/import_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/import_type.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/type/import_type.ts
+info: ts/type/import_type.ts
 ---
 
 # Input
@@ -27,6 +26,7 @@ type QualifiedImportType = typeof import('source').Qualified<TypeParams>;
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/type/intersection_type.ts
+info: ts/type/intersection_type.ts
 ---
 
 # Input
@@ -79,6 +78,7 @@ type SoftBreakBetweenNotObjectTypeInChain = {} & SomeLongType & {
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-assertion_line: 212
 info: ts/type/mapped_type.ts
 ---
 
@@ -21,6 +20,7 @@ type LongNameHereToCauseLineBreak_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/type/qualified_name.ts
+info: ts/type/qualified_name.ts
 ---
 
 # Input
@@ -21,6 +20,7 @@ type QualifiedType = A  .  B . C
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/type/template_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/template_type.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/type/template_type.ts
+info: ts/type/template_type.ts
 ---
 
 # Input
@@ -24,6 +23,7 @@ type TemplateType = `
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: ts/type/trailing-comma/type_trailing_comma.ts
+info: ts/type/trailing-comma/type_trailing_comma.ts
 ---
 
 # Input
@@ -33,6 +32,7 @@ interface C<    	adsadasdasdasdasdasdasdasdasdasdas,
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
@@ -58,6 +58,7 @@ interface C<
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
@@ -83,6 +84,7 @@ interface C<
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info: "ts\\type\\union_type.ts"
+info: ts/type/union_type.ts
 ---
 
 # Input
@@ -266,6 +266,7 @@ type SuperLongTypeNameLoremIpsumLoremIpsumBlaBlaBlaBlaBlaBlaBlaBlaBlaBlaBlaBla =
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_js_formatter/tests/specs/tsx/smoke.tsx.snap
+++ b/crates/rome_js_formatter/tests/specs/tsx/smoke.tsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rome_formatter_test/src/snapshot_builder.rs
-info:
-  test_file: tsx/smoke.tsx
+info: tsx/smoke.tsx
 ---
 
 # Input
@@ -21,6 +20,7 @@ info:
 Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
+JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always

--- a/crates/rome_service/src/configuration/javascript.rs
+++ b/crates/rome_service/src/configuration/javascript.rs
@@ -67,6 +67,9 @@ pub struct JavascriptFormatter {
     /// The style for quotes. Defaults to double.
     #[bpaf(long("quote-style"), argument("double|single"), optional)]
     pub quote_style: Option<QuoteStyle>,
+    /// The style for JSX quotes. Defaults to double.
+    #[bpaf(long("jsx-quote-style"), argument("double|single"), optional)]
+    pub jsx_quote_style: Option<QuoteStyle>,
     /// When properties in objects are quoted. Defaults to asNeeded.
     #[bpaf(long("quote-properties"), argument("preserve|as-needed"), optional)]
     pub quote_properties: Option<QuoteProperties>,
@@ -81,6 +84,7 @@ pub struct JavascriptFormatter {
 impl JavascriptFormatter {
     pub(crate) const KNOWN_KEYS: &'static [&'static str] = &[
         "quoteStyle",
+        "jsxQuoteStyle",
         "quoteProperties",
         "trailingComma",
         "semicolons",
@@ -94,6 +98,9 @@ impl MergeWith<JavascriptFormatter> for JavascriptFormatter {
         }
         if let Some(quote_style) = other.quote_style {
             self.quote_style = Some(quote_style);
+        }
+        if let Some(jsx_quote_style) = other.jsx_quote_style {
+            self.jsx_quote_style = Some(jsx_quote_style);
         }
         if let Some(semicolons) = other.semicolons {
             self.semicolons = Some(semicolons);

--- a/crates/rome_service/src/configuration/parse/json/javascript.rs
+++ b/crates/rome_service/src/configuration/parse/json/javascript.rs
@@ -75,6 +75,11 @@ impl VisitNode<JsonLanguage> for JavascriptFormatter {
         let (name, value) = self.get_key_and_value(key, value, diagnostics)?;
         let name_text = name.text();
         match name_text {
+            "jsxQuoteStyle" => {
+                let mut jsx_quote_style = QuoteStyle::default();
+                self.map_to_known_string(&value, name_text, &mut jsx_quote_style, diagnostics)?;
+                self.jsx_quote_style = Some(jsx_quote_style);
+            }
             "quoteStyle" => {
                 let mut quote_style = QuoteStyle::default();
                 self.map_to_known_string(&value, name_text, &mut quote_style, diagnostics)?;

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -45,6 +45,7 @@ use tracing::{debug, trace};
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct JsFormatterSettings {
     pub quote_style: Option<QuoteStyle>,
+    pub jsx_quote_style: Option<QuoteStyle>,
     pub quote_properties: Option<QuoteProperties>,
     pub trailing_comma: Option<TrailingComma>,
     pub semicolons: Option<Semicolons>,
@@ -79,6 +80,7 @@ impl Language for JsLanguage {
             .with_indent_style(global.indent_style.unwrap_or_default())
             .with_line_width(global.line_width.unwrap_or_default())
             .with_quote_style(language.quote_style.unwrap_or_default())
+            .with_jsx_quote_style(language.jsx_quote_style.unwrap_or_default())
             .with_quote_properties(language.quote_properties.unwrap_or_default())
             .with_trailing_comma(language.trailing_comma.unwrap_or_default())
             .with_semicolons(language.semicolons.unwrap_or_default())

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -76,6 +76,7 @@ impl WorkspaceSettings {
             let formatter = javascript.formatter;
             if let Some(formatter) = formatter {
                 self.languages.javascript.formatter.quote_style = formatter.quote_style;
+                self.languages.javascript.formatter.jsx_quote_style = formatter.jsx_quote_style;
                 self.languages.javascript.formatter.quote_properties = formatter.quote_properties;
                 self.languages.javascript.formatter.trailing_comma = formatter.trailing_comma;
                 self.languages.javascript.formatter.semicolons = formatter.semicolons;

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -629,6 +629,11 @@
 		"JavascriptFormatter": {
 			"type": "object",
 			"properties": {
+				"jsxQuoteStyle": {
+					"description": "The style for JSX quotes. Defaults to double.",
+					"default": null,
+					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]
+				},
 				"quoteProperties": {
 					"description": "When properties in objects are quoted. Defaults to asNeeded.",
 					"default": null,

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -162,6 +162,10 @@ The allowed range of values is 1..=320
 export type LineWidth = number;
 export interface JavascriptFormatter {
 	/**
+	 * The style for JSX quotes. Defaults to double.
+	 */
+	jsxQuoteStyle?: QuoteStyle;
+	/**
 	 * When properties in objects are quoted. Defaults to asNeeded.
 	 */
 	quoteProperties?: QuoteProperties;
@@ -198,8 +202,8 @@ export interface Rules {
 	suspicious?: Suspicious;
 }
 export type VcsClientKind = "git";
-export type QuoteProperties = "asNeeded" | "preserve";
 export type QuoteStyle = "double" | "single";
+export type QuoteProperties = "asNeeded" | "preserve";
 export type Semicolons = "always" | "asNeeded";
 /**
  * Print trailing commas wherever possible in multi-line comma-separated syntactic structures.

--- a/npm/js-api/tests/formatContent.test.ts
+++ b/npm/js-api/tests/formatContent.test.ts
@@ -123,4 +123,29 @@ describe("Rome WebAssembly formatContent", () => {
 
 		expect(result.content).toEqual(formatted);
 	});
+
+	it("should format content with custom configuration (8 spaces, jsx single quotes, preserve quotes)", () => {
+		const content = `<div bar="foo" baz={"foo"} />`;
+		const formatted = `<div bar='foo' baz={"foo"} />;
+`;
+
+		rome.applyConfiguration({
+			formatter: {
+				indentStyle: "space",
+				indentSize: 8,
+			},
+			javascript: {
+				formatter: {
+					jsxQuoteStyle: "single",
+					quoteProperties: "preserve",
+				},
+			},
+		});
+
+		const result = rome.formatContent(content, {
+			filePath: "example.js",
+		});
+
+		expect(result.content).toEqual(formatted);
+	});
 });

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -629,6 +629,11 @@
 		"JavascriptFormatter": {
 			"type": "object",
 			"properties": {
+				"jsxQuoteStyle": {
+					"description": "The style for JSX quotes. Defaults to double.",
+					"default": null,
+					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]
+				},
 				"quoteProperties": {
 					"description": "When properties in objects are quoted. Defaults to asNeeded.",
 					"default": null,

--- a/website/src/pages/configuration.mdx
+++ b/website/src/pages/configuration.mdx
@@ -334,6 +334,12 @@ The type of quote used when representing string literals. It can be `single` or 
 
 > Default: `double`
 
+### `javascript.formatter.jsxQuoteStyle`
+
+The type of quote used when representing jsx string literals. It can be `single` or `double`.
+
+> Default: `double`
+
 ### `javascript.formatter.quoteProperties`
 
 When properties inside objects should be quoted. It can be `asNeeded` or `preserve`.

--- a/website/src/pages/formatter/index.mdx
+++ b/website/src/pages/formatter/index.mdx
@@ -43,6 +43,7 @@ Available options:
         --indent-size <NUMBER>  The size of the indentation, 2 by default
         --line-width <NUMBER>  What's the max width of a line. Defaults to 80.
         --quote-style <double|single>  The style for quotes. Defaults to double.
+        --jsx-quote-style <double|single>  The style for jsx quotes. Defaults to double.
         --quote-properties <preserve|as-needed>  When properties in objects are quoted. Defaults to
                        asNeeded.
         --trailing-comma <all|es5|none>  Print trailing commas wherever possible in multi-line

--- a/website/src/pages/linter/index.mdx
+++ b/website/src/pages/linter/index.mdx
@@ -47,6 +47,7 @@ Available options:
         --indent-size <NUMBER>  The size of the indentation, 2 by default
         --line-width <NUMBER>  What's the max width of a line. Defaults to 80.
         --quote-style <double|single>  The style for quotes. Defaults to double.
+        --jsx-quote-style <double|single>  The style for jsx quotes. Defaults to double.
         --quote-properties <preserve|as-needed>  When properties in objects are quoted. Defaults to
                         asNeeded.
         --trailing-comma <all|es5|none>  Print trailing commas wherever possible in multi-line

--- a/website/src/playground/PlaygroundLoader.tsx
+++ b/website/src/playground/PlaygroundLoader.tsx
@@ -309,6 +309,9 @@ function initState(
 			quoteStyle:
 				(searchParams.get("quoteStyle") as QuoteStyle) ??
 				defaultPlaygroundState.settings.quoteStyle,
+			jsxQuoteStyle:
+				(searchParams.get("jsxQuoteStyle") as QuoteStyle) ??
+				defaultPlaygroundState.settings.jsxQuoteStyle,
 			quoteProperties:
 				(searchParams.get("quoteProperties") as QuoteProperties) ??
 				defaultPlaygroundState.settings.quoteProperties,

--- a/website/src/playground/tabs/SettingsTab.tsx
+++ b/website/src/playground/tabs/SettingsTab.tsx
@@ -39,6 +39,7 @@ export default function SettingsTab({
 			indentWidth,
 			indentStyle,
 			quoteStyle,
+			jsxQuoteStyle,
 			quoteProperties,
 			trailingComma,
 			semicolons,
@@ -63,6 +64,10 @@ export default function SettingsTab({
 	const setQuoteStyle = createPlaygroundSettingsSetter(
 		setPlaygroundState,
 		"quoteStyle",
+	);
+	const setJsxQuoteStyle = createPlaygroundSettingsSetter(
+		setPlaygroundState,
+		"jsxQuoteStyle",
 	);
 	const setQuoteProperties = createPlaygroundSettingsSetter(
 		setPlaygroundState,
@@ -220,6 +225,8 @@ export default function SettingsTab({
 				setIndentWidth={setIndentWidth}
 				quoteStyle={quoteStyle}
 				setQuoteStyle={setQuoteStyle}
+				jsxQuoteStyle={jsxQuoteStyle}
+				setJsxQuoteStyle={setJsxQuoteStyle}
 				quoteProperties={quoteProperties}
 				setQuoteProperties={setQuoteProperties}
 				trailingComma={trailingComma}
@@ -503,6 +510,8 @@ function FormatterSettings({
 	setIndentWidth,
 	quoteStyle,
 	setQuoteStyle,
+	jsxQuoteStyle,
+	setJsxQuoteStyle,
 	quoteProperties,
 	setQuoteProperties,
 	trailingComma,
@@ -518,6 +527,8 @@ function FormatterSettings({
 	setIndentWidth: (value: number) => void;
 	quoteStyle: QuoteStyle;
 	setQuoteStyle: (value: QuoteStyle) => void;
+	jsxQuoteStyle: QuoteStyle;
+	setJsxQuoteStyle: (value: QuoteStyle) => void;
 	quoteProperties: QuoteProperties;
 	setQuoteProperties: (value: QuoteProperties) => void;
 	trailingComma: TrailingComma;
@@ -566,6 +577,19 @@ function FormatterSettings({
 						name="quoteStyle"
 						value={quoteStyle ?? ""}
 						onChange={(e) => setQuoteStyle(e.target.value as QuoteStyle)}
+					>
+						<option value={QuoteStyle.Double}>Double</option>
+						<option value={QuoteStyle.Single}>Single</option>
+					</select>
+				</div>
+
+				<div className="field-row">
+					<label htmlFor="jsxQuoteStyle">Jsx Quote Style</label>
+					<select
+						id="jsxQuoteStyle"
+						name="jsxQuoteStyle"
+						value={jsxQuoteStyle ?? ""}
+						onChange={(e) => setJsxQuoteStyle(e.target.value as QuoteStyle)}
 					>
 						<option value={QuoteStyle.Double}>Double</option>
 						<option value={QuoteStyle.Single}>Single</option>

--- a/website/src/playground/types.ts
+++ b/website/src/playground/types.ts
@@ -101,6 +101,7 @@ export interface PlaygroundSettings {
 	indentStyle: IndentStyle;
 	indentWidth: number;
 	quoteStyle: QuoteStyle;
+	jsxQuoteStyle: QuoteStyle;
 	quoteProperties: QuoteProperties;
 	trailingComma: TrailingComma;
 	semicolons: Semicolons;
@@ -141,6 +142,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 		indentWidth: 2,
 		indentStyle: IndentStyle.Tab,
 		quoteStyle: QuoteStyle.Double,
+		jsxQuoteStyle: QuoteStyle.Double,
 		quoteProperties: QuoteProperties.AsNeeded,
 		trailingComma: TrailingComma.All,
 		semicolons: Semicolons.Always,

--- a/website/src/playground/workers/prettierWorker.ts
+++ b/website/src/playground/workers/prettierWorker.ts
@@ -28,6 +28,7 @@ self.addEventListener("message", (e) => {
 				indentStyle,
 				indentWidth,
 				quoteStyle,
+				jsxQuoteStyle,
 				quoteProperties,
 				trailingComma,
 				semicolons,
@@ -41,6 +42,7 @@ self.addEventListener("message", (e) => {
 				indentWidth,
 				filepath: filename,
 				quoteStyle,
+				jsxQuoteStyle,
 				quoteProperties,
 				trailingComma,
 				semicolons,
@@ -68,6 +70,7 @@ function formatWithPrettier(
 		indentWidth: number;
 		filepath: string;
 		quoteStyle: QuoteStyle;
+		jsxQuoteStyle: QuoteStyle;
 		quoteProperties: QuoteProperties;
 		trailingComma: TrailingComma;
 		semicolons: Semicolons;
@@ -82,6 +85,7 @@ function formatWithPrettier(
 			plugins: [parserBabel],
 			parser: getPrettierParser(options.filepath),
 			singleQuote: options.quoteStyle === QuoteStyle.Single,
+			jsxSingleQuote: options.jsxQuoteStyle === QuoteStyle.Single,
 			quoteProps: options.quoteProperties,
 			trailingComma: options.trailingComma,
 			semi: options.semicolons === Semicolons.Always,

--- a/website/src/playground/workers/romeWorker.ts
+++ b/website/src/playground/workers/romeWorker.ts
@@ -65,6 +65,7 @@ self.addEventListener("message", async (e) => {
 				indentStyle,
 				indentWidth,
 				quoteStyle,
+				jsxQuoteStyle,
 				quoteProperties,
 				lintRules,
 				enabledLinting,
@@ -93,6 +94,8 @@ self.addEventListener("message", async (e) => {
 				javascript: {
 					formatter: {
 						quoteStyle: quoteStyle === QuoteStyle.Double ? "double" : "single",
+						jsxQuoteStyle:
+							jsxQuoteStyle === QuoteStyle.Double ? "double" : "single",
 						quoteProperties:
 							quoteProperties === QuoteProperties.Preserve
 								? "preserve"


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix https://github.com/rome/tools/issues/4486

- Added a new option "jsxQuoteStyle": "double" / "single", "double" by default.
- Added a new control for the playground.

## Test Plan

`cargo test`

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [ ] I will create a new PR to update the documentation
