### PR TITLE
feat(rome_js_analyze): noUselessEmptyExport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,10 @@ if no error diagnostics are emitted.
 
 	This rule disallows `\8` and `\9` escape sequences in string literals.
 
+- Add [`noUselessEmptyExport`](https://docs.rome.tools/lint/rules/noUselessEmptyExport/)
+
+	This rule disallows useless `export {}`.
+
 #### Other changes
 
 - Add new TypeScript globals (`AsyncDisposable`, `Awaited`, `DecoratorContext`, and others) [4643](https://github.com/rome/tools/issues/4643).

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -93,6 +93,7 @@ define_categories! {
     "lint/nursery/noRedundantRoles": "https://docs.rome.tools/lint/rules/noRedundantRoles",
     "lint/nursery/noSelfAssign": "https://docs.rome.tools/lint/rules/noSelfAssign",
     "lint/nursery/noStaticOnlyClass": "https://docs.rome.tools/lint/rules/noStaticOnlyClass",
+    "lint/nursery/noUselessEmptyExport": "https://docs.rome.tools/lint/rules/noUselessEmptyExport",
     "lint/nursery/noVoid": "https://docs.rome.tools/lint/rules/noVoid",
     "lint/nursery/useAriaPropTypes": "https://docs.rome.tools/lint/rules/useAriaPropTypes",
     "lint/nursery/useArrowFunction": "https://docs.rome.tools/lint/rules/useArrowFunction",

--- a/crates/rome_js_analyze/src/analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery.rs
@@ -10,6 +10,7 @@ pub(crate) mod no_for_each;
 pub(crate) mod no_nonoctal_decimal_escape;
 pub(crate) mod no_self_assign;
 pub(crate) mod no_static_only_class;
+pub(crate) mod no_useless_empty_export;
 pub(crate) mod no_void;
 pub(crate) mod use_arrow_function;
 pub(crate) mod use_grouped_type_import;
@@ -30,6 +31,7 @@ declare_group! {
             self :: no_nonoctal_decimal_escape :: NoNonoctalDecimalEscape ,
             self :: no_self_assign :: NoSelfAssign ,
             self :: no_static_only_class :: NoStaticOnlyClass ,
+            self :: no_useless_empty_export :: NoUselessEmptyExport ,
             self :: no_void :: NoVoid ,
             self :: use_arrow_function :: UseArrowFunction ,
             self :: use_grouped_type_import :: UseGroupedTypeImport ,

--- a/crates/rome_js_analyze/src/analyzers/nursery/no_useless_empty_export.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/no_useless_empty_export.rs
@@ -1,0 +1,125 @@
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Ast, Rule, RuleDiagnostic};
+use rome_console::markup;
+use rome_diagnostics::Applicability;
+use rome_js_syntax::{AnyJsModuleItem, JsExport, JsModuleItemList, JsSyntaxToken};
+use rome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
+
+use crate::JsRuleAction;
+
+declare_rule! {
+    /// Disallow empty exports that don't change anything in a module file.
+    ///
+    /// An empty `export {}` is sometimes useful to turn a file that would otherwise be a script into a module.
+    /// Per the [TypeScript Handbook Modules page](https://www.typescriptlang.org/docs/handbook/modules.html):
+    ///
+    /// > In TypeScript, just as in ECMAScript 2015,
+    /// > any file containing a top-level import or export is considered a module.
+    /// > Conversely, a file without any top-level import or export declarations is treated as a script
+    /// > whose contents are available in the global scope.
+    ///
+    /// However, an `export {}` statement does nothing if there are any other top-level import or export in the file.
+    ///
+    /// Source: https://typescript-eslint.io/rules/no-useless-empty-export/
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// import { A } from "module";
+    /// export {};
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// export const A = 0;
+    /// export {};
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```js
+    /// export {};
+    /// ```
+    ///
+    pub(crate) NoUselessEmptyExport {
+        version: "next",
+        name: "noUselessEmptyExport",
+        recommended: true,
+    }
+}
+
+impl Rule for NoUselessEmptyExport {
+    type Query = Ast<JsExport>;
+    /// The first import or export that makes useless the empty export.
+    type State = JsSyntaxToken;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        if is_empty_export(node) {
+            let module_item_list = JsModuleItemList::cast(node.syntax().parent()?)?;
+            // allow reporting an empty export that precedes another empty export.
+            let mut ignore_empty_export = true;
+            for module_item in module_item_list {
+                match module_item {
+                    AnyJsModuleItem::AnyJsStatement(_) => {}
+                    AnyJsModuleItem::JsImport(import) => return import.import_token().ok(),
+                    AnyJsModuleItem::JsExport(export) => {
+                        if !is_empty_export(&export) {
+                            return export.export_token().ok();
+                        }
+                        if !ignore_empty_export {
+                            return export.export_token().ok();
+                        }
+                        if node == &export {
+                            ignore_empty_export = false
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, token: &Self::State) -> Option<RuleDiagnostic> {
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                ctx.query().range(),
+                markup! {
+                    "This empty "<Emphasis>"export"</Emphasis>" is useless because there's another "<Emphasis>"export"</Emphasis>" or "<Emphasis>"import"</Emphasis>"."
+                },
+            ).detail(token.text_trimmed_range(), markup! {
+                "This "<Emphasis>{token.text_trimmed()}</Emphasis>" makes useless the empty export."
+            }),
+        )
+    }
+
+    fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
+        let mut mutation = ctx.root().begin();
+        mutation.remove_node(ctx.query().clone());
+        Some(JsRuleAction {
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::Always,
+            message: markup! { "Remove this useless empty export." }.to_owned(),
+            mutation,
+        })
+    }
+}
+
+fn is_empty_export(export: &JsExport) -> bool {
+    (|| -> Option<bool> {
+        Some(
+            export
+                .export_clause()
+                .ok()?
+                .as_js_export_named_clause()?
+                .specifiers()
+                .iter()
+                .count()
+                == 0,
+        )
+    })()
+    .unwrap_or(false)
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_default_export.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_default_export.js
@@ -1,0 +1,2 @@
+export default {};
+export {}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_default_export.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_default_export.js.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid_with_default_export.js
+---
+# Input
+```js
+export default {};
+export {}
+```
+
+# Diagnostics
+```
+invalid_with_default_export.js:2:1 lint/nursery/noUselessEmptyExport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  ! This empty export is useless because there's another export or import.
+  
+    1 │ export default {};
+  > 2 │ export {}
+      │ ^^^^^^^^^
+  
+  i This export makes useless the empty export.
+  
+  > 1 │ export default {};
+      │ ^^^^^^
+    2 │ export {}
+  
+  i Safe fix: Remove this useless empty export.
+  
+    1 1 │   export default {};
+    2   │ - export·{}
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_empty_export.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_empty_export.js
@@ -1,0 +1,2 @@
+export {}
+export {}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_empty_export.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_empty_export.js.snap
@@ -1,0 +1,34 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid_with_empty_export.js
+---
+# Input
+```js
+export {}
+export {}
+```
+
+# Diagnostics
+```
+invalid_with_empty_export.js:1:1 lint/nursery/noUselessEmptyExport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This empty export is useless because there's another export or import.
+  
+  > 1 │ export {}
+      │ ^^^^^^^^^
+    2 │ export {}
+  
+  i This export makes useless the empty export.
+  
+    1 │ export {}
+  > 2 │ export {}
+      │ ^^^^^^
+  
+  i Safe fix: Remove this useless empty export.
+  
+    1 │ export·{}
+      │ ---------
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_export.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_export.js
@@ -1,0 +1,3 @@
+function f() { return 0 }
+export const A = f();
+export {}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_export.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_export.js.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid_with_export.js
+---
+# Input
+```js
+function f() { return 0 }
+export const A = f();
+export {}
+```
+
+# Diagnostics
+```
+invalid_with_export.js:3:1 lint/nursery/noUselessEmptyExport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This empty export is useless because there's another export or import.
+  
+    1 │ function f() { return 0 }
+    2 │ export const A = f();
+  > 3 │ export {}
+      │ ^^^^^^^^^
+  
+  i This export makes useless the empty export.
+  
+    1 │ function f() { return 0 }
+  > 2 │ export const A = f();
+      │ ^^^^^^
+    3 │ export {}
+  
+  i Safe fix: Remove this useless empty export.
+  
+    1 1 │   function f() { return 0 }
+    2 2 │   export const A = f();
+    3   │ - export·{}
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_export_from.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_export_from.js
@@ -1,0 +1,2 @@
+export * from "mod";
+export {}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_export_from.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_export_from.js.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid_with_export_from.js
+---
+# Input
+```js
+export * from "mod";
+export {}
+```
+
+# Diagnostics
+```
+invalid_with_export_from.js:2:1 lint/nursery/noUselessEmptyExport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This empty export is useless because there's another export or import.
+  
+    1 │ export * from "mod";
+  > 2 │ export {}
+      │ ^^^^^^^^^
+  
+  i This export makes useless the empty export.
+  
+  > 1 │ export * from "mod";
+      │ ^^^^^^
+    2 │ export {}
+  
+  i Safe fix: Remove this useless empty export.
+  
+    1 1 │   export * from "mod";
+    2   │ - export·{}
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_import.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_import.js
@@ -1,0 +1,3 @@
+import { A } from "mod"
+function f() { return 0 }
+export {}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_import.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_import.js.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid_with_import.js
+---
+# Input
+```js
+import { A } from "mod"
+function f() { return 0 }
+export {}
+```
+
+# Diagnostics
+```
+invalid_with_import.js:3:1 lint/nursery/noUselessEmptyExport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This empty export is useless because there's another export or import.
+  
+    1 │ import { A } from "mod"
+    2 │ function f() { return 0 }
+  > 3 │ export {}
+      │ ^^^^^^^^^
+  
+  i This import makes useless the empty export.
+  
+  > 1 │ import { A } from "mod"
+      │ ^^^^^^
+    2 │ function f() { return 0 }
+    3 │ export {}
+  
+  i Safe fix: Remove this useless empty export.
+  
+    1 1 │   import { A } from "mod"
+    2 2 │   function f() { return 0 }
+    3   │ - export·{}
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_sideeffect_import.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_sideeffect_import.js
@@ -1,0 +1,3 @@
+import "mod"
+function f() { return 0 }
+export {}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_sideeffect_import.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/invalid_with_sideeffect_import.js.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid_with_sideeffect_import.js
+---
+# Input
+```js
+import "mod"
+function f() { return 0 }
+export {}
+```
+
+# Diagnostics
+```
+invalid_with_sideeffect_import.js:3:1 lint/nursery/noUselessEmptyExport  FIXABLE  ━━━━━━━━━━━━━━━━━━
+
+  ! This empty export is useless because there's another export or import.
+  
+    1 │ import "mod"
+    2 │ function f() { return 0 }
+  > 3 │ export {}
+      │ ^^^^^^^^^
+  
+  i This import makes useless the empty export.
+  
+  > 1 │ import "mod"
+      │ ^^^^^^
+    2 │ function f() { return 0 }
+    3 │ export {}
+  
+  i Safe fix: Remove this useless empty export.
+  
+    1 1 │   import "mod"
+    2 2 │   function f() { return 0 }
+    3   │ - export·{}
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/valid_empty_export.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/valid_empty_export.js
@@ -1,0 +1,3 @@
+function f() {}
+f();
+export {}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/valid_empty_export.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/valid_empty_export.js.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid_empty_export.js
+---
+# Input
+```js
+function f() {}
+f();
+export {}
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/valid_export.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/valid_export.js
@@ -1,0 +1,1 @@
+export const A = 0;

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/valid_export.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessEmptyExport/valid_export.js.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid_export.js
+---
+# Input
+```js
+export const A = 0;
+```
+
+

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -1899,6 +1899,15 @@ pub struct Nursery {
     #[bpaf(long("no-static-only-class"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_static_only_class: Option<RuleConfiguration>,
+    #[doc = "Disallow empty exports that don't change anything in a module file."]
+    #[bpaf(
+        long("no-useless-empty-export"),
+        argument("on|off|warn"),
+        optional,
+        hide
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_useless_empty_export: Option<RuleConfiguration>,
     #[doc = "Disallow the use of void operators, which is not a familiar operator."]
     #[bpaf(long("no-void"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1974,7 +1983,7 @@ pub struct Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 31] = [
+    pub(crate) const GROUP_RULES: [&'static str; 32] = [
         "noAccumulatingSpread",
         "noAriaUnsupportedElements",
         "noBannedTypes",
@@ -1993,6 +2002,7 @@ impl Nursery {
         "noRedundantRoles",
         "noSelfAssign",
         "noStaticOnlyClass",
+        "noUselessEmptyExport",
         "noVoid",
         "useAriaPropTypes",
         "useArrowFunction",
@@ -2007,7 +2017,7 @@ impl Nursery {
         "useNamingConvention",
         "useSimpleNumberKeys",
     ];
-    const RECOMMENDED_RULES: [&'static str; 17] = [
+    const RECOMMENDED_RULES: [&'static str; 18] = [
         "noAriaUnsupportedElements",
         "noBannedTypes",
         "noConstantCondition",
@@ -2019,6 +2029,7 @@ impl Nursery {
         "noRedundantRoles",
         "noSelfAssign",
         "noStaticOnlyClass",
+        "noUselessEmptyExport",
         "useArrowFunction",
         "useExhaustiveDependencies",
         "useGroupedTypeImport",
@@ -2026,7 +2037,7 @@ impl Nursery {
         "useLiteralEnumMembers",
         "useLiteralKeys",
     ];
-    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 17] = [
+    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 18] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
@@ -2038,14 +2049,15 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 31] = [
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 32] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -2077,6 +2089,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
@@ -2177,69 +2190,74 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_void.as_ref() {
+        if let Some(rule) = self.no_useless_empty_export.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+        if let Some(rule) = self.no_void.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_arrow_function.as_ref() {
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_camel_case.as_ref() {
+        if let Some(rule) = self.use_arrow_function.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+        if let Some(rule) = self.use_camel_case.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.use_heading_content.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_heading_content.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.use_is_nan.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.use_literal_enum_members.as_ref() {
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.use_literal_keys.as_ref() {
+        if let Some(rule) = self.use_literal_enum_members.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_literal_keys.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
+            }
+        }
+        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
         index_set
@@ -2336,69 +2354,74 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_void.as_ref() {
+        if let Some(rule) = self.no_useless_empty_export.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+        if let Some(rule) = self.no_void.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_arrow_function.as_ref() {
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_camel_case.as_ref() {
+        if let Some(rule) = self.use_arrow_function.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+        if let Some(rule) = self.use_camel_case.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.use_heading_content.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_heading_content.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.use_is_nan.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.use_literal_enum_members.as_ref() {
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.use_literal_keys.as_ref() {
+        if let Some(rule) = self.use_literal_enum_members.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_literal_keys.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
+            }
+        }
+        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
         index_set
@@ -2409,10 +2432,10 @@ impl Nursery {
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
     }
-    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 17] {
+    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 18] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 31] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 32] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2451,6 +2474,7 @@ impl Nursery {
             "noRedundantRoles" => self.no_redundant_roles.as_ref(),
             "noSelfAssign" => self.no_self_assign.as_ref(),
             "noStaticOnlyClass" => self.no_static_only_class.as_ref(),
+            "noUselessEmptyExport" => self.no_useless_empty_export.as_ref(),
             "noVoid" => self.no_void.as_ref(),
             "useAriaPropTypes" => self.use_aria_prop_types.as_ref(),
             "useArrowFunction" => self.use_arrow_function.as_ref(),

--- a/crates/rome_service/src/configuration/parse/json/rules.rs
+++ b/crates/rome_service/src/configuration/parse/json/rules.rs
@@ -1662,6 +1662,7 @@ impl VisitNode<JsonLanguage> for Nursery {
                 "noRedundantRoles",
                 "noSelfAssign",
                 "noStaticOnlyClass",
+                "noUselessEmptyExport",
                 "noVoid",
                 "useAriaPropTypes",
                 "useArrowFunction",
@@ -2100,6 +2101,29 @@ impl VisitNode<JsonLanguage> for Nursery {
                         diagnostics,
                     )?;
                     self.no_static_only_class = Some(rule_configuration);
+                }
+                _ => {
+                    diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
+                        "object or string",
+                        value.range(),
+                    ));
+                }
+            },
+            "noUselessEmptyExport" => match value {
+                AnyJsonValue::JsonStringValue(_) => {
+                    let mut configuration = RuleConfiguration::default();
+                    self.map_to_known_string(&value, name_text, &mut configuration, diagnostics)?;
+                    self.no_useless_empty_export = Some(configuration);
+                }
+                AnyJsonValue::JsonObjectValue(_) => {
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUselessEmptyExport",
+                        diagnostics,
+                    )?;
+                    self.no_useless_empty_export = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -880,6 +880,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noUselessEmptyExport": {
+					"description": "Disallow empty exports that don't change anything in a module file.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noVoid": {
 					"description": "Disallow the use of void operators, which is not a familiar operator.",
 					"anyOf": [

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -578,6 +578,10 @@ export interface Nursery {
 	 */
 	noStaticOnlyClass?: RuleConfiguration;
 	/**
+	 * Disallow empty exports that don't change anything in a module file.
+	 */
+	noUselessEmptyExport?: RuleConfiguration;
+	/**
 	 * Disallow the use of void operators, which is not a familiar operator.
 	 */
 	noVoid?: RuleConfiguration;
@@ -1146,6 +1150,7 @@ export type Category =
 	| "lint/nursery/noRedundantRoles"
 	| "lint/nursery/noSelfAssign"
 	| "lint/nursery/noStaticOnlyClass"
+	| "lint/nursery/noUselessEmptyExport"
 	| "lint/nursery/noVoid"
 	| "lint/nursery/useAriaPropTypes"
 	| "lint/nursery/useArrowFunction"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -880,6 +880,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noUselessEmptyExport": {
+					"description": "Disallow empty exports that don't change anything in a module file.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noVoid": {
 					"description": "Disallow the use of void operators, which is not a familiar operator.",
 					"anyOf": [

--- a/website/src/components/generated/NumberOfRules.astro
+++ b/website/src/components/generated/NumberOfRules.astro
@@ -1,2 +1,2 @@
 <!-- this file is auto generated, use `cargo lintdoc` to update it -->
- <p>Rome's linter has a total of <strong><a href='/lint/rules'>150 rules</a></strong><p>
+ <p>Rome's linter has a total of <strong><a href='/lint/rules'>151 rules</a></strong><p>

--- a/website/src/frontend-scripts/mobile.ts
+++ b/website/src/frontend-scripts/mobile.ts
@@ -1,6 +1,3 @@
-// Yes TS I am a module.
-export {};
-
 export let isMobile = false;
 window.addEventListener("DOMContentLoaded", () => {
 	const mobileMatchMedia = matchMedia("(max-width: 768px)");

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -1005,6 +1005,12 @@ Disallow assignments where both sides are exactly the same.
 This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.
 </section>
 <section class="rule">
+<h3 data-toc-exclude id="noUselessEmptyExport">
+	<a href="/lint/rules/noUselessEmptyExport">noUselessEmptyExport</a>
+</h3>
+Disallow empty exports that don't change anything in a module file.
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noVoid">
 	<a href="/lint/rules/noVoid">noVoid</a>
 </h3>

--- a/website/src/pages/lint/rules/noUselessEmptyExport.md
+++ b/website/src/pages/lint/rules/noUselessEmptyExport.md
@@ -1,0 +1,94 @@
+---
+title: Lint Rule noUselessEmptyExport
+parent: lint/rules/index
+---
+
+# noUselessEmptyExport (since vnext)
+
+Disallow empty exports that don't change anything in a module file.
+
+An empty `export {}` is sometimes useful to turn a file that would otherwise be a script into a module.
+Per the [TypeScript Handbook Modules page](https://www.typescriptlang.org/docs/handbook/modules.html):
+
+>In TypeScript, just as in ECMAScript 2015,
+any file containing a top-level import or export is considered a module.
+Conversely, a file without any top-level import or export declarations is treated as a script
+whose contents are available in the global scope.
+
+
+However, an `export {}` statement does nothing if there are any other top-level import or export in the file.
+
+Source: https://typescript-eslint.io/rules/no-useless-empty-export/
+
+## Examples
+
+### Invalid
+
+```jsx
+import { A } from "module";
+export {};
+```
+
+<pre class="language-text"><code class="language-text">nursery/noUselessEmptyExport.js:2:1 <a href="https://docs.rome.tools/lint/rules/noUselessEmptyExport">lint/nursery/noUselessEmptyExport</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This empty </span><span style="color: Tomato;"><strong>export</strong></span><span style="color: Tomato;"> is useless because there's another </span><span style="color: Tomato;"><strong>export</strong></span><span style="color: Tomato;"> or </span><span style="color: Tomato;"><strong>import</strong></span><span style="color: Tomato;">.</span>
+  
+    <strong>1 │ </strong>import { A } from &quot;module&quot;;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>export {};
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">This </span><span style="color: rgb(38, 148, 255);"><strong>import</strong></span><span style="color: rgb(38, 148, 255);"> makes useless the empty export.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>import { A } from &quot;module&quot;;
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>export {};
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove this useless empty export.</span>
+  
+    <strong>1</strong> <strong>1</strong><strong> │ </strong>  import { A } from &quot;module&quot;;
+    <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>x</strong></span><span style="color: Tomato;"><strong>p</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>r</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>{</strong></span><span style="color: Tomato;"><strong>}</strong></span><span style="color: Tomato;"><strong>;</strong></span>
+    <strong>3</strong> <strong>2</strong><strong> │ </strong>  
+  
+</code></pre>
+
+```jsx
+export const A = 0;
+export {};
+```
+
+<pre class="language-text"><code class="language-text">nursery/noUselessEmptyExport.js:2:1 <a href="https://docs.rome.tools/lint/rules/noUselessEmptyExport">lint/nursery/noUselessEmptyExport</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This empty </span><span style="color: Tomato;"><strong>export</strong></span><span style="color: Tomato;"> is useless because there's another </span><span style="color: Tomato;"><strong>export</strong></span><span style="color: Tomato;"> or </span><span style="color: Tomato;"><strong>import</strong></span><span style="color: Tomato;">.</span>
+  
+    <strong>1 │ </strong>export const A = 0;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>export {};
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">This </span><span style="color: rgb(38, 148, 255);"><strong>export</strong></span><span style="color: rgb(38, 148, 255);"> makes useless the empty export.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>export const A = 0;
+   <strong>   │ </strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>export {};
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Remove this useless empty export.</span>
+  
+    <strong>1</strong> <strong>1</strong><strong> │ </strong>  export const A = 0;
+    <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>x</strong></span><span style="color: Tomato;"><strong>p</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>r</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>{</strong></span><span style="color: Tomato;"><strong>}</strong></span><span style="color: Tomato;"><strong>;</strong></span>
+    <strong>3</strong> <strong>2</strong><strong> │ </strong>  
+  
+</code></pre>
+
+## Valid
+
+```jsx
+export {};
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)


### PR DESCRIPTION
## Summary

This implements [no-useless-empty-export](https://typescript-eslint.io/rules/no-useless-empty-export/) with a minor improvement: we also report the case where several empty exports compete. In this case, we preserve the last empty export.

## Test Plan

Tests included.
