### PR TITLE
chore: remove changelog line and documentation parts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,26 +17,3 @@
 ## Test Plan
 
 <!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
-
-## Changelog
-
-<!--
-Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog
-
-Tick the checkbox if your PR requires a new line in the changelog.
--->
-
-- [ ] The PR requires a changelog line
-
-## Documentation
-
-<!--
-
-Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation
-
-Tick the checkboxes if your PR requires some documentation, and if you will follow up with that
-
--->
-
-- [ ] The PR requires documentation
-- [ ] I will create a new PR to update the documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,7 +273,7 @@ how the new formatting changes, and so on.
 #### Documentation
 
 If your PR requires some update on the website (new features, breaking changes, etc.), you should create a new PR once the previous PR is successfully merged.
-When addition new features, the documentation should be part of a new PR, which will be merged right before the release.
+When adding new features, the documentation should be part of a new PR, which will be merged right before the release.
 
 #### Magic comments
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ Please use the template provided.
 
 #### Changelog
 
-If the PR you're about to open is a bugfix/feature around Rome, you should add a new line to the `CHANGELOG.md`.
+If the PR you're about to open is a bugfix/feature around Rome, you can add a new line to the `CHANGELOG.md`, but it's not mandatory.
 
 At the top of the file you will see a `[Unreleased]` section. The headings divide the sections by "feature", make sure
 to add a new bullet point.
@@ -273,16 +273,7 @@ how the new formatting changes, and so on.
 #### Documentation
 
 If your PR requires some update on the website (new features, breaking changes, etc.), you should create a new PR once the previous PR is successfully merged.
-
-Go to the issues section and check the pinned issues.
-You will find a _**pinned issue**_ that starts with "Documentation and Focus". Inside, you will find the details of:
-- the name of the branch where to point the PR that updates the documentation;
-- the PR that we will merge when the release is ready;
-
-If you can't create a new PR, please let the team know.
-The template should help to give all the information to the team.
-
-Here are some other scripts that you might find useful.
+When addition new features, the documentation should be part of a new PR, which will be merged right before the release.
 
 #### Magic comments
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -96,3 +96,10 @@ Enables Rome to handle renames in the workspace (experimental).
 
 Disables formatting, linting, and syntax errors for projects without a `rome.json` file. Requires Rome 12 or newer.
 Enabled by default.
+
+## Versioning
+
+We follow the specs suggested by [the official documentation](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions):
+
+Odd minor versions are dedicated to pre-releases, e.g. `*.5.*` .
+Even minor versions are dedicated to official releases, e.g. `*.6.*`.

--- a/website/src/pages/vscode.mdx
+++ b/website/src/pages/vscode.mdx
@@ -102,3 +102,10 @@ Enables Rome to handle renames in the workspace (experimental).
 
 Disables formatting, linting, and syntax errors for projects without a `rome.json` file. Requires Rome 12 or newer.
 Enabled by default.
+
+## Versioning
+
+We follow the specs suggested by [the official documentation](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions):
+
+Odd minor versions are dedicated to pre-releases, e.g. `*.5.*` .
+Even minor versions are dedicated to official releases, e.g. `*.6.*`.


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Part of https://github.com/rome/tools/discussions/4585

This PR:
- update the PR template and removes the documentation part
- update the contribution guidelines
- adds some information to the VSCode extension


@rome/core-contributors I added a couple of labels. When merging a PR, use these labels for those PRs that needs some follow up for documentation and/or changelogs.

<img width="721" alt="Screenshot 2023-06-24 at 12 03 44" src="https://github.com/rome/tools/assets/602478/e046310e-6493-460b-89de-6f6e60fcda01">


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Changelog

<!--
Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#changelog

Tick the checkbox if your PR requires a new line in the changelog.
-->

- [ ] The PR requires a changelog line

## Documentation

<!--

Read the following paragraph for more information: https://github.com/rome/tools/blob/main/CONTRIBUTING.md#documentation

Tick the checkboxes if your PR requires some documentation, and if you will follow up with that

-->

- [ ] The PR requires documentation
- [ ] I will create a new PR to update the documentation
