### PR TITLE
feat(rome_service): add support for JSON linter in the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ multiple files:
 
 ### Editors
 
+#### Other changes
+
+- The Rome LSP is now able to show diagnostics that belong to JSON lint rules.
+
 ### Formatter
 
 - Added a new option called `--jsx-quote-style` to the formatter. This option allows you to choose between single and double quotes for JSX attributes. [#4486](https://github.com/rome/tools/issues/4486)
@@ -95,6 +99,8 @@ multiple files:
 
   This rule proposes turning function expressions into arrow functions.
   Function expressions that use `this` are ignored.
+
+- [`noDuplicateJsonKeys`](https://docs.rome.tools/lint/rules/noDuplicateJsonKeys/)
 
 #### Other changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,6 +2169,7 @@ dependencies = [
  "rome_js_parser",
  "rome_js_semantic",
  "rome_js_syntax",
+ "rome_json_analyze",
  "rome_json_formatter",
  "rome_json_parser",
  "rome_json_syntax",
@@ -2867,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3115bddce1b5f52dd4b5e0ec8298a66ce733e4cc6759247dc2d1c11508ec38"
+checksum = "501dbdbb99861e4ab6b60eb6a7493956a9defb644fd034bc4a5ef27c693c8a3a"
 dependencies = [
  "basic-toml",
  "glob",

--- a/crates/rome_cli/tests/commands/check.rs
+++ b/crates/rome_cli/tests/commands/check.rs
@@ -2398,3 +2398,46 @@ fn ignores_unknown_file() {
         result,
     ));
 }
+
+#[test]
+fn check_json_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path1 = Path::new("test.json");
+    fs.insert(
+        file_path1.into(),
+        r#"{ "foo": true, "foo": true }"#.as_bytes(),
+    );
+
+    let configuration = Path::new("rome.json");
+    fs.insert(
+        configuration.into(),
+        r#"{
+	"linter": {
+		"rules": {
+			"nursery": {
+				"noDuplicateJsonKeys": "error"
+			}
+		}
+	}
+	 }"#
+        .as_bytes(),
+    );
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(&[("check"), file_path1.as_os_str().to_str().unwrap()]),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "check_json_files",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/rome_cli/tests/snapshots/main_commands_check/check_json_files.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/check_json_files.snap
@@ -1,0 +1,60 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `rome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noDuplicateJsonKeys": "error"
+      }
+    }
+  }
+}
+```
+
+## `test.json`
+
+```json
+{ "foo": true, "foo": true }
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test.json:1:3 lint/nursery/noDuplicateJsonKeys ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The key foo was already declared.
+  
+  > 1 │ { "foo": true, "foo": true }
+      │   ^^^^^
+  
+  i This where a duplicated key was declared again.
+  
+  > 1 │ { "foo": true, "foo": true }
+      │                ^^^^^
+  
+  i If a key is defined multiple times, only the last definition takes effect. Previous definitions are ignored.
+  
+
+```
+
+```block
+Checked 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_deserialize/src/json.rs
+++ b/crates/rome_deserialize/src/json.rs
@@ -15,7 +15,7 @@ pub trait JsonDeserialize: Sized {
     /// It accepts a JSON AST and a visitor. The visitor is the [default](Default) implementation of the data
     /// type that implements this trait.
     fn deserialize_from_ast(
-        root: JsonRoot,
+        root: &JsonRoot,
         visitor: &mut impl VisitJsonNode,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()>;
@@ -23,7 +23,7 @@ pub trait JsonDeserialize: Sized {
 
 impl JsonDeserialize for () {
     fn deserialize_from_ast(
-        _root: JsonRoot,
+        _root: &JsonRoot,
         _visitor: &mut impl VisitJsonNode,
         _diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {
@@ -526,14 +526,14 @@ pub fn with_only_known_variants(
 ///         use rome_deserialize::Deserialized;
 ///         let mut output = Self::default();
 ///         let mut diagnostics = vec![];
-///         NewConfiguration::deserialize_from_ast(root, &mut output, &mut diagnostics);
+///         NewConfiguration::deserialize_from_ast(&root, &mut output, &mut diagnostics);
 ///         Deserialized::new(output, diagnostics)
 ///     }
 /// }
 ///
 ///
 /// impl JsonDeserialize for NewConfiguration {
-///     fn deserialize_from_ast(root: JsonRoot, visitor: &mut impl VisitJsonNode, diagnostics: &mut Vec<DeserializationDiagnostic>) -> Option<()> {
+///     fn deserialize_from_ast(root: &JsonRoot, visitor: &mut impl VisitJsonNode, diagnostics: &mut Vec<DeserializationDiagnostic>) -> Option<()> {
 ///         let object = root.value().ok()?;
 ///         let object = object.as_json_object_value()?;
 ///         for member in object.json_member_list() {
@@ -561,7 +561,7 @@ where
     let mut output = Output::default();
     let mut diagnostics = vec![];
     let parse = parse_json(source);
-    Output::deserialize_from_ast(parse.tree(), &mut output, &mut diagnostics);
+    Output::deserialize_from_ast(&parse.tree(), &mut output, &mut diagnostics);
     let mut errors = parse
         .into_diagnostics()
         .into_iter()
@@ -580,7 +580,7 @@ where
 }
 
 /// Attempts to deserialize a JSON AST, given the `Output`.
-pub fn deserialize_from_json_ast<Output>(parse: JsonRoot) -> Deserialized<Output>
+pub fn deserialize_from_json_ast<Output>(parse: &JsonRoot) -> Deserialized<Output>
 where
     Output: Default + VisitJsonNode + JsonDeserialize,
 {

--- a/crates/rome_diagnostics/Cargo.toml
+++ b/crates/rome_diagnostics/Cargo.toml
@@ -45,4 +45,4 @@ schema = ["schemars", "rome_text_edit/schemars", "rome_diagnostics_categories/sc
 
 [dev-dependencies]
 serde_json = "1.0.74"
-trybuild   = "1.0"
+trybuild   = "1.0.80"

--- a/crates/rome_service/Cargo.toml
+++ b/crates/rome_service/Cargo.toml
@@ -25,6 +25,7 @@ rome_js_formatter   = { workspace = true, features = ["serde"] }
 rome_js_parser      = { workspace = true }
 rome_js_semantic    = { workspace = true }
 rome_js_syntax      = { workspace = true, features = ["serde"] }
+rome_json_analyze   = { workspace = true }
 rome_json_formatter = { workspace = true }
 rome_json_parser    = { workspace = true }
 rome_json_syntax    = { workspace = true }

--- a/crates/rome_service/src/configuration/parse/json.rs
+++ b/crates/rome_service/src/configuration/parse/json.rs
@@ -18,7 +18,7 @@ use rome_rowan::AstNode;
 
 impl JsonDeserialize for Configuration {
     fn deserialize_from_ast(
-        root: JsonRoot,
+        root: &JsonRoot,
         visitor: &mut impl VisitJsonNode,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<()> {

--- a/justfile
+++ b/justfile
@@ -94,7 +94,8 @@ ready:
   git diff --exit-code --quiet
   just codegen
   just documentation
+  just format
   cargo lint
-  cargo fmt
-  cargo test
+  just t
+  cargo test --doc
   git diff --exit-code --quiet


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/4444

As for now I just limited myself to implement the `lint` function because we don't have actions for JSON lint rules.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test case to make sure we get diagnostics.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [x] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [x] The PR requires documentation
- [x] I will create a new PR to update the documentation
