### PR TITLE
feat(rome_js_analyze): add noGlobalIsFinite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,11 @@ multiple files:
 
 #### New rules
 
-- Add [`noGlobalThis`](https://docs.rome.tools/lint/rules/noglobalthis/)
+- Add [`noGlobalIsFinite`](https://docs.rome.tools/lint/rules/noglobalisfinite/)
+
+  This rule recommends using `Number.isFinite` instead of the global and unsafe `isFinite` that attempts a type coercion.
+
+- Add [`noGlobalIsNan`](https://docs.rome.tools/lint/rules/noglobalisnan/)
 
   This rule recommends using `Number.isNaN` instead of the global and unsafe `isNaN` that attempts a type coercion.
 

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -100,6 +100,7 @@ define_categories! {
     "lint/nursery/noDuplicateJsonKeys": "https://docs.rome.tools/lint/rules/noDuplicateJsonKeys",
     "lint/nursery/useNamingConvention": "https://docs.rome.tools/lint/rules/useNamingConvention",
 "lint/nursery/noGlobalIsNan": "https://docs.rome.tools/lint/rules/noGlobalIsNan",
+"lint/nursery/noGlobalIsFinite": "https://docs.rome.tools/lint/rules/noGlobalIsFinite",
     // Insert new nursery rule here
 
 

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery.rs
@@ -5,9 +5,10 @@ pub(crate) mod no_accumulating_spread;
 pub(crate) mod no_banned_types;
 pub(crate) mod no_console_log;
 pub(crate) mod no_constant_condition;
+pub(crate) mod no_global_is_finite;
 pub(crate) mod no_global_is_nan;
 pub(crate) mod use_camel_case;
 pub(crate) mod use_exhaustive_dependencies;
 pub(crate) mod use_hook_at_top_level;
 pub(crate) mod use_naming_convention;
-declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_accumulating_spread :: NoAccumulatingSpread , self :: no_banned_types :: NoBannedTypes , self :: no_console_log :: NoConsoleLog , self :: no_constant_condition :: NoConstantCondition , self :: no_global_is_nan :: NoGlobalIsNan , self :: use_camel_case :: UseCamelCase , self :: use_exhaustive_dependencies :: UseExhaustiveDependencies , self :: use_hook_at_top_level :: UseHookAtTopLevel , self :: use_naming_convention :: UseNamingConvention ,] } }
+declare_group! { pub (crate) Nursery { name : "nursery" , rules : [self :: no_accumulating_spread :: NoAccumulatingSpread , self :: no_banned_types :: NoBannedTypes , self :: no_console_log :: NoConsoleLog , self :: no_constant_condition :: NoConstantCondition , self :: no_global_is_finite :: NoGlobalIsFinite , self :: no_global_is_nan :: NoGlobalIsNan , self :: use_camel_case :: UseCamelCase , self :: use_exhaustive_dependencies :: UseExhaustiveDependencies , self :: use_hook_at_top_level :: UseHookAtTopLevel , self :: use_naming_convention :: UseNamingConvention ,] } }

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_global_is_finite.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_global_is_finite.rs
@@ -7,35 +7,34 @@ use rome_js_syntax::{AnyJsExpression, T};
 use rome_rowan::{AstNode, BatchMutationExt};
 
 declare_rule! {
-    /// Use `Number.isNaN` instead of global `isNaN`.
+    /// Use `Number.isFinite` instead of global `isFinite`.
     ///
-    /// `Number.isNaN()` and `isNaN()` [have not the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description).
-    /// When the argument to `isNaN()` is not a number, the value is first coerced to a number.
-    /// `Number.isNaN()` does not perform this coercion.
-    /// Therefore, it is a more reliable way to test whether a value is `NaN`.
+    /// `Number.isFinite()` and `isFinite()` [have not the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#difference_between_number.isfinite_and_global_isfinite).
+    /// When the argument to `isFinite()` is not a number, the value is first coerced to a number.
+    /// `Number.isFinite()` does not perform this coercion.
+    /// Therefore, it is a more reliable way to test whether a number is finite.
     ///
     /// ## Examples
     ///
     /// ### Invalid
     ///
     /// ```js,expect_diagnostic
-    /// isNaN({}); // true
+    /// isFinite(false); // true
     /// ```
     ///
     /// ## Valid
     ///
     /// ```js
-    /// Number.isNaN({}); // false
+    /// Number.isFinite(false); // false
     /// ```
-    ///
-    pub(crate) NoGlobalIsNan {
+    pub(crate) NoGlobalIsFinite {
         version: "next",
-        name: "noGlobalIsNan",
+        name: "noGlobalIsFinite",
         recommended: true,
     }
 }
 
-impl Rule for NoGlobalIsNan {
+impl Rule for NoGlobalIsFinite {
     type Query = Semantic<AnyJsExpression>;
     type State = ();
     type Signals = Option<Self::State>;
@@ -47,7 +46,7 @@ impl Rule for NoGlobalIsNan {
         match node {
             AnyJsExpression::JsIdentifierExpression(expression) => {
                 let name = expression.name().ok()?;
-                if name.has_name("isNaN") && model.binding(&name).is_none() {
+                if name.has_name("isFinite") && model.binding(&name).is_none() {
                     return Some(());
                 }
             }
@@ -62,7 +61,7 @@ impl Rule for NoGlobalIsNan {
                 let member = expression.member().ok()?;
                 if object_name.is_global_this()
                     && model.binding(&object_name).is_none()
-                    && member.as_js_name()?.value_token().ok()?.text_trimmed() == "isNaN"
+                    && member.as_js_name()?.value_token().ok()?.text_trimmed() == "isFinite"
                 {
                     return Some(());
                 }
@@ -81,7 +80,7 @@ impl Rule for NoGlobalIsNan {
                     .as_js_string_literal_expression()?;
                 if object_name.is_global_this()
                     && model.binding(&object_name).is_none()
-                    && member.inner_string_text().ok()?.text() == "isNaN"
+                    && member.inner_string_text().ok()?.text() == "isFinite"
                 {
                     return Some(());
                 }
@@ -98,11 +97,11 @@ impl Rule for NoGlobalIsNan {
                 rule_category!(),
                 node.range(),
                 markup! {
-                    <Emphasis>"isNaN"</Emphasis>" is unsafe. It attempts a type coercion. Use "<Emphasis>"Number.isNaN"</Emphasis>" instead."
+                    <Emphasis>"isFinite"</Emphasis>" is unsafe. It attempts a type coercion. Use "<Emphasis>"Number.isFinite"</Emphasis>" instead."
                 },
             )
             .note(markup! {
-                "See "<Hyperlink href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description">"the MDN documentation"</Hyperlink>" for more details."
+                "See "<Hyperlink href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isFinite#description">"the MDN documentation"</Hyperlink>" for more details."
             }),
         )
     }
@@ -153,7 +152,7 @@ impl Rule for NoGlobalIsNan {
             category: ActionCategory::QuickFix,
             applicability: Applicability::MaybeIncorrect,
             message: markup! {
-                "Use "<Emphasis>"Number.isNaN"</Emphasis>" instead."
+                "Use "<Emphasis>"Number.isFinite"</Emphasis>" instead."
             }
             .to_owned(),
             mutation,

--- a/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsFinite/invalid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsFinite/invalid.js
@@ -1,0 +1,17 @@
+isFinite({});
+
+(isFinite)({});
+
+globalThis.isFinite({});
+
+(globalThis).isFinite({});
+
+globalThis["isFinite"]({});
+
+(globalThis)[("isFinite")]({});
+
+function localIsNaN(isFinite) {
+    globalThis.isFinite({});
+}
+
+localIsNaN(isFinite);

--- a/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsFinite/invalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsFinite/invalid.js.snap
@@ -1,0 +1,224 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```js
+isFinite({});
+
+(isFinite)({});
+
+globalThis.isFinite({});
+
+(globalThis).isFinite({});
+
+globalThis["isFinite"]({});
+
+(globalThis)[("isFinite")]({});
+
+function localIsNaN(isFinite) {
+    globalThis.isFinite({});
+}
+
+localIsNaN(isFinite);
+
+```
+
+# Diagnostics
+```
+invalid.js:1:1 lint/nursery/noGlobalIsFinite  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isFinite is unsafe. It attempts a type coercion. Use Number.isFinite instead.
+  
+  > 1 │ isFinite({});
+      │ ^^^^^^^^
+    2 │ 
+    3 │ (isFinite)({});
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isFinite instead.
+  
+     1    │ - isFinite({});
+        1 │ + Number.isFinite({});
+     2  2 │   
+     3  3 │   (isFinite)({});
+  
+
+```
+
+```
+invalid.js:3:2 lint/nursery/noGlobalIsFinite  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isFinite is unsafe. It attempts a type coercion. Use Number.isFinite instead.
+  
+    1 │ isFinite({});
+    2 │ 
+  > 3 │ (isFinite)({});
+      │  ^^^^^^^^
+    4 │ 
+    5 │ globalThis.isFinite({});
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isFinite instead.
+  
+     1  1 │   isFinite({});
+     2  2 │   
+     3    │ - (isFinite)({});
+        3 │ + (Number.isFinite)({});
+     4  4 │   
+     5  5 │   globalThis.isFinite({});
+  
+
+```
+
+```
+invalid.js:5:1 lint/nursery/noGlobalIsFinite  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isFinite is unsafe. It attempts a type coercion. Use Number.isFinite instead.
+  
+    3 │ (isFinite)({});
+    4 │ 
+  > 5 │ globalThis.isFinite({});
+      │ ^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ (globalThis).isFinite({});
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isFinite instead.
+  
+     3  3 │   (isFinite)({});
+     4  4 │   
+     5    │ - globalThis.isFinite({});
+        5 │ + globalThis.Number.isFinite({});
+     6  6 │   
+     7  7 │   (globalThis).isFinite({});
+  
+
+```
+
+```
+invalid.js:7:1 lint/nursery/noGlobalIsFinite  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isFinite is unsafe. It attempts a type coercion. Use Number.isFinite instead.
+  
+    5 │ globalThis.isFinite({});
+    6 │ 
+  > 7 │ (globalThis).isFinite({});
+      │ ^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ globalThis["isFinite"]({});
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isFinite instead.
+  
+     5  5 │   globalThis.isFinite({});
+     6  6 │   
+     7    │ - (globalThis).isFinite({});
+        7 │ + (globalThis).Number.isFinite({});
+     8  8 │   
+     9  9 │   globalThis["isFinite"]({});
+  
+
+```
+
+```
+invalid.js:9:1 lint/nursery/noGlobalIsFinite  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isFinite is unsafe. It attempts a type coercion. Use Number.isFinite instead.
+  
+     7 │ (globalThis).isFinite({});
+     8 │ 
+   > 9 │ globalThis["isFinite"]({});
+       │ ^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
+    11 │ (globalThis)[("isFinite")]({});
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isFinite instead.
+  
+     7  7 │   (globalThis).isFinite({});
+     8  8 │   
+     9    │ - globalThis["isFinite"]({});
+        9 │ + globalThis.Number["isFinite"]({});
+    10 10 │   
+    11 11 │   (globalThis)[("isFinite")]({});
+  
+
+```
+
+```
+invalid.js:11:1 lint/nursery/noGlobalIsFinite  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isFinite is unsafe. It attempts a type coercion. Use Number.isFinite instead.
+  
+     9 │ globalThis["isFinite"]({});
+    10 │ 
+  > 11 │ (globalThis)[("isFinite")]({});
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ function localIsNaN(isFinite) {
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isFinite instead.
+  
+    11 │ (globalThis).Number[("isFinite")]({});
+       │             +++++++                   
+
+```
+
+```
+invalid.js:14:5 lint/nursery/noGlobalIsFinite  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isFinite is unsafe. It attempts a type coercion. Use Number.isFinite instead.
+  
+    13 │ function localIsNaN(isFinite) {
+  > 14 │     globalThis.isFinite({});
+       │     ^^^^^^^^^^^^^^^^^^^
+    15 │ }
+    16 │ 
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isFinite instead.
+  
+    12 12 │   
+    13 13 │   function localIsNaN(isFinite) {
+    14    │ - ····globalThis.isFinite({});
+       14 │ + ····globalThis.Number.isFinite({});
+    15 15 │   }
+    16 16 │   
+  
+
+```
+
+```
+invalid.js:17:12 lint/nursery/noGlobalIsFinite  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isFinite is unsafe. It attempts a type coercion. Use Number.isFinite instead.
+  
+    15 │ }
+    16 │ 
+  > 17 │ localIsNaN(isFinite);
+       │            ^^^^^^^^
+    18 │ 
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isFinite instead.
+  
+    15 15 │   }
+    16 16 │   
+    17    │ - localIsNaN(isFinite);
+       17 │ + localIsNaN(Number.isFinite);
+    18 18 │   
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsFinite/valid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsFinite/valid.js
@@ -1,0 +1,14 @@
+Number.isFinite(Number.NaN);
+
+globalThis.Number.isFinite(Number.NaN);
+
+function localIsFinite(isFinite) {
+    isFinite({});
+}
+
+function localVar() {
+    var isFinite;
+    isFinite()
+}
+
+localIsFinite(Number.isFinite);

--- a/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsFinite/valid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsFinite/valid.js.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```js
+Number.isFinite(Number.NaN);
+
+globalThis.Number.isFinite(Number.NaN);
+
+function localIsFinite(isFinite) {
+    isFinite({});
+}
+
+function localVar() {
+    var isFinite;
+    isFinite()
+}
+
+localIsFinite(Number.isFinite);
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsNan/invalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noGlobalIsNan/invalid.js.snap
@@ -92,7 +92,7 @@ invalid.js:5:1 lint/nursery/noGlobalIsNan  FIXABLE  ━━━━━━━━━�
      3  3 │   (isNaN)({});
      4  4 │   
      5    │ - globalThis.isNaN({});
-        5 │ + Number.isNaN({});
+        5 │ + globalThis.Number.isNaN({});
      6  6 │   
      7  7 │   (globalThis).isNaN({});
   
@@ -118,10 +118,57 @@ invalid.js:7:1 lint/nursery/noGlobalIsNan  FIXABLE  ━━━━━━━━━�
      5  5 │   globalThis.isNaN({});
      6  6 │   
      7    │ - (globalThis).isNaN({});
-        7 │ + Number.isNaN({});
+        7 │ + (globalThis).Number.isNaN({});
      8  8 │   
      9  9 │   globalThis["isNaN"]({});
   
+
+```
+
+```
+invalid.js:9:1 lint/nursery/noGlobalIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isNaN is unsafe. It attempts a type coercion. Use Number.isNaN instead.
+  
+     7 │ (globalThis).isNaN({});
+     8 │ 
+   > 9 │ globalThis["isNaN"]({});
+       │ ^^^^^^^^^^^^^^^^^^^
+    10 │ 
+    11 │ (globalThis)[("isNaN")]({});
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isNaN instead.
+  
+     7  7 │   (globalThis).isNaN({});
+     8  8 │   
+     9    │ - globalThis["isNaN"]({});
+        9 │ + globalThis.Number["isNaN"]({});
+    10 10 │   
+    11 11 │   (globalThis)[("isNaN")]({});
+  
+
+```
+
+```
+invalid.js:11:1 lint/nursery/noGlobalIsNan  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! isNaN is unsafe. It attempts a type coercion. Use Number.isNaN instead.
+  
+     9 │ globalThis["isNaN"]({});
+    10 │ 
+  > 11 │ (globalThis)[("isNaN")]({});
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ function localIsNaN(isNaN) {
+  
+  i See the MDN documentation for more details.
+  
+  i Suggested fix: Use Number.isNaN instead.
+  
+    11 │ (globalThis).Number[("isNaN")]({});
+       │             +++++++                
 
 ```
 
@@ -143,7 +190,7 @@ invalid.js:14:5 lint/nursery/noGlobalIsNan  FIXABLE  ━━━━━━━━━
     12 12 │   
     13 13 │   function localIsNaN(isNaN) {
     14    │ - ····globalThis.isNaN({});
-       14 │ + ····Number.isNaN({});
+       14 │ + ····globalThis.Number.isNaN({});
     15 15 │   }
     16 16 │   
   

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -1843,6 +1843,10 @@ pub struct Nursery {
     #[bpaf(long("no-for-each"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_for_each: Option<RuleConfiguration>,
+    #[doc = "Use Number.isFinite instead of global isFinite."]
+    #[bpaf(long("no-global-is-finite"), argument("on|off|warn"), optional, hide)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_global_is_finite: Option<RuleConfiguration>,
     #[doc = "Use Number.isNaN instead of global isNaN."]
     #[bpaf(long("no-global-is-nan"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1935,7 +1939,7 @@ pub struct Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 25] = [
+    pub(crate) const GROUP_RULES: [&'static str; 26] = [
         "noAccumulatingSpread",
         "noAriaUnsupportedElements",
         "noBannedTypes",
@@ -1945,6 +1949,7 @@ impl Nursery {
         "noDuplicateJsonKeys",
         "noDuplicateJsxProps",
         "noForEach",
+        "noGlobalIsFinite",
         "noGlobalIsNan",
         "noNoninteractiveTabindex",
         "noRedundantRoles",
@@ -1962,12 +1967,13 @@ impl Nursery {
         "useNamingConvention",
         "useSimpleNumberKeys",
     ];
-    const RECOMMENDED_RULES: [&'static str; 14] = [
+    const RECOMMENDED_RULES: [&'static str; 15] = [
         "noAriaUnsupportedElements",
         "noBannedTypes",
         "noConstantCondition",
         "noDuplicateJsonKeys",
         "noDuplicateJsxProps",
+        "noGlobalIsFinite",
         "noGlobalIsNan",
         "noRedundantRoles",
         "noSelfAssign",
@@ -1978,23 +1984,24 @@ impl Nursery {
         "useLiteralEnumMembers",
         "useLiteralKeys",
     ];
-    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 14] = [
+    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 15] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 25] = [
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 26] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -2020,6 +2027,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
@@ -2075,84 +2083,89 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_global_is_nan.as_ref() {
+        if let Some(rule) = self.no_global_is_finite.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
+        if let Some(rule) = self.no_global_is_nan.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_redundant_roles.as_ref() {
+        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_self_assign.as_ref() {
+        if let Some(rule) = self.no_redundant_roles.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_static_only_class.as_ref() {
+        if let Some(rule) = self.no_self_assign.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+        if let Some(rule) = self.no_static_only_class.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_camel_case.as_ref() {
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+        if let Some(rule) = self.use_camel_case.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.use_heading_content.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_heading_content.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_is_nan.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_literal_enum_members.as_ref() {
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.use_literal_keys.as_ref() {
+        if let Some(rule) = self.use_literal_enum_members.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_literal_keys.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
+            }
+        }
+        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
         index_set
@@ -2204,84 +2217,89 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
             }
         }
-        if let Some(rule) = self.no_global_is_nan.as_ref() {
+        if let Some(rule) = self.no_global_is_finite.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
             }
         }
-        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
+        if let Some(rule) = self.no_global_is_nan.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_redundant_roles.as_ref() {
+        if let Some(rule) = self.no_noninteractive_tabindex.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_self_assign.as_ref() {
+        if let Some(rule) = self.no_redundant_roles.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_static_only_class.as_ref() {
+        if let Some(rule) = self.no_self_assign.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+        if let Some(rule) = self.no_static_only_class.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.use_camel_case.as_ref() {
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+        if let Some(rule) = self.use_camel_case.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.use_heading_content.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_heading_content.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_is_nan.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_literal_enum_members.as_ref() {
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.use_literal_keys.as_ref() {
+        if let Some(rule) = self.use_literal_enum_members.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_literal_keys.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
+            }
+        }
+        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
         index_set
@@ -2292,10 +2310,10 @@ impl Nursery {
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
     }
-    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 14] {
+    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 15] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 25] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 26] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2325,6 +2343,7 @@ impl Nursery {
             "noDuplicateJsonKeys" => self.no_duplicate_json_keys.as_ref(),
             "noDuplicateJsxProps" => self.no_duplicate_jsx_props.as_ref(),
             "noForEach" => self.no_for_each.as_ref(),
+            "noGlobalIsFinite" => self.no_global_is_finite.as_ref(),
             "noGlobalIsNan" => self.no_global_is_nan.as_ref(),
             "noNoninteractiveTabindex" => self.no_noninteractive_tabindex.as_ref(),
             "noRedundantRoles" => self.no_redundant_roles.as_ref(),

--- a/crates/rome_service/src/configuration/parse/json/rules.rs
+++ b/crates/rome_service/src/configuration/parse/json/rules.rs
@@ -1357,6 +1357,7 @@ impl VisitNode<JsonLanguage> for Nursery {
                 "noDuplicateJsonKeys",
                 "noDuplicateJsxProps",
                 "noForEach",
+                "noGlobalIsFinite",
                 "noGlobalIsNan",
                 "noNoninteractiveTabindex",
                 "noRedundantRoles",
@@ -1546,6 +1547,24 @@ impl VisitNode<JsonLanguage> for Nursery {
                     let mut configuration = RuleConfiguration::default();
                     self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
                     self.no_for_each = Some(configuration);
+                }
+                _ => {
+                    diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
+                        "object or string",
+                        value.range(),
+                    ));
+                }
+            },
+            "noGlobalIsFinite" => match value {
+                AnyJsonValue::JsonStringValue(_) => {
+                    let mut configuration = RuleConfiguration::default();
+                    self.map_to_known_string(&value, name_text, &mut configuration, diagnostics)?;
+                    self.no_global_is_finite = Some(configuration);
+                }
+                AnyJsonValue::JsonObjectValue(_) => {
+                    let mut configuration = RuleConfiguration::default();
+                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
+                    self.no_global_is_finite = Some(configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -803,6 +803,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noGlobalIsFinite": {
+					"description": "Use Number.isFinite instead of global isFinite.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noGlobalIsNan": {
 					"description": "Use Number.isNaN instead of global isNaN.",
 					"anyOf": [

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -542,6 +542,10 @@ export interface Nursery {
 	 */
 	noForEach?: RuleConfiguration;
 	/**
+	 * Use Number.isFinite instead of global isFinite.
+	 */
+	noGlobalIsFinite?: RuleConfiguration;
+	/**
 	 * Use Number.isNaN instead of global isNaN.
 	 */
 	noGlobalIsNan?: RuleConfiguration;
@@ -1116,6 +1120,7 @@ export type Category =
 	| "lint/nursery/noDuplicateJsonKeys"
 	| "lint/nursery/useNamingConvention"
 	| "lint/nursery/noGlobalIsNan"
+	| "lint/nursery/noGlobalIsFinite"
 	| "lint/performance/noDelete"
 	| "lint/security/noDangerouslySetInnerHtml"
 	| "lint/security/noDangerouslySetInnerHtmlWithChildren"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -803,6 +803,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noGlobalIsFinite": {
+					"description": "Use Number.isFinite instead of global isFinite.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noGlobalIsNan": {
 					"description": "Use Number.isNaN instead of global isNaN.",
 					"anyOf": [

--- a/website/src/components/generated/NumberOfRules.astro
+++ b/website/src/components/generated/NumberOfRules.astro
@@ -1,2 +1,2 @@
 <!-- this file is auto generated, use `cargo lintdoc` to update it -->
- <p>Rome's linter has a total of <strong><a href='/lint/rules'>144 rules</a></strong><p>
+ <p>Rome's linter has a total of <strong><a href='/lint/rules'>145 rules</a></strong><p>

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -951,6 +951,12 @@ Prevents JSX properties to be assigned multiple times.
 Prefer <code>for...of</code> statement instead of <code>Array.forEach</code>.
 </section>
 <section class="rule">
+<h3 data-toc-exclude id="noGlobalIsFinite">
+	<a href="/lint/rules/noGlobalIsFinite">noGlobalIsFinite</a>
+</h3>
+Use <code>Number.isFinite</code> instead of global <code>isFinite</code>.
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noGlobalIsNan">
 	<a href="/lint/rules/noGlobalIsNan">noGlobalIsNan</a>
 </h3>

--- a/website/src/pages/lint/rules/noGlobalIsFinite.md
+++ b/website/src/pages/lint/rules/noGlobalIsFinite.md
@@ -1,0 +1,50 @@
+---
+title: Lint Rule noGlobalIsFinite
+parent: lint/rules/index
+---
+
+# noGlobalIsFinite (since vnext)
+
+Use `Number.isFinite` instead of global `isFinite`.
+
+`Number.isFinite()` and `isFinite()` [have not the same behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#difference_between_number.isfinite_and_global_isfinite).
+When the argument to `isFinite()` is not a number, the value is first coerced to a number.
+`Number.isFinite()` does not perform this coercion.
+Therefore, it is a more reliable way to test whether a number is finite.
+
+## Examples
+
+### Invalid
+
+```jsx
+isFinite(false); // true
+```
+
+<pre class="language-text"><code class="language-text">nursery/noGlobalIsFinite.js:1:1 <a href="https://docs.rome.tools/lint/rules/noGlobalIsFinite">lint/nursery/noGlobalIsFinite</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;"><strong>isFinite</strong></span><span style="color: Tomato;"> is unsafe. It attempts a type coercion. Use </span><span style="color: Tomato;"><strong>Number.isFinite</strong></span><span style="color: Tomato;"> instead.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>isFinite(false); // true
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">See </span><span style="color: rgb(38, 148, 255);"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isFinite#description">the MDN documentation</a></span><span style="color: rgb(38, 148, 255);"> for more details.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>Number.isFinite</strong></span><span style="color: rgb(38, 148, 255);"> instead.</span>
+  
+    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>s</strong></span><span style="color: Tomato;"><strong>F</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;">(</span><span style="color: Tomato;">f</span><span style="color: Tomato;">a</span><span style="color: Tomato;">l</span><span style="color: Tomato;">s</span><span style="color: Tomato;">e</span><span style="color: Tomato;">)</span><span style="color: Tomato;">;</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">/</span><span style="color: Tomato;">/</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">t</span><span style="color: Tomato;">r</span><span style="color: Tomato;">u</span><span style="color: Tomato;">e</span>
+      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><strong>N</strong></span><span style="color: MediumSeaGreen;"><strong>u</strong></span><span style="color: MediumSeaGreen;"><strong>m</strong></span><span style="color: MediumSeaGreen;"><strong>b</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;"><strong>r</strong></span><span style="color: MediumSeaGreen;"><strong>.</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;"><strong>F</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>n</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>t</strong></span><span style="color: MediumSeaGreen;"><strong>e</strong></span><span style="color: MediumSeaGreen;">(</span><span style="color: MediumSeaGreen;">f</span><span style="color: MediumSeaGreen;">a</span><span style="color: MediumSeaGreen;">l</span><span style="color: MediumSeaGreen;">s</span><span style="color: MediumSeaGreen;">e</span><span style="color: MediumSeaGreen;">)</span><span style="color: MediumSeaGreen;">;</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;">r</span><span style="color: MediumSeaGreen;">u</span><span style="color: MediumSeaGreen;">e</span>
+    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
+  
+</code></pre>
+
+## Valid
+
+```jsx
+Number.isFinite(false); // false
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)


### PR DESCRIPTION
## Summary

This rule recommends using `Number.isFinite` instead of the global and unsafe `isFinite` that attempts a type coercion.

I was wondering if this could not be merged with `noGlobalIsNan`. However, I didn't find a common name... This is why I proposed two distinct rules.

## Test Plan

Tests included.