### PR TITLE
ci: avoid installing `cargo-cache` twice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
       # ref: https://github.com/orgs/community/discussions/26952

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run tests on ${{ matrix.os }}
         run: cargo nextest run --workspace --verbose
       - name: Clean cache
-        run: cargo install cargo-cache --no-default-features --features ci-autoclean && cargo-cache
+        run: cargo cache --autoclean
 
   documentation:
     name: Documentation
@@ -136,4 +136,4 @@ jobs:
         continue-on-error: true
         run: cargo coverage
       - name: Clean cache
-        run: cargo install cargo-cache --no-default-features --features ci-autoclean && cargo-cache
+        run: cargo cache --autoclean

--- a/.github/workflows/parser_conformance.yml
+++ b/.github/workflows/parser_conformance.yml
@@ -106,4 +106,4 @@ jobs:
             ${{ steps.comparison.outputs.comment }}
 
       - name: Clean cache
-        run: cargo install cargo-cache --no-default-features --features ci-autoclean && cargo-cache
+        run: cargo cache --autoclean


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

We don't need to install `cargo-cache` when cleaning the cache because `moonrepo/setup-rust` action already done it in advance.

I've already checked it in other pull request on my fork. A `Documentation` job failed, but this is not related to changes in this pull request. The reason is that my fork doesn't have an appropriate GitHub token.

https://github.com/TaKO8Ki/tools/pull/1

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

CI should pass.