### PR TITLE
refactor(rome_js_analyze): set version for noUselessConstructor

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
+++ b/crates/rome_js_analyze/src/analyzers/complexity/no_useless_constructor.rs
@@ -69,7 +69,7 @@ declare_rule! {
     /// }
     /// ```
     pub(crate) NoUselessConstructor {
-        version: "next",
+        version: "12.1.0",
         name: "noUselessConstructor",
         recommended: true,
     }

--- a/website/src/pages/lint/rules/noUselessConstructor.md
+++ b/website/src/pages/lint/rules/noUselessConstructor.md
@@ -3,7 +3,7 @@ title: Lint Rule noUselessConstructor
 parent: lint/rules/index
 ---
 
-# noUselessConstructor (since vnext)
+# noUselessConstructor (since v12.1.0)
 
 > This rule is recommended by Rome.
 


### PR DESCRIPTION
## Summary

The version was not properly set for [`noUselessConstructor`](https://docs.rome.tools/lint/rules/nouselessconstructor/) (set to next instead of 12.1).
