### PR TITLE
feat(rome_js_analyze): relax `useLiteralEnumMembers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,31 @@ if no error diagnostics are emitted.
   var x = a => 1 ? 2 : 3;
   ```
 
+- Relax [`useLiteralEnumMembers`](https://docs.rome.tools/lint/rules/useLiteralEnumMembers/)
+
+  Enum members that refers to previous enum members are now allowed.
+  This allows common pattern in enum flags like in the following example:
+
+  ```ts
+  enum FileAccess {
+    None = 0,
+    Read = 1,
+    Write = 1 << 1,
+    All = Read | Write,
+  }
+  ```
+
+  Arbitrary numeric constant expressions are also allowed:
+
+  ```ts
+  enum FileAccess {
+    None = 0,
+    Read = 2**0,
+    Write = 2**1,
+    All = Read | Write,
+  }
+  ```
+
 - Improve [useLiteralKeys](https://docs.rome.tools/lint/rules/useLiteralKeys/).
 
   Now, the rule suggests simplifying computed properties to string literal properties:

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_literal_enum_members.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_literal_enum_members.rs
@@ -1,10 +1,11 @@
 use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::{
-    AnyJsExpression, JsBinaryExpression, JsSyntaxKind, JsUnaryExpression, JsUnaryOperator,
-    TsEnumMember,
+    AnyJsExpression, AnyJsLiteralExpression, AnyJsMemberExpression, JsUnaryOperator,
+    TsEnumDeclaration,
 };
-use rome_rowan::AstNode;
+use rome_rowan::{AstNode, TextRange};
+use rustc_hash::FxHashSet;
 
 declare_rule! {
     /// Require all enum members to be literal values.
@@ -12,10 +13,9 @@ declare_rule! {
     /// Usually, an enum member is initialized with a literal number or a literal string.
     /// However, _TypeScript_ allows the value of an enum member to be many different kinds of expressions.
     /// Using a computed enum member is often error-prone and confusing.
-    /// This rule requires the initialization of enum members with literal values.
-    /// It allows bitwise expressions for supporting [enum flags](https://stackoverflow.com/questions/39359740/what-are-enum-flags-in-typescript/39359953#39359953).
-    ///
-    /// In contrast to the equivalent _ESLint_ rule, this rule allows arbitrary bitwise constant expressions.
+    /// This rule requires the initialization of enum members with constant expressions.
+    /// It allows numeric and bitwise expressions for supporting [enum flags](https://stackoverflow.com/questions/39359740/what-are-enum-flags-in-typescript/39359953#39359953).
+    /// It also allows referencing previous enum members.
     ///
     /// Source: https://typescript-eslint.io/rules/prefer-literal-enum-member/
     ///
@@ -28,14 +28,6 @@ declare_rule! {
     /// enum Computed {
     ///     A,
     ///     B = x,
-    /// }
-    /// ```
-    ///
-    /// ```ts,expect_diagnostic
-    /// const x = 2;
-    /// enum Invalid {
-    ///     A,
-    ///     B = 2**3,
     /// }
     /// ```
     ///
@@ -68,7 +60,7 @@ declare_rule! {
     ///     None = 0,
     ///     Read = 1,
     ///     Write = 1 << 1,
-    ///     All = 1 | (1 << 1)
+    ///     All = Read | Write
     /// }
     /// ```
     pub(crate) UseLiteralEnumMembers {
@@ -79,37 +71,52 @@ declare_rule! {
 }
 
 impl Rule for UseLiteralEnumMembers {
-    type Query = Ast<TsEnumMember>;
-    type State = ();
-    type Signals = Option<Self::State>;
+    type Query = Ast<TsEnumDeclaration>;
+    type State = TextRange;
+    type Signals = Vec<Self::State>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let enum_member = ctx.query();
-        let Some(initializer) = enum_member.initializer() else {
-            // no initializer => sequentially assigned literal integer
-            return None;
+        let enum_declaration = ctx.query();
+        let mut result = Vec::new();
+        let mut enum_member_names = FxHashSet::default();
+        let Ok(enum_name) = enum_declaration.id() else {
+            return result;
         };
-        let expr = initializer.expression().ok()?.omit_parentheses();
-        if expr.as_any_js_literal_expression().is_some() || is_bitwise_constant_expression(&expr) {
-            return None;
-        } else if let Some(expr) = expr.as_js_unary_expression() {
-            if expr.is_signed_numeric_literal().ok()? {
-                return None;
-            }
-        } else if let Some(expr) = expr.as_js_template_expression() {
-            if expr.is_constant() {
-                return None;
+        let Some(enum_name) = enum_name.as_js_identifier_binding()
+            .and_then(|x| x.name_token().ok()) else {
+                return result;
+            };
+        let enum_name = enum_name.text_trimmed();
+        for enum_member in enum_declaration.members() {
+            let Ok(enum_member) = enum_member else {
+                continue;
+            };
+            // no initializer => sequentially assigned literal integer
+            if let Some(initializer) = enum_member.initializer() {
+                if let Ok(initializer) = initializer.expression() {
+                    let range = initializer.range();
+                    if !is_constant_enum_expression(initializer, enum_name, &enum_member_names) {
+                        result.push(range);
+                    }
+                }
+            };
+            if let Ok(name) = enum_member.name() {
+                if let Some(name) = name.name() {
+                    enum_member_names.insert(name.text().to_string());
+                }
             }
         }
-        Some(())
+        result
     }
 
-    fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
-        let enum_member = ctx.query();
+    fn diagnostic(
+        _: &RuleContext<Self>,
+        initializer_range: &Self::State,
+    ) -> Option<RuleDiagnostic> {
         Some(RuleDiagnostic::new(
             rule_category!(),
-            enum_member.initializer()?.expression().ok()?.range(),
+            initializer_range,
             markup! {
                 "The enum member should be initialized with a literal value such as a number or a string."
             },
@@ -117,23 +124,95 @@ impl Rule for UseLiteralEnumMembers {
     }
 }
 
-/// Returns true if `expr` is an expression that only includes literal numbers and bitwise operations.
-fn is_bitwise_constant_expression(expr: &AnyJsExpression) -> bool {
-    for node in expr.syntax().descendants() {
-        if let Some(exp) = JsUnaryExpression::cast_ref(&node) {
-            if exp.operator() != Ok(JsUnaryOperator::BitwiseNot) {
-                return false;
+/// Returns true if `expr` is a constant enum expression.
+/// A constant enum expression can contain numbers, string literals, and reference to
+/// one of the enum member of `enum_member_names` of the enum name `enum_name`.
+/// These values can be combined thanks to numeric, bitwise, and concatenation operations.
+fn is_constant_enum_expression(
+    expr: AnyJsExpression,
+    enum_name: &str,
+    enum_member_names: &FxHashSet<String>,
+) -> bool {
+    (move || {
+        // stack that holds expressions to validate.
+        let mut stack = Vec::new();
+        stack.push(expr);
+        while let Some(expr) = stack.pop() {
+            match expr.omit_parentheses() {
+                AnyJsExpression::AnyJsLiteralExpression(expr) => {
+                    if !matches!(
+                        expr,
+                        AnyJsLiteralExpression::JsNumberLiteralExpression(_)
+                            | AnyJsLiteralExpression::JsStringLiteralExpression(_)
+                    ) {
+                        return Some(false);
+                    }
+                }
+                AnyJsExpression::JsTemplateExpression(expr) => {
+                    if !expr.is_constant() {
+                        return Some(false);
+                    }
+                }
+                AnyJsExpression::JsUnaryExpression(expr) => {
+                    if !matches!(
+                        expr.operator(),
+                        Ok(JsUnaryOperator::BitwiseNot
+                            | JsUnaryOperator::Minus
+                            | JsUnaryOperator::Plus)
+                    ) {
+                        return Some(false);
+                    }
+                    stack.push(expr.argument().ok()?)
+                }
+                AnyJsExpression::JsBinaryExpression(expr) => {
+                    if !expr.is_binary_operation() && !expr.is_numeric_operation() {
+                        return Some(false);
+                    }
+                    stack.push(expr.left().ok()?);
+                    stack.push(expr.right().ok()?);
+                }
+                AnyJsExpression::JsIdentifierExpression(expr) => {
+                    // Allow reference to previous member name
+                    let name = expr.name().ok()?;
+                    if !enum_member_names.contains(name.value_token().ok()?.text_trimmed()) {
+                        return Some(false);
+                    }
+                }
+                AnyJsExpression::JsStaticMemberExpression(expr) => {
+                    if !is_enum_member_reference(expr.into(), enum_name, enum_member_names) {
+                        return Some(false);
+                    }
+                }
+                AnyJsExpression::JsComputedMemberExpression(expr) => {
+                    if !is_enum_member_reference(expr.into(), enum_name, enum_member_names) {
+                        return Some(false);
+                    }
+                }
+                _ => {
+                    return Some(false);
+                }
             }
-        } else if let Some(exp) = JsBinaryExpression::cast_ref(&node) {
-            if !exp.is_binary_operator() {
-                return false;
-            }
-        } else if !matches!(
-            node.kind(),
-            JsSyntaxKind::JS_NUMBER_LITERAL_EXPRESSION | JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION
-        ) {
-            return false;
         }
-    }
-    true
+        Some(true)
+    })()
+    .unwrap_or_default()
+}
+
+// Return true if `expr` is a reference to one of the enum member `enum_member_names`
+// of the enum named `enum_name`.
+fn is_enum_member_reference(
+    expr: AnyJsMemberExpression,
+    enum_name: &str,
+    enum_member_names: &FxHashSet<String>,
+) -> bool {
+    (move || {
+        // Allow reference to previous member name namespaced by the enum name
+        let object = expr.object().ok()?.omit_parentheses();
+        let object = object.as_js_identifier_expression()?;
+        Some(
+            object.name().ok()?.has_name(enum_name)
+                && enum_member_names.contains(expr.member_name()?.text()),
+        )
+    })()
+    .unwrap_or_default()
 }

--- a/crates/rome_js_analyze/tests/specs/nursery/useLiteralEnumMembers/invalid.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/useLiteralEnumMembers/invalid.ts
@@ -1,73 +1,37 @@
-enum InvalidObject {
+enum InvalidLiterals {
   A = {},
+  B = [],
+  C = true,
+  D = 1n,
 }
-
-
-enum InvalidArray {
-  A = [],
-}
-
 
 enum InvalidTemplateLiteral {
   A = `foo ${0}`,
 }
 
-
 enum InvalidConstructor {
   A = new Set(),
-}
-
-
-enum InvalidExpression {
-  A = 2 + 2,
 }
 
 enum InvalidExpression {
   A = delete 2,
   B = -a,
   C = void 2,
-  D = ~2,
-  E = !0,
+  D = !0,
 }
-
 
 const variable = 'Test';
 enum InvalidVariable {
   A = 'TestStr',
-  B = 2,
-  C,
   V = variable,
 }
-
-
-enum InvalidEnumMember {
-  A = 'TestStr',
-  B = A,
-}
-
-
-const Valid = { A: 2 };
-enum InvalidObjectMember {
-  A = 'TestStr',
-  B = Valid.A,
-}
-
 
 enum Valid {
   A,
 }
 enum InvalidEnumMember {
-  A = 'TestStr',
-  B = Valid.A,
+  A = Valid.A,
 }
-
-
-const obj = { a: 1 };
-enum InvalidSpread {
-  A = 'TestStr',
-  B = { ...a },
-}
-
 
 const x = 1;
 enum Foo {
@@ -80,3 +44,14 @@ enum Foo {
   G = ~x,
 }
 
+enum InvalidRef {
+  A = A,
+  B = InvalidRef.B,
+  C = InvalidRef["C"],
+  D = E,
+  E = InvalidRef.F,
+  F = InvalidRef["G"],
+  G
+}
+
+export {}

--- a/crates/rome_js_analyze/tests/specs/nursery/useLiteralEnumMembers/invalid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useLiteralEnumMembers/invalid.ts.snap
@@ -1,80 +1,43 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 96
 expression: invalid.ts
 ---
 # Input
 ```js
-enum InvalidObject {
+enum InvalidLiterals {
   A = {},
+  B = [],
+  C = true,
+  D = 1n,
 }
-
-
-enum InvalidArray {
-  A = [],
-}
-
 
 enum InvalidTemplateLiteral {
   A = `foo ${0}`,
 }
 
-
 enum InvalidConstructor {
   A = new Set(),
-}
-
-
-enum InvalidExpression {
-  A = 2 + 2,
 }
 
 enum InvalidExpression {
   A = delete 2,
   B = -a,
   C = void 2,
-  D = ~2,
-  E = !0,
+  D = !0,
 }
-
 
 const variable = 'Test';
 enum InvalidVariable {
   A = 'TestStr',
-  B = 2,
-  C,
   V = variable,
 }
-
-
-enum InvalidEnumMember {
-  A = 'TestStr',
-  B = A,
-}
-
-
-const Valid = { A: 2 };
-enum InvalidObjectMember {
-  A = 'TestStr',
-  B = Valid.A,
-}
-
 
 enum Valid {
   A,
 }
 enum InvalidEnumMember {
-  A = 'TestStr',
-  B = Valid.A,
+  A = Valid.A,
 }
-
-
-const obj = { a: 1 };
-enum InvalidSpread {
-  A = 'TestStr',
-  B = { ...a },
-}
-
 
 const x = 1;
 enum Foo {
@@ -87,7 +50,17 @@ enum Foo {
   G = ~x,
 }
 
+enum InvalidRef {
+  A = A,
+  B = InvalidRef.B,
+  C = InvalidRef["C"],
+  D = E,
+  E = InvalidRef.F,
+  F = InvalidRef["G"],
+  G
+}
 
+export {}
 ```
 
 # Diagnostics
@@ -96,39 +69,84 @@ invalid.ts:2:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    1 │ enum InvalidObject {
+    1 │ enum InvalidLiterals {
   > 2 │   A = {},
       │       ^^
-    3 │ }
-    4 │ 
+    3 │   B = [],
+    4 │   C = true,
   
 
 ```
 
 ```
-invalid.ts:7:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:3:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    6 │ enum InvalidArray {
-  > 7 │   A = [],
+    1 │ enum InvalidLiterals {
+    2 │   A = {},
+  > 3 │   B = [],
       │       ^^
-    8 │ }
-    9 │ 
+    4 │   C = true,
+    5 │   D = 1n,
   
 
 ```
 
 ```
-invalid.ts:12:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:4:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    11 │ enum InvalidTemplateLiteral {
-  > 12 │   A = `foo ${0}`,
+    2 │   A = {},
+    3 │   B = [],
+  > 4 │   C = true,
+      │       ^^^^
+    5 │   D = 1n,
+    6 │ }
+  
+
+```
+
+```
+invalid.ts:5:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    3 │   B = [],
+    4 │   C = true,
+  > 5 │   D = 1n,
+      │       ^^
+    6 │ }
+    7 │ 
+  
+
+```
+
+```
+invalid.ts:9:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+     8 │ enum InvalidTemplateLiteral {
+   > 9 │   A = `foo ${0}`,
        │       ^^^^^^^^^^
-    13 │ }
-    14 │ 
+    10 │ }
+    11 │ 
+  
+
+```
+
+```
+invalid.ts:13:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    12 │ enum InvalidConstructor {
+  > 13 │   A = new Set(),
+       │       ^^^^^^^^^
+    14 │ }
+    15 │ 
   
 
 ```
@@ -138,25 +156,56 @@ invalid.ts:17:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━�
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    16 │ enum InvalidConstructor {
-  > 17 │   A = new Set(),
-       │       ^^^^^^^^^
-    18 │ }
-    19 │ 
+    16 │ enum InvalidExpression {
+  > 17 │   A = delete 2,
+       │       ^^^^^^^^
+    18 │   B = -a,
+    19 │   C = void 2,
   
 
 ```
 
 ```
-invalid.ts:22:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:18:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    21 │ enum InvalidExpression {
-  > 22 │   A = 2 + 2,
-       │       ^^^^^
-    23 │ }
-    24 │ 
+    16 │ enum InvalidExpression {
+    17 │   A = delete 2,
+  > 18 │   B = -a,
+       │       ^^
+    19 │   C = void 2,
+    20 │   D = !0,
+  
+
+```
+
+```
+invalid.ts:19:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    17 │   A = delete 2,
+    18 │   B = -a,
+  > 19 │   C = void 2,
+       │       ^^^^^^
+    20 │   D = !0,
+    21 │ }
+  
+
+```
+
+```
+invalid.ts:20:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    18 │   B = -a,
+    19 │   C = void 2,
+  > 20 │   D = !0,
+       │       ^^
+    21 │ }
+    22 │ 
   
 
 ```
@@ -166,56 +215,42 @@ invalid.ts:26:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━�
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    25 │ enum InvalidExpression {
-  > 26 │   A = delete 2,
+    24 │ enum InvalidVariable {
+    25 │   A = 'TestStr',
+  > 26 │   V = variable,
        │       ^^^^^^^^
-    27 │   B = -a,
-    28 │   C = void 2,
+    27 │ }
+    28 │ 
   
 
 ```
 
 ```
-invalid.ts:27:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:33:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    25 │ enum InvalidExpression {
-    26 │   A = delete 2,
-  > 27 │   B = -a,
-       │       ^^
-    28 │   C = void 2,
-    29 │   D = ~2,
-  
-
-```
-
-```
-invalid.ts:28:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    26 │   A = delete 2,
-    27 │   B = -a,
-  > 28 │   C = void 2,
-       │       ^^^^^^
-    29 │   D = ~2,
-    30 │   E = !0,
-  
-
-```
-
-```
-invalid.ts:30:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    28 │   C = void 2,
-    29 │   D = ~2,
-  > 30 │   E = !0,
-       │       ^^
     31 │ }
-    32 │ 
+    32 │ enum InvalidEnumMember {
+  > 33 │   A = Valid.A,
+       │       ^^^^^^^
+    34 │ }
+    35 │ 
+  
+
+```
+
+```
+invalid.ts:38:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    36 │ const x = 1;
+    37 │ enum Foo {
+  > 38 │   A = x << 0,
+       │       ^^^^^^
+    39 │   B = x >> 0,
+    40 │   C = x >>> 0,
   
 
 ```
@@ -225,27 +260,146 @@ invalid.ts:39:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━�
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    37 │   B = 2,
-    38 │   C,
-  > 39 │   V = variable,
-       │       ^^^^^^^^
-    40 │ }
-    41 │ 
+    37 │ enum Foo {
+    38 │   A = x << 0,
+  > 39 │   B = x >> 0,
+       │       ^^^^^^
+    40 │   C = x >>> 0,
+    41 │   D = x | 0,
   
 
 ```
 
 ```
-invalid.ts:45:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:40:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    43 │ enum InvalidEnumMember {
-    44 │   A = 'TestStr',
-  > 45 │   B = A,
+    38 │   A = x << 0,
+    39 │   B = x >> 0,
+  > 40 │   C = x >>> 0,
+       │       ^^^^^^^
+    41 │   D = x | 0,
+    42 │   E = x & 0,
+  
+
+```
+
+```
+invalid.ts:41:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    39 │   B = x >> 0,
+    40 │   C = x >>> 0,
+  > 41 │   D = x | 0,
+       │       ^^^^^
+    42 │   E = x & 0,
+    43 │   F = x ^ 0,
+  
+
+```
+
+```
+invalid.ts:42:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    40 │   C = x >>> 0,
+    41 │   D = x | 0,
+  > 42 │   E = x & 0,
+       │       ^^^^^
+    43 │   F = x ^ 0,
+    44 │   G = ~x,
+  
+
+```
+
+```
+invalid.ts:43:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    41 │   D = x | 0,
+    42 │   E = x & 0,
+  > 43 │   F = x ^ 0,
+       │       ^^^^^
+    44 │   G = ~x,
+    45 │ }
+  
+
+```
+
+```
+invalid.ts:44:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    42 │   E = x & 0,
+    43 │   F = x ^ 0,
+  > 44 │   G = ~x,
+       │       ^^
+    45 │ }
+    46 │ 
+  
+
+```
+
+```
+invalid.ts:48:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    47 │ enum InvalidRef {
+  > 48 │   A = A,
        │       ^
-    46 │ }
-    47 │ 
+    49 │   B = InvalidRef.B,
+    50 │   C = InvalidRef["C"],
+  
+
+```
+
+```
+invalid.ts:49:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    47 │ enum InvalidRef {
+    48 │   A = A,
+  > 49 │   B = InvalidRef.B,
+       │       ^^^^^^^^^^^^
+    50 │   C = InvalidRef["C"],
+    51 │   D = E,
+  
+
+```
+
+```
+invalid.ts:50:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    48 │   A = A,
+    49 │   B = InvalidRef.B,
+  > 50 │   C = InvalidRef["C"],
+       │       ^^^^^^^^^^^^^^^
+    51 │   D = E,
+    52 │   E = InvalidRef.F,
+  
+
+```
+
+```
+invalid.ts:51:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The enum member should be initialized with a literal value such as a number or a string.
+  
+    49 │   B = InvalidRef.B,
+    50 │   C = InvalidRef["C"],
+  > 51 │   D = E,
+       │       ^
+    52 │   E = InvalidRef.F,
+    53 │   F = InvalidRef["G"],
   
 
 ```
@@ -255,147 +409,27 @@ invalid.ts:52:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━�
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    50 │ enum InvalidObjectMember {
-    51 │   A = 'TestStr',
-  > 52 │   B = Valid.A,
-       │       ^^^^^^^
-    53 │ }
-    54 │ 
+    50 │   C = InvalidRef["C"],
+    51 │   D = E,
+  > 52 │   E = InvalidRef.F,
+       │       ^^^^^^^^^^^^
+    53 │   F = InvalidRef["G"],
+    54 │   G
   
 
 ```
 
 ```
-invalid.ts:61:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:53:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The enum member should be initialized with a literal value such as a number or a string.
   
-    59 │ enum InvalidEnumMember {
-    60 │   A = 'TestStr',
-  > 61 │   B = Valid.A,
-       │       ^^^^^^^
-    62 │ }
-    63 │ 
-  
-
-```
-
-```
-invalid.ts:68:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    66 │ enum InvalidSpread {
-    67 │   A = 'TestStr',
-  > 68 │   B = { ...a },
-       │       ^^^^^^^^
-    69 │ }
-    70 │ 
-  
-
-```
-
-```
-invalid.ts:74:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    72 │ const x = 1;
-    73 │ enum Foo {
-  > 74 │   A = x << 0,
-       │       ^^^^^^
-    75 │   B = x >> 0,
-    76 │   C = x >>> 0,
-  
-
-```
-
-```
-invalid.ts:75:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    73 │ enum Foo {
-    74 │   A = x << 0,
-  > 75 │   B = x >> 0,
-       │       ^^^^^^
-    76 │   C = x >>> 0,
-    77 │   D = x | 0,
-  
-
-```
-
-```
-invalid.ts:76:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    74 │   A = x << 0,
-    75 │   B = x >> 0,
-  > 76 │   C = x >>> 0,
-       │       ^^^^^^^
-    77 │   D = x | 0,
-    78 │   E = x & 0,
-  
-
-```
-
-```
-invalid.ts:77:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    75 │   B = x >> 0,
-    76 │   C = x >>> 0,
-  > 77 │   D = x | 0,
-       │       ^^^^^
-    78 │   E = x & 0,
-    79 │   F = x ^ 0,
-  
-
-```
-
-```
-invalid.ts:78:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    76 │   C = x >>> 0,
-    77 │   D = x | 0,
-  > 78 │   E = x & 0,
-       │       ^^^^^
-    79 │   F = x ^ 0,
-    80 │   G = ~x,
-  
-
-```
-
-```
-invalid.ts:79:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    77 │   D = x | 0,
-    78 │   E = x & 0,
-  > 79 │   F = x ^ 0,
-       │       ^^^^^
-    80 │   G = ~x,
-    81 │ }
-  
-
-```
-
-```
-invalid.ts:80:7 lint/nursery/useLiteralEnumMembers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The enum member should be initialized with a literal value such as a number or a string.
-  
-    78 │   E = x & 0,
-    79 │   F = x ^ 0,
-  > 80 │   G = ~x,
-       │       ^^
-    81 │ }
-    82 │ 
+    51 │   D = E,
+    52 │   E = InvalidRef.F,
+  > 53 │   F = InvalidRef["G"],
+       │       ^^^^^^^^^^^^^^^
+    54 │   G
+    55 │ }
   
 
 ```

--- a/crates/rome_js_analyze/tests/specs/nursery/useLiteralEnumMembers/valid.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/useLiteralEnumMembers/valid.ts
@@ -1,60 +1,27 @@
-
-enum ValidRegex {
-  A = /test/
-}
-
-
 enum ValidString {
   A = 'test',
+  B = 'div' + 'ided',
+  C = `test2`,
+  D = `di` + `ided2`,
+  AA = A + ValidString.A,
 }
-
-
-enum ValidLiteral {
-  A = `test`,
-}
-
 
 enum ValidNumber {
-  A = 42,
-}
-
-
-enum ValidNumber {
-  A = -42,
-}
-
-
-enum ValidNumber {
-  A = +42,
-}
-
-
-enum ValidNull {
-  A = null,
-}
-
-
-enum ValidPlain {
   A,
+  B = 42,
+  C = -42,
+  D = +42,
+  E = 2 + 2,
+  F = A + ValidNumber.B,
 }
-
 
 enum ValidQuotedKey {
-  'a',
+  'A',
+  'B' = 1,
+  ['C'],
 }
 
-
-enum ValidQuotedKeyWithAssignment {
-  'a' = 1,
-}
-
-
-enum ValidKeyWithComputedSyntaxButNoComputedKey {
-  ['a'],
-}
-
-
-enum Foo {
+enum ValidFlags {
   A = 1 << 0,
   B = 1 >> 0,
   C = 1 >>> 0,
@@ -64,16 +31,30 @@ enum Foo {
   G = ~1,
 }
 
-
 enum FileAccess {
   None = 0,
   Read = 1,
   Write = 1 << 1,
-  All = (1 | (1 << 1)) // ESlint rejects this
+  All = (1 | (1 << 1)),
 }
 
-
-enum Parenthesis {
-  Left = ((("Left"))),
-  Right = (((1))),
+enum FileAccessWithRef {
+  None = 0,
+  Read = 1,
+  Write = FileAccessWithRef["Read"] << 1,
+  All = Read | FileAccessWithRef.Write,
 }
+
+enum ValidRef {
+  "A",
+  "B",
+  C = A | B,
+}
+
+enum ValidComputedRef {
+  ["A"],
+  ["B"],
+  C = A | B,
+}
+
+export {}

--- a/crates/rome_js_analyze/tests/specs/nursery/useLiteralEnumMembers/valid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useLiteralEnumMembers/valid.ts.snap
@@ -1,67 +1,33 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 96
 expression: valid.ts
 ---
 # Input
 ```js
-
-enum ValidRegex {
-  A = /test/
-}
-
-
 enum ValidString {
   A = 'test',
+  B = 'div' + 'ided',
+  C = `test2`,
+  D = `di` + `ided2`,
+  AA = A + ValidString.A,
 }
-
-
-enum ValidLiteral {
-  A = `test`,
-}
-
 
 enum ValidNumber {
-  A = 42,
-}
-
-
-enum ValidNumber {
-  A = -42,
-}
-
-
-enum ValidNumber {
-  A = +42,
-}
-
-
-enum ValidNull {
-  A = null,
-}
-
-
-enum ValidPlain {
   A,
+  B = 42,
+  C = -42,
+  D = +42,
+  E = 2 + 2,
+  F = A + ValidNumber.B,
 }
-
 
 enum ValidQuotedKey {
-  'a',
+  'A',
+  'B' = 1,
+  ['C'],
 }
 
-
-enum ValidQuotedKeyWithAssignment {
-  'a' = 1,
-}
-
-
-enum ValidKeyWithComputedSyntaxButNoComputedKey {
-  ['a'],
-}
-
-
-enum Foo {
+enum ValidFlags {
   A = 1 << 0,
   B = 1 >> 0,
   C = 1 >>> 0,
@@ -71,20 +37,33 @@ enum Foo {
   G = ~1,
 }
 
-
 enum FileAccess {
   None = 0,
   Read = 1,
   Write = 1 << 1,
-  All = (1 | (1 << 1)) // ESlint rejects this
+  All = (1 | (1 << 1)),
 }
 
-
-enum Parenthesis {
-  Left = ((("Left"))),
-  Right = (((1))),
+enum FileAccessWithRef {
+  None = 0,
+  Read = 1,
+  Write = FileAccessWithRef["Read"] << 1,
+  All = Read | FileAccessWithRef.Write,
 }
 
+enum ValidRef {
+  "A",
+  "B",
+  C = A | B,
+}
+
+enum ValidComputedRef {
+  ["A"],
+  ["B"],
+  C = A | B,
+}
+
+export {}
 ```
 
 

--- a/website/src/pages/lint/rules/useLiteralEnumMembers.md
+++ b/website/src/pages/lint/rules/useLiteralEnumMembers.md
@@ -10,10 +10,9 @@ Require all enum members to be literal values.
 Usually, an enum member is initialized with a literal number or a literal string.
 However, _TypeScript_ allows the value of an enum member to be many different kinds of expressions.
 Using a computed enum member is often error-prone and confusing.
-This rule requires the initialization of enum members with literal values.
-It allows bitwise expressions for supporting [enum flags](https://stackoverflow.com/questions/39359740/what-are-enum-flags-in-typescript/39359953#39359953).
-
-In contrast to the equivalent _ESLint_ rule, this rule allows arbitrary bitwise constant expressions.
+This rule requires the initialization of enum members with constant expressions.
+It allows numeric and bitwise expressions for supporting [enum flags](https://stackoverflow.com/questions/39359740/what-are-enum-flags-in-typescript/39359953#39359953).
+It also allows referencing previous enum members.
 
 Source: https://typescript-eslint.io/rules/prefer-literal-enum-member/
 
@@ -37,27 +36,6 @@ enum Computed {
     <strong>3 │ </strong>    A,
 <strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    B = x,
    <strong>   │ </strong>        <strong><span style="color: Tomato;">^</span></strong>
-    <strong>5 │ </strong>}
-    <strong>6 │ </strong>
-  
-</code></pre>
-
-```ts
-const x = 2;
-enum Invalid {
-    A,
-    B = 2**3,
-}
-```
-
-<pre class="language-text"><code class="language-text">nursery/useLiteralEnumMembers.js:4:9 <a href="https://docs.rome.tools/lint/rules/useLiteralEnumMembers">lint/nursery/useLiteralEnumMembers</a> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">The enum member should be initialized with a literal value such as a number or a string.</span>
-  
-    <strong>2 │ </strong>enum Invalid {
-    <strong>3 │ </strong>    A,
-<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>4 │ </strong>    B = 2**3,
-   <strong>   │ </strong>        <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
     <strong>5 │ </strong>}
     <strong>6 │ </strong>
   
@@ -92,7 +70,7 @@ enum FileAccess {
     None = 0,
     Read = 1,
     Write = 1 << 1,
-    All = 1 | (1 << 1)
+    All = Read | Write
 }
 ```
 


### PR DESCRIPTION
## Summary

This PR relaxes `useLiteralEnumMembers` to allow referencing to previous enum members. This is commonly used in enum flags (it is used multiple times in the TypeScript Compiler source code). For example:

```ts
enum FileAccess {
    None = 0,
    Read = 1,
    Write = 1 << 1,
    All = Read | Write,
}
```

A wide range of references are recognized (`Write`, `FileAccess.Write`, `FileAccess["Write"]` ``FileAccess[`Write`]``) 

To be more consistent, the rule is also relaxed to allow arbitrary numeric and string expressions that involve string and number literals.

I wonder if the rule should be renamed to `useConstantEnumMembers` to better reflect the new implementation.

## Test Plan

Tests updated and extended.
