### PR TITLE
fix(rome_cli): correctly check for organize imports support

### DIFF
--- a/crates/rome_cli/src/execute/traverse.rs
+++ b/crates/rome_cli/src/execute/traverse.rs
@@ -679,6 +679,7 @@ impl<'ctx, 'app> TraversalContext for TraversalOptions<'ctx, 'app> {
             TraversalMode::Check { .. } => {
                 file_features.supports_for(&FeatureName::Lint)
                     || file_features.supports_for(&FeatureName::Format)
+                    || file_features.supports_for(&FeatureName::OrganizeImports)
             }
             TraversalMode::CI { .. } => {
                 file_features.supports_for(&FeatureName::Lint)

--- a/crates/rome_cli/tests/snapshots/main_commands_check/applies_organize_imports_from_cli.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/applies_organize_imports_from_cli.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `check.js`
+
+```js
+import * as something from "../something";
+import { bar, foom, lorem } from "foo";
+
+```
+
+# Emitted Messages
+
+```block
+Fixed 1 file(s) in <TIME>
+```
+
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

There was a bug where the "organize imports" feature wasn't correctly checked.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test case. No need for changelog line because this is part of a previous refactor.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
