### PR TITLE
fix(rome_js_analyze):  noRedundantUseStrict check only 'use strict' directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,9 @@ parameter decorators:
 
 - [noRedundantUseStrict](https://docs.rome.tools/lint/rules/noredundantusestrict/) check only `'use strict'` directive to resolve false positive diagnostics.
 
+  React introduce new directives, "use client" and "use server".
+  The rule raises false positive errors about these directives.
+
 ### Parser
 
 ### VSCode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,8 @@ parameter decorators:
   }
   ```
 
+- [noRedundantUseStrict](https://docs.rome.tools/lint/rules/noredundantusestrict/) check only `'use strict'` directive to resolve false positive diagnostics.
+
 ### Parser
 
 ### VSCode

--- a/crates/rome_js_analyze/src/analyzers/suspicious/no_redundant_use_strict.rs
+++ b/crates/rome_js_analyze/src/analyzers/suspicious/no_redundant_use_strict.rs
@@ -91,6 +91,9 @@ impl Rule for NoRedundantUseStrict {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
+        if node.inner_string_text().ok()? != "use strict" {
+            return None;
+        }
         let mut outer_most: Option<AnyJsStrictModeNode> = None;
         let root = ctx.root();
         match root {

--- a/crates/rome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/validReactDirectives.tsx
+++ b/crates/rome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/validReactDirectives.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useState } from "react"
+
+export default function Counter() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div>
+      <p>You clicked {count} times</p>
+      <button type="button" onClick={() => setCount(count + 1)}>Click me</button>
+    </div>
+  )
+}

--- a/crates/rome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/validReactDirectives.tsx.snap
+++ b/crates/rome_js_analyze/tests/specs/suspicious/noRedundantUseStrict/validReactDirectives.tsx.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: validReactDirectives.tsx
+---
+# Input
+```js
+'use client'
+
+import { useState } from "react"
+
+export default function Counter() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div>
+      <p>You clicked {count} times</p>
+      <button type="button" onClick={() => setCount(count + 1)}>Click me</button>
+    </div>
+  )
+}
+
+```
+
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

React introduce new directives "use client" and "use server".
noRedundantUseStrict rule raise false positive error about these directives, so I fixed it.

see: [playground](https://docs.rome.tools/playground/?lineWidth=120&indentStyle=space&semicolons=as-needed&lintRules=all&code=JwB1AHMAZQAgAGMAbABpAGUAbgB0ACcACgAgAAoAaQBtAHAAbwByAHQAIAB7ACAAdQBzAGUAUwB0AGEAdABlACAAfQAgAGYAcgBvAG0AIAAnAHIAZQBhAGMAdAAnAAoAIAAKAGUAeABwAG8AcgB0ACAAZABlAGYAYQB1AGwAdAAgAGYAdQBuAGMAdABpAG8AbgAgAEMAbwB1AG4AdABlAHIAKAApACAAewAKACAAIABjAG8AbgBzAHQAIABbAGMAbwB1AG4AdAAsACAAcwBlAHQAQwBvAHUAbgB0AF0AIAA9ACAAdQBzAGUAUwB0AGEAdABlACgAMAApAAoAIAAKACAAIAByAGUAdAB1AHIAbgAgACgACgAgACAAIAAgADwAZABpAHYAPgAKACAAIAAgACAAIAAgADwAcAA%2BAFkAbwB1ACAAYwBsAGkAYwBrAGUAZAAgAHsAYwBvAHUAbgB0AH0AIAB0AGkAbQBlAHMAPAAvAHAAPgAKACAAIAAgACAAIAAgADwAYgB1AHQAdABvAG4AIAB0AHkAcABlAD0AIgBiAHUAdAB0AG8AbgAiACAAbwBuAEMAbABpAGMAawA9AHsAKAApACAAPQA%2BACAAcwBlAHQAQwBvAHUAbgB0ACgAYwBvAHUAbgB0ACAAKwAgADEAKQB9AD4AQwBsAGkAYwBrACAAbQBlADwALwBiAHUAdAB0AG8AbgA%2BAAoAIAAgACAAIAA8AC8AZABpAHYAPgAKACAAIAApAAoAfQA%3D)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added some snaphot tests.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
