### PR TITLE
fix typo in diagnostic message

### DIFF
--- a/crates/rome_cli/src/diagnostics.rs
+++ b/crates/rome_cli/src/diagnostics.rs
@@ -199,7 +199,7 @@ impl std::fmt::Display for CheckActionKind {
 #[diagnostic(
     category = "internalError/io",
     severity = Error,
-    message = "Fixes applied to the file, but there a still diagnostics to address."
+    message = "Fixes applied to the file, but there are still diagnostics to address."
 )]
 pub struct FileCheckApply {
     #[location(resource)]

--- a/crates/rome_cli/tests/snapshots/main_commands_check/apply_unsafe_with_error.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/apply_unsafe_with_error.snap
@@ -40,7 +40,7 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 ```block
 test1.js internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Fixes applied to the file, but there a still diagnostics to address.
+  × Fixes applied to the file, but there are still diagnostics to address.
   
 
 ```
@@ -48,7 +48,7 @@ test1.js internalError/io ━━━━━━━━━━━━━━━━━━
 ```block
 test2.js internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Fixes applied to the file, but there a still diagnostics to address.
+  × Fixes applied to the file, but there are still diagnostics to address.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check.snap
@@ -46,7 +46,7 @@ check.js organizeImports ━━━━━━━━━━━━━━━━━━�
 ```block
 check.js internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Fixes applied to the file, but there a still diagnostics to address.
+  × Fixes applied to the file, but there are still diagnostics to address.
   
 
 ```

--- a/crates/rome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check_apply.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check_apply.snap
@@ -46,7 +46,7 @@ check.js organizeImports ━━━━━━━━━━━━━━━━━━�
 ```block
 check.js internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Fixes applied to the file, but there a still diagnostics to address.
+  × Fixes applied to the file, but there are still diagnostics to address.
   
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Addresses this issue:

* https://github.com/rome/tools/issues/4579


> There seems to be a typo on [this line](https://github.com/rome/tools/blob/e3d8c8b5a89ea532d95870221c52250f356f7d2e/crates/rome_cli/src/diagnostics.rs#LL202C9-L202C9).
> 
> ```
>   × Fixes applied to the file, but there a still diagnostics to address.
> ```
> 
> It seems to be wanting to say "there **_are_** still diagnostics to address".

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->



## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [-] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [-] The PR requires documentation
- [-] I will create a new PR to update the documentation
