### PR TITLE
fix(rome_js_analyze): noUselessFragments use JsxString node when replacing JsxText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,10 @@ multiple files:
 
   The rule no longer reports false positive diagnostics when accessing properties directly from a hook and calling a hook inside function arguments.
 
+- Fix [noUselessFragments](https://docs.rome.tools/lint/rules/nouselessfragments/)'s panics when running `rome check --apply-unsafe` ([#4637](https://github.com/rome/tools/issues/4639))
+
+  This rule's code action emits an invalid AST, so I fixed using JsxString instead of JsStringLiteral
+
 ### Parser
 
 ### VSCode

--- a/crates/rome_js_analyze/src/semantic_analyzers/complexity/no_useless_fragments.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/complexity/no_useless_fragments.rs
@@ -5,9 +5,7 @@ use rome_analyze::context::RuleContext;
 use rome_analyze::{declare_rule, ActionCategory, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_diagnostics::Applicability;
-use rome_js_factory::make::{
-    ident, js_expression_statement, js_string_literal_expression, jsx_tag_expression,
-};
+use rome_js_factory::make::{ident, js_expression_statement, jsx_string, jsx_tag_expression};
 use rome_js_syntax::{
     AnyJsxChild, AnyJsxElementName, AnyJsxTag, JsLanguage, JsParenthesizedExpression, JsSyntaxKind,
     JsxChildList, JsxElement, JsxFragment, JsxTagExpression,
@@ -243,11 +241,7 @@ impl Rule for NoUselessFragments {
                     ),
                     AnyJsxChild::JsxText(text) => {
                         let new_value = format!("\"{}\"", text.value_token().ok()?);
-                        Some(
-                            js_string_literal_expression(ident(&new_value))
-                                .syntax()
-                                .clone(),
-                        )
+                        Some(jsx_string(ident(&new_value)).syntax().clone())
                     }
                     AnyJsxChild::JsxExpressionChild(child) => {
                         child.expression().map(|expression| {

--- a/crates/rome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4639.jsx
+++ b/crates/rome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4639.jsx
@@ -1,0 +1,3 @@
+export function SomeComponent() {
+  return <div x-some-prop={<>Foo</>} />;
+}

--- a/crates/rome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4639.jsx.snap
+++ b/crates/rome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4639.jsx.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: issue_4639.jsx
+---
+# Input
+```js
+export function SomeComponent() {
+  return <div x-some-prop={<>Foo</>} />;
+}
+
+```
+
+# Diagnostics
+```
+issue_4639.jsx:2:28 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Avoid using unnecessary Fragment.
+  
+    1 │ export function SomeComponent() {
+  > 2 │   return <div x-some-prop={<>Foo</>} />;
+      │                            ^^^^^^^^
+    3 │ }
+    4 │ 
+  
+  i Suggested fix: Remove the Fragment
+  
+    1 1 │   export function SomeComponent() {
+    2   │ - ··return·<div·x-some-prop={<>Foo</>}·/>;
+      2 │ + ··return·<div·x-some-prop="Foo"·/>;
+    3 3 │   }
+    4 4 │   
+  
+
+```
+
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix #4639

see: https://docs.rome.tools/playground/?lintRules=all&code=ZQB4AHAAbwByAHQAIABmAHUAbgBjAHQAaQBvAG4AIABTAG8AbQBlAEMAbwBtAHAAbwBuAGUAbgB0ACgAKQAgAHsACgAgACAAcgBlAHQAdQByAG4AIAA8AGQAaQB2ACAAeAAtAHMAbwBtAGUALQBwAHIAbwBwAD0AewA8AD4ARgBvAG8APAAvAD4AfQAgAC8APgA7AAoAfQAKAAoAZQB4AHAAbwByAHQAIABmAHUAbgBjAHQAaQBvAG4AIABTAG8AbQBlAEMAbwBtAHAAbwBuAGUAbgB0AEEAKAApACAAewAKACAAIAByAGUAdAB1AHIAbgAgADwAZABpAHYAIAB4AC0AcwBvAG0AZQAtAHAAcgBvAHAAPQAiAEYAbwBvACIAIAAvAD4AOwAKAH0A

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I update some snapshot tests and I checked the issue was resolved by using https://github.com/fubhy/rome-bug-repro.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
