### PR TITLE
feat(rome_js_formatter, rome_cli): add `arrowParentheses` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ multiple files:
 
 - Added a new option called `--jsx-quote-style` to the formatter. This option allows you to choose between single and double quotes for JSX attributes. [#4486](https://github.com/rome/tools/issues/4486)
 
+- Added a new option called `--arrow-parentheses` to the formatter. This option allows you to set the parentheses style for arrow functions. [#4666](https://github.com/rome/tools/issues/4666)
+
 ### Linter
 
 - [`noDuplicateParameters`](https://docs.rome.tools/lint/rules/noduplicateparameters/): enhanced rule to manage constructor parameters.

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -52,6 +52,23 @@ const APPLY_TRAILING_COMMA_AFTER: &str = r#"const a = [
 ];
 "#;
 
+const APPLY_ARROW_PARENTHESES_BEFORE: &str = r#"
+action => {}
+(action) => {}
+({ action }) => {}
+([ action ]) => {}
+(...action) => {}
+(action = 1) => {}
+"#;
+
+const APPLY_ARROW_PARENTHESES_AFTER: &str = r#"action => {};
+action => {};
+({ action }) => {};
+([action]) => {};
+(...action) => {};
+(action = 1) => {};
+"#;
+
 const DEFAULT_CONFIGURATION_BEFORE: &str = r#"function f() {
     return { a, b }
   }"#;
@@ -701,6 +718,51 @@ fn applies_custom_trailing_comma() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "applies_custom_trailing_comma",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn applies_custom_arrow_parentheses() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("file.js");
+    fs.insert(file_path.into(), APPLY_ARROW_PARENTHESES_BEFORE.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ("--arrow-parentheses"),
+                ("as-needed"),
+                ("--write"),
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let mut file = fs
+        .open(file_path)
+        .expect("formatting target file was removed by the CLI");
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .expect("failed to read file from memory FS");
+
+    assert_eq!(content, APPLY_ARROW_PARENTHESES_AFTER);
+
+    drop(file);
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "applies_custom_arrow_parentheses",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -33,6 +33,8 @@ The configuration that is contained inside the file `rome.json`
                               syntactic structures. Defaults to "all".
         --semicolons=<always|as-needed>  Whether the formatter prints semicolons for all statements or
                               only in for statements where it is necessary because of ASI.
+        --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
+                              Defaults to "always".
 
 Global options applied to all commands
         --colors=<off|force>    Set the formatting mode for markup: "off" prints everything as plain

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -34,6 +34,8 @@ The configuration that is contained inside the file `rome.json`
                               syntactic structures. Defaults to "all".
         --semicolons=<always|as-needed>  Whether the formatter prints semicolons for all statements or
                               only in for statements where it is necessary because of ASI.
+        --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
+                              Defaults to "always".
 
 Global options applied to all commands
         --colors=<off|force>    Set the formatting mode for markup: "off" prints everything as plain

--- a/crates/rome_cli/tests/snapshots/main_commands_format/applies_custom_arrow_parentheses.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/applies_custom_arrow_parentheses.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+action => {};
+action => {};
+({ action }) => {};
+([action]) => {};
+(...action) => {};
+(action = 1) => {};
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -57,6 +57,8 @@ Available options:
                               syntactic structures. Defaults to "all".
         --semicolons=<always|as-needed>  Whether the formatter prints semicolons for all statements or
                               only in for statements where it is necessary because of ASI.
+        --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
+                              Defaults to "always".
         --stdin-file-path=PATH  A file name with its extension to pass when reading from standard in,
                               e.g. echo 'let a;' | rome format --stdin-file-path=file.js".
         --write                 Writes formatted files to file system.

--- a/crates/rome_cli/tests/snapshots/main_commands_lint/check_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_lint/check_help.snap
@@ -33,6 +33,8 @@ The configuration that is contained inside the file `rome.json`
                               syntactic structures. Defaults to "all".
         --semicolons=<always|as-needed>  Whether the formatter prints semicolons for all statements or
                               only in for statements where it is necessary because of ASI.
+        --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow functions.
+                              Defaults to "always".
 
 Global options applied to all commands
         --colors=<off|force>    Set the formatting mode for markup: "off" prints everything as plain

--- a/crates/rome_js_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/parameters.rs
@@ -1,12 +1,13 @@
 use crate::prelude::*;
 use rome_formatter::{write, CstFormatContext};
 
+use crate::js::expressions::arrow_function_expression::can_avoid_parentheses;
 use crate::js::lists::parameter_list::FormatJsAnyParameterList;
 use crate::utils::test_call::is_test_call_argument;
 use rome_js_syntax::parameter_ext::{AnyJsParameterList, AnyParameter};
 use rome_js_syntax::{
-    AnyJsConstructorParameter, AnyJsFormalParameter, AnyTsType, JsConstructorParameters,
-    JsParameters, JsSyntaxToken,
+    AnyJsConstructorParameter, AnyJsFormalParameter, AnyTsType, JsArrowFunctionExpression,
+    JsConstructorParameters, JsParameters, JsSyntaxToken,
 };
 use rome_rowan::{declare_node_union, SyntaxResult};
 
@@ -48,6 +49,11 @@ impl Format<JsFormatContext> for FormatAnyJsParameters {
         let l_paren_token = self.l_paren_token()?;
         let r_paren_token = self.r_paren_token()?;
 
+        let parentheses_not_needed = match self.as_arrow_function_expression() {
+            Some(expression) => can_avoid_parentheses(&expression, f),
+            None => false,
+        };
+
         match layout {
             ParameterLayout::NoParameters => {
                 write!(
@@ -60,27 +66,50 @@ impl Format<JsFormatContext> for FormatAnyJsParameters {
                 )
             }
             ParameterLayout::Hug => {
+                if !parentheses_not_needed {
+                    write!(f, [l_paren_token.format()])?;
+                } else {
+                    write!(f, [format_removed(&l_paren_token)])?;
+                }
+
                 write!(
                     f,
-                    [
-                        l_paren_token.format(),
-                        FormatJsAnyParameterList::with_layout(&list, ParameterLayout::Hug),
-                        &r_paren_token.format()
-                    ]
-                )
+                    [FormatJsAnyParameterList::with_layout(
+                        &list,
+                        ParameterLayout::Hug
+                    )]
+                )?;
+
+                if !parentheses_not_needed {
+                    write!(f, [&r_paren_token.format()])?;
+                } else {
+                    write!(f, [format_removed(&r_paren_token)])?;
+                }
+
+                Ok(())
             }
             ParameterLayout::Default => {
+                if !parentheses_not_needed {
+                    write!(f, [l_paren_token.format()])?;
+                } else {
+                    write!(f, [format_removed(&l_paren_token)])?;
+                }
+
                 write!(
                     f,
-                    [
-                        l_paren_token.format(),
-                        soft_block_indent(&FormatJsAnyParameterList::with_layout(
-                            &list,
-                            ParameterLayout::Default
-                        )),
-                        r_paren_token.format()
-                    ]
-                )
+                    [soft_block_indent(&FormatJsAnyParameterList::with_layout(
+                        &list,
+                        ParameterLayout::Default
+                    ))]
+                )?;
+
+                if !parentheses_not_needed {
+                    write!(f, [r_paren_token.format()])?;
+                } else {
+                    write!(f, [format_removed(&r_paren_token)])?;
+                }
+
+                Ok(())
             }
         }
     }
@@ -127,6 +156,16 @@ impl FormatAnyJsParameters {
         };
 
         Ok(result)
+    }
+
+    fn as_arrow_function_expression(&self) -> Option<JsArrowFunctionExpression> {
+        match self {
+            FormatAnyJsParameters::JsParameters(parameters) => parameters
+                .syntax()
+                .parent()
+                .and_then(JsArrowFunctionExpression::cast),
+            FormatAnyJsParameters::JsConstructorParameters(_) => None,
+        }
     }
 }
 

--- a/crates/rome_js_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_js_formatter/src/js/bindings/parameters.rs
@@ -49,10 +49,9 @@ impl Format<JsFormatContext> for FormatAnyJsParameters {
         let l_paren_token = self.l_paren_token()?;
         let r_paren_token = self.r_paren_token()?;
 
-        let parentheses_not_needed = match self.as_arrow_function_expression() {
-            Some(expression) => can_avoid_parentheses(&expression, f),
-            None => false,
-        };
+        let parentheses_not_needed = self
+            .as_arrow_function_expression()
+            .map_or(false, |expression| can_avoid_parentheses(&expression, f));
 
         match layout {
             ParameterLayout::NoParameters => {

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -137,6 +137,7 @@ impl FormatNodeRule<JsArrowFunctionExpression> for FormatJsArrowFunctionExpressi
                             );
 
                             !are_parentheses_mandatory
+                                && f.options().arrow_parentheses().is_always()
                         }
                         _ => false,
                     };
@@ -220,7 +221,14 @@ fn format_signature(
                 AnyJsArrowFunctionParameters::AnyJsBinding(binding) => {
                     let should_hug = is_test_call_argument(arrow.syntax())?;
 
-                    write!(f, [text("(")])?;
+                    let parentheses_not_needed = f.options().arrow_parentheses().is_as_needed()
+                        && arrow.parameters()?.len() == 1
+                        && arrow.type_parameters().is_none()
+                        && arrow.return_type_annotation().is_none();
+
+                    if !parentheses_not_needed {
+                        write!(f, [text("(")])?;
+                    }
 
                     if should_hug {
                         write!(f, [binding.format()])?;
@@ -234,7 +242,9 @@ fn format_signature(
                         )?
                     }
 
-                    write!(f, [text(")")])?;
+                    if !parentheses_not_needed {
+                        write!(f, [text(")")])?;
+                    }
                 }
                 AnyJsArrowFunctionParameters::JsParameters(params) => {
                     write!(f, [params.format()])?;

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -332,23 +332,20 @@ fn has_rest_object_or_array_parameter(parameters: &AnyJsArrowFunctionParameters)
     }
 }
 
-/// Returns `true` if the `arrow_parentheses` formatter option is enabled and parentheses can be safely avoided
+/// Returns `true` if parentheses can be safely avoided and the `arrow_parentheses` formatter option allows it
 pub fn can_avoid_parentheses(arrow: &JsArrowFunctionExpression, f: &mut JsFormatter) -> bool {
-    match arrow.parameters() {
-        Ok(parameters) => {
-            f.options().arrow_parentheses().is_as_needed()
-                && parameters.len() == 1
-                && arrow.type_parameters().is_none()
-                && arrow.return_type_annotation().is_none()
-                && !has_rest_object_or_array_parameter(&parameters)
-                && !parameters
-                    .as_js_parameters()
-                    .and_then(|p| p.items().first()?.ok())
-                    .and_then(|p| JsFormalParameter::cast(p.syntax().clone()))
-                    .is_some_and(|p| p.initializer().is_some())
-        }
-        Err(_) => false,
-    }
+    arrow.parameters().map_or(false, |parameters| {
+        f.options().arrow_parentheses().is_as_needed()
+            && parameters.len() == 1
+            && arrow.type_parameters().is_none()
+            && arrow.return_type_annotation().is_none()
+            && !has_rest_object_or_array_parameter(&parameters)
+            && !parameters
+                .as_js_parameters()
+                .and_then(|p| p.items().first()?.ok())
+                .and_then(|p| JsFormalParameter::cast(p.syntax().clone()))
+                .is_some_and(|p| p.initializer().is_some())
+    })
 }
 
 #[derive(Clone, Debug)]

--- a/crates/rome_js_formatter/tests/language.rs
+++ b/crates/rome_js_formatter/tests/language.rs
@@ -2,7 +2,7 @@ use rome_formatter::{FormatContext, FormatResult, Formatted, IndentStyle, LineWi
 use rome_formatter_test::TestFormatLanguage;
 use rome_js_formatter::context::trailing_comma::TrailingComma;
 use rome_js_formatter::context::{
-    JsFormatContext, JsFormatOptions, QuoteProperties, QuoteStyle, Semicolons,
+    ArrowParentheses, JsFormatContext, JsFormatOptions, QuoteProperties, QuoteStyle, Semicolons,
 };
 use rome_js_formatter::{format_node, format_range, JsFormatLanguage};
 use rome_js_parser::{parse, JsParserOptions};
@@ -152,6 +152,21 @@ impl From<JsSerializableSemicolons> for Semicolons {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
+pub enum JsSerializableArrowParentheses {
+    Always,
+    AsNeeded,
+}
+
+impl From<JsSerializableArrowParentheses> for ArrowParentheses {
+    fn from(test: JsSerializableArrowParentheses) -> Self {
+        match test {
+            JsSerializableArrowParentheses::Always => ArrowParentheses::Always,
+            JsSerializableArrowParentheses::AsNeeded => ArrowParentheses::AsNeeded,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
 pub struct JsSerializableFormatOptions {
     /// The indent style.
@@ -172,7 +187,11 @@ pub struct JsSerializableFormatOptions {
     /// Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
     pub trailing_comma: Option<JsSerializableTrailingComma>,
 
+    /// Whether the formatter prints semicolons for all statements or only in for statements where it is necessary because of ASI.
     pub semicolons: Option<JsSerializableSemicolons>,
+
+    /// Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
+    pub arrow_parentheses: Option<JsSerializableArrowParentheses>,
 }
 
 impl JsSerializableFormatOptions {
@@ -206,6 +225,10 @@ impl JsSerializableFormatOptions {
             .with_semicolons(
                 self.semicolons
                     .map_or_else(|| Semicolons::Always, |value| value.into()),
+            )
+            .with_arrow_parentheses(
+                self.arrow_parentheses
+                    .map_or_else(|| ArrowParentheses::Always, |value| value.into()),
             )
     }
 }

--- a/crates/rome_js_formatter/tests/quick_test.rs
+++ b/crates/rome_js_formatter/tests/quick_test.rs
@@ -1,5 +1,5 @@
 use rome_formatter_test::check_reformat::CheckReformat;
-use rome_js_formatter::context::{JsFormatOptions, QuoteStyle, Semicolons};
+use rome_js_formatter::context::{ArrowParentheses, JsFormatOptions, QuoteStyle, Semicolons};
 use rome_js_formatter::format_node;
 use rome_js_parser::{parse, JsParserOptions};
 use rome_js_syntax::JsFileSource;
@@ -8,20 +8,11 @@ mod language {
     include!("language.rs");
 }
 
-#[ignore]
+// #[ignore]
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
-    let src = r#"
-class Foo {
-				constructor(
-				@dec
-				/*leading parameter*/ private parameter
-				) {	}
-			}
-
-
-"#;
+    let src = r#"export const lol = a => "lol";"#;
     let syntax = JsFileSource::tsx();
     let tree = parse(
         src,
@@ -32,7 +23,8 @@ class Foo {
     let options = JsFormatOptions::new(syntax)
         .with_semicolons(Semicolons::AsNeeded)
         .with_quote_style(QuoteStyle::Double)
-        .with_jsx_quote_style(QuoteStyle::Single);
+        .with_jsx_quote_style(QuoteStyle::Single)
+        .with_arrow_parentheses(ArrowParentheses::AsNeeded);
     let result = format_node(options.clone(), &tree.syntax())
         .unwrap()
         .print()
@@ -46,14 +38,7 @@ class Foo {
 
     assert_eq!(
         result.as_code(),
-        r#"
-        // A
-@Foo()
-// B
-@Bar()
-// C
-export class Bar{}
-
+        r#"export const lol = a => "lol"
 "#
     );
 }

--- a/crates/rome_js_formatter/tests/quick_test.rs
+++ b/crates/rome_js_formatter/tests/quick_test.rs
@@ -8,11 +8,18 @@ mod language {
     include!("language.rs");
 }
 
-// #[ignore]
+#[ignore]
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
-    let src = r#"export const lol = a => "lol";"#;
+    let src = r#"
+        action => {}
+        (action) => {}
+        ({ action }) => {}
+        ([ action ]) => {}
+        (...action) => {}
+        (action = 1) => {}
+    "#;
     let syntax = JsFileSource::tsx();
     let tree = parse(
         src,
@@ -36,9 +43,15 @@ fn quick_test() {
         CheckReformat::new(root, result.as_code(), "quick_test", &language, options);
     check_reformat.check_reformat();
 
+    // I don't know why semicolons are added there, but it's not related to my code changes so ¯\_(ツ)_/¯
     assert_eq!(
         result.as_code(),
-        r#"export const lol = a => "lol"
+        r#";action => {}
+;action => {}
+;({ action }) => {}
+;([action]) => {}
+;(...action) => {}
+;(action = 1) => {}
 "#
     );
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
@@ -65,6 +65,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
@@ -36,6 +36,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/array/spaces.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/spaces.js.snap
@@ -29,6 +29,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/array/spread.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/spread.js.snap
@@ -29,6 +29,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/trailing-comma/array_trailing_comma.js.snap
@@ -34,6 +34,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -61,6 +62,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -88,6 +90,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
@@ -45,6 +45,43 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
+-----
+
+```js
+// array
+(action) =>
+	// eslint-disable-next-line react/no-array-index-key
+	[<li />];
+
+// function body
+(action) =>
+	// eslint-disable-next-line react/no-array-index-key
+	{
+		return <li />;
+	};
+
+// object expression
+(action) =>
+	// eslint-disable-next-line react/no-array-index-key
+	({ a: 10 });
+
+(action) => /* comment */ `
+${test}
+multiline`;
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
@@ -81,7 +81,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
-Arrow parentheses: Always
+Arrow parentheses: As needed
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
@@ -86,23 +86,23 @@ Arrow parentheses: As needed
 
 ```js
 // array
-(action) =>
+action =>
 	// eslint-disable-next-line react/no-array-index-key
 	[<li />];
 
 // function body
-(action) =>
+action =>
 	// eslint-disable-next-line react/no-array-index-key
 	{
 		return <li />;
 	};
 
 // object expression
-(action) =>
+action =>
 	// eslint-disable-next-line react/no-array-index-key
 	({ a: 10 });
 
-(action) => /* comment */ `
+action => /* comment */ `
 ${test}
 multiline`;
 ```

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -65,7 +65,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
-Arrow parentheses: Always
+Arrow parentheses: As needed
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -33,6 +33,39 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
+-----
+
+```js
+x =
+	(bifornCringerMoshedPerplexSawder) =>
+	(askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) =>
+	(f00) => {
+		averredBathersBoxroomBuggyNurl();
+	}; // BOOM
+
+x2 =
+	(a) =>
+	(
+		askTrovenaBeenaDependsRowans1,
+		askTrovenaBeenaDependsRowans2,
+		askTrovenaBeenaDependsRowans3,
+	) => {
+		c();
+	} /* ! */; // KABOOM
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -70,14 +70,14 @@ Arrow parentheses: As needed
 
 ```js
 x =
-	(bifornCringerMoshedPerplexSawder) =>
+	bifornCringerMoshedPerplexSawder =>
 	(askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) =>
-	(f00) => {
+	f00 => {
 		averredBathersBoxroomBuggyNurl();
 	}; // BOOM
 
 x2 =
-	(a) =>
+	a =>
 	(
 		askTrovenaBeenaDependsRowans1,
 		askTrovenaBeenaDependsRowans2,

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -56,7 +56,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
-Arrow parentheses: Always
+Arrow parentheses: As needed
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -30,6 +30,33 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
+-----
+
+```js
+() => {};
+async () => {};
+(foo) => {};
+(
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+	bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+	ccccccccccccccccccccccccccccc,
+) => {};
+
+() => (1, 3, 4);
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -62,7 +62,7 @@ Arrow parentheses: As needed
 ```js
 () => {};
 async () => {};
-(foo) => {};
+foo => {};
 (
 	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
 	bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -93,11 +93,11 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
-Arrow parentheses: Always
+Arrow parentheses: As needed
 -----
 
 ```js
-Seq(typeDef.interface.groups).forEach((group) =>
+Seq(typeDef.interface.groups).forEach(group =>
 	Seq(group.members).forEach((member, memberName) =>
 		markdownDoc(member.doc, {
 			typePath: typePath.concat(memberName.slice(1)),
@@ -106,7 +106,7 @@ Seq(typeDef.interface.groups).forEach((group) =>
 	),
 );
 
-const promiseFromCallback = (fn) =>
+const promiseFromCallback = fn =>
 	new Promise((resolve, reject) =>
 		fn((err, result) => {
 			if (err) return reject(err);

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -51,6 +51,49 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
+-----
+
+```js
+Seq(typeDef.interface.groups).forEach((group) =>
+	Seq(group.members).forEach((member, memberName) =>
+		markdownDoc(member.doc, {
+			typePath: typePath.concat(memberName.slice(1)),
+			signatures: member.signatures,
+		}),
+	),
+);
+
+const promiseFromCallback = (fn) =>
+	new Promise((resolve, reject) =>
+		fn((err, result) => {
+			if (err) return reject(err);
+			return resolve(result);
+		}),
+	);
+
+runtimeAgent.getProperties(
+	objectId,
+	false, // ownProperties
+	false, // accessorPropertiesOnly
+	false, // generatePreview
+	(error, properties, internalProperties) => {
+		return 1;
+	},
+);
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
@@ -28,6 +28,32 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
+-----
+
+```js
+it("should have the default duration when using the onClose arguments", (done) => {
+	expect(true);
+	done();
+});
+```
+
+# Lines exceeding max width of 80 characters
+```
+    1: it("should have the default duration when using the onClose arguments", (done) => {
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
@@ -53,11 +53,11 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
-Arrow parentheses: Always
+Arrow parentheses: As needed
 -----
 
 ```js
-it("should have the default duration when using the onClose arguments", (done) => {
+it("should have the default duration when using the onClose arguments", done => {
 	expect(true);
 	done();
 });
@@ -65,7 +65,7 @@ it("should have the default duration when using the onClose arguments", (done) =
 
 # Lines exceeding max width of 80 characters
 ```
-    1: it("should have the default duration when using the onClose arguments", (done) => {
+    1: it("should have the default duration when using the onClose arguments", done => {
 ```
 
 

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -137,11 +137,11 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
-Arrow parentheses: Always
+Arrow parentheses: As needed
 -----
 
 ```js
-const testResults = results.testResults.map((testResult) =>
+const testResults = results.testResults.map(testResult =>
 	formatResult(testResult, formatter, reporter),
 );
 
@@ -180,7 +180,7 @@ const b = Observable.fromPromise(axiosInstance.get(url)).map(
 
 func(
 	veryLoooooooooooooooooooooooongName,
-	(veryLooooooooooooooooooooooooongName) =>
+	veryLooooooooooooooooooooooooongName =>
 		veryLoooooooooooooooongName.something(),
 );
 
@@ -189,7 +189,7 @@ const composition = (ViewComponent, ContainerComponent) =>
 		static propTypes = {};
 	};
 
-romise.then((result) =>
+romise.then(result =>
 	result.veryLongVariable.veryLongPropertyName > someOtherVariable
 		? "ok"
 		: "fail",

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -68,6 +68,76 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
+-----
+
+```js
+const testResults = results.testResults.map((testResult) =>
+	formatResult(testResult, formatter, reporter),
+);
+
+it("mocks regexp instances", () => {
+	expect(
+		// () => moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),
+	).not.toThrow();
+});
+
+expect(() => asyncRequest({ url: "/test-endpoint" }));
+// .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ url: "/test-endpoint-but-with-a-long-url" }));
+// .toThrowError(/Required parameter/);
+
+expect(() =>
+	asyncRequest({ url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url" }),
+);
+// .toThrowError(/Required parameter/);
+
+expect(() =>
+	asyncRequest({ type: "foo", url: "/test-endpoint" }),
+).not.toThrowError();
+
+expect(() =>
+	asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" }),
+).not.toThrowError();
+
+const a = Observable.fromPromise(axiosInstance.post("/carts/mine")).map(
+	(response) => response.data,
+);
+
+const b = Observable.fromPromise(axiosInstance.get(url)).map(
+	(response) => response.data,
+);
+
+func(
+	veryLoooooooooooooooooooooooongName,
+	(veryLooooooooooooooooooooooooongName) =>
+		veryLoooooooooooooooongName.something(),
+);
+
+const composition = (ViewComponent, ContainerComponent) =>
+	class extends React.Component {
+		static propTypes = {};
+	};
+
+romise.then((result) =>
+	result.veryLongVariable.veryLongPropertyName > someOtherVariable
+		? "ok"
+		: "fail",
+);
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -171,11 +171,11 @@ expect(() =>
 ).not.toThrowError();
 
 const a = Observable.fromPromise(axiosInstance.post("/carts/mine")).map(
-	(response) => response.data,
+	response => response.data,
 );
 
 const b = Observable.fromPromise(axiosInstance.get(url)).map(
-	(response) => response.data,
+	response => response.data,
 );
 
 func(

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
@@ -41,6 +41,40 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
+-----
+
+```js
+const fn = (b) => (c) => (d) => {
+	return 3;
+};
+
+const foo = (a, b) => (c) => (d) => {
+	return 3;
+};
+
+const bar = (a) => (b) => (c) => a + b + c;
+
+const mw = (store) => (next) => (action) => {
+	return next(action);
+};
+
+const middleware = (options) => (req, res, next) => {
+	// ...
+};
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
@@ -74,25 +74,25 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
-Arrow parentheses: Always
+Arrow parentheses: As needed
 -----
 
 ```js
-const fn = (b) => (c) => (d) => {
+const fn = b => c => d => {
 	return 3;
 };
 
-const foo = (a, b) => (c) => (d) => {
+const foo = (a, b) => c => d => {
 	return 3;
 };
 
-const bar = (a) => (b) => (c) => a + b + c;
+const bar = a => b => c => a + b + c;
 
-const mw = (store) => (next) => (action) => {
+const mw = store => next => action => {
 	return next(action);
 };
 
-const middleware = (options) => (req, res, next) => {
+const middleware = options => (req, res, next) => {
 	// ...
 };
 ```

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/options.json
@@ -1,7 +1,7 @@
 {
 	"cases": [
 		{
-			"arrowParentheses": "AsNeeded"
+			"arrow_parentheses": "AsNeeded"
 		}
 	]
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"arrowParentheses": "AsNeeded"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -662,12 +662,12 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
-Arrow parentheses: Always
+Arrow parentheses: As needed
 -----
 
 ```js
 fooooooooooooooooooooooooooooooooooooooooooooooooooo(
-	(action) => (next) => dispatch(action),
+	action => next => dispatch(action),
 );
 
 foo(

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -345,6 +345,324 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
+-----
+
+```js
+fooooooooooooooooooooooooooooooooooooooooooooooooooo(
+	(action) => (next) => dispatch(action),
+);
+
+foo(
+	({
+		a,
+
+		b,
+	}) => {},
+);
+
+foo(({ a, b }) => {});
+
+foo(({ a, b }) => {});
+
+foo(
+	a,
+	({
+		a,
+
+		b,
+	}) => {},
+);
+
+foo(
+	({
+		a,
+
+		b,
+	}) => a,
+);
+
+foo(({ a, b }) => a);
+
+foo(({ a, b }) => a);
+
+foo(
+	({
+		a: {
+			a,
+
+			b,
+		},
+	}) => {},
+);
+
+foo(
+	({
+		a: {
+			b: {
+				c,
+
+				d,
+			},
+		},
+	}) => {},
+);
+
+foo(
+	({
+		a: {
+			b: {
+				c: {
+					d,
+
+					e,
+				},
+			},
+		},
+	}) => {},
+);
+
+foo(
+	({
+		a: {
+			a,
+
+			b,
+		},
+	}) => a,
+);
+
+foo(
+	({
+		a: {
+			b: {
+				c,
+
+				d,
+			},
+		},
+	}) => a,
+);
+
+foo(
+	({
+		a: {
+			b: {
+				c: {
+					d,
+
+					e,
+				},
+			},
+		},
+	}) => a,
+);
+
+foo(
+	([
+		{
+			a: {
+				b: {
+					c: {
+						d,
+
+						e,
+					},
+				},
+			},
+		},
+	]) => {},
+);
+
+foo(
+	([
+		...{
+			a: {
+				b: {
+					c: {
+						d,
+
+						e,
+					},
+				},
+			},
+		}
+	]) => {},
+);
+
+foo(
+	(
+		n = {
+			a: {
+				b: {
+					c: {
+						d,
+
+						e,
+					},
+				},
+			},
+		},
+	) => {},
+);
+
+foo(
+	({
+		x: [
+			{
+				a,
+
+				b,
+			},
+		],
+	}) => {},
+);
+
+foo(
+	(
+		a = [
+			{
+				a,
+
+				b,
+			},
+		],
+	) => a,
+);
+
+foo(
+	([
+		[
+			{
+				a,
+
+				b,
+			},
+		],
+	]) => {},
+);
+
+foo(
+	([
+		[
+			[
+				[
+					{
+						a,
+						b: {
+							c,
+							d: {
+								e,
+
+								f,
+							},
+						},
+					},
+				],
+			],
+		],
+	]) => {},
+);
+
+foo(
+	(
+		...{
+			a,
+
+			b,
+		}
+	) => {},
+);
+
+foo(
+	(
+		...[
+			{
+				a,
+
+				b,
+			},
+		]
+	) => {},
+);
+
+foo(
+	([
+		...[
+			{
+				a,
+
+				b,
+			},
+		]
+	]) => {},
+);
+
+foo(
+	(
+		a = [
+			{
+				a,
+
+				b,
+			},
+		],
+	) => {},
+);
+
+foo(
+	(
+		a = (({
+			a,
+
+			b,
+		}) => {})(),
+	) => {},
+);
+
+foo(
+	(
+		a = f({
+			a,
+
+			b,
+		}),
+	) => {},
+);
+
+foo(
+	(
+		a = ({
+			a,
+
+			b,
+		}) => {},
+	) => {},
+);
+
+foo(
+	(
+		a = 1 +
+			f({
+				a,
+
+				b,
+			}),
+	) => {},
+);
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -178,6 +178,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/call_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/call_expression.js.snap
@@ -71,6 +71,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -94,6 +94,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/class/private_method.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/private_method.js.snap
@@ -40,6 +40,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -102,6 +102,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
@@ -289,6 +289,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
@@ -116,6 +116,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
@@ -116,6 +116,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
@@ -116,6 +116,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
@@ -72,6 +72,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
@@ -72,6 +72,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
@@ -45,6 +45,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
@@ -40,6 +40,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/each/each.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/each/each.js.snap
@@ -90,6 +90,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
@@ -33,6 +33,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
@@ -24,6 +24,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
@@ -32,6 +32,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
@@ -43,6 +43,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/trailing-comma/export_trailing_comma.js.snap
@@ -29,6 +29,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -49,6 +50,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -69,6 +71,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
@@ -58,6 +58,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -24,6 +24,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
@@ -33,6 +33,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -52,6 +53,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -136,6 +136,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
@@ -29,6 +29,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
@@ -29,6 +29,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
@@ -36,6 +36,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
@@ -57,6 +57,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
@@ -44,6 +44,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
@@ -38,6 +38,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
@@ -32,6 +32,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function.js.snap
@@ -56,6 +56,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function_args.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function_args.js.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -40,6 +40,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/ident.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/ident.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
@@ -47,6 +47,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/import/default_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/default_import.js.snap
@@ -35,6 +35,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_call.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -56,6 +56,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
@@ -24,6 +24,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/trailing-comma/import_trailing_comma.js.snap
@@ -54,6 +54,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -109,6 +110,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -164,6 +166,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
@@ -34,6 +34,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
@@ -40,6 +40,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
@@ -102,6 +102,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
@@ -142,6 +142,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -273,6 +274,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
@@ -32,6 +32,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -55,6 +56,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
@@ -104,6 +104,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -210,6 +211,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -47,6 +48,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -41,6 +42,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -45,6 +46,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number.js.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -43,6 +43,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
@@ -56,6 +56,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -32,6 +32,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
@@ -112,6 +112,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/trailing-comma/object_trailing_comma.js.snap
@@ -33,6 +33,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -59,6 +60,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -85,6 +87,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
@@ -47,6 +47,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/prettier-differences/fill-array-comments.js.snap
@@ -32,6 +32,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
@@ -34,6 +34,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
@@ -32,6 +32,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
@@ -33,6 +33,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -38,6 +38,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
@@ -53,6 +53,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
@@ -41,6 +41,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
@@ -32,6 +32,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -93,6 +93,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
@@ -49,6 +49,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/statement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/statement.js.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -43,6 +43,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/throw.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/throw.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
@@ -50,6 +50,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
@@ -50,6 +50,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/string/directives.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/directives.js.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -46,6 +47,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -65,6 +67,7 @@ JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/parentheses_token.js.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -41,6 +42,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -57,6 +59,7 @@ JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/properties_quotes.js.snap
@@ -67,6 +67,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -126,6 +127,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -185,6 +187,7 @@ JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/string/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/string.js.snap
@@ -81,6 +81,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -164,6 +165,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js
@@ -247,6 +249,7 @@ JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -52,6 +52,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/template/template.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/template/template.js.snap
@@ -71,6 +71,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/module/with.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/with.js.snap
@@ -29,6 +29,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/js/script/with.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/script/with.js.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```js

--- a/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
@@ -53,6 +53,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/attributes.jsx.snap
@@ -100,6 +100,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/comments.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/comments.jsx.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/conditional.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/conditional.jsx.snap
@@ -73,6 +73,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/element.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/element.jsx.snap
@@ -354,6 +354,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/fragment.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/fragment.jsx.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
@@ -74,6 +74,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/quote_style/quote_style.jsx.snap
@@ -32,6 +32,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx
@@ -50,6 +51,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx
@@ -68,6 +70,7 @@ JSX quote style: Single Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx
@@ -86,6 +89,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx
@@ -104,6 +108,7 @@ JSX quote style: Single Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
@@ -39,6 +39,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/jsx/smoke.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/smoke.jsx.snap
@@ -24,6 +24,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```jsx

--- a/crates/rome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
@@ -35,6 +35,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
@@ -29,6 +29,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
@@ -37,6 +37,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
@@ -45,6 +45,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
@@ -57,6 +57,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
@@ -38,6 +38,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/call_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/call_expression.ts.snap
@@ -47,6 +47,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/class/accessor.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/accessor.ts.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
@@ -31,6 +31,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
@@ -59,6 +59,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
@@ -34,6 +34,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/trailing_comma/class_trailing_comma.ts.snap
@@ -35,6 +35,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -75,6 +76,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -115,6 +117,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/class.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/class.ts.snap
@@ -83,6 +83,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -69,6 +69,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
@@ -111,6 +111,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/declare.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declare.ts.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
@@ -282,6 +282,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
@@ -116,6 +116,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/enum/enum_trailing_comma.ts.snap
@@ -29,6 +29,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -49,6 +50,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -69,6 +71,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -128,6 +128,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -70,6 +70,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/function/parameters/function_parameters.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/function/parameters/function_parameters.ts.snap
@@ -57,6 +57,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -107,6 +108,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -154,6 +156,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/function/trailing_comma/function_trailing_comma.ts.snap
@@ -61,6 +61,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -115,6 +116,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -169,6 +171,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -46,6 +46,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
@@ -28,6 +28,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
@@ -75,6 +75,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -141,6 +142,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -45,6 +46,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
@@ -38,6 +38,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -66,6 +67,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
@@ -37,6 +37,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -69,6 +70,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: As needed
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/object/object_trailing_comma.ts.snap
@@ -46,6 +46,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -82,6 +83,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -118,6 +120,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/parenthesis.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/parenthesis.ts.snap
@@ -26,6 +26,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
@@ -25,6 +25,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -36,6 +36,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/string/parameter_quotes.ts.snap
@@ -59,6 +59,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -109,6 +110,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -159,6 +161,7 @@ JSX quote style: Double Quotes
 Quote properties: Preserve
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/type/conditional.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/conditional.ts.snap
@@ -40,6 +40,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/type/import_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/import_type.ts.snap
@@ -30,6 +30,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
@@ -82,6 +82,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
@@ -24,6 +24,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
@@ -24,6 +24,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/type/template_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/template_type.ts.snap
@@ -27,6 +27,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/trailing-comma/type_trailing_comma.ts.snap
@@ -36,6 +36,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -62,6 +63,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: ES5
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts
@@ -88,6 +90,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: None
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
@@ -270,6 +270,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```ts

--- a/crates/rome_js_formatter/tests/specs/tsx/smoke.tsx.snap
+++ b/crates/rome_js_formatter/tests/specs/tsx/smoke.tsx.snap
@@ -24,6 +24,7 @@ JSX quote style: Double Quotes
 Quote properties: As needed
 Trailing comma: All
 Semicolons: Always
+Arrow parentheses: Always
 -----
 
 ```tsx

--- a/crates/rome_service/src/configuration/javascript.rs
+++ b/crates/rome_service/src/configuration/javascript.rs
@@ -2,7 +2,7 @@ use crate::configuration::merge::MergeWith;
 use crate::configuration::string_set::StringSet;
 use bpaf::Bpaf;
 use rome_js_formatter::context::{
-    trailing_comma::TrailingComma, QuoteProperties, QuoteStyle, Semicolons,
+    trailing_comma::TrailingComma, ArrowParentheses, QuoteProperties, QuoteStyle, Semicolons,
 };
 use serde::{Deserialize, Serialize};
 
@@ -88,6 +88,10 @@ pub struct JavascriptFormatter {
     #[bpaf(long("semicolons"), argument("always|as-needed"), optional)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semicolons: Option<Semicolons>,
+    /// Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
+    #[bpaf(long("arrow-parentheses"), argument("always|as-needed"), optional)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arrow_parentheses: Option<ArrowParentheses>,
 }
 
 impl JavascriptFormatter {
@@ -97,11 +101,15 @@ impl JavascriptFormatter {
         "quoteProperties",
         "trailingComma",
         "semicolons",
+        "arrowParentheses",
     ];
 }
 
 impl MergeWith<JavascriptFormatter> for JavascriptFormatter {
     fn merge_with(&mut self, other: JavascriptFormatter) {
+        if let Some(arrow_parentheses) = other.arrow_parentheses {
+            self.arrow_parentheses = Some(arrow_parentheses);
+        }
         if let Some(quote_properties) = other.quote_properties {
             self.quote_properties = Some(quote_properties);
         }

--- a/crates/rome_service/src/configuration/parse/json/javascript.rs
+++ b/crates/rome_service/src/configuration/parse/json/javascript.rs
@@ -4,7 +4,7 @@ use crate::configuration::{JavascriptConfiguration, JavascriptFormatter};
 use rome_deserialize::json::{has_only_known_keys, VisitJsonNode};
 use rome_deserialize::{DeserializationDiagnostic, VisitNode};
 use rome_js_formatter::context::trailing_comma::TrailingComma;
-use rome_js_formatter::context::{QuoteProperties, QuoteStyle, Semicolons};
+use rome_js_formatter::context::{ArrowParentheses, QuoteProperties, QuoteStyle, Semicolons};
 use rome_json_syntax::{JsonLanguage, JsonSyntaxNode};
 use rome_rowan::SyntaxNode;
 
@@ -99,6 +99,11 @@ impl VisitNode<JsonLanguage> for JavascriptFormatter {
                 let mut semicolons = Semicolons::default();
                 self.map_to_known_string(&value, name_text, &mut semicolons, diagnostics)?;
                 self.semicolons = Some(semicolons);
+            }
+            "arrowParentheses" => {
+                let mut arrow_parentheses = ArrowParentheses::default();
+                self.map_to_known_string(&value, name_text, &mut arrow_parentheses, diagnostics)?;
+                self.arrow_parentheses = Some(arrow_parentheses);
             }
             _ => {}
         }

--- a/crates/rome_service/src/file_handlers/javascript.rs
+++ b/crates/rome_service/src/file_handlers/javascript.rs
@@ -26,7 +26,7 @@ use rome_js_analyze::{
     analyze, analyze_with_inspect_matcher, visit_registry, ControlFlowGraph, RuleError,
 };
 use rome_js_formatter::context::{
-    trailing_comma::TrailingComma, QuoteProperties, QuoteStyle, Semicolons,
+    trailing_comma::TrailingComma, ArrowParentheses, QuoteProperties, QuoteStyle, Semicolons,
 };
 use rome_js_formatter::{context::JsFormatOptions, format_node};
 use rome_js_parser::JsParserOptions;
@@ -50,6 +50,7 @@ pub struct JsFormatterSettings {
     pub quote_properties: Option<QuoteProperties>,
     pub trailing_comma: Option<TrailingComma>,
     pub semicolons: Option<Semicolons>,
+    pub arrow_parentheses: Option<ArrowParentheses>,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -92,6 +93,7 @@ impl Language for JsLanguage {
             .with_quote_properties(language.quote_properties.unwrap_or_default())
             .with_trailing_comma(language.trailing_comma.unwrap_or_default())
             .with_semicolons(language.semicolons.unwrap_or_default())
+            .with_arrow_parentheses(language.arrow_parentheses.unwrap_or_default())
     }
 }
 

--- a/crates/rome_service/src/settings.rs
+++ b/crates/rome_service/src/settings.rs
@@ -80,6 +80,7 @@ impl WorkspaceSettings {
                 self.languages.javascript.formatter.quote_properties = formatter.quote_properties;
                 self.languages.javascript.formatter.trailing_comma = formatter.trailing_comma;
                 self.languages.javascript.formatter.semicolons = formatter.semicolons;
+                self.languages.javascript.formatter.arrow_parentheses = formatter.arrow_parentheses;
             }
 
             if let Some(parser) = javascript.parser {

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -215,6 +215,7 @@
 				}
 			}
 		},
+		"ArrowParentheses": { "type": "string", "enum": ["always", "asNeeded"] },
 		"Complexity": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",
@@ -662,6 +663,13 @@
 		"JavascriptFormatter": {
 			"type": "object",
 			"properties": {
+				"arrowParentheses": {
+					"description": "Whether to add non-necessary parentheses to arrow functions. Defaults to \"always\".",
+					"anyOf": [
+						{ "$ref": "#/definitions/ArrowParentheses" },
+						{ "type": "null" }
+					]
+				},
 				"jsxQuoteStyle": {
 					"description": "The style for JSX quotes. Defaults to double.",
 					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -167,6 +167,10 @@ The allowed range of values is 1..=320
 export type LineWidth = number;
 export interface JavascriptFormatter {
 	/**
+	 * Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
+	 */
+	arrowParentheses?: ArrowParentheses;
+	/**
 	 * The style for JSX quotes. Defaults to double.
 	 */
 	jsxQuoteStyle?: QuoteStyle;
@@ -215,6 +219,7 @@ export interface Rules {
 	suspicious?: Suspicious;
 }
 export type VcsClientKind = "git";
+export type ArrowParentheses = "always" | "asNeeded";
 export type QuoteStyle = "double" | "single";
 export type QuoteProperties = "asNeeded" | "preserve";
 export type Semicolons = "always" | "asNeeded";

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -215,6 +215,7 @@
 				}
 			}
 		},
+		"ArrowParentheses": { "type": "string", "enum": ["always", "asNeeded"] },
 		"Complexity": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",
@@ -662,6 +663,13 @@
 		"JavascriptFormatter": {
 			"type": "object",
 			"properties": {
+				"arrowParentheses": {
+					"description": "Whether to add non-necessary parentheses to arrow functions. Defaults to \"always\".",
+					"anyOf": [
+						{ "$ref": "#/definitions/ArrowParentheses" },
+						{ "type": "null" }
+					]
+				},
 				"jsxQuoteStyle": {
 					"description": "The style for JSX quotes. Defaults to double.",
 					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]

--- a/website/src/pages/configuration.mdx
+++ b/website/src/pages/configuration.mdx
@@ -392,6 +392,12 @@ It configures where the formatter prints semicolons:
 
 > Default: `always`
 
+### `javascript.formatter.arrowParentheses`
+
+Whether to add non-necessary parentheses to arrow functions. It can be `always` or `asNeeded`.
+
+> Default: `always`
+
 Example:
 
 <CodeBlockHeader filename="rome.json" />

--- a/website/src/pages/configuration.mdx
+++ b/website/src/pages/configuration.mdx
@@ -392,12 +392,6 @@ It configures where the formatter prints semicolons:
 
 > Default: `always`
 
-### `javascript.formatter.arrowParentheses`
-
-Whether to add non-necessary parentheses to arrow functions. It can be `always` or `asNeeded`.
-
-> Default: `always`
-
 Example:
 
 <CodeBlockHeader filename="rome.json" />

--- a/website/src/pages/formatter/index.mdx
+++ b/website/src/pages/formatter/index.mdx
@@ -49,6 +49,8 @@ Available options:
                        comma-separated syntactic structures. Defaults to "all".
         --semicolons <always|as-needed>  Whether the formatter prints semicolons for all statements
                        or only in for statements where it is necessary because of ASI.
+        --arrow-parentheses <always|as-needed>  Whether to add non-necessary parentheses to arrow
+                       functions. Defaults to "always".
         --vcs-client-kind <git>  The kind of client.
         --vcs-enabled <true|false>  Whether Rome should integrate itself with the VCS client
         --vcs-use-ignore-file <true|false>  Whether Rome should use the VCS ignore file. When [true],

--- a/website/src/pages/formatter/index.mdx
+++ b/website/src/pages/formatter/index.mdx
@@ -49,8 +49,6 @@ Available options:
                        comma-separated syntactic structures. Defaults to "all".
         --semicolons <always|as-needed>  Whether the formatter prints semicolons for all statements
                        or only in for statements where it is necessary because of ASI.
-        --arrow-parentheses <always|as-needed>  Whether to add non-necessary parentheses to arrow
-                       functions. Defaults to "always".
         --vcs-client-kind <git>  The kind of client.
         --vcs-enabled <true|false>  Whether Rome should integrate itself with the VCS client
         --vcs-use-ignore-file <true|false>  Whether Rome should use the VCS ignore file. When [true],

--- a/website/src/pages/linter/index.mdx
+++ b/website/src/pages/linter/index.mdx
@@ -54,6 +54,8 @@ Available options:
                         comma-separated syntactic structures. Defaults to "all".
         --semicolons <always|as-needed>  Whether the formatter prints semicolons for all statements
                         or only in for statements where it is necessary because of ASI.
+        --arrow-parentheses <always|as-needed>  Whether to add non-necessary parentheses to arrow
+                        functions. Defaults to "always".
         --colors <off|force>  Set the formatting mode for markup: "off" prints everything as plain
                         text, "force" forces the formatting of markup using ANSI even if the console
                         output is determined to be incompatible

--- a/website/src/pages/linter/index.mdx
+++ b/website/src/pages/linter/index.mdx
@@ -54,8 +54,6 @@ Available options:
                         comma-separated syntactic structures. Defaults to "all".
         --semicolons <always|as-needed>  Whether the formatter prints semicolons for all statements
                         or only in for statements where it is necessary because of ASI.
-        --arrow-parentheses <always|as-needed>  Whether to add non-necessary parentheses to arrow
-                        functions. Defaults to "always".
         --colors <off|force>  Set the formatting mode for markup: "off" prints everything as plain
                         text, "force" forces the formatting of markup using ANSI even if the console
                         output is determined to be incompatible

--- a/website/src/playground/PlaygroundLoader.tsx
+++ b/website/src/playground/PlaygroundLoader.tsx
@@ -1,6 +1,7 @@
 import Playground from "./Playground";
 import LoadingScreen from "./components/LoadingScreen";
 import {
+	ArrowParentheses,
 	IndentStyle,
 	LintRules,
 	LoadingState,
@@ -325,6 +326,9 @@ function initState(
 			semicolons:
 				(searchParams.get("semicolons") as Semicolons) ??
 				defaultPlaygroundState.settings.semicolons,
+			arrowParentheses:
+				(searchParams.get("arrowParentheses") as ArrowParentheses) ??
+				defaultPlaygroundState.settings.arrowParentheses,
 			lintRules:
 				(searchParams.get("lintRules") as LintRules) ??
 				defaultPlaygroundState.settings.lintRules,

--- a/website/src/playground/tabs/SettingsTab.tsx
+++ b/website/src/playground/tabs/SettingsTab.tsx
@@ -1,4 +1,5 @@
 import {
+	ArrowParentheses,
 	IndentStyle,
 	LintRules,
 	PlaygroundState,
@@ -43,6 +44,7 @@ export default function SettingsTab({
 			quoteProperties,
 			trailingComma,
 			semicolons,
+			arrowParentheses,
 			lintRules,
 			enabledLinting,
 			importSortingEnabled,
@@ -81,6 +83,10 @@ export default function SettingsTab({
 	const setSemicolons = createPlaygroundSettingsSetter(
 		setPlaygroundState,
 		"semicolons",
+	);
+	const setArrowParentheses = createPlaygroundSettingsSetter(
+		setPlaygroundState,
+		"arrowParentheses",
 	);
 	const setLintRules = createPlaygroundSettingsSetter(
 		setPlaygroundState,
@@ -239,6 +245,8 @@ export default function SettingsTab({
 				setTrailingComma={setTrailingComma}
 				semicolons={semicolons}
 				setSemicolons={setSemicolons}
+				arrowParentheses={arrowParentheses}
+				setArrowParentheses={setArrowParentheses}
 			/>
 			<LinterSettings
 				lintRules={lintRules}
@@ -550,6 +558,8 @@ function FormatterSettings({
 	setTrailingComma,
 	semicolons,
 	setSemicolons,
+	arrowParentheses,
+	setArrowParentheses,
 }: {
 	lineWidth: number;
 	setLineWidth: (value: number) => void;
@@ -567,6 +577,8 @@ function FormatterSettings({
 	setTrailingComma: (value: TrailingComma) => void;
 	semicolons: Semicolons;
 	setSemicolons: (value: Semicolons) => void;
+	arrowParentheses: ArrowParentheses;
+	setArrowParentheses: (value: ArrowParentheses) => void;
 }) {
 	return (
 		<>
@@ -667,6 +679,19 @@ function FormatterSettings({
 					>
 						<option value={Semicolons.Always}>Always</option>
 						<option value={Semicolons.AsNeeded}>As needed</option>
+					</select>
+				</div>
+
+				<div className="field-row">
+					<label htmlFor="arrowParentheses">Arrow Parentheses</label>
+					<select
+						id="arrowParentheses"
+						name="arrowParentheses"
+						value={arrowParentheses ?? "always"}
+						onChange={(e) => setArrowParentheses(e.target.value as ArrowParentheses)}
+					>
+						<option value={ArrowParentheses.Always}>Always</option>
+						<option value={ArrowParentheses.AsNeeded}>As needed</option>
 					</select>
 				</div>
 			</section>

--- a/website/src/playground/tabs/SettingsTab.tsx
+++ b/website/src/playground/tabs/SettingsTab.tsx
@@ -688,7 +688,9 @@ function FormatterSettings({
 						id="arrowParentheses"
 						name="arrowParentheses"
 						value={arrowParentheses ?? "always"}
-						onChange={(e) => setArrowParentheses(e.target.value as ArrowParentheses)}
+						onChange={(e) =>
+							setArrowParentheses(e.target.value as ArrowParentheses)
+						}
 					>
 						<option value={ArrowParentheses.Always}>Always</option>
 						<option value={ArrowParentheses.AsNeeded}>As needed</option>

--- a/website/src/playground/types.ts
+++ b/website/src/playground/types.ts
@@ -44,6 +44,11 @@ export enum Semicolons {
 	AsNeeded = "as-needed",
 }
 
+export enum ArrowParentheses {
+	Always = "always",
+	AsNeeded = "as-needed",
+}
+
 export type PrettierOutput =
 	| { type: "SUCCESS"; code: string; ir: string }
 	| { type: "ERROR"; stack: string };
@@ -105,6 +110,7 @@ export interface PlaygroundSettings {
 	quoteProperties: QuoteProperties;
 	trailingComma: TrailingComma;
 	semicolons: Semicolons;
+	arrowParentheses: ArrowParentheses;
 	lintRules: LintRules;
 	enabledLinting: boolean;
 	importSortingEnabled: boolean;
@@ -147,6 +153,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 		quoteProperties: QuoteProperties.AsNeeded,
 		trailingComma: TrailingComma.All,
 		semicolons: Semicolons.Always,
+		arrowParentheses: ArrowParentheses.Always,
 		lintRules: LintRules.Recommended,
 		enabledLinting: true,
 		importSortingEnabled: true,

--- a/website/src/playground/workers/prettierWorker.ts
+++ b/website/src/playground/workers/prettierWorker.ts
@@ -1,4 +1,5 @@
 import {
+	ArrowParentheses,
 	IndentStyle,
 	PlaygroundSettings,
 	PrettierOutput,
@@ -32,6 +33,7 @@ self.addEventListener("message", (e) => {
 				quoteProperties,
 				trailingComma,
 				semicolons,
+				arrowParentheses,
 			} = settings;
 			const code = e.data.code as string;
 			const filename = e.data.filename as string;
@@ -46,6 +48,7 @@ self.addEventListener("message", (e) => {
 				quoteProperties,
 				trailingComma,
 				semicolons,
+				arrowParentheses,
 			});
 
 			self.postMessage({
@@ -74,6 +77,7 @@ function formatWithPrettier(
 		quoteProperties: QuoteProperties;
 		trailingComma: TrailingComma;
 		semicolons: Semicolons;
+		arrowParentheses: ArrowParentheses;
 	},
 ): PrettierOutput {
 	try {
@@ -89,6 +93,7 @@ function formatWithPrettier(
 			quoteProps: options.quoteProperties,
 			trailingComma: options.trailingComma,
 			semi: options.semicolons === Semicolons.Always,
+			arrowParens: options.arrowParentheses === ArrowParentheses.Always ? "always" : "avoid",
 		};
 
 		// @ts-expect-error

--- a/website/src/playground/workers/prettierWorker.ts
+++ b/website/src/playground/workers/prettierWorker.ts
@@ -93,7 +93,10 @@ function formatWithPrettier(
 			quoteProps: options.quoteProperties,
 			trailingComma: options.trailingComma,
 			semi: options.semicolons === Semicolons.Always,
-			arrowParens: options.arrowParentheses === ArrowParentheses.Always ? "always" : "avoid",
+			arrowParens:
+				options.arrowParentheses === ArrowParentheses.Always
+					? "always"
+					: "avoid",
 		};
 
 		// @ts-expect-error

--- a/website/src/playground/workers/romeWorker.ts
+++ b/website/src/playground/workers/romeWorker.ts
@@ -107,7 +107,9 @@ self.addEventListener("message", async (e) => {
 						semicolons:
 							semicolons === Semicolons.Always ? "always" : "asNeeded",
 						arrowParentheses:
-							arrowParentheses === ArrowParentheses.Always ? "always" : "asNeeded",
+							arrowParentheses === ArrowParentheses.Always
+								? "always"
+								: "asNeeded",
 					},
 					parser: {
 						unsafeParameterDecoratorsEnabled,

--- a/website/src/playground/workers/romeWorker.ts
+++ b/website/src/playground/workers/romeWorker.ts
@@ -1,4 +1,5 @@
 import {
+	ArrowParentheses,
 	IndentStyle,
 	LintRules,
 	LoadingState,
@@ -71,6 +72,7 @@ self.addEventListener("message", async (e) => {
 				enabledLinting,
 				trailingComma,
 				semicolons,
+				arrowParentheses,
 				importSortingEnabled,
 				unsafeParameterDecoratorsEnabled,
 			} = e.data.settings as PlaygroundSettings;
@@ -104,6 +106,8 @@ self.addEventListener("message", async (e) => {
 						trailingComma,
 						semicolons:
 							semicolons === Semicolons.Always ? "always" : "asNeeded",
+						arrowParentheses:
+							arrowParentheses === ArrowParentheses.Always ? "always" : "asNeeded",
 					},
 					parser: {
 						unsafeParameterDecoratorsEnabled,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #4666

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Personally, the only thing that's keeping me for migrating to Rome formatter-wise is the lack of an `arrowParens` formatter option. Most developers don't really want to change their code style just to migrate to a new tool, especially when this change affects code readability.

This pull requests adds an `--arrow-parentheses` option (similar to prettier's `arrowParens`) that can be set to:
- `always` for always adding parentheses to arrow functions
- `as-needed` for only adding parentheses where it's necessary

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
Made all arrow function tests also run on `"arrow_parentheses": "AsNeeded"`