### PR TITLE
fix(rome_js_analyzer): Big pack of js/ts files that crashes rome #4323

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 ### Formatter
 ### Linter
 
+- Fix a crash in the `NoParameterAssign` rule that occurred when there was a bogus binding. [#4323](https://github.com/rome/tools/issues/4323)
+
 #### Other changes
 
 - The rules [`useExhaustiveDependencies`](https://docs.rome.tools/lint/rules/useexhaustivedependencies/) and [`useHookAtTopLevel`](https://docs.rome.tools/lint/rules/usehookattoplevel/) accept a different

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -2275,6 +2275,38 @@ if (true) {
 }
 
 #[test]
+fn apply_bogus_argument() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("fix.js");
+    fs.insert(
+        file_path.into(),
+        "function _13_1_3_fun(arguments) { }".as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[
+            ("check"),
+            file_path.as_os_str().to_str().unwrap(),
+            ("--apply-unsafe"),
+        ]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "apply_bogus_argument",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn ignores_unknown_file() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/rome_cli/tests/snapshots/main_commands_check/apply_bogus_argument.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/apply_bogus_argument.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `fix.js`
+
+```js
+function _13_1_3_fun(arguments) { }
+
+```
+
+# Emitted Messages
+
+```block
+Fixed 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_js_analyze/src/semantic_analyzers/style/no_parameter_assign.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/style/no_parameter_assign.rs
@@ -2,7 +2,7 @@ use crate::semantic_services::Semantic;
 use rome_analyze::{context::RuleContext, declare_rule, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_semantic::{AllBindingWriteReferencesIter, Reference, ReferencesExtensions};
-use rome_js_syntax::{AnyJsBindingPattern, AnyJsFormalParameter, AnyJsParameter};
+use rome_js_syntax::{AnyJsBinding, AnyJsBindingPattern, AnyJsFormalParameter, AnyJsParameter};
 use rome_rowan::AstNode;
 
 declare_rule! {
@@ -71,10 +71,10 @@ impl Rule for NoParameterAssign {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let param = ctx.query();
         let model = ctx.model();
-        if let Some(binding) = binding_of(param) {
-            if let Some(binding) = binding.as_any_js_binding() {
-                return binding.all_writes(model);
-            }
+        if let Some(AnyJsBindingPattern::AnyJsBinding(AnyJsBinding::JsIdentifierBinding(binding))) =
+            binding_of(param)
+        {
+            return binding.all_writes(model);
         }
         // Empty iterator that conforms to `AllBindingWriteReferencesIter` type.
         std::iter::successors(None, |_| None)

--- a/crates/rome_js_analyze/tests/specs/style/noParameterAssign/valid.jsonc
+++ b/crates/rome_js_analyze/tests/specs/style/noParameterAssign/valid.jsonc
@@ -57,5 +57,6 @@
 	"function foo(a) { for ([a.b] of []); }",
 	"function foo(a) { a.b &&= c; }",
 	"function foo(a) { a.b.c ||= d; }",
-	"function foo(a) { a[b] ??= c; }"
+	"function foo(a) { a[b] ??= c; }",
+	"function foo(arguments) { }"
 ]

--- a/crates/rome_js_analyze/tests/specs/style/noParameterAssign/valid.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/style/noParameterAssign/valid.jsonc.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 91
 expression: valid.jsonc
 ---
 # Input
@@ -296,6 +295,11 @@ function foo(a) { a.b.c ||= d; }
 # Input
 ```js
 function foo(a) { a[b] ??= c; }
+```
+
+# Input
+```js
+function foo(arguments) { }
 ```
 
 

--- a/crates/rome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/rome_js_semantic/src/semantic_model/binding.rs
@@ -1,7 +1,5 @@
 use super::*;
-use rome_js_syntax::{
-    binding_ext::AnyJsIdentifierBinding, AnyJsBinding, TextRange, TsTypeParameterName,
-};
+use rome_js_syntax::{binding_ext::AnyJsIdentifierBinding, TextRange, TsTypeParameterName};
 
 /// Internal type with all the semantic data of a specific binding
 #[derive(Debug)]
@@ -135,7 +133,6 @@ pub trait IsBindingAstNode: AstNode<Language = JsLanguage> {
 impl IsBindingAstNode for JsIdentifierBinding {}
 impl IsBindingAstNode for TsIdentifierBinding {}
 impl IsBindingAstNode for AnyJsIdentifierBinding {}
-impl IsBindingAstNode for AnyJsBinding {}
 impl IsBindingAstNode for TsTypeParameterName {}
 
 /// Extension method to allow nodes that have declaration to easily

--- a/crates/rome_js_semantic/src/semantic_model/model.rs
+++ b/crates/rome_js_semantic/src/semantic_model/model.rs
@@ -373,7 +373,7 @@ impl SemanticModel {
         };
 
         Some(AllCallsIter {
-            references: identifier.all_reads(self),
+            references: identifier.as_js_identifier_binding()?.all_reads(self),
         })
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix a semantic model crash when we have `JsBogusBinding`.

```
function _13_1_3_fun(arguments) { }
```

```
        0: JS_FUNCTION_DECLARATION@0..44
          0: (empty)
          1: FUNCTION_KW@0..18 "function" [Newline("\n"), Whitespace("        ")] [Whitespace(" ")]
          2: (empty)
          3: JS_IDENTIFIER_BINDING@18..29
            0: IDENT@18..29 "_13_1_3_fun" [] []
          4: (empty)
          5: JS_PARAMETERS@29..41
            0: L_PAREN@29..30 "(" [] []
            1: JS_PARAMETER_LIST@30..39
              0: JS_FORMAL_PARAMETER@30..39
                0: JS_BOGUS_BINDING@30..39
                  0: IDENT@30..39 "arguments" [] []
                1: (empty)
                2: (empty)
                3: (empty)
            2: R_PAREN@39..41 ")" [] [Whitespace(" ")]
          6: (empty)
```

We have the crash here for the `NoParameterAssign` rule:
https://github.com/rome/tools/blob/dad13a9f6cc2a9743d5aa8c08fad0830b67e7a1c/crates/rome_js_semantic/src/semantic_model/model.rs#L330-L337

I believe that we can ignore any bogus nodes while we do an analysis.

## Test Plan

`cargo test`

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
