### PR TITLE
refactor(rome_js_analyze): handle globalThis for `noNewSymbol`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,10 @@ if no error diagnostics are emitted.
 
   These suggestions are made in object literals, classes, interfaces, and object types.
 
+- Improve [`noNewSymbol`](https://docs.rome.tools/lint/rules/noNewSymbol/).
+
+  The rule now handles cases where `Symbol` is namespaced with the global `globalThis` or `window`.
+
 - The rules [`useExhaustiveDependencies`](https://docs.rome.tools/lint/rules/useexhaustivedependencies/) and [`useHookAtTopLevel`](https://docs.rome.tools/lint/rules/usehookattoplevel/) accept a different shape of options
 
   Old configuration

--- a/crates/rome_js_analyze/src/analyzers/correctness.rs
+++ b/crates/rome_js_analyze/src/analyzers/correctness.rs
@@ -6,7 +6,6 @@ pub(crate) mod no_constructor_return;
 pub(crate) mod no_empty_pattern;
 pub(crate) mod no_inner_declarations;
 pub(crate) mod no_invalid_constructor_super;
-pub(crate) mod no_new_symbol;
 pub(crate) mod no_precision_loss;
 pub(crate) mod no_setter_return;
 pub(crate) mod no_string_case_mismatch;
@@ -29,7 +28,6 @@ declare_group! {
             self :: no_empty_pattern :: NoEmptyPattern ,
             self :: no_inner_declarations :: NoInnerDeclarations ,
             self :: no_invalid_constructor_super :: NoInvalidConstructorSuper ,
-            self :: no_new_symbol :: NoNewSymbol ,
             self :: no_precision_loss :: NoPrecisionLoss ,
             self :: no_setter_return :: NoSetterReturn ,
             self :: no_string_case_mismatch :: NoStringCaseMismatch ,

--- a/crates/rome_js_analyze/src/semantic_analyzers/correctness.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/correctness.rs
@@ -5,6 +5,7 @@ use rome_analyze::declare_group;
 pub(crate) mod no_children_prop;
 pub(crate) mod no_const_assign;
 pub(crate) mod no_global_object_calls;
+pub(crate) mod no_new_symbol;
 pub(crate) mod no_render_return_value;
 pub(crate) mod no_undeclared_variables;
 pub(crate) mod no_unused_variables;
@@ -17,6 +18,7 @@ declare_group! {
             self :: no_children_prop :: NoChildrenProp ,
             self :: no_const_assign :: NoConstAssign ,
             self :: no_global_object_calls :: NoGlobalObjectCalls ,
+            self :: no_new_symbol :: NoNewSymbol ,
             self :: no_render_return_value :: NoRenderReturnValue ,
             self :: no_undeclared_variables :: NoUndeclaredVariables ,
             self :: no_unused_variables :: NoUnusedVariables ,

--- a/crates/rome_js_analyze/tests/specs/correctness/noNewSymbol/invalid.jsonc
+++ b/crates/rome_js_analyze/tests/specs/correctness/noNewSymbol/invalid.jsonc
@@ -1,5 +1,7 @@
 [
 	"var foo = new Symbol('foo');",
+	"var foo = new globalThis.Symbol('foo');",
+	"var foo = new window.Symbol('foo');",
 	"var foo2 = new Symbol();",
 	"var lorem = new Symbol() // comment",
 	"var s = /* prefix_cmt */ new /* suffix_cmt */ Symbol() // comment"

--- a/crates/rome_js_analyze/tests/specs/correctness/noNewSymbol/invalid.jsonc.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noNewSymbol/invalid.jsonc.snap
@@ -25,6 +25,48 @@ invalid.jsonc:1:11 lint/correctness/noNewSymbol  FIXABLE  ━━━━━━━�
 
 # Input
 ```js
+var foo = new globalThis.Symbol('foo');
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:11 lint/correctness/noNewSymbol  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Symbol cannot be called as a constructor.
+  
+  > 1 │ var foo = new globalThis.Symbol('foo');
+      │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i Suggested fix: Remove new.
+  
+    1 │ var·foo·=·new·globalThis.Symbol('foo');
+      │           ----                         
+
+```
+
+# Input
+```js
+var foo = new window.Symbol('foo');
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:11 lint/correctness/noNewSymbol  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Symbol cannot be called as a constructor.
+  
+  > 1 │ var foo = new window.Symbol('foo');
+      │           ^^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i Suggested fix: Remove new.
+  
+    1 │ var·foo·=·new·window.Symbol('foo');
+      │           ----                     
+
+```
+
+# Input
+```js
 var foo2 = new Symbol();
 ```
 

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -1231,7 +1231,7 @@ pub struct Correctness {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_invalid_constructor_super: Option<RuleConfiguration>,
-    #[doc = "Disallow new operators with the Symbol object"]
+    #[doc = "Disallow new operators with the Symbol object."]
     #[bpaf(long("no-new-symbol"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_new_symbol: Option<RuleConfiguration>,

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -393,7 +393,7 @@
 					]
 				},
 				"noNewSymbol": {
-					"description": "Disallow new operators with the Symbol object",
+					"description": "Disallow new operators with the Symbol object.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -426,7 +426,7 @@ export interface Correctness {
 	 */
 	noInvalidConstructorSuper?: RuleConfiguration;
 	/**
-	 * Disallow new operators with the Symbol object
+	 * Disallow new operators with the Symbol object.
 	 */
 	noNewSymbol?: RuleConfiguration;
 	/**

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -393,7 +393,7 @@
 					]
 				},
 				"noNewSymbol": {
-					"description": "Disallow new operators with the Symbol object",
+					"description": "Disallow new operators with the Symbol object.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -318,7 +318,7 @@ It also checks whether a call <code>super()</code> is missing from classes that 
 	<a href="/lint/rules/noNewSymbol">noNewSymbol</a>
 	<span class="recommended">recommended</span>
 </h3>
-Disallow <code>new</code> operators with the <code>Symbol</code> object
+Disallow <code>new</code> operators with the <code>Symbol</code> object.
 </section>
 <section class="rule">
 <h3 data-toc-exclude id="noPrecisionLoss">

--- a/website/src/pages/lint/rules/noNewSymbol.md
+++ b/website/src/pages/lint/rules/noNewSymbol.md
@@ -7,7 +7,11 @@ parent: lint/rules/index
 
 > This rule is recommended by Rome.
 
-Disallow `new` operators with the `Symbol` object
+Disallow `new` operators with the `Symbol` object.
+
+`Symbol` cannot be instantiated. This results in throwing a `TypeError`.
+
+Source: https://eslint.org/docs/latest/rules/no-new-symbol
 
 ## Examples
 


### PR DESCRIPTION
## Summary

This PR improves `noNewSymbol` by handling `globalThis` and `window` global namespaces.
I also moved the rule to the correct location (`analyzers` to `semantic_analyzers`).

I noted that other rules are in the wrong location.
I think we should merge `semantic_analyzers` into `analyzers`. The separation seems confusing for most of the contributors...

## Test Plan

Test added.