### PR TITLE
fix(rome_js_analyze): skip `this` reference identifier in the semantic analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,10 @@ if no error diagnostics are emitted.
 
   This rule's code action emits an invalid AST, so I fixed using JsxString instead of JsStringLiteral
 
+- Fix [noUndeclaredVariables](https://docs.rome.tools/lint/rules/noundeclaredvariables/)'s false positive diagnostics ([#4675](https://github.com/rome/tools/issues/4675))
+
+  The semantic analyzer no longer handles `this` reference identifier in the semantic analyzer.
+
 ### Parser
 
 - Add support for decorators in class method parameters, example:

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
@@ -48,7 +48,9 @@ impl Rule for NoUndeclaredVariables {
         ctx.query()
             .all_unresolved_references()
             .filter_map(|reference| {
+                // dbg!(&reference);
                 let identifier = reference.tree();
+                dbg!(&identifier);
                 let under_as_expression = identifier
                     .parent::<TsReferenceType>()
                     .and_then(|ty| ty.parent::<TsAsExpression>())

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness/no_undeclared_variables.rs
@@ -48,9 +48,7 @@ impl Rule for NoUndeclaredVariables {
         ctx.query()
             .all_unresolved_references()
             .filter_map(|reference| {
-                // dbg!(&reference);
                 let identifier = reference.tree();
-                dbg!(&identifier);
                 let under_as_expression = identifier
                     .parent::<TsReferenceType>()
                     .and_then(|ty| ty.parent::<TsAsExpression>())

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.ts
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.ts
@@ -11,5 +11,16 @@ export type WhateverDefault<S extends number = 2> = `Hello ${S}`
 // Const assertions are valid
 const fruits = ["banana"] as const;
 
+class X {
+  f() {
+    this.g;
+    type T1 = typeof this.g;
+    type T2 = X['g'];
+  }
+
+  g() {
+  }
+}
+
 // Invalid
 export type Invalid<S extends number> = `Hello ${T}`

--- a/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noUndeclaredVariables/noUndeclaredVariables.ts.snap
@@ -17,19 +17,32 @@ export type WhateverDefault<S extends number = 2> = `Hello ${S}`
 // Const assertions are valid
 const fruits = ["banana"] as const;
 
+class X {
+  f() {
+    this.g;
+    type T1 = typeof this.g;
+    type T2 = X['g'];
+  }
+
+  g() {
+  }
+}
+
 // Invalid
 export type Invalid<S extends number> = `Hello ${T}`
+
 ```
 
 # Diagnostics
 ```
-noUndeclaredVariables.ts:15:50 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+noUndeclaredVariables.ts:26:50 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The T variable is undeclared
   
-    14 │ // Invalid
-  > 15 │ export type Invalid<S extends number> = `Hello ${T}`
+    25 │ // Invalid
+  > 26 │ export type Invalid<S extends number> = `Hello ${T}`
        │                                                  ^
+    27 │ 
   
 
 ```

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -479,6 +479,10 @@ impl SemanticEventExtractor {
                 // SAFETY: kind check above
                 let reference = JsReferenceIdentifier::unwrap_cast(node.clone());
                 let name_token = reference.value_token().ok()?;
+                // skip `this` reference representing the class instance
+                if name_token.token_text_trimmed() == "this" {
+                    return None;
+                }
                 (
                     name_token.token_text_trimmed(),
                     self.is_js_reference_identifier_exported(node),


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fix #4642 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I update some snapshot tests.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
