### PR TITLE
fix(rome_js_analyze): noNonoctalDecimalEscape returns single diagnostic

### DIFF
--- a/crates/rome_js_analyze/src/analyzers/nursery/no_nonoctal_decimal_escape.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_nonoctal_decimal_escape.rs
@@ -61,7 +61,6 @@ declare_rule! {
 #[derive(Debug)]
 pub(crate) enum FixSuggestionKind {
     Refactor,
-    // EscapeBackslash,
 }
 
 #[derive(Debug)]
@@ -148,14 +147,6 @@ impl Rule for NoNonoctalDecimalEscape {
                         replace_string_range: replace_string_range.clone(),
                     })
                 }
-                // \8 -> \\8
-                // signals.push(RuleState {
-                //     kind: FixSuggestionKind::EscapeBackslash,
-                //     diagnostics_text_range: decimal_escape_range,
-                //     replace_to: format!("\\{}", decimal_escape),
-                //     replace_from: decimal_escape.to_string(),
-                //     replace_string_range,
-                // });
             }
         }
 
@@ -214,9 +205,6 @@ impl Rule for NoNonoctalDecimalEscape {
 				FixSuggestionKind::Refactor => {
 					markup! ("Replace "<Emphasis>{replace_from}</Emphasis>" with "<Emphasis>{replace_to}</Emphasis>". This maintains the current functionality.").to_owned()
 				}
-				// FixSuggestionKind::EscapeBackslash => {
-				// 	markup! ("Replace "<Emphasis>{replace_from}</Emphasis>" with "<Emphasis>{replace_to}</Emphasis>" to include the actual backslash character." ).to_owned()
-				// }
 			},
             mutation,
         })

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_nonoctal_decimal_escape.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_nonoctal_decimal_escape.rs
@@ -41,10 +41,6 @@ declare_rule! {
     /// const x = "Don't use \9 escape.";
     /// ```
     ///
-    /// ```js,expect_diagnostic
-    /// const x = "\0\8";
-    /// ```
-    ///
     /// ## Valid
     ///
     /// ```js
@@ -53,10 +49,6 @@ declare_rule! {
     ///
     /// ```js
     /// const x = "Don't use \\8 and \\9 escapes.";
-    /// ```
-    ///
-    /// ```js
-    /// const x = "\0\u0038";;
     /// ```
     ///
     pub(crate) NoNonoctalDecimalEscape {

--- a/crates/rome_js_analyze/tests/specs/nursery/noNonoctalDecimalEscape/invalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noNonoctalDecimalEscape/invalid.js.snap
@@ -72,25 +72,6 @@ invalid.js:1:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:1:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-  > 1 │ let x = "\8"
-      │          ^^
-    2 │ let x = "\9"
-    3 │ let x = "\"\8\""
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    1 │ let·x·=·"\\8"
-      │           +  
-
-```
-
-```
 invalid.js:2:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -107,26 +88,6 @@ invalid.js:2:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     2 │ let·x·=·"\9"
       │          -  
-
-```
-
-```
-invalid.js:2:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    1 │ let x = "\8"
-  > 2 │ let x = "\9"
-      │          ^^
-    3 │ let x = "\"\8\""
-    4 │ let x = "f\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    2 │ let·x·=·"\\9"
-      │           +  
 
 ```
 
@@ -148,27 +109,6 @@ invalid.js:3:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     3 │ let·x·=·"\"\8\""
       │            -    
-
-```
-
-```
-invalid.js:3:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    1 │ let x = "\8"
-    2 │ let x = "\9"
-  > 3 │ let x = "\"\8\""
-      │            ^^
-    4 │ let x = "f\9"
-    5 │ let x = "fo\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    3 │ let·x·=·"\"\\8\""
-      │             +    
 
 ```
 
@@ -199,27 +139,6 @@ invalid.js:4:11 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:4:11 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    2 │ let x = "\9"
-    3 │ let x = "\"\8\""
-  > 4 │ let x = "f\9"
-      │           ^^
-    5 │ let x = "fo\9"
-    6 │ let x = "foo\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    4 │ let·x·=·"f\\9"
-      │            +  
-
-```
-
-```
 invalid.js:5:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -242,27 +161,6 @@ invalid.js:5:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
      6  6 │   let x = "foo\9"
      7  7 │   let x = "foo\8bar"
   
-
-```
-
-```
-invalid.js:5:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    3 │ let x = "\"\8\""
-    4 │ let x = "f\9"
-  > 5 │ let x = "fo\9"
-      │            ^^
-    6 │ let x = "foo\9"
-    7 │ let x = "foo\8bar"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    5 │ let·x·=·"fo\\9"
-      │             +  
 
 ```
 
@@ -293,27 +191,6 @@ invalid.js:6:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:6:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    4 │ let x = "f\9"
-    5 │ let x = "fo\9"
-  > 6 │ let x = "foo\9"
-      │             ^^
-    7 │ let x = "foo\8bar"
-    8 │ let x = "👍\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    6 │ let·x·=·"foo\\9"
-      │              +  
-
-```
-
-```
 invalid.js:7:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -340,27 +217,6 @@ invalid.js:7:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:7:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    5 │ let x = "fo\9"
-    6 │ let x = "foo\9"
-  > 7 │ let x = "foo\8bar"
-      │             ^^
-    8 │ let x = "👍\8"
-    9 │ let x = "\\\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    7 │ let·x·=·"foo\\8bar"
-      │              +     
-
-```
-
-```
 invalid.js:8:11 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -378,27 +234,6 @@ invalid.js:8:11 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     8 │ let·x·=·"👍\8"
       │            -  
-
-```
-
-```
-invalid.js:8:11 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-     6 │ let x = "foo\9"
-     7 │ let x = "foo\8bar"
-   > 8 │ let x = "👍\8"
-       │            ^^
-     9 │ let x = "\\\8"
-    10 │ let x = "\\\\\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    8 │ let·x·=·"👍\\8"
-      │             +  
 
 ```
 
@@ -424,27 +259,6 @@ invalid.js:9:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:9:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-     7 │ let x = "foo\8bar"
-     8 │ let x = "👍\8"
-   > 9 │ let x = "\\\8"
-       │            ^^
-    10 │ let x = "\\\\\9"
-    11 │ let x = "foo\\\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    9 │ let·x·=·"\\\\8"
-      │             +  
-
-```
-
-```
 invalid.js:10:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -462,27 +276,6 @@ invalid.js:10:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     10 │ let·x·=·"\\\\\9"
        │              -  
-
-```
-
-```
-invalid.js:10:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-     8 │ let x = "👍\8"
-     9 │ let x = "\\\8"
-  > 10 │ let x = "\\\\\9"
-       │              ^^
-    11 │ let x = "foo\\\8"
-    12 │ let x = "\\ \8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    10 │ let·x·=·"\\\\\\9"
-       │               +  
 
 ```
 
@@ -508,27 +301,6 @@ invalid.js:11:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:11:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-     9 │ let x = "\\\8"
-    10 │ let x = "\\\\\9"
-  > 11 │ let x = "foo\\\8"
-       │               ^^
-    12 │ let x = "\\ \8"
-    13 │ let x = "\\1\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    11 │ let·x·=·"foo\\\\8"
-       │                +  
-
-```
-
-```
 invalid.js:12:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -546,27 +318,6 @@ invalid.js:12:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     12 │ let·x·=·"\\·\8"
        │             -  
-
-```
-
-```
-invalid.js:12:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    10 │ let x = "\\\\\9"
-    11 │ let x = "foo\\\8"
-  > 12 │ let x = "\\ \8"
-       │             ^^
-    13 │ let x = "\\1\9"
-    14 │ let x = "foo\\1\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    12 │ let·x·=·"\\·\\8"
-       │              +  
 
 ```
 
@@ -597,27 +348,6 @@ invalid.js:13:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:13:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    11 │ let x = "foo\\\8"
-    12 │ let x = "\\ \8"
-  > 13 │ let x = "\\1\9"
-       │             ^^
-    14 │ let x = "foo\\1\9"
-    15 │ let x = "\\n\\n\8\\n"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    13 │ let·x·=·"\\1\\9"
-       │              +  
-
-```
-
-```
 invalid.js:14:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -640,27 +370,6 @@ invalid.js:14:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
     15 15 │   let x = "\\n\\n\8\\n"
     16 16 │   let x = "\\n.\\n\8\\n"
   
-
-```
-
-```
-invalid.js:14:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    12 │ let x = "\\ \8"
-    13 │ let x = "\\1\9"
-  > 14 │ let x = "foo\\1\9"
-       │                ^^
-    15 │ let x = "\\n\\n\8\\n"
-    16 │ let x = "\\n.\\n\8\\n"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    14 │ let·x·=·"foo\\1\\9"
-       │                 +  
 
 ```
 
@@ -691,27 +400,6 @@ invalid.js:15:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:15:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    13 │ let x = "\\1\9"
-    14 │ let x = "foo\\1\9"
-  > 15 │ let x = "\\n\\n\8\\n"
-       │                ^^
-    16 │ let x = "\\n.\\n\8\\n"
-    17 │ let x = "\\n.\\nn\8\\n"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    15 │ let·x·=·"\\n\\n\\8\\n"
-       │                 +     
-
-```
-
-```
 invalid.js:16:17 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -734,27 +422,6 @@ invalid.js:16:17 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
     17 17 │   let x = "\\n.\\nn\8\\n"
     18 18 │   let x = "\\👍\8"
   
-
-```
-
-```
-invalid.js:16:17 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    14 │ let x = "foo\\1\9"
-    15 │ let x = "\\n\\n\8\\n"
-  > 16 │ let x = "\\n.\\n\8\\n"
-       │                 ^^
-    17 │ let x = "\\n.\\nn\8\\n"
-    18 │ let x = "\\👍\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    16 │ let·x·=·"\\n.\\n\\8\\n"
-       │                  +     
 
 ```
 
@@ -785,27 +452,6 @@ invalid.js:17:18 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:17:18 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    15 │ let x = "\\n\\n\8\\n"
-    16 │ let x = "\\n.\\n\8\\n"
-  > 17 │ let x = "\\n.\\nn\8\\n"
-       │                  ^^
-    18 │ let x = "\\👍\8"
-    19 │ let x = "\\\8\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    17 │ let·x·=·"\\n.\\nn\\8\\n"
-       │                   +     
-
-```
-
-```
 invalid.js:18:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -823,27 +469,6 @@ invalid.js:18:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     18 │ let·x·=·"\\👍\8"
        │              -  
-
-```
-
-```
-invalid.js:18:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    16 │ let x = "\\n.\\n\8\\n"
-    17 │ let x = "\\n.\\nn\8\\n"
-  > 18 │ let x = "\\👍\8"
-       │              ^^
-    19 │ let x = "\\\8\9"
-    20 │ let x = "\8\\\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    18 │ let·x·=·"\\👍\\8"
-       │               +  
 
 ```
 
@@ -869,48 +494,6 @@ invalid.js:19:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:19:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    17 │ let x = "\\n.\\nn\8\\n"
-    18 │ let x = "\\👍\8"
-  > 19 │ let x = "\\\8\9"
-       │            ^^
-    20 │ let x = "\8\\\9"
-    21 │ let x = "\8 \\\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    19 │ let·x·=·"\\\\8\9"
-       │             +    
-
-```
-
-```
-invalid.js:19:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    17 │ let x = "\\n.\\nn\8\\n"
-    18 │ let x = "\\👍\8"
-  > 19 │ let x = "\\\8\9"
-       │              ^^
-    20 │ let x = "\8\\\9"
-    21 │ let x = "\8 \\\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    19 │ let·x·=·"\\\8\\9"
-       │               +  
-
-```
-
-```
 invalid.js:20:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -932,48 +515,6 @@ invalid.js:20:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:20:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    18 │ let x = "\\👍\8"
-    19 │ let x = "\\\8\9"
-  > 20 │ let x = "\8\\\9"
-       │          ^^
-    21 │ let x = "\8 \\\9"
-    22 │ let x = "\8\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    20 │ let·x·=·"\\8\\\9"
-       │           +      
-
-```
-
-```
-invalid.js:20:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    18 │ let x = "\\👍\8"
-    19 │ let x = "\\\8\9"
-  > 20 │ let x = "\8\\\9"
-       │              ^^
-    21 │ let x = "\8 \\\9"
-    22 │ let x = "\8\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    20 │ let·x·=·"\8\\\\9"
-       │               +  
-
-```
-
-```
 invalid.js:21:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -991,48 +532,6 @@ invalid.js:21:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     21 │ let·x·=·"\8·\\\9"
        │          -       
-
-```
-
-```
-invalid.js:21:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    19 │ let x = "\\\8\9"
-    20 │ let x = "\8\\\9"
-  > 21 │ let x = "\8 \\\9"
-       │          ^^
-    22 │ let x = "\8\8"
-    23 │ let x = "\9\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    21 │ let·x·=·"\\8·\\\9"
-       │           +       
-
-```
-
-```
-invalid.js:21:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    19 │ let x = "\\\8\9"
-    20 │ let x = "\8\\\9"
-  > 21 │ let x = "\8 \\\9"
-       │               ^^
-    22 │ let x = "\8\8"
-    23 │ let x = "\9\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    21 │ let·x·=·"\8·\\\\9"
-       │                +  
 
 ```
 
@@ -1079,48 +578,6 @@ invalid.js:22:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:22:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    20 │ let x = "\8\\\9"
-    21 │ let x = "\8 \\\9"
-  > 22 │ let x = "\8\8"
-       │          ^^
-    23 │ let x = "\9\8"
-    24 │ let x = "foo\8bar\9baz"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    22 │ let·x·=·"\\8\8"
-       │           +    
-
-```
-
-```
-invalid.js:22:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    20 │ let x = "\8\\\9"
-    21 │ let x = "\8 \\\9"
-  > 22 │ let x = "\8\8"
-       │            ^^
-    23 │ let x = "\9\8"
-    24 │ let x = "foo\8bar\9baz"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    22 │ let·x·=·"\8\\8"
-       │             +  
-
-```
-
-```
 invalid.js:23:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -1138,48 +595,6 @@ invalid.js:23:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     23 │ let·x·=·"\9\8"
        │          -    
-
-```
-
-```
-invalid.js:23:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    21 │ let x = "\8 \\\9"
-    22 │ let x = "\8\8"
-  > 23 │ let x = "\9\8"
-       │          ^^
-    24 │ let x = "foo\8bar\9baz"
-    25 │ let x = "\8\\1\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    23 │ let·x·=·"\\9\8"
-       │           +    
-
-```
-
-```
-invalid.js:23:12 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    21 │ let x = "\8 \\\9"
-    22 │ let x = "\8\8"
-  > 23 │ let x = "\9\8"
-       │            ^^
-    24 │ let x = "foo\8bar\9baz"
-    25 │ let x = "\8\\1\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    23 │ let·x·=·"\9\\8"
-       │             +  
 
 ```
 
@@ -1206,48 +621,6 @@ invalid.js:24:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
     25 25 │   let x = "\8\\1\9"
     26 26 │   let x = "\9\\n9\\\9\9"
   
-
-```
-
-```
-invalid.js:24:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    22 │ let x = "\8\8"
-    23 │ let x = "\9\8"
-  > 24 │ let x = "foo\8bar\9baz"
-       │             ^^
-    25 │ let x = "\8\\1\9"
-    26 │ let x = "\9\\n9\\\9\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    24 │ let·x·=·"foo\\8bar\9baz"
-       │              +          
-
-```
-
-```
-invalid.js:24:18 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    22 │ let x = "\8\8"
-    23 │ let x = "\9\8"
-  > 24 │ let x = "foo\8bar\9baz"
-       │                  ^^
-    25 │ let x = "\8\\1\9"
-    26 │ let x = "\9\\n9\\\9\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    24 │ let·x·=·"foo\8bar\\9baz"
-       │                   +     
 
 ```
 
@@ -1299,48 +672,6 @@ invalid.js:25:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:25:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    23 │ let x = "\9\8"
-    24 │ let x = "foo\8bar\9baz"
-  > 25 │ let x = "\8\\1\9"
-       │          ^^
-    26 │ let x = "\9\\n9\\\9\9"
-    27 │ let x = "\8\\\\\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    25 │ let·x·=·"\\8\\1\9"
-       │           +       
-
-```
-
-```
-invalid.js:25:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    23 │ let x = "\9\8"
-    24 │ let x = "foo\8bar\9baz"
-  > 25 │ let x = "\8\\1\9"
-       │               ^^
-    26 │ let x = "\9\\n9\\\9\9"
-    27 │ let x = "\8\\\\\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    25 │ let·x·=·"\8\\1\\9"
-       │                +  
-
-```
-
-```
 invalid.js:25:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -1388,27 +719,6 @@ invalid.js:26:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:26:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    24 │ let x = "foo\8bar\9baz"
-    25 │ let x = "\8\\1\9"
-  > 26 │ let x = "\9\\n9\\\9\9"
-       │          ^^
-    27 │ let x = "\8\\\\\9"
-    28 │ let x = "var foo = '\8'; bar('\9')"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    26 │ let·x·=·"\\9\\n9\\\9\9"
-       │           +            
-
-```
-
-```
 invalid.js:26:18 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -1426,48 +736,6 @@ invalid.js:26:18 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     26 │ let·x·=·"\9\\n9\\\9\9"
        │                  -    
-
-```
-
-```
-invalid.js:26:18 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    24 │ let x = "foo\8bar\9baz"
-    25 │ let x = "\8\\1\9"
-  > 26 │ let x = "\9\\n9\\\9\9"
-       │                  ^^
-    27 │ let x = "\8\\\\\9"
-    28 │ let x = "var foo = '\8'; bar('\9')"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    26 │ let·x·=·"\9\\n9\\\\9\9"
-       │                   +    
-
-```
-
-```
-invalid.js:26:20 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    24 │ let x = "foo\8bar\9baz"
-    25 │ let x = "\8\\1\9"
-  > 26 │ let x = "\9\\n9\\\9\9"
-       │                    ^^
-    27 │ let x = "\8\\\\\9"
-    28 │ let x = "var foo = '\8'; bar('\9')"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    26 │ let·x·=·"\9\\n9\\\9\\9"
-       │                     +  
 
 ```
 
@@ -1493,48 +761,6 @@ invalid.js:27:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:27:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    25 │ let x = "\8\\1\9"
-    26 │ let x = "\9\\n9\\\9\9"
-  > 27 │ let x = "\8\\\\\9"
-       │          ^^
-    28 │ let x = "var foo = '\8'; bar('\9')"
-    29 │ let x = "var foo = '8'\n  bar = '\9'"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    27 │ let·x·=·"\\8\\\\\9"
-       │           +        
-
-```
-
-```
-invalid.js:27:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    25 │ let x = "\8\\1\9"
-    26 │ let x = "\9\\n9\\\9\9"
-  > 27 │ let x = "\8\\\\\9"
-       │                ^^
-    28 │ let x = "var foo = '\8'; bar('\9')"
-    29 │ let x = "var foo = '8'\n  bar = '\9'"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    27 │ let·x·=·"\8\\\\\\9"
-       │                 +  
-
-```
-
-```
 invalid.js:28:21 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -1552,48 +778,6 @@ invalid.js:28:21 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     28 │ let·x·=·"var·foo·=·'\8';·bar('\9')"
        │                     -              
-
-```
-
-```
-invalid.js:28:21 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    26 │ let x = "\9\\n9\\\9\9"
-    27 │ let x = "\8\\\\\9"
-  > 28 │ let x = "var foo = '\8'; bar('\9')"
-       │                     ^^
-    29 │ let x = "var foo = '8'\n  bar = '\9'"
-    30 │ let x = "\\\n\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    28 │ let·x·=·"var·foo·=·'\\8';·bar('\9')"
-       │                      +              
-
-```
-
-```
-invalid.js:28:31 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    26 │ let x = "\9\\n9\\\9\9"
-    27 │ let x = "\8\\\\\9"
-  > 28 │ let x = "var foo = '\8'; bar('\9')"
-       │                               ^^
-    29 │ let x = "var foo = '8'\n  bar = '\9'"
-    30 │ let x = "\\\n\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    28 │ let·x·=·"var·foo·=·'\8';·bar('\\9')"
-       │                                +    
 
 ```
 
@@ -1640,27 +824,6 @@ invalid.js:29:34 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:29:34 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    27 │ let x = "\8\\\\\9"
-    28 │ let x = "var foo = '\8'; bar('\9')"
-  > 29 │ let x = "var foo = '8'\n  bar = '\9'"
-       │                                  ^^
-    30 │ let x = "\\\n\8"
-    31 │ let x = "\\\r\n\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    29 │ let·x·=·"var·foo·=·'8'\n··bar·=·'\\9'"
-       │                                   +   
-
-```
-
-```
 invalid.js:30:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -1683,27 +846,6 @@ invalid.js:30:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
     31 31 │   let x = "\\\r\n\9"
     32 32 │   let x = "\\\\\n\8"
   
-
-```
-
-```
-invalid.js:30:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    28 │ let x = "var foo = '\8'; bar('\9')"
-    29 │ let x = "var foo = '8'\n  bar = '\9'"
-  > 30 │ let x = "\\\n\8"
-       │              ^^
-    31 │ let x = "\\\r\n\9"
-    32 │ let x = "\\\\\n\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    30 │ let·x·=·"\\\n\\8"
-       │               +  
 
 ```
 
@@ -1734,27 +876,6 @@ invalid.js:31:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:31:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    29 │ let x = "var foo = '8'\n  bar = '\9'"
-    30 │ let x = "\\\n\8"
-  > 31 │ let x = "\\\r\n\9"
-       │                ^^
-    32 │ let x = "\\\\\n\8"
-    33 │ let x = "foo\\\nbar\9baz"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    31 │ let·x·=·"\\\r\n\\9"
-       │                 +  
-
-```
-
-```
 invalid.js:32:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -1781,27 +902,6 @@ invalid.js:32:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:32:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    30 │ let x = "\\\n\8"
-    31 │ let x = "\\\r\n\9"
-  > 32 │ let x = "\\\\\n\8"
-       │                ^^
-    33 │ let x = "foo\\\nbar\9baz"
-    34 │ let x = "\\0\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    32 │ let·x·=·"\\\\\n\\8"
-       │                 +  
-
-```
-
-```
 invalid.js:33:20 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -1824,27 +924,6 @@ invalid.js:33:20 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
     34 34 │   let x = "\\0\8"
     35 35 │   let x = "foo\\0\9bar"
   
-
-```
-
-```
-invalid.js:33:20 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    31 │ let x = "\\\r\n\9"
-    32 │ let x = "\\\\\n\8"
-  > 33 │ let x = "foo\\\nbar\9baz"
-       │                    ^^
-    34 │ let x = "\\0\8"
-    35 │ let x = "foo\\0\9bar"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    33 │ let·x·=·"foo\\\nbar\\9baz"
-       │                     +     
 
 ```
 
@@ -1901,27 +980,6 @@ invalid.js:34:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:34:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    32 │ let x = "\\\\\n\8"
-    33 │ let x = "foo\\\nbar\9baz"
-  > 34 │ let x = "\\0\8"
-       │             ^^
-    35 │ let x = "foo\\0\9bar"
-    36 │ let x = "\\1\\0\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    34 │ let·x·=·"\\0\\8"
-       │              +  
-
-```
-
-```
 invalid.js:35:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -1970,27 +1028,6 @@ invalid.js:35:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
     36 36 │   let x = "\\1\\0\8"
     37 37 │   let x = "\\0\8\9"
   
-
-```
-
-```
-invalid.js:35:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    33 │ let x = "foo\\\nbar\9baz"
-    34 │ let x = "\\0\8"
-  > 35 │ let x = "foo\\0\9bar"
-       │                ^^
-    36 │ let x = "\\1\\0\8"
-    37 │ let x = "\\0\8\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    35 │ let·x·=·"foo\\0\\9bar"
-       │                 +     
 
 ```
 
@@ -2047,27 +1084,6 @@ invalid.js:36:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:36:16 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    34 │ let x = "\\0\8"
-    35 │ let x = "foo\\0\9bar"
-  > 36 │ let x = "\\1\\0\8"
-       │                ^^
-    37 │ let x = "\\0\8\9"
-    38 │ let x = "\8\\0\9"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    36 │ let·x·=·"\\1\\0\\8"
-       │                 +  
-
-```
-
-```
 invalid.js:37:11 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -2107,27 +1123,6 @@ invalid.js:37:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
   i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
   
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    37 │ let·x·=·"\\0\\8\9"
-       │              +    
-
-```
-
-```
-invalid.js:37:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    35 │ let x = "foo\\0\9bar"
-    36 │ let x = "\\1\\0\8"
-  > 37 │ let x = "\\0\8\9"
-       │             ^^
-    38 │ let x = "\8\\0\9"
-    39 │ let x = "0\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
   i Suggested fix: Replace \8 with \u0038. This maintains the current functionality.
   
     35 35 │   let x = "foo\\0\9bar"
@@ -2137,27 +1132,6 @@ invalid.js:37:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
     38 38 │   let x = "\8\\0\9"
     39 39 │   let x = "0\8"
   
-
-```
-
-```
-invalid.js:37:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    35 │ let x = "foo\\0\9bar"
-    36 │ let x = "\\1\\0\8"
-  > 37 │ let x = "\\0\8\9"
-       │               ^^
-    38 │ let x = "\8\\0\9"
-    39 │ let x = "0\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    37 │ let·x·=·"\\0\8\\9"
-       │                +  
 
 ```
 
@@ -2179,27 +1153,6 @@ invalid.js:38:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     38 │ let·x·=·"\8\\0\9"
        │          -       
-
-```
-
-```
-invalid.js:38:10 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    36 │ let x = "\\1\\0\8"
-    37 │ let x = "\\0\8\9"
-  > 38 │ let x = "\8\\0\9"
-       │          ^^
-    39 │ let x = "0\8"
-    40 │ let x = "\\0\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    38 │ let·x·=·"\\8\\0\9"
-       │           +       
 
 ```
 
@@ -2256,27 +1209,6 @@ invalid.js:38:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:38:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    36 │ let x = "\\1\\0\8"
-    37 │ let x = "\\0\8\9"
-  > 38 │ let x = "\8\\0\9"
-       │               ^^
-    39 │ let x = "0\8"
-    40 │ let x = "\\0\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \9 with \\9 to include the actual backslash character.
-  
-    38 │ let·x·=·"\8\\0\\9"
-       │                +  
-
-```
-
-```
 invalid.js:39:11 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -2299,27 +1231,6 @@ invalid.js:39:11 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
     40 40 │   let x = "\\0\8"
     41 41 │   let x = "\0 \8"
   
-
-```
-
-```
-invalid.js:39:11 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    37 │ let x = "\\0\8\9"
-    38 │ let x = "\8\\0\9"
-  > 39 │ let x = "0\8"
-       │           ^^
-    40 │ let x = "\\0\8"
-    41 │ let x = "\0 \8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    39 │ let·x·=·"0\\8"
-       │            +  
 
 ```
 
@@ -2376,27 +1287,6 @@ invalid.js:40:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:40:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    38 │ let x = "\8\\0\9"
-    39 │ let x = "0\8"
-  > 40 │ let x = "\\0\8"
-       │             ^^
-    41 │ let x = "\0 \8"
-    42 │ let x = "\01\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    40 │ let·x·=·"\\0\\8"
-       │              +  
-
-```
-
-```
 invalid.js:41:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -2414,27 +1304,6 @@ invalid.js:41:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
   
     41 │ let·x·=·"\0·\8"
        │             -  
-
-```
-
-```
-invalid.js:41:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    39 │ let x = "0\8"
-    40 │ let x = "\\0\8"
-  > 41 │ let x = "\0 \8"
-       │             ^^
-    42 │ let x = "\01\8"
-    43 │ let x = "\0\1\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    41 │ let·x·=·"\0·\\8"
-       │              +  
 
 ```
 
@@ -2465,27 +1334,6 @@ invalid.js:42:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:42:13 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    40 │ let x = "\\0\8"
-    41 │ let x = "\0 \8"
-  > 42 │ let x = "\01\8"
-       │             ^^
-    43 │ let x = "\0\1\8"
-    44 │ let x = "\0\\n\8"
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    42 │ let·x·=·"\01\\8"
-       │              +  
-
-```
-
-```
 invalid.js:43:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -2512,27 +1360,6 @@ invalid.js:43:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:43:14 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    41 │ let x = "\0 \8"
-    42 │ let x = "\01\8"
-  > 43 │ let x = "\0\1\8"
-       │              ^^
-    44 │ let x = "\0\\n\8"
-    45 │ 
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    43 │ let·x·=·"\0\1\\8"
-       │               +  
-
-```
-
-```
 invalid.js:44:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Don't use `\8` and `\9` escape sequences in string literals.
@@ -2553,26 +1380,6 @@ invalid.js:44:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━�
        44 │ + let·x·=·"\0\\n8"
     45 45 │   
   
-
-```
-
-```
-invalid.js:44:15 lint/nursery/noNonoctalDecimalEscape  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Don't use `\8` and `\9` escape sequences in string literals.
-  
-    42 │ let x = "\01\8"
-    43 │ let x = "\0\1\8"
-  > 44 │ let x = "\0\\n\8"
-       │               ^^
-    45 │ 
-  
-  i The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.
-  
-  i Suggested fix: Replace \8 with \\8 to include the actual backslash character.
-  
-    44 │ let·x·=·"\0\\n\\8"
-       │                +  
 
 ```
 

--- a/website/src/pages/lint/rules/noNonoctalDecimalEscape.md
+++ b/website/src/pages/lint/rules/noNonoctalDecimalEscape.md
@@ -44,20 +44,6 @@ const x = "\8";
   
 <strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;<span style="color: Tomato;">\</span>8&quot;;
 <strong>  </strong><strong>    │ </strong>           <span style="color: Tomato;">-</span>   
-nursery/noNonoctalDecimalEscape.js:1:12 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;\8&quot;;
-   <strong>   │ </strong>           <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.</span>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\8</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>\\8</strong></span><span style="color: rgb(38, 148, 255);"> to include the actual backslash character.</span>
-  
-<strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;\<span style="color: MediumSeaGreen;">\</span>8&quot;;
-<strong>  </strong><strong>    │ </strong>            <span style="color: MediumSeaGreen;">+</span>   
 </code></pre>
 
 ```jsx
@@ -78,20 +64,6 @@ const x = "Don't use \8 escape.";
   
 <strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span><span style="color: Tomato;">\</span>8<span style="opacity: 0.8;">·</span>escape.&quot;;
 <strong>  </strong><strong>    │ </strong>                     <span style="color: Tomato;">-</span>           
-nursery/noNonoctalDecimalEscape.js:1:22 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;Don't use \8 escape.&quot;;
-   <strong>   │ </strong>                     <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.</span>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\8</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>\\8</strong></span><span style="color: rgb(38, 148, 255);"> to include the actual backslash character.</span>
-  
-<strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span>\<span style="color: MediumSeaGreen;">\</span>8<span style="opacity: 0.8;">·</span>escape.&quot;;
-<strong>  </strong><strong>    │ </strong>                      <span style="color: MediumSeaGreen;">+</span>           
 </code></pre>
 
 ```jsx
@@ -112,58 +84,6 @@ const x = "Don't use \9 escape.";
   
 <strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span><span style="color: Tomato;">\</span>9<span style="opacity: 0.8;">·</span>escape.&quot;;
 <strong>  </strong><strong>    │ </strong>                     <span style="color: Tomato;">-</span>           
-nursery/noNonoctalDecimalEscape.js:1:22 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;Don't use \9 escape.&quot;;
-   <strong>   │ </strong>                     <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.</span>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\9</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>\\9</strong></span><span style="color: rgb(38, 148, 255);"> to include the actual backslash character.</span>
-  
-<strong>  </strong><strong>  1 │ </strong>const<span style="opacity: 0.8;">·</span>x<span style="opacity: 0.8;">·</span>=<span style="opacity: 0.8;">·</span>&quot;Don't<span style="opacity: 0.8;">·</span>use<span style="opacity: 0.8;">·</span>\<span style="color: MediumSeaGreen;">\</span>9<span style="opacity: 0.8;">·</span>escape.&quot;;
-<strong>  </strong><strong>    │ </strong>                      <span style="color: MediumSeaGreen;">+</span>           
-</code></pre>
-
-```jsx
-const x = "\0\8";
-```
-
-<pre class="language-text"><code class="language-text">nursery/noNonoctalDecimalEscape.js:1:12 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;\0\8&quot;;
-   <strong>   │ </strong>           <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.</span>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\0\8</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>\u00008</strong></span><span style="color: rgb(38, 148, 255);">. This maintains the current functionality.</span>
-  
-    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">c</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;">s</span><span style="color: Tomato;">t</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">x</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">=</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">\</span><span style="color: Tomato;"><strong>0</strong></span><span style="color: Tomato;"><strong>\</strong></span><span style="color: Tomato;"><strong>8</strong></span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">;</span>
-      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">c</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">n</span><span style="color: MediumSeaGreen;">s</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">x</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">=</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">\</span><span style="color: MediumSeaGreen;"><strong>u</strong></span><span style="color: MediumSeaGreen;"><strong>0</strong></span><span style="color: MediumSeaGreen;"><strong>0</strong></span><span style="color: MediumSeaGreen;"><strong>0</strong></span><span style="color: MediumSeaGreen;"><strong>0</strong></span><span style="color: MediumSeaGreen;"><strong>8</strong></span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">;</span>
-    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
-  
-nursery/noNonoctalDecimalEscape.js:1:14 <a href="https://docs.rome.tools/lint/rules/noNonoctalDecimalEscape">lint/nursery/noNonoctalDecimalEscape</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">Don't use </span><span style="color: Tomato;"><strong>`\8`</strong></span><span style="color: Tomato;"> and </span><span style="color: Tomato;"><strong>`\9`</strong></span><span style="color: Tomato;"> escape sequences in string literals.</span>
-  
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>const x = &quot;\0\8&quot;;
-   <strong>   │ </strong>             <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
-    <strong>2 │ </strong>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The nonoctal decimal escape is a deprecated syntax that is left for compatibility and should not be used.</span>
-  
-<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Suggested fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Replace </span><span style="color: rgb(38, 148, 255);"><strong>\8</strong></span><span style="color: rgb(38, 148, 255);"> with </span><span style="color: rgb(38, 148, 255);"><strong>\u0038</strong></span><span style="color: rgb(38, 148, 255);">. This maintains the current functionality.</span>
-  
-    <strong>1</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;">c</span><span style="color: Tomato;">o</span><span style="color: Tomato;">n</span><span style="color: Tomato;">s</span><span style="color: Tomato;">t</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">x</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">=</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">\</span><span style="color: Tomato;">0</span><span style="color: Tomato;">\</span><span style="color: Tomato;"><strong>8</strong></span><span style="color: Tomato;">&quot;</span><span style="color: Tomato;">;</span>
-      <strong>1</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">c</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">n</span><span style="color: MediumSeaGreen;">s</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">x</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">=</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">\</span><span style="color: MediumSeaGreen;">0</span><span style="color: MediumSeaGreen;">\</span><span style="color: MediumSeaGreen;"><strong>u</strong></span><span style="color: MediumSeaGreen;"><strong>0</strong></span><span style="color: MediumSeaGreen;"><strong>0</strong></span><span style="color: MediumSeaGreen;"><strong>3</strong></span><span style="color: MediumSeaGreen;"><strong>8</strong></span><span style="color: MediumSeaGreen;">&quot;</span><span style="color: MediumSeaGreen;">;</span>
-    <strong>2</strong> <strong>2</strong><strong> │ </strong>  
-  
 </code></pre>
 
 ## Valid
@@ -174,10 +94,6 @@ const x = "8";
 
 ```jsx
 const x = "Don't use \\8 and \\9 escapes.";
-```
-
-```jsx
-const x = "\0\u0038";;
 ```
 
 ## Related links


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Addresses https://discord.com/channels/678763474494423051/978209399120216076/1126496823587115018

This PR modifies the noNonoctalDecimalEscape rule and narrows the scope of its fixes. This change eliminates the unusual circumstance of multiple diagnostics being performed on behalf of the user and also rectifies issues with the `cargo lintdoc` command.

If I understand correctly, the current analyzer should only be able to return one action for each diagnostic.
In this rule, below example `\0\8` should have multiple diagnoses and suggest multiple fixes.

```javascript
const x = "\0\8";
// `\0\8` should be reported and fixed to `\u00008` 
// `\8` should be reported and fixed to `\0\u0038`
// `\8` should be reported and fixed to `\0\\8` (this fix will be removed by this PR because of diagnostic duplication and EscapeBackslash is uncommon change)
// `\8` should be reported and fixed to `\08` (this fix will be removed by this PR because of diagnostic duplication)
```

Ideally, this rule would allow a unique `TextRange` to propose a single diagnostic and multiple actions (fixes) for it.
However, this rule in its current state has diagnosed the same place many times.

I remove the code regarding addition of `EscapeBackslash` for reducing multiple diagnoses anyway. `EscapeBackslash` is valid change. But fixing the mistake to simple number (`8` or `9`) is more strait-forward.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

`cargo test -p rome_js_analyze -- no_nonoctal_decimal_escape`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Thought
[RuleAdvice](https://github.com/rome/tools/blob/4e89132793f89c28e4ea02c922dfc8aae7e9279a/crates/rome_analyze/src/rule.rs#L392
) can have `SuggestionList` and `CodeSuggestionList`. But this isn't used by Rule directly and they need `MarkupBuf` instead of properties that `JsRuleAction` requires. 


