### PR TITLE
fix(rome_js_formatter): improve handling of arrow parentheses

### DIFF
--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -55,13 +55,6 @@ const APPLY_TRAILING_COMMA_AFTER: &str = r#"const a = [
 const APPLY_ARROW_PARENTHESES_BEFORE: &str = r#"
 action => {}
 (action) => {}
-(action?) => {}
-(action: h) => {}
-(action): h => {}
-(
-    action
-    // hhhhhhhh
-) => {}
 ({ action }) => {}
 ([ action ]) => {}
 (...action) => {}
@@ -70,13 +63,6 @@ action => {}
 
 const APPLY_ARROW_PARENTHESES_AFTER: &str = r#"action => {};
 action => {};
-(action?) => {};
-(action: h) => {};
-(action): h => {};
-(
-	action
-	// hhhhhhhh
-) => {}
 ({ action }) => {};
 ([action]) => {};
 (...action) => {};

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -55,6 +55,13 @@ const APPLY_TRAILING_COMMA_AFTER: &str = r#"const a = [
 const APPLY_ARROW_PARENTHESES_BEFORE: &str = r#"
 action => {}
 (action) => {}
+(action?) => {}
+(action: h) => {}
+(action): h => {}
+(
+    action
+    // hhhhhhhh
+) => {}
 ({ action }) => {}
 ([ action ]) => {}
 (...action) => {}
@@ -63,6 +70,13 @@ action => {}
 
 const APPLY_ARROW_PARENTHESES_AFTER: &str = r#"action => {};
 action => {};
+(action?) => {};
+(action: h) => {};
+(action): h => {};
+(
+	action
+	// hhhhhhhh
+) => {}
 ({ action }) => {};
 ([action]) => {};
 (...action) => {};

--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -344,7 +344,12 @@ pub fn can_avoid_parentheses(arrow: &JsArrowFunctionExpression, f: &mut JsFormat
                 .as_js_parameters()
                 .and_then(|p| p.items().first()?.ok())
                 .and_then(|p| JsFormalParameter::cast(p.syntax().clone()))
-                .is_some_and(|p| p.initializer().is_some())
+                .is_some_and(|p| {
+                    f.context().comments().has_comments(p.syntax())
+                        || p.initializer().is_some()
+                        || p.question_mark_token().is_some()
+                        || p.type_annotation().is_some()
+                })
     })
 }
 

--- a/crates/rome_js_formatter/tests/quick_test.rs
+++ b/crates/rome_js_formatter/tests/quick_test.rs
@@ -13,8 +13,11 @@ mod language {
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-        action => {}
-        (action) => {}
+        (action: h) => {}
+        (action?) => {}
+        (action
+        // yes
+        ) => {}
         ({ action }) => {}
         ([ action ]) => {}
         (...action) => {}
@@ -28,7 +31,7 @@ fn quick_test() {
     );
     dbg!(tree.syntax());
     let options = JsFormatOptions::new(syntax)
-        .with_semicolons(Semicolons::AsNeeded)
+        .with_semicolons(Semicolons::Always)
         .with_quote_style(QuoteStyle::Double)
         .with_jsx_quote_style(QuoteStyle::Single)
         .with_arrow_parentheses(ArrowParentheses::AsNeeded);
@@ -46,12 +49,16 @@ fn quick_test() {
     // I don't know why semicolons are added there, but it's not related to my code changes so ¯\_(ツ)_/¯
     assert_eq!(
         result.as_code(),
-        r#";action => {}
-;action => {}
-;({ action }) => {}
-;([action]) => {}
-;(...action) => {}
-;(action = 1) => {}
+        r#"(action: h) => {};
+(action?) => {};
+(
+	action,
+	// yes
+) => {};
+({ action }) => {};
+([action]) => {};
+(...action) => {};
+(action = 1) => {};
 "#
     );
 }

--- a/crates/rome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts
+++ b/crates/rome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts
@@ -1,0 +1,13 @@
+action => {}
+(action) => {}
+(action?) => {}
+(action: string) => {}
+(action): void => {}
+(
+    action
+    // hhhhhhhh
+) => {}
+({ action }) => {}
+([ action ]) => {}
+(...action) => {}
+(action = 1) => {}

--- a/crates/rome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
@@ -1,0 +1,88 @@
+---
+source: crates/rome_formatter_test/src/snapshot_builder.rs
+info: ts/arrow/arrow_parentheses.ts
+---
+
+# Input
+
+```ts
+action => {}
+(action) => {}
+(action?) => {}
+(action: string) => {}
+(action): void => {}
+(
+    action
+    // hhhhhhhh
+) => {}
+({ action }) => {}
+([ action ]) => {}
+(...action) => {}
+(action = 1) => {}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: Always
+-----
+
+```ts
+(action) => {};
+(action) => {};
+(action?) => {};
+(action: string) => {};
+(action): void => {};
+(
+	action,
+	// hhhhhhhh
+) => {};
+({ action }) => {};
+([action]) => {};
+(...action) => {};
+(action = 1) => {};
+```
+
+## Output 2
+
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing comma: All
+Semicolons: Always
+Arrow parentheses: As needed
+-----
+
+```ts
+action => {};
+action => {};
+(action?) => {};
+(action: string) => {};
+(action): void => {};
+(
+	action,
+	// hhhhhhhh
+) => {};
+({ action }) => {};
+([action]) => {};
+(...action) => {};
+(action = 1) => {};
+```
+
+

--- a/crates/rome_js_formatter/tests/specs/ts/arrow/options.json
+++ b/crates/rome_js_formatter/tests/specs/ts/arrow/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"arrow_parentheses": "AsNeeded"
+		}
+	]
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

I missed a few cases in #4667 that lead to syntax errors in some arrow function parameters when `arrow_parentheses` is set to `asNeeded`
![image](https://github.com/rome/tools/assets/53496941/b2c96b1c-39b7-4d0c-ae05-cab4693c0b22)

## Test Plan

Added a new test file `arrow_parentheses.ts`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
