### PR TITLE
feat(rome_service): add `extends` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,28 @@
 
 ### CLI
 
+#### BREAKING CHANGES
+
+- The CLI now exists with an error then there's an error inside the configuration.
+
+	Previously, rome would raise warnings and continue the execution, by applying its defaults.
+
+	This wasn't ideal for users, because this could have created false positives in linting, or formatted
+	code with a configuration that wasn't the of the user.
+
+
 #### Other changes
 
-- Fixes [#4556](https://github.com/rome/tools/issues/4556) using `lines()` to enable OS independent line parsing when processing the .gitignore file.
-- Add a new option to ignore unknown files
+- The command `rome check` now shows formatter diagnostics when checking the code.
+- Fix [#4556](https://github.com/rome/tools/issues/4556), which correctly handles new lines in the
+`.gitignore` file across OS.
+- Add a new option to ignore unknown files.
 
 	```shell
 	rome format ./src --files-ignore-unknown=true
 	```
 
-	Doing so, Rome won't emit diagnostics for file that it doesn't know how to handle.
+	Doing so, Rome won't emit diagnostics for files that doesn't know how to handle.
 
 ### Configuration
 
@@ -30,7 +42,7 @@
 	```
 	Doing so, Rome won't emit diagnostics for file that it doesn't know how to handle.
 
-- Add a new `"javascript"` option to support the usafe/experimental
+- Add a new `"javascript"` option to support the unsafe/experimental
 parameter decorators:
 
 	```json
@@ -42,6 +54,17 @@ parameter decorators:
 		}
 	}
 	```
+- Add a new `"extends"` option, useful to split the configuration file in
+multiple files:
+
+  ```json
+  {
+    "extends": ["../sharedFormatter.json", "linter.json"]
+  }
+  ```
+
+  The resolution of the files is file system based, Rome doesn't know how to
+  resolve dependencies yet.
 
 ### Editors
 
@@ -94,7 +117,7 @@ parameter decorators:
 - The rules [`useExhaustiveDependencies`](https://docs.rome.tools/lint/rules/useexhaustivedependencies/) and [`useHookAtTopLevel`](https://docs.rome.tools/lint/rules/usehookattoplevel/) accept a different shape of options
 
   Old configuration
-  
+
   ```json
   {
   	"linter": {
@@ -115,7 +138,7 @@ parameter decorators:
   ```
 
   New configuration
-  
+
   ```json
   {
   	"linter": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,88 +1,88 @@
 [workspace]
 # Use the newer version of the cargo resolver
 # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
-resolver = "2"
 members = [
-	"crates/*",
-	"xtask/bench",
-	"xtask/codegen",
-	"xtask/coverage",
-	"xtask/lintdoc",
-	"xtask/libs_bench",
-	"xtask/contributors",
+  "crates/*",
+  "xtask/bench",
+  "xtask/codegen",
+  "xtask/coverage",
+  "xtask/lintdoc",
+  "xtask/libs_bench",
+  "xtask/contributors",
 ]
+resolver = "2"
 
 [workspace.package]
-edition = "2021"
-authors = ["Rome Tools Developers and Contributors"]
-license = "MIT"
+authors    = ["Rome Tools Developers and Contributors"]
+edition    = "2021"
+homepage   = "https://rome.tools"
+license    = "MIT"
 repository = "https://github.com/rome/tools"
-homepage = "https://rome.tools"
 
 [profile.release-with-debug]
+debug    = true
 inherits = "release"
-debug = true
 
 [workspace.dependencies]
-indexmap = "1.9.3"
-tracing = { version = "0.1.31", default-features = false, features = ["std"] }
-dashmap = "5.4.0"
+countme    = "3.0.1"
+dashmap    = "5.4.0"
+indexmap   = "1.9.3"
 rustc-hash = "1.1.0"
-countme = "3.0.1"
+tracing    = { version = "0.1.31", default-features = false, features = ["std"] }
 # pinning to version 1.18 to avoid multiple versions of windows-sys as dependency
-tokio = { version = "~1.18.5" }
-insta = "1.21.2"
-quote = { version = "1.0.21" }
-lazy_static = "1.4.0"
-bpaf = { version = "0.8.0", features = ["derive"] }
-bitflags = "2.2.1"
-rome_rowan = { version = "0.0.1", path = "./crates/rome_rowan" }
-rome_console = { version = "0.0.1", path = "./crates/rome_console" }
-rome_diagnostics = { version = "0.0.1", path = "./crates/rome_diagnostics" }
-rome_json_parser = { path = "./crates/rome_json_parser" }
-rome_deserialize = { version = "0.0.0", path = "./crates/rome_deserialize" }
-rome_aria_metadata = { path = "./crates/rome_aria_metadata" }
-rome_aria = { path = "./crates/rome_aria" }
-rome_formatter = { version = "0.0.1", path = "./crates/rome_formatter" }
-rome_service = { path = "./crates/rome_service" }
-rome_flags = { path = "./crates/rome_flags" }
-rome_fs = { path = "./crates/rome_fs" }
-rome_text_edit = { version = "0.0.1", path = "./crates/rome_text_edit" }
-rome_lsp = { path = "./crates/rome_lsp" }
-rome_text_size = { version = "0.0.1", path = "./crates/rome_text_size" }
-rome_json_formatter = { path = "./crates/rome_json_formatter" }
-rome_json_syntax = { version = "0.0.1", path = "./crates/rome_json_syntax" }
-rome_migrate = { path = "./crates/rome_migrate" }
-rome_js_formatter = { path = "./crates/rome_js_formatter" }
-rome_markup = { version = "0.0.1", path = "./crates/rome_markup" }
-rome_css_syntax = { path = "./crates/rome_css_syntax" }
-rome_diagnostics_macros = { version = "0.0.1", path = "./crates/rome_diagnostics_macros" }
+bitflags                    = "2.2.1"
+bpaf                        = { version = "0.8.0", features = ["derive"] }
+insta                       = "1.21.2"
+lazy_static                 = "1.4.0"
+quote                       = { version = "1.0.21" }
+rome_analyze                = { path = "./crates/rome_analyze" }
+rome_aria                   = { path = "./crates/rome_aria" }
+rome_aria_metadata          = { path = "./crates/rome_aria_metadata" }
+rome_console                = { version = "0.0.1", path = "./crates/rome_console" }
+rome_control_flow           = { path = "./crates/rome_control_flow" }
+rome_css_syntax             = { path = "./crates/rome_css_syntax" }
+rome_deserialize            = { version = "0.0.0", path = "./crates/rome_deserialize" }
+rome_diagnostics            = { version = "0.0.1", path = "./crates/rome_diagnostics" }
 rome_diagnostics_categories = { version = "0.0.1", path = "./crates/rome_diagnostics_categories" }
-rome_js_parser = { path = "./crates/rome_js_parser" }
-rome_js_syntax = { version = "0.0.2", path = "./crates/rome_js_syntax" }
-rome_js_factory = { version = "0.0.2", path = "./crates/rome_js_factory" }
-rome_parser = { version = "0.0.1", path = "./crates/rome_parser" }
-rome_analyze = { path = "./crates/rome_analyze" }
-rome_control_flow = { path = "./crates/rome_control_flow" }
-rome_js_semantic = { path = "./crates/rome_js_semantic" }
-rome_js_unicode_table = { version = "0.0.1", path = "./crates/rome_js_unicode_table" }
-rome_json_factory = { version = "0.0.1", path = "./crates/rome_json_factory" }
-tests_macros = { path = "./crates/tests_macros" }
-rome_formatter_test = { path = "./crates/rome_formatter_test" }
-rome_js_analyze  = { path = "./crates/rome_js_analyze" }
-rome_json_analyze  = { path = "./crates/rome_json_analyze" }
-schemars = { version = "0.8.10" }
-smallvec = { version = "1.8.0", features = ["union", "const_new"] }
+rome_diagnostics_macros     = { version = "0.0.1", path = "./crates/rome_diagnostics_macros" }
+rome_flags                  = { path = "./crates/rome_flags" }
+rome_formatter              = { version = "0.0.1", path = "./crates/rome_formatter" }
+rome_formatter_test         = { path = "./crates/rome_formatter_test" }
+rome_fs                     = { path = "./crates/rome_fs" }
+rome_js_analyze             = { path = "./crates/rome_js_analyze" }
+rome_js_factory             = { version = "0.0.2", path = "./crates/rome_js_factory" }
+rome_js_formatter           = { path = "./crates/rome_js_formatter" }
+rome_js_parser              = { path = "./crates/rome_js_parser" }
+rome_js_semantic            = { path = "./crates/rome_js_semantic" }
+rome_js_syntax              = { version = "0.0.2", path = "./crates/rome_js_syntax" }
+rome_js_unicode_table       = { version = "0.0.1", path = "./crates/rome_js_unicode_table" }
+rome_json_analyze           = { path = "./crates/rome_json_analyze" }
+rome_json_factory           = { version = "0.0.1", path = "./crates/rome_json_factory" }
+rome_json_formatter         = { path = "./crates/rome_json_formatter" }
+rome_json_parser            = { path = "./crates/rome_json_parser" }
+rome_json_syntax            = { version = "0.0.1", path = "./crates/rome_json_syntax" }
+rome_lsp                    = { path = "./crates/rome_lsp" }
+rome_markup                 = { version = "0.0.1", path = "./crates/rome_markup" }
+rome_migrate                = { path = "./crates/rome_migrate" }
+rome_parser                 = { version = "0.0.1", path = "./crates/rome_parser" }
+rome_rowan                  = { version = "0.0.1", path = "./crates/rome_rowan" }
+rome_service                = { path = "./crates/rome_service" }
+rome_text_edit              = { version = "0.0.1", path = "./crates/rome_text_edit" }
+rome_text_size              = { version = "0.0.1", path = "./crates/rome_text_size" }
+schemars                    = { version = "0.8.10" }
+smallvec                    = { version = "1.8.0", features = ["union", "const_new"] }
+tests_macros                = { path = "./crates/tests_macros" }
+tokio                       = { version = "~1.18.5" }
 
 
 [profile.dev.package.rome_wasm]
+debug     = true
 opt-level = 1
-debug = true
 
 [profile.test.package.rome_wasm]
+debug     = true
 opt-level = 1
-debug = true
 
 [profile.release.package.rome_wasm]
+debug     = false
 opt-level = 3
-debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,88 +1,88 @@
 [workspace]
 # Use the newer version of the cargo resolver
 # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
-members = [
-  "crates/*",
-  "xtask/bench",
-  "xtask/codegen",
-  "xtask/coverage",
-  "xtask/lintdoc",
-  "xtask/libs_bench",
-  "xtask/contributors",
-]
 resolver = "2"
+members = [
+	"crates/*",
+	"xtask/bench",
+	"xtask/codegen",
+	"xtask/coverage",
+	"xtask/lintdoc",
+	"xtask/libs_bench",
+	"xtask/contributors",
+]
 
 [workspace.package]
-authors    = ["Rome Tools Developers and Contributors"]
-edition    = "2021"
-homepage   = "https://rome.tools"
-license    = "MIT"
+edition = "2021"
+authors = ["Rome Tools Developers and Contributors"]
+license = "MIT"
 repository = "https://github.com/rome/tools"
+homepage = "https://rome.tools"
 
 [profile.release-with-debug]
-debug    = true
 inherits = "release"
+debug = true
 
 [workspace.dependencies]
-countme    = "3.0.1"
-dashmap    = "5.4.0"
-indexmap   = "1.9.1"
+indexmap = "1.9.3"
+tracing = { version = "0.1.31", default-features = false, features = ["std"] }
+dashmap = "5.4.0"
 rustc-hash = "1.1.0"
-tracing    = { version = "0.1.31", default-features = false, features = ["std"] }
+countme = "3.0.1"
 # pinning to version 1.18 to avoid multiple versions of windows-sys as dependency
-bitflags                    = "2.2.1"
-bpaf                        = { version = "0.8.0", features = ["derive"] }
-insta                       = "1.21.2"
-lazy_static                 = "1.4.0"
-quote                       = { version = "1.0.21" }
-rome_analyze                = { path = "./crates/rome_analyze" }
-rome_aria                   = { path = "./crates/rome_aria" }
-rome_aria_metadata          = { path = "./crates/rome_aria_metadata" }
-rome_console                = { version = "0.0.1", path = "./crates/rome_console" }
-rome_control_flow           = { path = "./crates/rome_control_flow" }
-rome_css_syntax             = { path = "./crates/rome_css_syntax" }
-rome_deserialize            = { version = "0.0.0", path = "./crates/rome_deserialize" }
-rome_diagnostics            = { version = "0.0.1", path = "./crates/rome_diagnostics" }
+tokio = { version = "~1.18.5" }
+insta = "1.21.2"
+quote = { version = "1.0.21" }
+lazy_static = "1.4.0"
+bpaf = { version = "0.8.0", features = ["derive"] }
+bitflags = "2.2.1"
+rome_rowan = { version = "0.0.1", path = "./crates/rome_rowan" }
+rome_console = { version = "0.0.1", path = "./crates/rome_console" }
+rome_diagnostics = { version = "0.0.1", path = "./crates/rome_diagnostics" }
+rome_json_parser = { path = "./crates/rome_json_parser" }
+rome_deserialize = { version = "0.0.0", path = "./crates/rome_deserialize" }
+rome_aria_metadata = { path = "./crates/rome_aria_metadata" }
+rome_aria = { path = "./crates/rome_aria" }
+rome_formatter = { version = "0.0.1", path = "./crates/rome_formatter" }
+rome_service = { path = "./crates/rome_service" }
+rome_flags = { path = "./crates/rome_flags" }
+rome_fs = { path = "./crates/rome_fs" }
+rome_text_edit = { version = "0.0.1", path = "./crates/rome_text_edit" }
+rome_lsp = { path = "./crates/rome_lsp" }
+rome_text_size = { version = "0.0.1", path = "./crates/rome_text_size" }
+rome_json_formatter = { path = "./crates/rome_json_formatter" }
+rome_json_syntax = { version = "0.0.1", path = "./crates/rome_json_syntax" }
+rome_migrate = { path = "./crates/rome_migrate" }
+rome_js_formatter = { path = "./crates/rome_js_formatter" }
+rome_markup = { version = "0.0.1", path = "./crates/rome_markup" }
+rome_css_syntax = { path = "./crates/rome_css_syntax" }
+rome_diagnostics_macros = { version = "0.0.1", path = "./crates/rome_diagnostics_macros" }
 rome_diagnostics_categories = { version = "0.0.1", path = "./crates/rome_diagnostics_categories" }
-rome_diagnostics_macros     = { version = "0.0.1", path = "./crates/rome_diagnostics_macros" }
-rome_flags                  = { path = "./crates/rome_flags" }
-rome_formatter              = { version = "0.0.1", path = "./crates/rome_formatter" }
-rome_formatter_test         = { path = "./crates/rome_formatter_test" }
-rome_fs                     = { path = "./crates/rome_fs" }
-rome_js_analyze             = { path = "./crates/rome_js_analyze" }
-rome_js_factory             = { version = "0.0.2", path = "./crates/rome_js_factory" }
-rome_js_formatter           = { path = "./crates/rome_js_formatter" }
-rome_js_parser              = { path = "./crates/rome_js_parser" }
-rome_js_semantic            = { path = "./crates/rome_js_semantic" }
-rome_js_syntax              = { version = "0.0.2", path = "./crates/rome_js_syntax" }
-rome_js_unicode_table       = { version = "0.0.1", path = "./crates/rome_js_unicode_table" }
-rome_json_analyze           = { path = "./crates/rome_json_analyze" }
-rome_json_factory           = { version = "0.0.1", path = "./crates/rome_json_factory" }
-rome_json_formatter         = { path = "./crates/rome_json_formatter" }
-rome_json_parser            = { path = "./crates/rome_json_parser" }
-rome_json_syntax            = { version = "0.0.1", path = "./crates/rome_json_syntax" }
-rome_lsp                    = { path = "./crates/rome_lsp" }
-rome_markup                 = { version = "0.0.1", path = "./crates/rome_markup" }
-rome_migrate                = { path = "./crates/rome_migrate" }
-rome_parser                 = { version = "0.0.1", path = "./crates/rome_parser" }
-rome_rowan                  = { version = "0.0.1", path = "./crates/rome_rowan" }
-rome_service                = { path = "./crates/rome_service" }
-rome_text_edit              = { version = "0.0.1", path = "./crates/rome_text_edit" }
-rome_text_size              = { version = "0.0.1", path = "./crates/rome_text_size" }
-schemars                    = { version = "0.8.10" }
-smallvec                    = { version = "1.8.0", features = ["union", "const_new"] }
-tests_macros                = { path = "./crates/tests_macros" }
-tokio                       = { version = "~1.18.5" }
+rome_js_parser = { path = "./crates/rome_js_parser" }
+rome_js_syntax = { version = "0.0.2", path = "./crates/rome_js_syntax" }
+rome_js_factory = { version = "0.0.2", path = "./crates/rome_js_factory" }
+rome_parser = { version = "0.0.1", path = "./crates/rome_parser" }
+rome_analyze = { path = "./crates/rome_analyze" }
+rome_control_flow = { path = "./crates/rome_control_flow" }
+rome_js_semantic = { path = "./crates/rome_js_semantic" }
+rome_js_unicode_table = { version = "0.0.1", path = "./crates/rome_js_unicode_table" }
+rome_json_factory = { version = "0.0.1", path = "./crates/rome_json_factory" }
+tests_macros = { path = "./crates/tests_macros" }
+rome_formatter_test = { path = "./crates/rome_formatter_test" }
+rome_js_analyze  = { path = "./crates/rome_js_analyze" }
+rome_json_analyze  = { path = "./crates/rome_json_analyze" }
+schemars = { version = "0.8.10" }
+smallvec = { version = "1.8.0", features = ["union", "const_new"] }
 
 
 [profile.dev.package.rome_wasm]
-debug     = true
 opt-level = 1
+debug = true
 
 [profile.test.package.rome_wasm]
-debug     = true
 opt-level = 1
+debug = true
 
 [profile.release.package.rome_wasm]
-debug     = false
 opt-level = 3
+debug = false

--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -3,7 +3,7 @@ use crate::configuration::{load_configuration, LoadedConfiguration};
 use crate::vcs::store_path_to_ignore_from_vcs;
 use crate::{execute_mode, CliDiagnostic, CliSession, Execution, TraversalMode};
 use rome_console::{markup, ConsoleExt};
-use rome_diagnostics::{PrintDiagnostic, Severity};
+use rome_diagnostics::{DiagnosticExt, PrintDiagnostic};
 use rome_service::configuration::organize_imports::OrganizeImports;
 use rome_service::configuration::{FormatterConfiguration, LinterConfiguration};
 use rome_service::workspace::{FixFileMode, UpdateSettingsParams};
@@ -57,7 +57,7 @@ pub(crate) fn check(
         configuration: mut fs_configuration,
         diagnostics,
         directory_path: configuration_path,
-        ..
+        file_path,
     } = load_configuration(&mut session, &cli_options)?;
     if !diagnostics.is_empty() {
         let console = &mut session.app.console;
@@ -65,6 +65,11 @@ pub(crate) fn check(
            <Error>"Found errors in the configuration file, Rome will use its defaults for the sections that are incorrect."</Error>
         });
         for diagnostic in diagnostics {
+            let diagnostic = if let Some(file_path) = &file_path {
+                diagnostic.with_file_path(file_path.display().to_string())
+            } else {
+                diagnostic
+            };
             console.error(markup! {
 				{if cli_options.verbose { PrintDiagnostic::verbose(&diagnostic) } else { PrintDiagnostic::simple(&diagnostic) }}
             })

--- a/crates/rome_cli/src/commands/check.rs
+++ b/crates/rome_cli/src/commands/check.rs
@@ -2,8 +2,6 @@ use crate::cli_options::CliOptions;
 use crate::configuration::{load_configuration, LoadedConfiguration};
 use crate::vcs::store_path_to_ignore_from_vcs;
 use crate::{execute_mode, CliDiagnostic, CliSession, Execution, TraversalMode};
-use rome_console::{markup, ConsoleExt};
-use rome_diagnostics::{DiagnosticExt, PrintDiagnostic};
 use rome_service::configuration::organize_imports::OrganizeImports;
 use rome_service::configuration::{FormatterConfiguration, LinterConfiguration};
 use rome_service::workspace::{FixFileMode, UpdateSettingsParams};
@@ -55,26 +53,10 @@ pub(crate) fn check(
 
     let LoadedConfiguration {
         configuration: mut fs_configuration,
-        diagnostics,
         directory_path: configuration_path,
-        file_path,
-    } = load_configuration(&mut session, &cli_options)?;
-    if !diagnostics.is_empty() {
-        let console = &mut session.app.console;
-        console.log(markup!{
-           <Error>"Found errors in the configuration file, Rome will use its defaults for the sections that are incorrect."</Error>
-        });
-        for diagnostic in diagnostics {
-            let diagnostic = if let Some(file_path) = &file_path {
-                diagnostic.with_file_path(file_path.display().to_string())
-            } else {
-                diagnostic
-            };
-            console.error(markup! {
-				{if cli_options.verbose { PrintDiagnostic::verbose(&diagnostic) } else { PrintDiagnostic::simple(&diagnostic) }}
-            })
-        }
-    }
+        ..
+    } = load_configuration(&mut session, &cli_options)?
+        .or_diagnostic(session.app.console, cli_options.verbose)?;
 
     let formatter = fs_configuration
         .formatter

--- a/crates/rome_cli/src/commands/ci.rs
+++ b/crates/rome_cli/src/commands/ci.rs
@@ -5,8 +5,6 @@ use crate::{
     configuration::load_configuration, execute_mode, CliDiagnostic, CliSession, Execution,
     TraversalMode,
 };
-use rome_console::{markup, ConsoleExt};
-use rome_diagnostics::{DiagnosticExt, PrintDiagnostic};
 use rome_service::configuration::organize_imports::OrganizeImports;
 use rome_service::configuration::{FormatterConfiguration, LinterConfiguration};
 use rome_service::workspace::UpdateSettingsParams;
@@ -26,30 +24,10 @@ pub(crate) struct CiCommandPayload {
 pub(crate) fn ci(mut session: CliSession, payload: CiCommandPayload) -> Result<(), CliDiagnostic> {
     let LoadedConfiguration {
         mut configuration,
-        diagnostics,
         directory_path: configuration_path,
-        file_path,
-    } = load_configuration(&mut session, &payload.cli_options)?;
-
-    if !diagnostics.is_empty() {
-        let console = &mut session.app.console;
-        console.log(markup!{
-           <Error>"Found errors in the configuration file, Rome will use its defaults for the sections that are incorrect."</Error>
-        });
-        for diagnostic in diagnostics {
-            let diagnostic = if let Some(file_path) = &file_path {
-                diagnostic.with_file_path(file_path.display().to_string())
-            } else {
-                diagnostic
-            };
-            console.error(markup! {
-				{if payload.cli_options.verbose { PrintDiagnostic::verbose(&diagnostic) } else { PrintDiagnostic::simple(&diagnostic) }}
-            })
-        }
-        return Err(CliDiagnostic::incompatible_end_configuration(
-            "The deserialization of the configuration resulted into an error.",
-        ));
-    }
+        ..
+    } = load_configuration(&mut session, &payload.cli_options)?
+        .or_diagnostic(session.app.console, payload.cli_options.verbose)?;
 
     let formatter = configuration
         .formatter

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -42,14 +42,19 @@ pub(crate) fn format(
         mut configuration,
         diagnostics,
         directory_path: configuration_path,
-        ..
+        file_path,
     } = load_configuration(&mut session, &cli_options)?;
     if !diagnostics.is_empty() {
         let console = &mut session.app.console;
         console.log(markup!{
-           <Warn>"Found errors in the configuration file, Rome will use its defaults for the sections that are incorrect."</Warn>
+           <Error>"Found errors in the configuration file, Rome will use its defaults for the sections that are incorrect."</Error>
         });
         for diagnostic in diagnostics {
+            let diagnostic = if let Some(file_path) = &file_path {
+                diagnostic.with_file_path(file_path.display().to_string())
+            } else {
+                diagnostic
+            };
             let diagnostic = diagnostic.with_severity(Severity::Warning);
             console.log(markup! {
                 {PrintDiagnostic::verbose(&diagnostic)}

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -1,5 +1,5 @@
 use crate::cli_options::CliOptions;
-use crate::configuration::load_configuration;
+use crate::configuration::{load_configuration, LoadedConfiguration};
 use crate::execute::ReportMode;
 use crate::vcs::store_path_to_ignore_from_vcs;
 use crate::{execute_mode, CliDiagnostic, CliSession, Execution, TraversalMode};
@@ -38,8 +38,12 @@ pub(crate) fn format(
         files_configuration,
         write,
     } = payload;
-    let (mut configuration, diagnostics, configuration_path) =
-        load_configuration(&mut session, &cli_options)?.consume();
+    let LoadedConfiguration {
+        mut configuration,
+        diagnostics,
+        directory_path: configuration_path,
+        ..
+    } = load_configuration(&mut session, &cli_options)?;
     if !diagnostics.is_empty() {
         let console = &mut session.app.console;
         console.log(markup!{

--- a/crates/rome_cli/src/commands/migrate.rs
+++ b/crates/rome_cli/src/commands/migrate.rs
@@ -1,5 +1,5 @@
 use crate::cli_options::CliOptions;
-use crate::configuration::load_configuration;
+use crate::configuration::{load_configuration, LoadedConfiguration};
 use crate::diagnostics::MigrationDiagnostic;
 use crate::execute::{execute_mode, Execution, TraversalMode};
 use crate::{CliDiagnostic, CliSession};
@@ -10,7 +10,12 @@ pub(crate) fn migrate(
     cli_options: CliOptions,
     write: bool,
 ) -> Result<(), CliDiagnostic> {
-    let (_, _, path) = load_configuration(&mut session, &cli_options)?.consume();
+    let LoadedConfiguration {
+        configuration: _,
+        diagnostics: _,
+        directory_path: path,
+        ..
+    } = load_configuration(&mut session, &cli_options)?;
     let config_name = session.app.fs.config_name();
     if let Some(path) = path {
         execute_mode(

--- a/crates/rome_cli/src/commands/mod.rs
+++ b/crates/rome_cli/src/commands/mod.rs
@@ -90,17 +90,18 @@ pub enum RomeCommand {
         #[bpaf(external, optional, hide_usage)]
         files_configuration: Option<FilesConfiguration>,
 
-        /// A file name with its extension to pass when reading from standard in, e.g. echo 'let a;' | rome format --stdin-file-path=file.js"
+        /// A file name with its extension to pass when reading from standard in, e.g. echo 'let a;' | rome format --stdin-file-path=file.js".
         #[bpaf(long("stdin-file-path"), argument("PATH"), hide_usage)]
         stdin_file_path: Option<String>,
 
         #[bpaf(external, hide_usage)]
         cli_options: CliOptions,
 
+        /// Writes formatted files to file system.
         #[bpaf(switch)]
         write: bool,
 
-        /// Single file, single path or list of paths
+        /// Single file, single path or list of paths.
         #[bpaf(positional("PATH"), many)]
         paths: Vec<OsString>,
     },
@@ -188,6 +189,23 @@ impl RomeCommand {
 
     pub const fn has_metrics(&self) -> bool {
         false
+    }
+
+    pub fn is_verbose(&self) -> bool {
+        match self {
+            RomeCommand::Version(_) => false,
+            RomeCommand::Rage(_) => false,
+            RomeCommand::Start => false,
+            RomeCommand::Stop => false,
+            RomeCommand::Check { cli_options, .. } => cli_options.verbose,
+            RomeCommand::Format { cli_options, .. } => cli_options.verbose,
+            RomeCommand::Ci { cli_options, .. } => cli_options.verbose,
+            RomeCommand::Init => false,
+            RomeCommand::LspProxy(cli_options) => cli_options.verbose,
+            RomeCommand::Migrate(cli_options, _) => cli_options.verbose,
+            RomeCommand::RunServer { .. } => false,
+            RomeCommand::PrintSocket => false,
+        }
     }
 }
 

--- a/crates/rome_cli/src/commands/rage.rs
+++ b/crates/rome_cli/src/commands/rage.rs
@@ -165,9 +165,8 @@ impl Display for RageConfiguration<'_, '_> {
 
         match load_config(self.0, ConfigurationBasePath::default()) {
             Ok(None) => KeyValuePair("Status", markup!(<Dim>"unset"</Dim>)).fmt(fmt)?,
-            Ok(Some(deserialized)) => {
-                let (deserialized, _) = deserialized;
-                let (configuration, diagnostics) = deserialized.consume();
+            Ok(Some(result)) => {
+                let (configuration, diagnostics) = result.deserialized.consume();
                 let status = if !diagnostics.is_empty() {
                     for diagnostic in diagnostics {
                         (markup! {

--- a/crates/rome_cli/src/configuration.rs
+++ b/crates/rome_cli/src/configuration.rs
@@ -1,30 +1,97 @@
-use std::path::PathBuf;
-
 use crate::cli_options::CliOptions;
 use crate::{CliDiagnostic, CliSession};
+use rome_console::markup;
+use rome_deserialize::json::deserialize_from_json_str;
 use rome_deserialize::Deserialized;
-use rome_service::{load_config, Configuration, ConfigurationBasePath};
+use rome_diagnostics::Error;
+use rome_fs::{FileSystem, OpenOptions};
+use rome_service::configuration::diagnostics::CantLoadExtendFile;
+use rome_service::configuration::ConfigurationPayload;
+use rome_service::{
+    load_config, Configuration, ConfigurationBasePath, DynRef, MergeWith, WorkspaceError,
+};
+use std::path::PathBuf;
 
 #[derive(Default)]
 pub struct LoadedConfiguration {
-    deserialized: Deserialized<Configuration>,
-    path: Option<PathBuf>,
+    pub(crate) directory_path: Option<PathBuf>,
+    pub(crate) file_path: Option<PathBuf>,
+    pub(crate) configuration: Configuration,
+    pub(crate) diagnostics: Vec<Error>,
 }
 
 impl LoadedConfiguration {
-    pub fn consume(self) -> (Configuration, Vec<rome_diagnostics::Error>, Option<PathBuf>) {
-        let path = self.path;
-        let (configuration, diagnostics) = self.deserialized.consume();
-        (configuration, diagnostics, path)
+    /// It updates the loaded configuration by resolving the `extends` field.
+    ///
+    /// If a configuration can't be resolved from the file system, the operation will fail.
+    pub fn apply_extends(&mut self, fs: &DynRef<dyn FileSystem>) -> Result<(), WorkspaceError> {
+        let deserialized = self.deserialize_extends(fs)?;
+        let (configurations, errors): (Vec<_>, Vec<_>) =
+            deserialized.into_iter().map(|d| d.consume()).unzip();
+        for c in configurations {
+            self.configuration.merge_with(c);
+        }
+        self.diagnostics
+            .extend(errors.into_iter().flatten().collect::<Vec<_>>());
+
+        Ok(())
+    }
+
+    fn deserialize_extends(
+        &mut self,
+        fs: &DynRef<dyn FileSystem>,
+    ) -> Result<Vec<Deserialized<Configuration>>, WorkspaceError> {
+        let Some(extends) = &self.configuration.extends else {
+			return Ok(vec![]);
+		};
+
+        let directory_path = self
+            .directory_path
+            .as_ref()
+            .cloned()
+            .unwrap_or(fs.working_directory().unwrap_or(PathBuf::from("./")));
+        let mut deserialized_configurations = vec![];
+        for path in extends.index_set() {
+            let config_path = directory_path.join(path);
+            let mut file = fs
+					.open_with_options(config_path.as_path(), OpenOptions::default().read(true))
+					.map_err(|err| {
+						CantLoadExtendFile::new(config_path.display().to_string(), err.to_string()).with_verbose_advice(
+							markup!{
+								"Rome tried to load the configuration file "<Emphasis>{directory_path.display().to_string()}</Emphasis>" using "<Emphasis>{config_path.display().to_string()}</Emphasis>" as base path."
+							}
+						)
+					})?;
+            let mut content = String::new();
+            file.read_to_string(&mut content).map_err(|err| {
+					CantLoadExtendFile::new(config_path.display().to_string(), err.to_string()).with_verbose_advice(
+						markup!{
+							"It's possible that the file was created with a different user/group. Make sure you have the rights to read the file."
+						}
+					)
+
+				})?;
+            let deserialized = deserialize_from_json_str::<Configuration>(content.as_str());
+            deserialized_configurations.push(deserialized)
+        }
+        Ok(deserialized_configurations)
     }
 }
 
-impl From<Option<(Deserialized<Configuration>, PathBuf)>> for LoadedConfiguration {
-    fn from(value: Option<(Deserialized<Configuration>, PathBuf)>) -> Self {
-        if let Some((deserialized, path)) = value {
-            LoadedConfiguration {
+impl From<Option<ConfigurationPayload>> for LoadedConfiguration {
+    fn from(value: Option<ConfigurationPayload>) -> Self {
+        if let Some(value) = value {
+            let ConfigurationPayload {
+                configuration_directory_path,
+                configuration_file_path,
                 deserialized,
-                path: Some(path),
+            } = value;
+            let (configuration, diagnostics) = deserialized.consume();
+            LoadedConfiguration {
+                configuration,
+                diagnostics,
+                directory_path: Some(configuration_directory_path),
+                file_path: Some(configuration_file_path),
             }
         } else {
             LoadedConfiguration::default()
@@ -43,7 +110,10 @@ pub(crate) fn load_configuration(
         Some(path) => ConfigurationBasePath::FromUser(PathBuf::from(path)),
     };
 
-    let config = load_config(&session.app.fs, base_path)?;
+    let fs = &session.app.fs;
+    let config = load_config(fs, base_path)?;
+    let mut loaded_configuration = LoadedConfiguration::from(config);
 
-    Ok(config.into())
+    loaded_configuration.apply_extends(fs)?;
+    Ok(loaded_configuration)
 }

--- a/crates/rome_cli/src/diagnostics.rs
+++ b/crates/rome_cli/src/diagnostics.rs
@@ -163,10 +163,16 @@ pub struct CheckError {
     action_kind: CheckActionKind,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum CheckActionKind {
     Check,
     Apply,
+}
+
+impl Debug for CheckActionKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
 }
 
 impl Display for CheckActionKind {
@@ -688,7 +694,7 @@ mod test {
     fn termination_diagnostic_size() {
         assert_eq!(
             std::mem::size_of::<CliDiagnostic>(),
-            88,
+            104,
             "you successfully decreased the size of the diagnostic!"
         )
     }

--- a/crates/rome_cli/src/execute/process_file.rs
+++ b/crates/rome_cli/src/execute/process_file.rs
@@ -330,13 +330,7 @@ pub(crate) fn process_file(ctx: &TraversalOptions, path: &Path) -> FileResult {
             let should_write = match ctx.execution.traversal_mode() {
                 // In check mode do not run the formatter and return the result immediately,
                 // but only if the argument `--apply` is not passed.
-                TraversalMode::Check { .. } => {
-                    if ctx.execution.as_fix_file_mode().is_some() {
-                        true
-                    } else {
-                        false
-                    }
-                }
+                TraversalMode::Check { .. } => ctx.execution.as_fix_file_mode().is_some(),
                 TraversalMode::CI { .. } => false,
                 TraversalMode::Format { write, .. } => *write,
                 TraversalMode::Migrate { write: dry_run, .. } => *dry_run,

--- a/crates/rome_cli/src/execute/process_file.rs
+++ b/crates/rome_cli/src/execute/process_file.rs
@@ -104,6 +104,17 @@ pub(crate) fn process_file(ctx: &TraversalOptions, path: &Path) -> FileResult {
                 })
                 .and(
                     file_features
+                        .support_kind_for(&FeatureName::Format)
+                        .and_then(|support_kind| {
+                            if support_kind.is_not_enabled() {
+                                Some(support_kind)
+                            } else {
+                                None
+                            }
+                        }),
+                )
+                .and(
+                    file_features
                         .support_kind_for(&FeatureName::OrganizeImports)
                         .and_then(|support_kind| {
                             if support_kind.is_not_enabled() {
@@ -323,7 +334,7 @@ pub(crate) fn process_file(ctx: &TraversalOptions, path: &Path) -> FileResult {
                     if ctx.execution.as_fix_file_mode().is_some() {
                         true
                     } else {
-                        return Ok(result);
+                        false
                     }
                 }
                 TraversalMode::CI { .. } => false,

--- a/crates/rome_cli/src/execute/traverse.rs
+++ b/crates/rome_cli/src/execute/traverse.rs
@@ -666,7 +666,10 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
         };
 
         match self.execution.traversal_mode() {
-            TraversalMode::Check { .. } => file_features.supports_for(&FeatureName::Lint),
+            TraversalMode::Check { .. } => {
+                file_features.supports_for(&FeatureName::Lint)
+                    || file_features.supports_for(&FeatureName::Format)
+            }
             TraversalMode::CI { .. } => {
                 file_features.supports_for(&FeatureName::Lint)
                     || file_features.supports_for(&FeatureName::Format)

--- a/crates/rome_cli/src/main.rs
+++ b/crates/rome_cli/src/main.rs
@@ -37,7 +37,6 @@ fn main() -> ExitCode {
             let result = run_workspace(&mut console, command);
             match result {
                 Err(termination) => {
-                    dbg!(&is_verbose);
                     console.error(markup! {
 						{if is_verbose { PrintDiagnostic::verbose(&termination) } else { PrintDiagnostic::simple(&termination) }}
             		});

--- a/crates/rome_cli/src/main.rs
+++ b/crates/rome_cli/src/main.rs
@@ -33,12 +33,15 @@ fn main() -> ExitCode {
         Ok(command) => {
             let color_mode = to_color_mode(command.get_color());
             console.set_color(color_mode);
+            let is_verbose = command.is_verbose();
             let result = run_workspace(&mut console, command);
             match result {
                 Err(termination) => {
+                    dbg!(&is_verbose);
                     console.error(markup! {
-                        {PrintDiagnostic::verbose(&termination)}
-                    });
+						{if is_verbose { PrintDiagnostic::verbose(&termination) } else { PrintDiagnostic::simple(&termination) }}
+            		});
+
                     termination.report()
                 }
                 Ok(_) => ExitCode::SUCCESS,

--- a/crates/rome_cli/src/vcs.rs
+++ b/crates/rome_cli/src/vcs.rs
@@ -71,12 +71,13 @@ pub(crate) fn read_vcs_ignore_file(
             }
         }
         if !configuration.ignore_file_disabled() {
-            let buffer = file_system
+            let result = file_system
                 .auto_search(current_directory, client_kind.ignore_file(), false)
                 .map_err(WorkspaceError::from)?;
 
-            if let Some((buffer, _)) = buffer {
-                return Ok(buffer
+            if let Some(result) = result {
+                return Ok(result
+                    .content
                     .lines()
                     // remove empty lines
                     .filter(|line| !line.is_empty())

--- a/crates/rome_cli/tests/cases/config_extends.rs
+++ b/crates/rome_cli/tests/cases/config_extends.rs
@@ -1,0 +1,215 @@
+use crate::run_cli;
+use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
+use bpaf::Args;
+use rome_console::BufferConsole;
+use rome_fs::MemoryFileSystem;
+use rome_service::DynRef;
+use std::path::Path;
+
+#[test]
+fn extends_config_ok_formatter_no_linter() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let rome_json = Path::new("rome.json");
+    fs.insert(
+        rome_json.into(),
+        r#"{ "extends": ["format.json", "linter.json"] }"#,
+    );
+    let format = Path::new("format.json");
+    fs.insert(
+        format.into(),
+        r#"{ "javascript": { "formatter": { "quoteStyle": "single" } } }"#,
+    );
+    let lint = Path::new("linter.json");
+    fs.insert(lint.into(), r#"{ "linter": { "enabled": false } }"#);
+
+    let test_file = Path::new("test.js");
+    fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[("check"), test_file.as_os_str().to_str().unwrap()]),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "extends_config_ok_formatter_no_linter",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn extends_config_ok_linter_not_formatter() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let rome_json = Path::new("rome.json");
+    fs.insert(
+        rome_json.into(),
+        r#"{ "extends": ["format.json", "linter.json"] }"#,
+    );
+    let format = Path::new("format.json");
+    fs.insert(format.into(), r#"{ "formatter": { "enabled": true } }"#);
+    let lint = Path::new("linter.json");
+    fs.insert(
+        lint.into(),
+        r#"{
+  "linter": {
+    "rules": {
+      "all": false,
+      "suspicious": {
+        "noDebugger": "warn"
+      }
+    }
+  }
+}
+        "#,
+    );
+
+    let test_file = Path::new("test.js");
+    fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[("check"), test_file.as_os_str().to_str().unwrap()]),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "extends_config_ok_linter_not_formatter",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn extends_should_raise_an_error_for_unresolved_configuration() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let rome_json = Path::new("rome.json");
+    fs.insert(
+        rome_json.into(),
+        r#"{ "extends": ["formatTYPO.json", "linter.json"] }"#,
+    );
+    let format = Path::new("format.json");
+    fs.insert(
+        format.into(),
+        r#"{ "javascript": { "formatter": { "quoteStyle": "single" } } }"#,
+    );
+    let lint = Path::new("linter.json");
+    fs.insert(lint.into(), r#"{ "linter": { "enabled": false } }"#);
+
+    let test_file = Path::new("test.js");
+    fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[("check"), test_file.as_os_str().to_str().unwrap()]),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "extends_should_raise_an_error_for_unresolved_configuration",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let rome_json = Path::new("rome.json");
+    fs.insert(
+        rome_json.into(),
+        r#"{ "extends": ["formatTYPO.json", "linter.json"] }"#,
+    );
+    let format = Path::new("format.json");
+    fs.insert(
+        format.into(),
+        r#"{ "javascript": { "formatter": { "quoteStyle": "single" } } }"#,
+    );
+    let lint = Path::new("linter.json");
+    fs.insert(lint.into(), r#"{ "linter": { "enabled": false } }"#);
+
+    let test_file = Path::new("test.js");
+    fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[
+            ("check"),
+            "--verbose",
+            test_file.as_os_str().to_str().unwrap(),
+        ]),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn extends_resolves_when_using_config_path() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let rome_json = Path::new("config/rome.json");
+    fs.insert(
+        rome_json.into(),
+        r#"{ "extends": ["format.json", "linter.json"] }"#,
+    );
+    let format = Path::new("config/format.json");
+    fs.insert(
+        format.into(),
+        r#"{ "javascript": { "formatter": { "quoteStyle": "single" } } }"#,
+    );
+    let lint = Path::new("config/linter.json");
+    fs.insert(lint.into(), r#"{ "linter": { "enabled": true } }"#);
+
+    let test_file = Path::new("test.js");
+    fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[
+            ("check"),
+            "--config-path=config/",
+            test_file.as_os_str().to_str().unwrap(),
+        ]),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "extends_resolves_when_using_config_path",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/rome_cli/tests/cases/mod.rs
+++ b/crates/rome_cli/tests/cases/mod.rs
@@ -1,0 +1,4 @@
+//! Add here test cases that are not related directly to a command, but to specific
+//! case that affects many commands
+
+mod config_extends;

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -424,7 +424,7 @@ fn no_lint_if_linter_is_disabled_when_run_apply() {
         ]),
     );
 
-    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert!(result.is_ok(), "run_cli returned {result:?}");
 
     let mut buffer = String::new();
     fs.open(file_path)
@@ -432,7 +432,7 @@ fn no_lint_if_linter_is_disabled_when_run_apply() {
         .read_to_string(&mut buffer)
         .unwrap();
 
-    assert_eq!(buffer, FIX_BEFORE);
+    assert_eq!(buffer, FIX_AFTER);
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
@@ -460,7 +460,7 @@ fn no_lint_if_linter_is_disabled() {
         Args::from(&[("check"), file_path.as_os_str().to_str().unwrap()]),
     );
 
-    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert!(result.is_ok(), "run_cli returned {result:?}");
 
     let mut buffer = String::new();
     fs.open(file_path)

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -2,6 +2,7 @@ mod commands;
 mod configs;
 #[cfg(test)]
 mod snap_test;
+mod cases;
 
 #[cfg(test)]
 use snap_test::assert_cli_snapshot;

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -1,8 +1,8 @@
+mod cases;
 mod commands;
 mod configs;
 #[cfg(test)]
 mod snap_test;
-mod cases;
 
 #[cfg(test)]
 use snap_test::assert_cli_snapshot;

--- a/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_formatter_no_linter.snap
+++ b/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_formatter_no_linter.snap
@@ -2,17 +2,28 @@
 source: crates/rome_cli/tests/snap_test.rs
 expression: content
 ---
+## `rome.json`
+
+```json
+{ "extends": ["format.json", "linter.json"] }
+```
+
+## `format.json`
+
+```json
+{ "javascript": { "formatter": { "quoteStyle": "single" } } }
+```
+
+## `linter.json`
+
+```json
+{ "linter": { "enabled": false } }
+```
+
 ## `test.js`
 
 ```js
-console.log('bar');
-
-```
-
-## `test.txt`
-
-```txt
-content
+debugger; console.log("string"); 
 ```
 
 # Emitted Messages
@@ -22,9 +33,10 @@ test.js format ━━━━━━━━━━━━━━━━━━━━━�
 
   i Formatter would have printed the following content:
   
-    1   │ - console.log('bar');
-      1 │ + console.log("bar");
-    2 2 │   
+    1   │ - debugger;·console.log("string");·
+      1 │ + debugger;
+      2 │ + console.log('string');
+      3 │ + 
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_linter_not_formatter.snap
+++ b/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_linter_not_formatter.snap
@@ -1,0 +1,71 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{ "extends": ["format.json", "linter.json"] }
+```
+
+## `format.json`
+
+```json
+{ "formatter": { "enabled": true } }
+```
+
+## `linter.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "all": false,
+      "suspicious": {
+        "noDebugger": "warn"
+      }
+    }
+  }
+}
+        
+```
+
+## `test.js`
+
+```js
+debugger; console.log("string"); 
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This is an unexpected use of the debugger statement.
+  
+  > 1 │ debugger; console.log("string");·
+      │ ^^^^^^^^^
+  
+  i Suggested fix: Remove debugger statement
+  
+    1 │ debugger;·console.log("string");·
+      │ ----------                       
+
+```
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_resolves_when_using_config_path.snap
+++ b/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_resolves_when_using_config_path.snap
@@ -1,0 +1,61 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `config/format.json`
+
+```json
+{ "javascript": { "formatter": { "quoteStyle": "single" } } }
+```
+
+## `config/linter.json`
+
+```json
+{ "linter": { "enabled": true } }
+```
+
+## `config/rome.json`
+
+```json
+{ "extends": ["format.json", "linter.json"] }
+```
+
+## `test.js`
+
+```js
+debugger; console.log("string"); 
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This is an unexpected use of the debugger statement.
+  
+  > 1 │ debugger; console.log("string");·
+      │ ^^^^^^^^^
+  
+  i Suggested fix: Remove debugger statement
+  
+    1 │ debugger;·console.log("string");·
+      │ ----------                       
+
+```
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
+++ b/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{ "extends": ["formatTYPO.json", "linter.json"] }
+```
+
+## `format.json`
+
+```json
+{ "javascript": { "formatter": { "quoteStyle": "single" } } }
+```
+
+## `linter.json`
+
+```json
+{ "linter": { "enabled": false } }
+```
+
+## `test.js`
+
+```js
+debugger; console.log("string"); 
+```
+
+# Termination Message
+
+```block
+formatTYPO.json configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! path "formatTYPO.json" does not exists in memory filesystem
+  
+  Verbose advice
+  
+    i Rome tried to load the configuration file  using formatTYPO.json as base path.
+    
+
+
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
+++ b/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration.snap
@@ -31,7 +31,7 @@ debugger; console.log("string");
 ```block
 formatTYPO.json configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! path "formatTYPO.json" does not exists in memory filesystem
+  × path "formatTYPO.json" does not exists in memory filesystem
   
   Verbose advice
   

--- a/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
+++ b/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{ "extends": ["formatTYPO.json", "linter.json"] }
+```
+
+## `format.json`
+
+```json
+{ "javascript": { "formatter": { "quoteStyle": "single" } } }
+```
+
+## `linter.json`
+
+```json
+{ "linter": { "enabled": false } }
+```
+
+## `test.js`
+
+```js
+debugger; console.log("string"); 
+```
+
+# Termination Message
+
+```block
+formatTYPO.json configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! path "formatTYPO.json" does not exists in memory filesystem
+  
+  Verbose advice
+  
+    i Rome tried to load the configuration file  using formatTYPO.json as base path.
+    
+
+
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
+++ b/crates/rome_cli/tests/snapshots/main_cases_config_extends/extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose.snap
@@ -31,7 +31,7 @@ debugger; console.log("string");
 ```block
 formatTYPO.json configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! path "formatTYPO.json" does not exists in memory filesystem
+  × path "formatTYPO.json" does not exists in memory filesystem
   
   Verbose advice
   

--- a/crates/rome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/deprecated_suppression_comment.snap
@@ -30,6 +30,19 @@ file.js:1:1 suppressions/deprecatedSyntax  FIXABLE  ━━━━━━━━━�
 ```
 
 ```block
+file.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1 1 │   // rome-ignore lint(suspicious/noDoubleEquals): test
+    2   │ - a·==·b;
+      2 │ + a·==·b;
+      3 │ + 
+  
+
+```
+
+```block
 Checked 1 file(s) in <TIME>
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/downgrade_severity.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/downgrade_severity.snap
@@ -41,6 +41,18 @@ file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━�
 ```
 
 ```block
+file.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - debugger;
+      1 │ + debugger;
+      2 │ + 
+  
+
+```
+
+```block
 Checked 1 file(s) in <TIME>
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/ignore_configured_globals.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/ignore_configured_globals.snap
@@ -21,6 +21,19 @@ foo.call(); bar.call();
 # Emitted Messages
 
 ```block
+fix.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - foo.call();·bar.call();
+      1 │ + foo.call();
+      2 │ + bar.call();
+      3 │ + 
+  
+
+```
+
+```block
 Checked 1 file(s) in <TIME>
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/ignore_vcs_os_independent_parse.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/ignore_vcs_os_independent_parse.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 346
 expression: content
 ---
 ## `rome.json`
@@ -48,6 +47,18 @@ console.log('rome is cool');
 ```
 
 # Emitted Messages
+
+```block
+file1.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - blah.call();
+      1 │ + blah.call();
+      2 │ + 
+  
+
+```
 
 ```block
 Checked 1 file(s) in <TIME>

--- a/crates/rome_cli/tests/snapshots/main_commands_check/no_lint_if_files_are_listed_in_ignore_option.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/no_lint_if_files_are_listed_in_ignore_option.snap
@@ -46,7 +46,19 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Fixed 0 file(s) in <TIME>
+test2.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file test2.js was ignored
+  
+
+```
+
+```block
+Fixed 1 file(s) in <TIME>
+```
+
+```block
+Skipped 1 file(s)
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled.snap
@@ -20,21 +20,23 @@ expression: content
 
 ```
 
-# Termination Message
-
-```block
-internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × No files were processed in the specified paths.
-  
-
-
-```
-
 # Emitted Messages
 
 ```block
-Checked 0 file(s) in <TIME>
+fix.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - 
+    2   │ - (1·>=·-0)
+      1 │ + 1·>=·-0;
+    3 2 │   
+  
+
+```
+
+```block
+Checked 1 file(s) in <TIME>
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled_when_run_apply.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/no_lint_if_linter_is_disabled_when_run_apply.snap
@@ -15,26 +15,14 @@ expression: content
 ## `fix.js`
 
 ```js
-
-(1 >= -0)
-
-```
-
-# Termination Message
-
-```block
-internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × No files were processed in the specified paths.
-  
-
+1 >= 0;
 
 ```
 
 # Emitted Messages
 
 ```block
-Fixed 0 file(s) in <TIME>
+Fixed 1 file(s) in <TIME>
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/no_lint_when_file_is_ignored.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/no_lint_when_file_is_ignored.snap
@@ -35,7 +35,19 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Fixed 0 file(s) in <TIME>
+test.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file test.js was ignored
+  
+
+```
+
+```block
+Fixed 1 file(s) in <TIME>
+```
+
+```block
+Skipped 1 file(s)
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/should_apply_correct_file_source.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/should_apply_correct_file_source.snap
@@ -26,6 +26,19 @@ type A = { a: string }; type B = Partial<A>
 # Emitted Messages
 
 ```block
+file.ts format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - type·A·=·{·a:·string·};·type·B·=·Partial<A>
+      1 │ + type·A·=·{·a:·string·};
+      2 │ + type·B·=·Partial<A>;
+      3 │ + 
+  
+
+```
+
+```block
 Checked 1 file(s) in <TIME>
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/should_not_enable_all_recommended_rules.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/should_not_enable_all_recommended_rules.snap
@@ -42,6 +42,30 @@ expression: content
 # Emitted Messages
 
 ```block
+fix.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - 
+    2   │ - ····→ → LOOP:·for·(const·x·of·xs)·{
+    3   │ - ····→ → ····if·(x·>·0)·{
+    4   │ - ····→ → ········break;
+    5   │ - ····→ → ····}
+    6   │ - ····→ → ····f(x);
+    7   │ - ····→ → }
+    8   │ - → → 
+      1 │ + LOOP:·for·(const·x·of·xs)·{
+      2 │ + → if·(x·>·0)·{
+      3 │ + → → break;
+      4 │ + → }
+      5 │ + → f(x);
+      6 │ + }
+      7 │ + 
+  
+
+```
+
+```block
 Checked 1 file(s) in <TIME>
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/should_not_enable_nursery_rules.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/should_not_enable_nursery_rules.snap
@@ -37,6 +37,16 @@ if (true) {
 # Emitted Messages
 
 ```block
+fix.ts format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    7 │ → → 
+      │ ----
+
+```
+
+```block
 Checked 1 file(s) in <TIME>
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
@@ -131,6 +131,26 @@ fix.js:4:12 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━�
 ```
 
 ```block
+fix.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - 
+    2   │ - ····function·f()·{arguments;}
+    3   │ - ····const·FOO·=·"FOO";
+    4   │ - ····var·x,·y;
+    5   │ - ····
+      1 │ + function·f()·{
+      2 │ + → arguments;
+      3 │ + }
+      4 │ + const·FOO·=·"FOO";
+      5 │ + var·x,·y;
+      6 │ + 
+  
+
+```
+
+```block
 Checked 1 file(s) in <TIME>
 ```
 

--- a/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -10,7 +10,7 @@ Run the formatter on a set of files.
 Usage: [--write] [<PATH>]...
 
 Available positional items:
-    <PATH>  Single file, single path or list of paths
+    <PATH>  Single file, single path or list of paths.
 
 Available options:
   Options applied to the formatter
@@ -44,7 +44,7 @@ Available options:
                        that doesn't know
 
         --stdin-file-path <PATH>  A file name with its extension to pass when reading from standard
-                       in, e.g. echo 'let a;' | rome format --stdin-file-path=file.js"
+                       in, e.g. echo 'let a;' | rome format --stdin-file-path=file.js".
   Global options applied to all commands
         --colors <off|force>  Set the formatting mode for markup: "off" prints everything as plain
                        text, "force" forces the formatting of markup using ANSI even if the console
@@ -58,7 +58,7 @@ Available options:
                        diagnostic.
         --json         Reports information using the JSON format
 
-        --write
+        --write        Writes formatted files to file system.
     -h, --help         Prints help information
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_format/invalid_config_file_path.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/invalid_config_file_path.snap
@@ -15,6 +15,8 @@ test/rome.json internalError/fs ━━━━━━━━━━━━━━━━
 
   × Rome couldn't read the file
   
+  × Rome couldn't read the following file, maybe for permissions reasons or it doesn't exists: test/rome.json
+  
 
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_configuration/incorrect_globals.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/incorrect_globals.snap
@@ -35,7 +35,7 @@ Found errors in the configuration file, Rome will use its defaults for the secti
 ```block
 rome.json:6:17 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Incorrect type, expected a string.
+  × Incorrect type, expected a string.
   
     4 │   },
     5 │   "javascript": {

--- a/crates/rome_cli/tests/snapshots/main_configuration/incorrect_globals.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/incorrect_globals.snap
@@ -18,19 +18,15 @@ expression: content
 # Termination Message
 
 ```block
-internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × No files were processed in the specified paths.
+  × Rome exited because the configuration resulted in errors. Please fix them.
   
 
 
 ```
 
 # Emitted Messages
-
-```block
-Found errors in the configuration file, Rome will use its defaults for the sections that are incorrect.
-```
 
 ```block
 rome.json:6:17 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -45,10 +41,6 @@ rome.json:6:17 deserialize ━━━━━━━━━━━━━━━━━�
     8 │ }
   
 
-```
-
-```block
-Checked 0 file(s) in <TIME>
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
@@ -23,19 +23,15 @@ expression: content
 # Termination Message
 
 ```block
-internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × No files were processed in the specified paths.
+  × Rome exited because the configuration resulted in errors. Please fix them.
   
 
 
 ```
 
 # Emitted Messages
-
-```block
-Found errors in the configuration file, Rome will use its defaults for the sections that are incorrect.
-```
 
 ```block
 rome.json:6:13 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -80,10 +76,6 @@ rome.json:6:13 deserialize ━━━━━━━━━━━━━━━━━�
   - useYield
   
 
-```
-
-```block
-Checked 0 file(s) in <TIME>
 ```
 
 

--- a/crates/rome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/incorrect_rule_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_cli/tests/snap_test.rs
-assertion_line: 346
 expression: content
 ---
 ## `rome.json`
@@ -41,7 +40,7 @@ Found errors in the configuration file, Rome will use its defaults for the secti
 ```block
 rome.json:6:13 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Found an unknown key `foo_rule`.
+  × Found an unknown key `foo_rule`.
   
     4 │     "rules": {
     5 │         "correctness": {

--- a/crates/rome_cli/tests/snapshots/main_configuration/line_width_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_configuration/line_width_error.snap
@@ -15,9 +15,9 @@ expression: content
 # Termination Message
 
 ```block
-internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × No files were processed in the specified paths.
+  × Rome exited because the configuration resulted in errors. Please fix them.
   
 
 
@@ -26,13 +26,9 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-Found errors in the configuration file, Rome will use its defaults for the sections that are incorrect.
-```
-
-```block
 rome.json:3:18 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The line width exceeds the maximum value (320)
+  × The line width exceeds the maximum value (320)
   
   
     1 │ {
@@ -45,10 +41,6 @@ rome.json:3:18 deserialize ━━━━━━━━━━━━━━━━━�
   i Maximum value accepted is 320
   
 
-```
-
-```block
-Compared 0 file(s) in <TIME>
 ```
 
 

--- a/crates/rome_deserialize/src/lib.rs
+++ b/crates/rome_deserialize/src/lib.rs
@@ -3,7 +3,7 @@ mod visitor;
 
 pub mod json;
 pub use diagnostics::{DeserializationAdvice, DeserializationDiagnostic};
-use rome_diagnostics::{DiagnosticExt, Error};
+use rome_diagnostics::Error;
 pub use visitor::VisitNode;
 
 /// A small type to interrogate the result of a JSON deserialization
@@ -43,18 +43,5 @@ impl<P> Deserialized<P> {
     /// Consume itself to return the parsed result and its diagnostics
     pub fn consume(self) -> (P, Vec<Error>) {
         (self.deserialized, self.diagnostics)
-    }
-
-    /// It inject the file path to the current diagnostics
-    pub fn with_file_path(self, path: &str) -> Self {
-        let (deserialized, diagnostics) = self.consume();
-
-        Deserialized {
-            deserialized,
-            diagnostics: diagnostics
-                .into_iter()
-                .map(|diagnostic| diagnostic.with_file_path(path))
-                .collect(),
-        }
     }
 }

--- a/crates/rome_fs/src/lib.rs
+++ b/crates/rome_fs/src/lib.rs
@@ -3,8 +3,8 @@ mod interner;
 mod path;
 
 pub use fs::{
-    ErrorEntry, File, FileSystem, FileSystemDiagnostic, FileSystemExt, MemoryFileSystem,
-    OpenOptions, OsFileSystem, TraversalContext, TraversalScope, CONFIG_NAME,
+    AutoSearchResult, ErrorEntry, File, FileSystem, FileSystemDiagnostic, FileSystemExt,
+    MemoryFileSystem, OpenOptions, OsFileSystem, TraversalContext, TraversalScope, CONFIG_NAME,
 };
 pub use interner::PathInterner;
 pub use path::RomePath;

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -395,8 +395,8 @@ impl Session {
         };
 
         let status = match load_config(&self.fs, base_path) {
-            Ok(Some((deserialized, _))) => {
-                let (configuration, diagnostics) = deserialized.consume();
+            Ok(Some(payload)) => {
+                let (configuration, diagnostics) = payload.deserialized.consume();
                 if !diagnostics.is_empty() {
                     warn!("The deserialization of the configuration resulted in errors. Rome will use its defaults where possible.");
                 }

--- a/crates/rome_service/src/configuration/diagnostics.rs
+++ b/crates/rome_service/src/configuration/diagnostics.rs
@@ -25,6 +25,9 @@ pub enum ConfigurationDiagnostic {
     /// - incorrect values
     Deserialization(DeserializationDiagnostic),
 
+    /// When something is wrong with the configuration
+    InvalidConfiguration(InvalidConfiguration),
+
     /// Thrown when the pattern inside the `ignore` field errors
     InvalidIgnorePattern(InvalidIgnorePattern),
 
@@ -64,8 +67,14 @@ impl ConfigurationDiagnostic {
         })
     }
 
-    pub(crate) fn new_already_exists() -> Self {
+    pub fn new_already_exists() -> Self {
         Self::ConfigAlreadyExists(ConfigAlreadyExists {})
+    }
+
+    pub fn invalid_configuration(message: impl Display) -> Self {
+        Self::InvalidConfiguration(InvalidConfiguration {
+            message: MessageAndDescription::from(markup! {{message}}.to_owned()),
+        })
     }
 }
 
@@ -89,6 +98,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::Deserialization(error) => error.severity(),
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.severity(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.severity(),
+            ConfigurationDiagnostic::InvalidConfiguration(error) => error.severity(),
         }
     }
 
@@ -99,6 +109,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::Deserialization(error) => error.category(),
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.category(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.category(),
+            ConfigurationDiagnostic::InvalidConfiguration(error) => error.category(),
         }
     }
 
@@ -109,6 +120,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::Deserialization(error) => error.tags(),
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.tags(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.tags(),
+            ConfigurationDiagnostic::InvalidConfiguration(error) => error.tags(),
         }
     }
 
@@ -119,6 +131,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::Deserialization(error) => error.location(),
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.location(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.location(),
+            ConfigurationDiagnostic::InvalidConfiguration(error) => error.location(),
         }
     }
 
@@ -129,6 +142,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::Deserialization(error) => error.source(),
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.source(),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.source(),
+            ConfigurationDiagnostic::InvalidConfiguration(error) => error.source(),
         }
     }
 
@@ -139,6 +153,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::Deserialization(error) => error.message(fmt),
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.message(fmt),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.message(fmt),
+            ConfigurationDiagnostic::InvalidConfiguration(error) => error.message(fmt),
         }
     }
 
@@ -149,6 +164,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::Deserialization(error) => error.description(fmt),
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.description(fmt),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.description(fmt),
+            ConfigurationDiagnostic::InvalidConfiguration(error) => error.description(fmt),
         }
     }
 
@@ -159,6 +175,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::Deserialization(error) => error.advices(visitor),
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.advices(visitor),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.advices(visitor),
+            ConfigurationDiagnostic::InvalidConfiguration(error) => error.advices(visitor),
         }
     }
 
@@ -169,6 +186,7 @@ impl Diagnostic for ConfigurationDiagnostic {
             ConfigurationDiagnostic::Deserialization(error) => error.verbose_advices(visitor),
             ConfigurationDiagnostic::InvalidIgnorePattern(error) => error.verbose_advices(visitor),
             ConfigurationDiagnostic::CantLoadExtendFile(error) => error.verbose_advices(visitor),
+            ConfigurationDiagnostic::InvalidConfiguration(error) => error.verbose_advices(visitor),
         }
     }
 }
@@ -218,7 +236,7 @@ pub struct InvalidIgnorePattern {
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]
 #[diagnostic(
 	category = "configuration",
-	severity = Warning,
+	severity = Error,
 )]
 pub struct CantLoadExtendFile {
     #[location(resource)]
@@ -252,6 +270,17 @@ impl From<CantLoadExtendFile> for WorkspaceError {
     fn from(value: CantLoadExtendFile) -> Self {
         WorkspaceError::Configuration(ConfigurationDiagnostic::CantLoadExtendFile(value))
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+#[diagnostic(
+	category = "configuration",
+	severity = Error,
+)]
+pub struct InvalidConfiguration {
+    #[message]
+    #[description]
+    message: MessageAndDescription,
 }
 
 #[cfg(test)]

--- a/crates/rome_service/src/configuration/diagnostics.rs
+++ b/crates/rome_service/src/configuration/diagnostics.rs
@@ -274,7 +274,7 @@ mod test {
 
     #[test]
     fn diagnostic_size() {
-        assert_eq!(std::mem::size_of::<ConfigurationDiagnostic>(), 88);
+        assert_eq!(std::mem::size_of::<ConfigurationDiagnostic>(), 104);
     }
 
     #[test]

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -333,7 +333,6 @@ pub fn load_config(
             None => PathBuf::new(),
         },
     };
-    let configuration_file_path = configuration_directory.join(config_name);
     let should_error = base_path.is_from_user();
 
     let result = file_system.auto_search(configuration_directory, config_name, should_error)?;
@@ -344,8 +343,7 @@ pub fn load_config(
             directory_path,
             file_path,
         } = auto_search_result;
-        let deserialized = deserialize_from_json_str::<Configuration>(&content)
-            .with_file_path(&configuration_file_path.display().to_string());
+        let deserialized = deserialize_from_json_str::<Configuration>(&content);
         Ok(Some(ConfigurationPayload {
             deserialized,
             configuration_file_path: file_path,

--- a/crates/rome_service/src/configuration/parse/json/configuration.rs
+++ b/crates/rome_service/src/configuration/parse/json/configuration.rs
@@ -3,6 +3,7 @@ use crate::configuration::parse::json::vcs::validate_vcs_configuration;
 use crate::configuration::vcs::VcsConfiguration;
 use crate::configuration::{
     FilesConfiguration, FormatterConfiguration, JavascriptConfiguration, LinterConfiguration,
+    StringSet,
 };
 use crate::Configuration;
 use rome_deserialize::json::{has_only_known_keys, VisitJsonNode};
@@ -63,6 +64,11 @@ impl VisitNode<JsonLanguage> for Configuration {
                 let mut organize_imports = OrganizeImports::default();
                 self.map_to_object(&value, name_text, &mut organize_imports, diagnostics)?;
                 self.organize_imports = Some(organize_imports);
+            }
+            "extends" => {
+                self.extends = self
+                    .map_to_index_set_string(&value, name_text, diagnostics)
+                    .map(StringSet::new);
             }
             _ => {}
         }

--- a/crates/rome_service/src/diagnostics.rs
+++ b/crates/rome_service/src/diagnostics.rs
@@ -2,7 +2,7 @@ use crate::file_handlers::Language;
 use crate::ConfigurationDiagnostic;
 use rome_console::fmt::Bytes;
 use rome_console::markup;
-use rome_diagnostics::{category, Category, Diagnostic, DiagnosticTags, Location, Severity};
+use rome_diagnostics::{category, Category, Diagnostic, DiagnosticTags, Location, Severity, Visit};
 use rome_formatter::{FormatError, PrintError};
 use rome_fs::FileSystemDiagnostic;
 use rome_js_analyze::utils::rename::RenameError;
@@ -256,6 +256,47 @@ impl Diagnostic for WorkspaceError {
             WorkspaceError::FileIgnored(error) => Diagnostic::source(error),
             WorkspaceError::FileTooLarge(error) => Diagnostic::source(error),
             WorkspaceError::FileSystem(error) => Diagnostic::source(error),
+        }
+    }
+
+    fn advices(&self, visitor: &mut dyn Visit) -> std::io::Result<()> {
+        match self {
+            WorkspaceError::FormatError(err) => err.advices(visitor),
+            WorkspaceError::PrintError(err) => err.advices(visitor),
+            WorkspaceError::RuleError(error) => error.advices(visitor),
+            WorkspaceError::Configuration(error) => error.advices(visitor),
+            WorkspaceError::RenameError(error) => error.advices(visitor),
+            WorkspaceError::TransportError(error) => error.advices(visitor),
+            WorkspaceError::ReportNotSerializable(error) => error.advices(visitor),
+            WorkspaceError::DirtyWorkspace(error) => error.advices(visitor),
+            WorkspaceError::NotFound(error) => error.advices(visitor),
+            WorkspaceError::SourceFileNotSupported(error) => error.advices(visitor),
+            WorkspaceError::FormatWithErrorsDisabled(error) => error.advices(visitor),
+            WorkspaceError::CantReadDirectory(error) => error.advices(visitor),
+            WorkspaceError::CantReadFile(error) => error.advices(visitor),
+            WorkspaceError::FileIgnored(error) => error.advices(visitor),
+            WorkspaceError::FileTooLarge(error) => error.advices(visitor),
+            WorkspaceError::FileSystem(error) => error.advices(visitor),
+        }
+    }
+    fn verbose_advices(&self, visitor: &mut dyn Visit) -> std::io::Result<()> {
+        match self {
+            WorkspaceError::FormatError(err) => err.verbose_advices(visitor),
+            WorkspaceError::PrintError(err) => err.verbose_advices(visitor),
+            WorkspaceError::RuleError(error) => error.verbose_advices(visitor),
+            WorkspaceError::Configuration(error) => error.verbose_advices(visitor),
+            WorkspaceError::RenameError(error) => error.verbose_advices(visitor),
+            WorkspaceError::TransportError(error) => error.verbose_advices(visitor),
+            WorkspaceError::ReportNotSerializable(error) => error.verbose_advices(visitor),
+            WorkspaceError::DirtyWorkspace(error) => error.verbose_advices(visitor),
+            WorkspaceError::NotFound(error) => error.verbose_advices(visitor),
+            WorkspaceError::SourceFileNotSupported(error) => error.verbose_advices(visitor),
+            WorkspaceError::FormatWithErrorsDisabled(error) => error.verbose_advices(visitor),
+            WorkspaceError::CantReadDirectory(error) => error.verbose_advices(visitor),
+            WorkspaceError::CantReadFile(error) => error.verbose_advices(visitor),
+            WorkspaceError::FileIgnored(error) => error.verbose_advices(visitor),
+            WorkspaceError::FileTooLarge(error) => error.verbose_advices(visitor),
+            WorkspaceError::FileSystem(error) => error.verbose_advices(visitor),
         }
     }
 }

--- a/crates/rome_service/src/diagnostics.rs
+++ b/crates/rome_service/src/diagnostics.rs
@@ -547,7 +547,7 @@ mod test {
 
     #[test]
     fn diagnostic_size() {
-        assert_eq!(std::mem::size_of::<WorkspaceError>(), 88)
+        assert_eq!(std::mem::size_of::<WorkspaceError>(), 104)
     }
 
     #[test]

--- a/crates/rome_service/tests/invalid/top_level_extraneous_field.json.snap
+++ b/crates/rome_service/tests/invalid/top_level_extraneous_field.json.snap
@@ -21,6 +21,7 @@ top_level_extraneous_field.json:2:2 deserialize ━━━━━━━━━━�
   - javascript
   - $schema
   - organizeImports
+  - extends
   
 
 

--- a/crates/rome_service/tests/invalid/wrong_extends_incorrect_items.json
+++ b/crates/rome_service/tests/invalid/wrong_extends_incorrect_items.json
@@ -1,0 +1,3 @@
+{
+	"extends": ["something.json", 3, false, null]
+}

--- a/crates/rome_service/tests/invalid/wrong_extends_incorrect_items.json.snap
+++ b/crates/rome_service/tests/invalid/wrong_extends_incorrect_items.json.snap
@@ -1,0 +1,42 @@
+---
+source: crates/rome_service/tests/spec_tests.rs
+expression: wrong_extends_incorrect_items.json
+---
+wrong_extends_incorrect_items.json:2:32 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Incorrect type, expected a string.
+  
+    1 │ {
+  > 2 │ 	"extends": ["something.json", 3, false, null]
+      │ 	                              ^
+    3 │ }
+    4 │ 
+  
+
+
+
+wrong_extends_incorrect_items.json:2:35 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Incorrect type, expected a string.
+  
+    1 │ {
+  > 2 │ 	"extends": ["something.json", 3, false, null]
+      │ 	                                 ^^^^^
+    3 │ }
+    4 │ 
+  
+
+
+
+wrong_extends_incorrect_items.json:2:42 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Incorrect type, expected a string.
+  
+    1 │ {
+  > 2 │ 	"extends": ["something.json", 3, false, null]
+      │ 	                                        ^^^^
+    3 │ }
+    4 │ 
+  
+
+

--- a/crates/rome_service/tests/invalid/wrong_extends_type.json
+++ b/crates/rome_service/tests/invalid/wrong_extends_type.json
@@ -1,0 +1,3 @@
+{
+	"extends": "something"
+}

--- a/crates/rome_service/tests/invalid/wrong_extends_type.json.snap
+++ b/crates/rome_service/tests/invalid/wrong_extends_type.json.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rome_service/tests/spec_tests.rs
+expression: wrong_extends_type.json
+---
+wrong_extends_type.json:2:13 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The value of key extends is incorrect. Expected a array.
+  
+    1 │ {
+  > 2 │ 	"extends": "something"
+      │ 	           ^^^^^^^^^^^
+    3 │ }
+    4 │ 
+  
+
+

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -8,6 +8,10 @@
 			"description": "A field for the [JSON schema](https://json-schema.org/) specification",
 			"type": ["string", "null"]
 		},
+		"extends": {
+			"description": "A list of paths to other JSON files, used to extends the current configuration.",
+			"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+		},
 		"files": {
 			"description": "The configuration of the filesystem",
 			"anyOf": [

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -28,6 +28,10 @@ export interface Configuration {
 	 */
 	$schema?: string;
 	/**
+	 * A list of paths to other JSON files, used to extends the current configuration.
+	 */
+	extends?: StringSet;
+	/**
 	 * The configuration of the filesystem
 	 */
 	files?: FilesConfiguration;
@@ -52,6 +56,7 @@ export interface Configuration {
 	 */
 	vcs?: VcsConfiguration;
 }
+export type StringSet = string[];
 /**
  * The configuration of the filesystem
  */
@@ -153,7 +158,6 @@ If Rome can't find the configuration, it will attempt to use the current working
 	 */
 	useIgnoreFile?: boolean;
 }
-export type StringSet = string[];
 export type PlainIndentStyle = "tab" | "space";
 /**
 	* Validated value for the `line_width` formatter options

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -8,6 +8,10 @@
 			"description": "A field for the [JSON schema](https://json-schema.org/) specification",
 			"type": ["string", "null"]
 		},
+		"extends": {
+			"description": "A list of paths to other JSON files, used to extends the current configuration.",
+			"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+		},
 		"files": {
 			"description": "The configuration of the filesystem",
 			"anyOf": [


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/4038

This PR introduces breaking changes, mainly how the CLI handles broken configurations.

Before, a broken configuration would have resulted in warnings and Rome applying its defaults for the broken sections. I realised that while this is "cool", this isn't ideal for users because this would result in the following:
- false positives while running the linter
- incorrect formatting, with a configuration that isn't the one of the users

That's a breaking change.

Plus, now the `rome check` command shows diagnostics that belong to the formatter too.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added some test cases

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
