### PR TITLE
refactor(rome_service): better messaging for rule options

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/nursery/no_nonoctal_decimal_escape.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_nonoctal_decimal_escape.rs
@@ -13,7 +13,7 @@ declare_rule! {
     /// Since ECMAScript 2021, the escape sequences \8 and \9 have been defined as non-octal decimal escape sequences.
     /// However, most JavaScript engines consider them to be "useless" escapes. For example:
     ///
-    /// ```js
+    /// ```js,ignore
     /// "\8" === "8"; // true
     /// "\9" === "9"; // true
     /// ```
@@ -34,7 +34,11 @@ declare_rule! {
     /// ```
     ///
     /// ```js,expect_diagnostic
-    /// const x = "Don't use \8 and \9 escapes.";
+    /// const x = "Don't use \8 escape.";
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// const x = "Don't use \9 escape.";
     /// ```
     ///
     /// ```js,expect_diagnostic

--- a/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/malformedOptions.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExhaustiveDependencies/malformedOptions.js.snap
@@ -22,10 +22,7 @@ malformedOptions.options:9:7 deserialize ━━━━━━━━━━━━━
   
   i Accepted keys
   
-  - enumMemberCase
   - hooks
-  - maxAllowedComplexity
-  - strictCase
   
 
 ```

--- a/crates/rome_service/src/configuration/parse/json/rules.rs
+++ b/crates/rome_service/src/configuration/parse/json/rules.rs
@@ -166,9 +166,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.no_access_key = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_access_key = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noAccessKey",
+                        diagnostics,
+                    )?;
+                    self.no_access_key = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -184,9 +189,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.no_autofocus = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_autofocus = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noAutofocus",
+                        diagnostics,
+                    )?;
+                    self.no_autofocus = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -202,9 +212,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.no_blank_target = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_blank_target = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noBlankTarget",
+                        diagnostics,
+                    )?;
+                    self.no_blank_target = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -220,9 +235,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.no_distracting_elements = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_distracting_elements = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDistractingElements",
+                        diagnostics,
+                    )?;
+                    self.no_distracting_elements = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -238,9 +258,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.no_header_scope = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_header_scope = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noHeaderScope",
+                        diagnostics,
+                    )?;
+                    self.no_header_scope = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -256,9 +281,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.no_noninteractive_element_to_interactive_role = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_noninteractive_element_to_interactive_role = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noNoninteractiveElementToInteractiveRole",
+                        diagnostics,
+                    )?;
+                    self.no_noninteractive_element_to_interactive_role = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -274,9 +304,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.no_positive_tabindex = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_positive_tabindex = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noPositiveTabindex",
+                        diagnostics,
+                    )?;
+                    self.no_positive_tabindex = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -292,9 +327,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.no_redundant_alt = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_redundant_alt = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noRedundantAlt",
+                        diagnostics,
+                    )?;
+                    self.no_redundant_alt = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -310,9 +350,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.no_svg_without_title = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_svg_without_title = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noSvgWithoutTitle",
+                        diagnostics,
+                    )?;
+                    self.no_svg_without_title = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -328,9 +373,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_alt_text = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_alt_text = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useAltText",
+                        diagnostics,
+                    )?;
+                    self.use_alt_text = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -346,9 +396,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_anchor_content = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_anchor_content = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useAnchorContent",
+                        diagnostics,
+                    )?;
+                    self.use_anchor_content = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -364,9 +419,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_aria_props_for_role = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_aria_props_for_role = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useAriaPropsForRole",
+                        diagnostics,
+                    )?;
+                    self.use_aria_props_for_role = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -382,9 +442,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_button_type = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_button_type = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useButtonType",
+                        diagnostics,
+                    )?;
+                    self.use_button_type = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -400,9 +465,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_html_lang = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_html_lang = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useHtmlLang",
+                        diagnostics,
+                    )?;
+                    self.use_html_lang = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -418,9 +488,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_iframe_title = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_iframe_title = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useIframeTitle",
+                        diagnostics,
+                    )?;
+                    self.use_iframe_title = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -436,9 +511,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_key_with_click_events = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_key_with_click_events = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useKeyWithClickEvents",
+                        diagnostics,
+                    )?;
+                    self.use_key_with_click_events = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -454,9 +534,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_key_with_mouse_events = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_key_with_mouse_events = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useKeyWithMouseEvents",
+                        diagnostics,
+                    )?;
+                    self.use_key_with_mouse_events = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -472,9 +557,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_media_caption = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_media_caption = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useMediaCaption",
+                        diagnostics,
+                    )?;
+                    self.use_media_caption = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -490,9 +580,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_valid_anchor = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_valid_anchor = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useValidAnchor",
+                        diagnostics,
+                    )?;
+                    self.use_valid_anchor = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -508,9 +603,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_valid_aria_props = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_valid_aria_props = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useValidAriaProps",
+                        diagnostics,
+                    )?;
+                    self.use_valid_aria_props = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -526,9 +626,14 @@ impl VisitNode<JsonLanguage> for A11y {
                     self.use_valid_lang = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_valid_lang = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useValidLang",
+                        diagnostics,
+                    )?;
+                    self.use_valid_lang = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -593,9 +698,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_extra_boolean_cast = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_extra_boolean_cast = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noExtraBooleanCast",
+                        diagnostics,
+                    )?;
+                    self.no_extra_boolean_cast = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -611,9 +721,15 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_multiple_spaces_in_regular_expression_literals = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_multiple_spaces_in_regular_expression_literals = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noMultipleSpacesInRegularExpressionLiterals",
+                        diagnostics,
+                    )?;
+                    self.no_multiple_spaces_in_regular_expression_literals =
+                        Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -629,9 +745,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_useless_catch = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_useless_catch = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUselessCatch",
+                        diagnostics,
+                    )?;
+                    self.no_useless_catch = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -647,9 +768,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_useless_constructor = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_useless_constructor = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUselessConstructor",
+                        diagnostics,
+                    )?;
+                    self.no_useless_constructor = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -665,9 +791,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_useless_fragments = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_useless_fragments = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUselessFragments",
+                        diagnostics,
+                    )?;
+                    self.no_useless_fragments = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -683,9 +814,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_useless_label = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_useless_label = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUselessLabel",
+                        diagnostics,
+                    )?;
+                    self.no_useless_label = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -701,9 +837,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_useless_rename = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_useless_rename = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUselessRename",
+                        diagnostics,
+                    )?;
+                    self.no_useless_rename = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -719,9 +860,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_useless_switch_case = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_useless_switch_case = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUselessSwitchCase",
+                        diagnostics,
+                    )?;
+                    self.no_useless_switch_case = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -737,9 +883,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_useless_type_constraint = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_useless_type_constraint = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUselessTypeConstraint",
+                        diagnostics,
+                    )?;
+                    self.no_useless_type_constraint = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -755,9 +906,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.no_with = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_with = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noWith",
+                        diagnostics,
+                    )?;
+                    self.no_with = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -773,9 +929,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.use_flat_map = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_flat_map = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useFlatMap",
+                        diagnostics,
+                    )?;
+                    self.use_flat_map = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -791,9 +952,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.use_optional_chain = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_optional_chain = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useOptionalChain",
+                        diagnostics,
+                    )?;
+                    self.use_optional_chain = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -809,9 +975,14 @@ impl VisitNode<JsonLanguage> for Complexity {
                     self.use_simplified_logic_expression = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_simplified_logic_expression = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useSimplifiedLogicExpression",
+                        diagnostics,
+                    )?;
+                    self.use_simplified_logic_expression = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -888,9 +1059,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_children_prop = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_children_prop = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noChildrenProp",
+                        diagnostics,
+                    )?;
+                    self.no_children_prop = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -906,9 +1082,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_const_assign = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_const_assign = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noConstAssign",
+                        diagnostics,
+                    )?;
+                    self.no_const_assign = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -924,9 +1105,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_constructor_return = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_constructor_return = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noConstructorReturn",
+                        diagnostics,
+                    )?;
+                    self.no_constructor_return = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -942,9 +1128,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_empty_pattern = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_empty_pattern = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noEmptyPattern",
+                        diagnostics,
+                    )?;
+                    self.no_empty_pattern = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -960,9 +1151,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_global_object_calls = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_global_object_calls = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noGlobalObjectCalls",
+                        diagnostics,
+                    )?;
+                    self.no_global_object_calls = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -978,9 +1174,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_inner_declarations = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_inner_declarations = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noInnerDeclarations",
+                        diagnostics,
+                    )?;
+                    self.no_inner_declarations = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -996,9 +1197,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_invalid_constructor_super = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_invalid_constructor_super = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noInvalidConstructorSuper",
+                        diagnostics,
+                    )?;
+                    self.no_invalid_constructor_super = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1014,9 +1220,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_new_symbol = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_new_symbol = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noNewSymbol",
+                        diagnostics,
+                    )?;
+                    self.no_new_symbol = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1032,9 +1243,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_precision_loss = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_precision_loss = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noPrecisionLoss",
+                        diagnostics,
+                    )?;
+                    self.no_precision_loss = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1050,9 +1266,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_render_return_value = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_render_return_value = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noRenderReturnValue",
+                        diagnostics,
+                    )?;
+                    self.no_render_return_value = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1068,9 +1289,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_setter_return = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_setter_return = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noSetterReturn",
+                        diagnostics,
+                    )?;
+                    self.no_setter_return = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1086,9 +1312,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_string_case_mismatch = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_string_case_mismatch = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noStringCaseMismatch",
+                        diagnostics,
+                    )?;
+                    self.no_string_case_mismatch = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1104,9 +1335,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_switch_declarations = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_switch_declarations = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noSwitchDeclarations",
+                        diagnostics,
+                    )?;
+                    self.no_switch_declarations = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1122,9 +1358,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_undeclared_variables = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_undeclared_variables = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUndeclaredVariables",
+                        diagnostics,
+                    )?;
+                    self.no_undeclared_variables = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1140,9 +1381,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_unnecessary_continue = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_unnecessary_continue = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUnnecessaryContinue",
+                        diagnostics,
+                    )?;
+                    self.no_unnecessary_continue = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1158,9 +1404,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_unreachable = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_unreachable = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUnreachable",
+                        diagnostics,
+                    )?;
+                    self.no_unreachable = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1176,9 +1427,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_unreachable_super = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_unreachable_super = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUnreachableSuper",
+                        diagnostics,
+                    )?;
+                    self.no_unreachable_super = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1194,9 +1450,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_unsafe_finally = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_unsafe_finally = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUnsafeFinally",
+                        diagnostics,
+                    )?;
+                    self.no_unsafe_finally = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1212,9 +1473,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_unsafe_optional_chaining = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_unsafe_optional_chaining = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUnsafeOptionalChaining",
+                        diagnostics,
+                    )?;
+                    self.no_unsafe_optional_chaining = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1230,9 +1496,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_unused_labels = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_unused_labels = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUnusedLabels",
+                        diagnostics,
+                    )?;
+                    self.no_unused_labels = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1248,9 +1519,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_unused_variables = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_unused_variables = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUnusedVariables",
+                        diagnostics,
+                    )?;
+                    self.no_unused_variables = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1266,9 +1542,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_void_elements_with_children = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_void_elements_with_children = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noVoidElementsWithChildren",
+                        diagnostics,
+                    )?;
+                    self.no_void_elements_with_children = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1284,9 +1565,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.no_void_type_return = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_void_type_return = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noVoidTypeReturn",
+                        diagnostics,
+                    )?;
+                    self.no_void_type_return = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1302,9 +1588,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.use_valid_for_direction = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_valid_for_direction = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useValidForDirection",
+                        diagnostics,
+                    )?;
+                    self.use_valid_for_direction = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1320,9 +1611,14 @@ impl VisitNode<JsonLanguage> for Correctness {
                     self.use_yield = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_yield = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useYield",
+                        diagnostics,
+                    )?;
+                    self.use_yield = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1404,9 +1700,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_accumulating_spread = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_accumulating_spread = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noAccumulatingSpread",
+                        diagnostics,
+                    )?;
+                    self.no_accumulating_spread = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1422,9 +1723,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_aria_unsupported_elements = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_aria_unsupported_elements = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noAriaUnsupportedElements",
+                        diagnostics,
+                    )?;
+                    self.no_aria_unsupported_elements = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1440,9 +1746,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_banned_types = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_banned_types = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noBannedTypes",
+                        diagnostics,
+                    )?;
+                    self.no_banned_types = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1458,9 +1769,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_confusing_arrow = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_confusing_arrow = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noConfusingArrow",
+                        diagnostics,
+                    )?;
+                    self.no_confusing_arrow = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1476,9 +1792,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_console_log = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_console_log = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noConsoleLog",
+                        diagnostics,
+                    )?;
+                    self.no_console_log = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1494,9 +1815,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_constant_condition = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_constant_condition = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noConstantCondition",
+                        diagnostics,
+                    )?;
+                    self.no_constant_condition = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1512,9 +1838,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_duplicate_json_keys = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_duplicate_json_keys = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDuplicateJsonKeys",
+                        diagnostics,
+                    )?;
+                    self.no_duplicate_json_keys = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1530,9 +1861,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_duplicate_jsx_props = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_duplicate_jsx_props = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDuplicateJsxProps",
+                        diagnostics,
+                    )?;
+                    self.no_duplicate_jsx_props = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1548,9 +1884,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_excessive_complexity = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_excessive_complexity = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noExcessiveComplexity",
+                        diagnostics,
+                    )?;
+                    self.no_excessive_complexity = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1566,9 +1907,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_for_each = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_for_each = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noForEach",
+                        diagnostics,
+                    )?;
+                    self.no_for_each = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1584,9 +1930,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_global_is_finite = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_global_is_finite = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noGlobalIsFinite",
+                        diagnostics,
+                    )?;
+                    self.no_global_is_finite = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1602,9 +1953,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_global_is_nan = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_global_is_nan = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noGlobalIsNan",
+                        diagnostics,
+                    )?;
+                    self.no_global_is_nan = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1620,9 +1976,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_noninteractive_tabindex = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_noninteractive_tabindex = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noNoninteractiveTabindex",
+                        diagnostics,
+                    )?;
+                    self.no_noninteractive_tabindex = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1638,9 +1999,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_nonoctal_decimal_escape = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_nonoctal_decimal_escape = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noNonoctalDecimalEscape",
+                        diagnostics,
+                    )?;
+                    self.no_nonoctal_decimal_escape = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1656,9 +2022,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_redundant_roles = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_redundant_roles = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noRedundantRoles",
+                        diagnostics,
+                    )?;
+                    self.no_redundant_roles = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1674,9 +2045,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_self_assign = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_self_assign = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noSelfAssign",
+                        diagnostics,
+                    )?;
+                    self.no_self_assign = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1692,9 +2068,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_static_only_class = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_static_only_class = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noStaticOnlyClass",
+                        diagnostics,
+                    )?;
+                    self.no_static_only_class = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1710,9 +2091,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.no_void = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_void = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noVoid",
+                        diagnostics,
+                    )?;
+                    self.no_void = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1728,9 +2114,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_aria_prop_types = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_aria_prop_types = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useAriaPropTypes",
+                        diagnostics,
+                    )?;
+                    self.use_aria_prop_types = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1746,9 +2137,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_arrow_function = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_arrow_function = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useArrowFunction",
+                        diagnostics,
+                    )?;
+                    self.use_arrow_function = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1764,9 +2160,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_camel_case = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_camel_case = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useCamelCase",
+                        diagnostics,
+                    )?;
+                    self.use_camel_case = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1782,9 +2183,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_exhaustive_dependencies = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_exhaustive_dependencies = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useExhaustiveDependencies",
+                        diagnostics,
+                    )?;
+                    self.use_exhaustive_dependencies = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1800,9 +2206,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_grouped_type_import = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_grouped_type_import = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useGroupedTypeImport",
+                        diagnostics,
+                    )?;
+                    self.use_grouped_type_import = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1818,9 +2229,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_heading_content = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_heading_content = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useHeadingContent",
+                        diagnostics,
+                    )?;
+                    self.use_heading_content = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1836,9 +2252,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_hook_at_top_level = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_hook_at_top_level = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useHookAtTopLevel",
+                        diagnostics,
+                    )?;
+                    self.use_hook_at_top_level = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1854,9 +2275,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_is_nan = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_is_nan = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useIsNan",
+                        diagnostics,
+                    )?;
+                    self.use_is_nan = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1872,9 +2298,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_literal_enum_members = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_literal_enum_members = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useLiteralEnumMembers",
+                        diagnostics,
+                    )?;
+                    self.use_literal_enum_members = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1890,9 +2321,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_literal_keys = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_literal_keys = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useLiteralKeys",
+                        diagnostics,
+                    )?;
+                    self.use_literal_keys = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1908,9 +2344,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_naming_convention = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_naming_convention = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useNamingConvention",
+                        diagnostics,
+                    )?;
+                    self.use_naming_convention = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1926,9 +2367,14 @@ impl VisitNode<JsonLanguage> for Nursery {
                     self.use_simple_number_keys = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_simple_number_keys = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useSimpleNumberKeys",
+                        diagnostics,
+                    )?;
+                    self.use_simple_number_keys = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -1973,9 +2419,14 @@ impl VisitNode<JsonLanguage> for Performance {
                     self.no_delete = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_delete = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDelete",
+                        diagnostics,
+                    )?;
+                    self.no_delete = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2029,9 +2480,14 @@ impl VisitNode<JsonLanguage> for Security {
                     self.no_dangerously_set_inner_html = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_dangerously_set_inner_html = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDangerouslySetInnerHtml",
+                        diagnostics,
+                    )?;
+                    self.no_dangerously_set_inner_html = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2047,9 +2503,14 @@ impl VisitNode<JsonLanguage> for Security {
                     self.no_dangerously_set_inner_html_with_children = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_dangerously_set_inner_html_with_children = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDangerouslySetInnerHtmlWithChildren",
+                        diagnostics,
+                    )?;
+                    self.no_dangerously_set_inner_html_with_children = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2127,9 +2588,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_arguments = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_arguments = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noArguments",
+                        diagnostics,
+                    )?;
+                    self.no_arguments = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2145,9 +2611,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_comma_operator = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_comma_operator = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noCommaOperator",
+                        diagnostics,
+                    )?;
+                    self.no_comma_operator = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2163,9 +2634,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_implicit_boolean = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_implicit_boolean = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noImplicitBoolean",
+                        diagnostics,
+                    )?;
+                    self.no_implicit_boolean = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2181,9 +2657,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_inferrable_types = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_inferrable_types = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noInferrableTypes",
+                        diagnostics,
+                    )?;
+                    self.no_inferrable_types = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2199,9 +2680,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_namespace = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_namespace = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noNamespace",
+                        diagnostics,
+                    )?;
+                    self.no_namespace = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2217,9 +2703,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_negation_else = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_negation_else = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noNegationElse",
+                        diagnostics,
+                    )?;
+                    self.no_negation_else = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2235,9 +2726,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_non_null_assertion = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_non_null_assertion = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noNonNullAssertion",
+                        diagnostics,
+                    )?;
+                    self.no_non_null_assertion = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2253,9 +2749,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_parameter_assign = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_parameter_assign = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noParameterAssign",
+                        diagnostics,
+                    )?;
+                    self.no_parameter_assign = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2271,9 +2772,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_parameter_properties = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_parameter_properties = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noParameterProperties",
+                        diagnostics,
+                    )?;
+                    self.no_parameter_properties = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2289,9 +2795,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_restricted_globals = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_restricted_globals = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noRestrictedGlobals",
+                        diagnostics,
+                    )?;
+                    self.no_restricted_globals = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2307,9 +2818,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_shouty_constants = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_shouty_constants = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noShoutyConstants",
+                        diagnostics,
+                    )?;
+                    self.no_shouty_constants = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2325,9 +2841,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_unused_template_literal = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_unused_template_literal = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUnusedTemplateLiteral",
+                        diagnostics,
+                    )?;
+                    self.no_unused_template_literal = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2343,9 +2864,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.no_var = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_var = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noVar",
+                        diagnostics,
+                    )?;
+                    self.no_var = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2361,9 +2887,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_block_statements = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_block_statements = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useBlockStatements",
+                        diagnostics,
+                    )?;
+                    self.use_block_statements = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2379,9 +2910,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_const = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_const = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useConst",
+                        diagnostics,
+                    )?;
+                    self.use_const = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2397,9 +2933,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_default_parameter_last = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_default_parameter_last = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useDefaultParameterLast",
+                        diagnostics,
+                    )?;
+                    self.use_default_parameter_last = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2415,9 +2956,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_enum_initializers = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_enum_initializers = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useEnumInitializers",
+                        diagnostics,
+                    )?;
+                    self.use_enum_initializers = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2433,9 +2979,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_exponentiation_operator = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_exponentiation_operator = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useExponentiationOperator",
+                        diagnostics,
+                    )?;
+                    self.use_exponentiation_operator = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2451,9 +3002,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_fragment_syntax = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_fragment_syntax = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useFragmentSyntax",
+                        diagnostics,
+                    )?;
+                    self.use_fragment_syntax = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2469,9 +3025,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_numeric_literals = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_numeric_literals = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useNumericLiterals",
+                        diagnostics,
+                    )?;
+                    self.use_numeric_literals = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2487,9 +3048,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_self_closing_elements = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_self_closing_elements = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useSelfClosingElements",
+                        diagnostics,
+                    )?;
+                    self.use_self_closing_elements = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2505,9 +3071,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_shorthand_array_type = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_shorthand_array_type = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useShorthandArrayType",
+                        diagnostics,
+                    )?;
+                    self.use_shorthand_array_type = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2523,9 +3094,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_single_case_statement = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_single_case_statement = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useSingleCaseStatement",
+                        diagnostics,
+                    )?;
+                    self.use_single_case_statement = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2541,9 +3117,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_single_var_declarator = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_single_var_declarator = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useSingleVarDeclarator",
+                        diagnostics,
+                    )?;
+                    self.use_single_var_declarator = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2559,9 +3140,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_template = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_template = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useTemplate",
+                        diagnostics,
+                    )?;
+                    self.use_template = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2577,9 +3163,14 @@ impl VisitNode<JsonLanguage> for Style {
                     self.use_while = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_while = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useWhile",
+                        diagnostics,
+                    )?;
+                    self.use_while = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2662,9 +3253,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_array_index_key = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_array_index_key = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noArrayIndexKey",
+                        diagnostics,
+                    )?;
+                    self.no_array_index_key = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2680,9 +3276,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_assign_in_expressions = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_assign_in_expressions = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noAssignInExpressions",
+                        diagnostics,
+                    )?;
+                    self.no_assign_in_expressions = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2698,9 +3299,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_async_promise_executor = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_async_promise_executor = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noAsyncPromiseExecutor",
+                        diagnostics,
+                    )?;
+                    self.no_async_promise_executor = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2716,9 +3322,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_catch_assign = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_catch_assign = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noCatchAssign",
+                        diagnostics,
+                    )?;
+                    self.no_catch_assign = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2734,9 +3345,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_class_assign = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_class_assign = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noClassAssign",
+                        diagnostics,
+                    )?;
+                    self.no_class_assign = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2752,9 +3368,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_comment_text = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_comment_text = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noCommentText",
+                        diagnostics,
+                    )?;
+                    self.no_comment_text = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2770,9 +3391,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_compare_neg_zero = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_compare_neg_zero = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noCompareNegZero",
+                        diagnostics,
+                    )?;
+                    self.no_compare_neg_zero = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2788,9 +3414,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_confusing_labels = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_confusing_labels = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noConfusingLabels",
+                        diagnostics,
+                    )?;
+                    self.no_confusing_labels = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2806,9 +3437,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_const_enum = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_const_enum = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noConstEnum",
+                        diagnostics,
+                    )?;
+                    self.no_const_enum = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2824,9 +3460,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_debugger = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_debugger = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDebugger",
+                        diagnostics,
+                    )?;
+                    self.no_debugger = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2842,9 +3483,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_double_equals = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_double_equals = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDoubleEquals",
+                        diagnostics,
+                    )?;
+                    self.no_double_equals = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2860,9 +3506,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_duplicate_case = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_duplicate_case = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDuplicateCase",
+                        diagnostics,
+                    )?;
+                    self.no_duplicate_case = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2878,9 +3529,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_duplicate_class_members = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_duplicate_class_members = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDuplicateClassMembers",
+                        diagnostics,
+                    )?;
+                    self.no_duplicate_class_members = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2896,9 +3552,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_duplicate_object_keys = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_duplicate_object_keys = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDuplicateObjectKeys",
+                        diagnostics,
+                    )?;
+                    self.no_duplicate_object_keys = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2914,9 +3575,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_duplicate_parameters = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_duplicate_parameters = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noDuplicateParameters",
+                        diagnostics,
+                    )?;
+                    self.no_duplicate_parameters = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2932,9 +3598,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_empty_interface = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_empty_interface = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noEmptyInterface",
+                        diagnostics,
+                    )?;
+                    self.no_empty_interface = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2950,9 +3621,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_explicit_any = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_explicit_any = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noExplicitAny",
+                        diagnostics,
+                    )?;
+                    self.no_explicit_any = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2968,9 +3644,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_extra_non_null_assertion = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_extra_non_null_assertion = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noExtraNonNullAssertion",
+                        diagnostics,
+                    )?;
+                    self.no_extra_non_null_assertion = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -2986,9 +3667,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_function_assign = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_function_assign = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noFunctionAssign",
+                        diagnostics,
+                    )?;
+                    self.no_function_assign = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3004,9 +3690,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_import_assign = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_import_assign = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noImportAssign",
+                        diagnostics,
+                    )?;
+                    self.no_import_assign = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3022,9 +3713,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_label_var = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_label_var = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noLabelVar",
+                        diagnostics,
+                    )?;
+                    self.no_label_var = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3040,9 +3736,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_prototype_builtins = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_prototype_builtins = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noPrototypeBuiltins",
+                        diagnostics,
+                    )?;
+                    self.no_prototype_builtins = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3058,9 +3759,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_redeclare = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_redeclare = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noRedeclare",
+                        diagnostics,
+                    )?;
+                    self.no_redeclare = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3076,9 +3782,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_redundant_use_strict = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_redundant_use_strict = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noRedundantUseStrict",
+                        diagnostics,
+                    )?;
+                    self.no_redundant_use_strict = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3094,9 +3805,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_self_compare = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_self_compare = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noSelfCompare",
+                        diagnostics,
+                    )?;
+                    self.no_self_compare = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3112,9 +3828,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_shadow_restricted_names = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_shadow_restricted_names = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noShadowRestrictedNames",
+                        diagnostics,
+                    )?;
+                    self.no_shadow_restricted_names = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3130,9 +3851,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_sparse_array = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_sparse_array = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noSparseArray",
+                        diagnostics,
+                    )?;
+                    self.no_sparse_array = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3148,9 +3874,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.no_unsafe_negation = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.no_unsafe_negation = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUnsafeNegation",
+                        diagnostics,
+                    )?;
+                    self.no_unsafe_negation = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3166,9 +3897,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.use_default_switch_clause_last = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_default_switch_clause_last = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useDefaultSwitchClauseLast",
+                        diagnostics,
+                    )?;
+                    self.use_default_switch_clause_last = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3184,9 +3920,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.use_namespace_keyword = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_namespace_keyword = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useNamespaceKeyword",
+                        diagnostics,
+                    )?;
+                    self.use_namespace_keyword = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
@@ -3202,9 +3943,14 @@ impl VisitNode<JsonLanguage> for Suspicious {
                     self.use_valid_typeof = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.use_valid_typeof = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useValidTypeof",
+                        diagnostics,
+                    )?;
+                    self.use_valid_typeof = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(

--- a/crates/rome_service/tests/invalid/hooks_incorrect_options.json
+++ b/crates/rome_service/tests/invalid/hooks_incorrect_options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../npm/rome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useExhaustiveDependencies": {
+					"level": "error",
+					"options": {
+						"hooksTYPO": {}
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/rome_service/tests/invalid/hooks_incorrect_options.json.snap
+++ b/crates/rome_service/tests/invalid/hooks_incorrect_options.json.snap
@@ -1,0 +1,21 @@
+---
+source: crates/rome_service/tests/spec_tests.rs
+expression: hooks_incorrect_options.json
+---
+hooks_incorrect_options.json:9:7 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Found an unknown key `hooksTYPO`.
+  
+     7 │ 					"level": "error",
+     8 │ 					"options": {
+   > 9 │ 						"hooksTYPO": {}
+       │ 						^^^^^^^^^^^
+    10 │ 					}
+    11 │ 				}
+  
+  i Accepted keys
+  
+  - hooks
+  
+
+

--- a/crates/rome_service/tests/invalid/naming_convention_incorrect_options.json
+++ b/crates/rome_service/tests/invalid/naming_convention_incorrect_options.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../npm/rome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useNamingConvention": {
+					"level": "error",
+					"options": {
+						"strictCaseTYPO": {}
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/rome_service/tests/invalid/naming_convention_incorrect_options.json.snap
+++ b/crates/rome_service/tests/invalid/naming_convention_incorrect_options.json.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rome_service/tests/spec_tests.rs
+expression: naming_convention_incorrect_options.json
+---
+naming_convention_incorrect_options.json:9:7 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Found an unknown key `strictCaseTYPO`.
+  
+     7 │ 					"level": "error",
+     8 │ 					"options": {
+   > 9 │ 						"strictCaseTYPO": {}
+       │ 						^^^^^^^^^^^^^^^^
+    10 │ 					}
+    11 │ 				}
+  
+  i Accepted keys
+  
+  - strictCase
+  - enumMemberCase
+  
+
+

--- a/website/src/pages/lint/rules/noNonoctalDecimalEscape.md
+++ b/website/src/pages/lint/rules/noNonoctalDecimalEscape.md
@@ -15,24 +15,6 @@ However, most JavaScript engines consider them to be "useless" escapes. For exam
 "\9" === "9"; // true
 ```
 
-nursery/noNonoctalDecimalEscape.js:1:2 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>&quot;\8&quot; === &quot;8&quot;; // true
-   <strong>   │ </strong> <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>&quot;\9&quot; === &quot;9&quot;; // true
-    <strong>3 │ </strong>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.</span>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\8</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>8</strong></span><span style="color: rgb(38, 148, 255);">. This maintains the current functionality.</span>
-  
-    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">&quot;</span><span style="color: Tomato;"><strong>\</strong></span><span style="color: Tomato;">8</span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;">=</span><span style="color: Tomato;">=</span><span style="color: Tomato;">=</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">8</span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">;</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">/</span><span style="color: Tomato;">/</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">t</span><span style="color: Tomato;">r</span><span style="color: Tomato;">u</span><span style="color: Tomato;">e</span>
-      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">8</span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: MediumSeaGreen;">=</span><span style="color: MediumSeaGreen;">=</span><span style="color: MediumSeaGreen;">=</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">8</span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">;</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;">/</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;">r</span><span style="color: MediumSeaGreen;">u</span><span style="color: MediumSeaGreen;">e</span>
-    <strong>2</strong> <strong>2</strong><strong> │ </strong>  &quot;\9&quot; === &quot;9&quot;; // true
-    <strong>3</strong> <strong>3</strong><strong> │ </strong>  
-  
 Although this syntax is deprecated, it is still supported for compatibility reasons.
 If the ECMAScript host is not a web browser, this syntax is optional.
 However, web browsers are still required to support it, but only in non-strict mode.
@@ -79,14 +61,14 @@ nursery/noNonoctalDecimalEscape.js:1:12 <a href="https://docs.rome.tools/lint/ru
 </code></pre>
 
 ```jsx
-const x = "Don't use \8 and \9 escapes.";
+const x = "Don't use \8 escape.";
 ```
 
 <pre class="language-text"><code class="language-text">nursery/noNonoctalDecimalEscape.js:1:22 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;Don't use \8 and \9 escapes.&quot;;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;Don't use \8 escape.&quot;;
    <strong>   │ </strong>                     <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
   
@@ -94,13 +76,13 @@ const x = "Don't use \8 and \9 escapes.";
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\8</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>8</strong></span><span style="color: rgb(38, 148, 255);">. This maintains the current functionality.</span>
   
-<strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span><span style="color: Tomato;">\</span>8<span style="opacity: 0.8;">·</span>and<span style="opacity: 0.8;">·</span>\9<span style="opacity: 0.8;">·</span>escapes.&quot;;
-<strong>  </strong><strong>    │ </strong>                     <span style="color: Tomato;">-</span>                   
+<strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span><span style="color: Tomato;">\</span>8<span style="opacity: 0.8;">·</span>escape.&quot;;
+<strong>  </strong><strong>    │ </strong>                     <span style="color: Tomato;">-</span>           
 nursery/noNonoctalDecimalEscape.js:1:22 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━
 
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
   
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;Don't use \8 and \9 escapes.&quot;;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;Don't use \8 escape.&quot;;
    <strong>   │ </strong>                     <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>2 │ </strong>
   
@@ -108,8 +90,42 @@ nursery/noNonoctalDecimalEscape.js:1:22 <a href="https://docs.rome.tools/lint/ru
   
 <strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\8</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>\\8</strong></span><span style="color: rgb(38, 148, 255);"> to include the actual backslash character.</span>
   
-<strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span>\<span style="color: MediumSeaGreen;">\</span>8<span style="opacity: 0.8;">·</span>and<span style="opacity: 0.8;">·</span>\9<span style="opacity: 0.8;">·</span>escapes.&quot;;
-<strong>  </strong><strong>    │ </strong>                      <span style="color: MediumSeaGreen;">+</span>                   
+<strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span>\<span style="color: MediumSeaGreen;">\</span>8<span style="opacity: 0.8;">·</span>escape.&quot;;
+<strong>  </strong><strong>    │ </strong>                      <span style="color: MediumSeaGreen;">+</span>           
+</code></pre>
+
+```jsx
+const x = "Don't use \9 escape.";
+```
+
+<pre class="language-text"><code class="language-text">nursery/noNonoctalDecimalEscape.js:1:22 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;Don't use \9 escape.&quot;;
+   <strong>   │ </strong>                     <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\9</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>9</strong></span><span style="color: rgb(38, 148, 255);">. This maintains the current functionality.</span>
+  
+<strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span><span style="color: Tomato;">\</span>9<span style="opacity: 0.8;">·</span>escape.&quot;;
+<strong>  </strong><strong>    │ </strong>                     <span style="color: Tomato;">-</span>           
+nursery/noNonoctalDecimalEscape.js:1:22 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;Don't use \9 escape.&quot;;
+   <strong>   │ </strong>                     <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\9</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>\\9</strong></span><span style="color: rgb(38, 148, 255);"> to include the actual backslash character.</span>
+  
+<strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span>\<span style="color: MediumSeaGreen;">\</span>9<span style="opacity: 0.8;">·</span>escape.&quot;;
+<strong>  </strong><strong>    │ </strong>                      <span style="color: MediumSeaGreen;">+</span>           
 </code></pre>
 
 ```jsx

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -610,9 +610,9 @@ fn generate_visitor(group: &str, rules: &BTreeMap<&'static str, RuleMetadata>) -
                     self.#rule_identifier = Some(configuration);
                 }
                 AnyJsonValue::JsonObjectValue(_) => {
-                    let mut configuration = RuleConfiguration::default();
-                    self.map_to_object(&value, name_text, &mut configuration, diagnostics)?;
-                    self.#rule_identifier = Some(configuration);
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(&value, name_text, #rule_name, diagnostics)?;
+                    self.#rule_identifier = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR refactors the way we deserialize the options of the lint rules.

I wasn't delighted with the diagnostic messages, there were very unclear and we were showing suggestions that didn't belong to the rule we were scanning.

I created ad-hoc functions to pass down the rule name and use it to emit correct diagnostics. This involves a bit more code, but it gives the user a better message.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new test cases and updated the current ones

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
