### PR TITLE
refactor(rome_js_analyze): noFallthroughSwitchClause handle block statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ if no error diagnostics are emitted.
 
 #### New rules
 
+- Add [`noFallthroughSwitchClause`](https://docs.rome.tools/lint/rules/noFallthroughSwitchClause/)
+
 - Add [`noGlobalIsFinite`](https://docs.rome.tools/lint/rules/noglobalisfinite/)
 
   This rule recommends using `Number.isFinite` instead of the global and unsafe `isFinite` that attempts a type coercion.

--- a/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/valid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/valid.js
@@ -5,3 +5,5 @@ function bar(foo) { switch(foo) { case 1: doSomething(); return; case 2: doSomet
 switch(foo) { case 1: doSomething(); throw new Error("Boo!"); case 2: doSomething(); }
 
 switch(foo) { case 1: case 2: doSomething(); }
+
+switch(foo) { case 1: { doSomething(); break; } case 2: doSomething(); }

--- a/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/valid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noFallthroughSwitchClause/valid.js.snap
@@ -12,6 +12,8 @@ switch(foo) { case 1: doSomething(); throw new Error("Boo!"); case 2: doSomethin
 
 switch(foo) { case 1: case 2: doSomething(); }
 
+switch(foo) { case 1: { doSomething(); break; } case 2: doSomething(); }
+
 ```
 
 

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -1848,7 +1848,7 @@ pub struct Nursery {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_excessive_complexity: Option<RuleConfiguration>,
-    #[doc = "Disallow fallthrough of case statements."]
+    #[doc = "Disallow fallthrough of switch clauses."]
     #[bpaf(
         long("no-fallthrough-switch-clause"),
         argument("on|off|warn"),

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -818,7 +818,7 @@
 					]
 				},
 				"noFallthroughSwitchClause": {
-					"description": "Disallow fallthrough of case statements.",
+					"description": "Disallow fallthrough of switch clauses.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -542,7 +542,7 @@ export interface Nursery {
 	 */
 	noExcessiveComplexity?: RuleConfiguration;
 	/**
-	 * Disallow fallthrough of case statements.
+	 * Disallow fallthrough of switch clauses.
 	 */
 	noFallthroughSwitchClause?: RuleConfiguration;
 	/**

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -818,7 +818,7 @@
 					]
 				},
 				"noFallthroughSwitchClause": {
-					"description": "Disallow fallthrough of case statements.",
+					"description": "Disallow fallthrough of switch clauses.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -954,7 +954,7 @@ Disallow functions that exceed a given complexity score.
 <h3 data-toc-exclude id="noFallthroughSwitchClause">
 	<a href="/lint/rules/noFallthroughSwitchClause">noFallthroughSwitchClause</a>
 </h3>
-Disallow fallthrough of case statements.
+Disallow fallthrough of <code>switch</code> clauses.
 </section>
 <section class="rule">
 <h3 data-toc-exclude id="noForEach">

--- a/website/src/pages/lint/rules/noFallthroughSwitchClause.md
+++ b/website/src/pages/lint/rules/noFallthroughSwitchClause.md
@@ -3,12 +3,12 @@ title: Lint Rule noFallthroughSwitchClause
 parent: lint/rules/index
 ---
 
-# noFallthroughSwitchClause (since v12.0.0)
+# noFallthroughSwitchClause (since vnext)
 
-Disallow fallthrough of case statements.
+Disallow fallthrough of `switch` clauses.
 
-Case statements in switch statements fall through by default. This can lead to unexpected behavior when forgotten.
-This rule disallows the fallthrough of case statements.
+Switch clauses in `switch` statements fall through by default.
+This can lead to unexpected behavior when forgotten.
 
 Source: https://eslint.org/docs/latest/rules/no-fallthrough
 


### PR DESCRIPTION

## Summary

This PR fixes an issue with `noFallthroughSwitchClause` that reported code with block statements:

```js
switch x {
  // this case was reported by the rule
   case 0: {
    f();
    break;
  }
  case 1:
    f();
}
```

## Test Plan

New test included.