### PR TITLE
Install correct binstall crate

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,12 +8,12 @@ alias r := ready
 
 # Installs the tools needed to develop with Rome
 install-tools:
-	cargo install binstall
+	cargo install cargo-binstall
 	cargo binstall cargo-insta cargo-nextest taplo-cli wasm-pack
 
 # Upgrades the tools needed to develop with Rome
 upgrade-tools:
-	cargo install binstall --force
+	cargo install cargo-binstall --force
 	cargo binstall cargo-insta cargo-nextest taplo-cli wasm-pack --force
 
 # Generate all files across crates and tools. You rarely want to use it locally.


### PR DESCRIPTION
## Summary

I just ran `just install-tools` as the `CONTRIBUTING.md` guide told me to, but it didn't work for me, because it appears to install the wrong `binstall` crate. The one it installed was this unmaintained crate: https://crates.io/crates/binstall, but the one it should install (to make `cargo binstall` work) is this one: https://crates.io/crates/cargo-binstall

## Test Plan

If you want to reproduce it, make sure no `binstall` crate is installed:

```sh
cargo uninstall binstall
cargo uninstall cargo-binstall

cargo binstall # This should error now.
```

Then you can rerun `just install-tools`, and with this PR it should install the correct one.
