### PR TITLE
fix(rome_js_formatter): properly retain parentheses in body

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/arrow_function_expression.rs
@@ -137,7 +137,6 @@ impl FormatNodeRule<JsArrowFunctionExpression> for FormatJsArrowFunctionExpressi
                             );
 
                             !are_parentheses_mandatory
-                                && f.options().arrow_parentheses().is_always()
                         }
                         _ => false,
                     };


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

The `arrow_parentheses` option currently removes parentheses to the body that would otherwise be added to avoid confusion. Since this is probably not expected to anyone using the option (considering prettier doesn't remove them), this PR reverts this behavior

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

`cargo t`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
