### PR TITLE
refactor(rome_rowan): rework SyntaxTokenText into TokenText

### DIFF
--- a/crates/rome_deserialize/src/json.rs
+++ b/crates/rome_deserialize/src/json.rs
@@ -7,7 +7,7 @@ use rome_json_syntax::{
     AnyJsonValue, JsonArrayValue, JsonBooleanValue, JsonLanguage, JsonMemberName, JsonNumberValue,
     JsonObjectValue, JsonRoot, JsonStringValue, JsonSyntaxNode,
 };
-use rome_rowan::{AstNode, AstSeparatedList, SyntaxNodeCast, SyntaxTokenText, TextRange};
+use rome_rowan::{AstNode, AstSeparatedList, SyntaxNodeCast, TextRange, TokenText};
 use std::num::ParseIntError;
 
 /// Main trait to
@@ -49,7 +49,7 @@ pub trait VisitJsonNode: VisitNode<JsonLanguage> {
         key: &JsonSyntaxNode,
         value: &JsonSyntaxNode,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<(SyntaxTokenText, AnyJsonValue)> {
+    ) -> Option<(TokenText, AnyJsonValue)> {
         let member = key.clone().cast::<JsonMemberName>()?;
         self.visit_member_name(member.syntax(), diagnostics)?;
         let name = member.inner_string_text().ok()?;

--- a/crates/rome_formatter/src/builders.rs
+++ b/crates/rome_formatter/src/builders.rs
@@ -3,7 +3,7 @@ use crate::prelude::tag::{DedentMode, GroupMode, LabelId};
 use crate::prelude::*;
 use crate::{format_element, write, Argument, Arguments, GroupId, TextRange, TextSize};
 use crate::{Buffer, VecBuffer};
-use rome_rowan::{Language, SyntaxNode, SyntaxToken, SyntaxTokenText, TextLen};
+use rome_rowan::{Language, SyntaxNode, SyntaxToken, TextLen, TokenText};
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::marker::PhantomData;
@@ -335,7 +335,7 @@ impl<L: Language, Context> Format<Context> for SyntaxTokenCowSlice<'_, L> {
                 let relative_range = range - self.token.text_range().start();
                 let slice = self.token.token_text().slice(relative_range);
 
-                f.write_element(FormatElement::SyntaxTokenTextSlice {
+                f.write_element(FormatElement::LocatedTokenText {
                     slice,
                     source_position: self.start,
                 })
@@ -355,38 +355,38 @@ impl<L: Language> std::fmt::Debug for SyntaxTokenCowSlice<'_, L> {
 }
 
 /// Copies a source text 1:1 into the output text.
-pub fn syntax_token_text_slice<L: Language>(
+pub fn located_token_text<L: Language>(
     token: &SyntaxToken<L>,
     range: TextRange,
-) -> SyntaxTokenTextSlice {
+) -> LocatedTokenText {
     let relative_range = range - token.text_range().start();
     let slice = token.token_text().slice(relative_range);
 
     debug_assert_no_newlines(&slice);
 
-    SyntaxTokenTextSlice {
+    LocatedTokenText {
         text: slice,
         source_position: range.start(),
     }
 }
 
-pub struct SyntaxTokenTextSlice {
-    text: SyntaxTokenText,
+pub struct LocatedTokenText {
+    text: TokenText,
     source_position: TextSize,
 }
 
-impl<Context> Format<Context> for SyntaxTokenTextSlice {
+impl<Context> Format<Context> for LocatedTokenText {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::SyntaxTokenTextSlice {
+        f.write_element(FormatElement::LocatedTokenText {
             slice: self.text.clone(),
             source_position: self.source_position,
         })
     }
 }
 
-impl std::fmt::Debug for SyntaxTokenTextSlice {
+impl std::fmt::Debug for LocatedTokenText {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::write!(f, "SyntaxTokenTextSlice({})", self.text)
+        std::write!(f, "LocatedTokenText({})", self.text)
     }
 }
 

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use crate::{TagKind, TextSize};
 #[cfg(target_pointer_width = "64")]
 use rome_rowan::static_assert;
-use rome_rowan::SyntaxTokenText;
+use rome_rowan::TokenText;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::rc::Rc;
@@ -40,11 +40,11 @@ pub enum FormatElement {
 
     /// A token for a text that is taken as is from the source code (input text and formatted representation are identical).
     /// Implementing by taking a slice from a `SyntaxToken` to avoid allocating a new string.
-    SyntaxTokenTextSlice {
+    LocatedTokenText {
         /// The start position of the token in the unformatted source code
         source_position: TextSize,
         /// The token text
-        slice: SyntaxTokenText,
+        slice: TokenText,
     },
 
     /// Prevents that line suffixes move past this boundary. Forces the printer to print any pending
@@ -75,10 +75,9 @@ impl std::fmt::Debug for FormatElement {
             FormatElement::DynamicText { text, .. } => {
                 fmt.debug_tuple("DynamicText").field(text).finish()
             }
-            FormatElement::SyntaxTokenTextSlice { slice, .. } => fmt
-                .debug_tuple("SyntaxTokenTextSlice")
-                .field(slice)
-                .finish(),
+            FormatElement::LocatedTokenText { slice, .. } => {
+                fmt.debug_tuple("LocatedTokenText").field(slice).finish()
+            }
             FormatElement::LineSuffixBoundary => write!(fmt, "LineSuffixBoundary"),
             FormatElement::BestFitting(best_fitting) => {
                 fmt.debug_tuple("BestFitting").field(&best_fitting).finish()
@@ -224,7 +223,7 @@ impl FormatElement {
     pub const fn is_text(&self) -> bool {
         matches!(
             self,
-            FormatElement::SyntaxTokenTextSlice { .. }
+            FormatElement::LocatedTokenText { .. }
                 | FormatElement::DynamicText { .. }
                 | FormatElement::StaticText { .. }
         )
@@ -243,7 +242,7 @@ impl FormatElements for FormatElement {
             FormatElement::Line(line_mode) => matches!(line_mode, LineMode::Hard | LineMode::Empty),
             FormatElement::StaticText { text } => text.contains('\n'),
             FormatElement::DynamicText { text, .. } => text.contains('\n'),
-            FormatElement::SyntaxTokenTextSlice { slice, .. } => slice.contains('\n'),
+            FormatElement::LocatedTokenText { slice, .. } => slice.contains('\n'),
             FormatElement::Interned(interned) => interned.will_break(),
             // Traverse into the most flat version because the content is guaranteed to expand when even
             // the most flat version contains some content that forces a break.

--- a/crates/rome_formatter/src/format_element/document.rs
+++ b/crates/rome_formatter/src/format_element/document.rs
@@ -81,7 +81,7 @@ impl Document {
                     }
                     FormatElement::StaticText { text } => text.contains('\n'),
                     FormatElement::DynamicText { text, .. } => text.contains('\n'),
-                    FormatElement::SyntaxTokenTextSlice { slice, .. } => slice.contains('\n'),
+                    FormatElement::LocatedTokenText { slice, .. } => slice.contains('\n'),
                     FormatElement::ExpandParent
                     | FormatElement::Line(LineMode::Hard | LineMode::Empty) => true,
                     _ => false,
@@ -194,7 +194,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                 element @ FormatElement::Space
                 | element @ FormatElement::StaticText { .. }
                 | element @ FormatElement::DynamicText { .. }
-                | element @ FormatElement::SyntaxTokenTextSlice { .. } => {
+                | element @ FormatElement::LocatedTokenText { .. } => {
                     if !in_text {
                         write!(f, [text("\"")])?;
                     }

--- a/crates/rome_formatter/src/printer/mod.rs
+++ b/crates/rome_formatter/src/printer/mod.rs
@@ -99,7 +99,7 @@ impl<'a> Printer<'a> {
                 text,
                 source_position,
             } => self.print_text(text, Some(*source_position)),
-            FormatElement::SyntaxTokenTextSlice {
+            FormatElement::LocatedTokenText {
                 slice,
                 source_position,
             } => self.print_text(slice, Some(*source_position)),
@@ -1001,7 +1001,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
 
             FormatElement::StaticText { text } => return Ok(self.fits_text(text)),
             FormatElement::DynamicText { text, .. } => return Ok(self.fits_text(text)),
-            FormatElement::SyntaxTokenTextSlice { slice, .. } => return Ok(self.fits_text(slice)),
+            FormatElement::LocatedTokenText { slice, .. } => return Ok(self.fits_text(slice)),
 
             FormatElement::LineSuffixBoundary => {
                 if self.state.has_line_suffix {

--- a/crates/rome_formatter/src/source_map.rs
+++ b/crates/rome_formatter/src/source_map.rs
@@ -207,7 +207,7 @@ impl TransformSourceMap {
     ///
     /// The printer creates a source map that allows mapping positions from the newly formatted document
     /// back to the locations of the tree. However, the source positions stored in [crate::FormatElement::DynamicText]
-    /// and [crate::FormatElement::SyntaxTokenTextSlice] are relative to the transformed tree
+    /// and [crate::FormatElement::LocatedTokenText] are relative to the transformed tree
     /// and not the original tree passed to [crate::format_node].
     ///
     /// This function re-maps the positions from the positions in the transformed tree back to the positions

--- a/crates/rome_formatter/src/trivia.rs
+++ b/crates/rome_formatter/src/trivia.rs
@@ -304,7 +304,7 @@ where
 {
     fn fmt(&self, f: &mut Formatter<C>) -> FormatResult<()> {
         let trimmed_range = self.token.text_trimmed_range();
-        syntax_token_text_slice(self.token, trimmed_range).fmt(f)
+        located_token_text(self.token, trimmed_range).fmt(f)
     }
 }
 /// Formats the skipped token trivia of a removed token and marks the token as tracked.
@@ -547,7 +547,7 @@ impl<L: Language> FormatSkippedTokenTrivia<'_, L> {
                 length: skipped_range.len(),
             },
         )))?;
-        write!(f, [syntax_token_text_slice(self.token, skipped_range)])?;
+        write!(f, [located_token_text(self.token, skipped_range)])?;
         f.write_element(FormatElement::Tag(Tag::EndVerbatim))?;
 
         // Write whitespace separator between skipped/last comment and token

--- a/crates/rome_js_analyze/src/analyzers/nursery/use_import_restrictions.rs
+++ b/crates/rome_js_analyze/src/analyzers/nursery/use_import_restrictions.rs
@@ -1,7 +1,7 @@
 use rome_analyze::{context::RuleContext, declare_rule, Ast, Rule, RuleDiagnostic};
 use rome_console::markup;
 use rome_js_syntax::JsModuleSource;
-use rome_rowan::{AstNode, SyntaxTokenText};
+use rome_rowan::{AstNode, TokenText};
 
 const INDEX_BASENAMES: &[&str] = &["index", "mod"];
 
@@ -114,7 +114,7 @@ pub(crate) struct ImportRestrictionsState {
     suggestion: String,
 }
 
-fn get_restricted_import(module_path: &SyntaxTokenText) -> Option<ImportRestrictionsState> {
+fn get_restricted_import(module_path: &TokenText) -> Option<ImportRestrictionsState> {
     if !module_path.starts_with('.') {
         return None;
     }

--- a/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
+++ b/crates/rome_js_analyze/src/assists/correctness/organize_imports.rs
@@ -18,7 +18,7 @@ use rome_js_syntax::{
 };
 use rome_rowan::{
     chain_trivia_pieces, syntax::SyntaxTrivia, AstNode, AstNodeExt, AstNodeList, AstSeparatedList,
-    BatchMutationExt, SyntaxTokenText, SyntaxTriviaPiece, TriviaPiece,
+    BatchMutationExt, SyntaxTriviaPiece, TokenText, TriviaPiece,
 };
 
 use crate::JsRuleAction;
@@ -553,7 +553,7 @@ impl ImportNode {
 ///
 /// Currently named import specifiers are sorted using their import name,
 /// not the local name they get imported as
-fn import_specifier_name(import_specifier: &AnyJsNamedImportSpecifier) -> Option<SyntaxTokenText> {
+fn import_specifier_name(import_specifier: &AnyJsNamedImportSpecifier) -> Option<TokenText> {
     let token = match import_specifier {
         AnyJsNamedImportSpecifier::JsNamedImportSpecifier(import_specifier) => {
             import_specifier.name().ok()?.value().ok()?
@@ -636,7 +636,7 @@ fn leading_trivia_iter(
 }
 
 #[derive(Debug)]
-struct ImportKey(SyntaxTokenText);
+struct ImportKey(TokenText);
 
 impl Ord for ImportKey {
     fn cmp(&self, other: &Self) -> Ordering {

--- a/crates/rome_js_formatter/src/utils/jsx.rs
+++ b/crates/rome_js_formatter/src/utils/jsx.rs
@@ -7,7 +7,7 @@ use rome_js_syntax::{
     JsStaticMemberExpression, JsSyntaxKind, JsxChildList, JsxExpressionChild, JsxTagExpression,
     JsxText, TextLen,
 };
-use rome_rowan::{Direction, SyntaxResult, SyntaxTokenText, TextRange, TextSize};
+use rome_rowan::{Direction, SyntaxResult, TextRange, TextSize, TokenText};
 use std::iter::{FusedIterator, Peekable};
 use std::str::Chars;
 
@@ -401,12 +401,12 @@ impl JsxChild {
 /// A word in a Jsx Text. A word is string sequence that isn't separated by any JSX whitespace.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct JsxWord {
-    text: SyntaxTokenText,
+    text: TokenText,
     source_position: TextSize,
 }
 
 impl JsxWord {
-    fn new(text: SyntaxTokenText, source_position: TextSize) -> Self {
+    fn new(text: TokenText, source_position: TextSize) -> Self {
         JsxWord {
             text,
             source_position,
@@ -425,7 +425,7 @@ impl JsxWord {
 
 impl Format<JsFormatContext> for JsxWord {
     fn fmt(&self, f: &mut Formatter<JsFormatContext>) -> FormatResult<()> {
-        f.write_element(FormatElement::SyntaxTokenTextSlice {
+        f.write_element(FormatElement::LocatedTokenText {
             source_position: self.source_position,
             slice: self.text.clone(),
         })

--- a/crates/rome_js_formatter/src/utils/test_call.rs
+++ b/crates/rome_js_formatter/src/utils/test_call.rs
@@ -4,7 +4,7 @@ use rome_js_syntax::{
     AnyJsLiteralExpression, AnyJsName, AnyJsTemplateElement, JsCallArgumentList, JsCallArguments,
     JsCallExpression, JsSyntaxNode, JsTemplateExpression,
 };
-use rome_rowan::{SyntaxResult, SyntaxTokenText};
+use rome_rowan::{SyntaxResult, TokenText};
 
 /// Returns `Ok(true)` if `maybe_argument` is an argument of a [test call expression](is_test_call_expression).
 pub(crate) fn is_test_call_argument(maybe_argument: &JsSyntaxNode) -> SyntaxResult<bool> {
@@ -260,7 +260,7 @@ fn is_test_each_pattern_callee(template: &JsTemplateExpression) -> bool {
     if let Some(tag) = template.tag() {
         let mut members = CalleeNamesIterator::new(tag);
 
-        let texts: [Option<SyntaxTokenText>; 5] = [
+        let texts: [Option<TokenText>; 5] = [
             members.next(),
             members.next(),
             members.next(),
@@ -339,7 +339,7 @@ fn is_test_each_pattern_callee(template: &JsTemplateExpression) -> bool {
 fn contains_a_test_pattern(callee: &AnyJsExpression) -> SyntaxResult<bool> {
     let mut members = CalleeNamesIterator::new(callee.clone());
 
-    let texts: [Option<SyntaxTokenText>; 5] = [
+    let texts: [Option<TokenText>; 5] = [
         members.next(),
         members.next(),
         members.next(),
@@ -399,7 +399,7 @@ impl CalleeNamesIterator {
 }
 
 impl Iterator for CalleeNamesIterator {
-    type Item = SyntaxTokenText;
+    type Item = TokenText;
 
     fn next(&mut self) -> Option<Self::Item> {
         use AnyJsExpression::*;

--- a/crates/rome_js_semantic/src/events.rs
+++ b/crates/rome_js_semantic/src/events.rs
@@ -10,7 +10,7 @@ use rome_js_syntax::{
     JsSyntaxToken, JsVariableDeclaration, JsVariableDeclarator, JsVariableDeclaratorList,
     JsxReferenceIdentifier, TextRange, TextSize, TsIdentifierBinding, TsTypeParameterName,
 };
-use rome_rowan::{syntax::Preorder, AstNode, SyntaxNodeCast, SyntaxNodeOptionExt, SyntaxTokenText};
+use rome_rowan::{syntax::Preorder, AstNode, SyntaxNodeCast, SyntaxNodeOptionExt, TokenText};
 
 /// Events emitted by the [SemanticEventExtractor]. These events are later
 /// made into the Semantic Model.
@@ -26,7 +26,7 @@ pub enum SemanticEvent {
         scope_started_at: TextSize,
         scope_id: usize,
         hoisted_scope_id: Option<usize>,
-        name: SyntaxTokenText,
+        name: TokenText,
     },
 
     /// Tracks where a symbol is read, but only if its declaration
@@ -161,7 +161,7 @@ pub struct SemanticEventExtractor {
     next_scope_id: usize,
     /// At any point this is the set of available bindings and
     /// the range of its declaration
-    bindings: FxHashMap<SyntaxTokenText, BindingInfo>,
+    bindings: FxHashMap<TokenText, BindingInfo>,
 }
 
 /// Holds the text range of the token when it is bound,
@@ -176,7 +176,7 @@ struct BindingInfo {
 
 #[derive(Debug)]
 struct Binding {
-    name: SyntaxTokenText,
+    name: TokenText,
 }
 
 #[derive(Debug)]
@@ -212,10 +212,10 @@ struct Scope {
     bindings: Vec<Binding>,
     /// References that still needs to be bound and
     /// will be solved at the end of the scope
-    references: HashMap<SyntaxTokenText, Vec<Reference>>,
+    references: HashMap<TokenText, Vec<Reference>>,
     /// All bindings that where shadowed and will be
     /// restored after this scope ends.
-    shadowed: Vec<(SyntaxTokenText, BindingInfo)>,
+    shadowed: Vec<(TokenText, BindingInfo)>,
     /// If this scope allows declarations to be hoisted
     /// to parent scope or not
     hoisting: ScopeHoisting,

--- a/crates/rome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/rome_js_semantic/src/semantic_model/scope.rs
@@ -1,6 +1,6 @@
 use super::*;
 use rome_js_syntax::TextRange;
-use rome_rowan::SyntaxTokenText;
+use rome_rowan::TokenText;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
@@ -15,7 +15,7 @@ pub(crate) struct SemanticModelScopeData {
     // All bindings of this scope (points to SemanticModelData::bindings)
     pub(crate) bindings: Vec<usize>,
     // Map pointing to the [bindings] vec  of each bindings by its name
-    pub(crate) bindings_by_name: FxHashMap<SyntaxTokenText, usize>,
+    pub(crate) bindings_by_name: FxHashMap<TokenText, usize>,
     // All read references of a scope
     pub(crate) read_references: Vec<SemanticModelScopeReference>,
     // All write references of a scope

--- a/crates/rome_js_syntax/src/directive_ext.rs
+++ b/crates/rome_js_syntax/src/directive_ext.rs
@@ -1,4 +1,4 @@
-use rome_rowan::{SyntaxResult, SyntaxTokenText, TextSize};
+use rome_rowan::{SyntaxResult, TextRange, TextSize, TokenText};
 
 use crate::JsDirective;
 
@@ -20,19 +20,19 @@ impl JsDirective {
     ///         let text = js_directive.inner_string_text().unwrap();
     ///         assert_eq!(text, "use strict")
     /// ```
-    pub fn inner_string_text(&self) -> SyntaxResult<SyntaxTokenText> {
+    pub fn inner_string_text(&self) -> SyntaxResult<TokenText> {
         let value = self.value_token()?;
         let mut text = value.token_text_trimmed();
 
         static QUOTES: [char; 2] = ['"', '\''];
 
         if text.starts_with(QUOTES) {
-            let range = text.range().add_start(TextSize::from(1));
+            let range = TextRange::new(1.into(), text.len());
             text = text.slice(range);
         }
 
         if text.ends_with(QUOTES) {
-            let range = text.range().sub_end(TextSize::from(1));
+            let range = TextRange::new(0.into(), text.len() - TextSize::from(1));
             text = text.slice(range);
         }
 

--- a/crates/rome_js_syntax/src/import_ext.rs
+++ b/crates/rome_js_syntax/src/import_ext.rs
@@ -1,5 +1,5 @@
 use crate::{AnyJsImportClause, JsImport, JsModuleSource, TextSize};
-use rome_rowan::{SyntaxResult, SyntaxTokenText};
+use rome_rowan::{SyntaxResult, TextRange, TokenText};
 
 impl JsImport {
     /// It checks if the source of an import against the string `source_to_check`
@@ -41,19 +41,19 @@ impl JsModuleSource {
     /// let text = source.inner_string_text().unwrap();
     /// assert_eq!(text.text(), "react");
     /// ```
-    pub fn inner_string_text(&self) -> SyntaxResult<SyntaxTokenText> {
+    pub fn inner_string_text(&self) -> SyntaxResult<TokenText> {
         let value = self.value_token()?;
         let mut text = value.token_text_trimmed();
 
         static QUOTES: [char; 2] = ['"', '\''];
 
         if text.starts_with(QUOTES) {
-            let range = text.range().add_start(TextSize::from(1));
+            let range = TextRange::new(1.into(), text.len());
             text = text.slice(range);
         }
 
         if text.ends_with(QUOTES) {
-            let range = text.range().sub_end(TextSize::from(1));
+            let range = TextRange::new(0.into(), text.len() - TextSize::from(1));
             text = text.slice(range);
         }
 

--- a/crates/rome_json_syntax/src/member_ext.rs
+++ b/crates/rome_json_syntax/src/member_ext.rs
@@ -1,20 +1,20 @@
 use crate::JsonMemberName;
-use rome_rowan::{SyntaxResult, SyntaxTokenText, TextSize};
+use rome_rowan::{SyntaxResult, TextRange, TextSize, TokenText};
 
 impl JsonMemberName {
-    pub fn inner_string_text(&self) -> SyntaxResult<SyntaxTokenText> {
+    pub fn inner_string_text(&self) -> SyntaxResult<TokenText> {
         let value = self.value_token()?;
         let mut text = value.token_text_trimmed();
 
         static QUOTES: [char; 1] = ['"'];
 
         if text.starts_with(QUOTES) {
-            let range = text.range().add_start(TextSize::from(1));
+            let range = TextRange::new(1.into(), text.len());
             text = text.slice(range);
         }
 
         if text.ends_with(QUOTES) {
-            let range = text.range().sub_end(TextSize::from(1));
+            let range = TextRange::new(0.into(), text.len() - TextSize::from(1));
             text = text.slice(range);
         }
 

--- a/crates/rome_json_syntax/src/string_ext.rs
+++ b/crates/rome_json_syntax/src/string_ext.rs
@@ -1,19 +1,20 @@
 use crate::{JsonStringValue, TextSize};
-use rome_rowan::{SyntaxResult, SyntaxTokenText};
+use rome_rowan::{SyntaxResult, TextRange, TokenText};
 
 impl JsonStringValue {
-    pub fn inner_string_text(&self) -> SyntaxResult<SyntaxTokenText> {
+    pub fn inner_string_text(&self) -> SyntaxResult<TokenText> {
         let value = self.value_token()?;
         let mut text = value.token_text_trimmed();
 
         static QUOTES: [char; 1] = ['"'];
 
         if text.starts_with(QUOTES) {
-            let range = text.range().add_start(TextSize::from(1));
+            let range = TextRange::new(1.into(), text.len());
             text = text.slice(range);
         }
+
         if text.ends_with(QUOTES) {
-            let range = text.range().sub_end(TextSize::from(1));
+            let range = TextRange::new(0.into(), text.len() - TextSize::from(1));
             text = text.slice(range);
         }
 

--- a/crates/rome_rowan/src/cursor/token.rs
+++ b/crates/rome_rowan/src/cursor/token.rs
@@ -1,8 +1,6 @@
 use crate::cursor::{NodeData, SyntaxElement, SyntaxNode, SyntaxTrivia};
 use crate::green::GreenElementRef;
-use crate::{
-    green, Direction, GreenToken, GreenTokenData, RawSyntaxKind, SyntaxTokenText, WalkEvent,
-};
+use crate::{green, Direction, GreenToken, GreenTokenData, RawSyntaxKind, TokenText, WalkEvent};
 use rome_text_size::{TextRange, TextSize};
 use std::hash::{Hash, Hasher};
 use std::ptr::NonNull;
@@ -105,16 +103,16 @@ impl SyntaxToken {
     }
 
     #[inline]
-    pub fn token_text(&self) -> SyntaxTokenText {
-        SyntaxTokenText::new(self.green().to_owned())
+    pub fn token_text(&self) -> TokenText {
+        TokenText::new(self.green().to_owned())
     }
 
     #[inline]
-    pub fn token_text_trimmed(&self) -> SyntaxTokenText {
+    pub fn token_text_trimmed(&self) -> TokenText {
         let green = self.green().to_owned();
         let mut range = self.text_trimmed_range();
         range -= self.data().offset;
-        SyntaxTokenText::with_range(green, range)
+        TokenText::with_range(green, range)
     }
 
     #[inline]

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -30,7 +30,7 @@ pub mod raw_language;
 #[cfg(feature = "serde")]
 mod serde_impls;
 mod syntax_factory;
-mod syntax_token_text;
+mod token_text;
 mod tree_builder;
 
 pub use rome_text_size::{TextLen, TextRange, TextSize};
@@ -48,7 +48,7 @@ pub use crate::{
     },
     syntax_factory::*,
     syntax_node_text::SyntaxNodeText,
-    syntax_token_text::SyntaxTokenText,
+    token_text::TokenText,
     tree_builder::{Checkpoint, TreeBuilder},
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };

--- a/crates/rome_rowan/src/syntax/token.rs
+++ b/crates/rome_rowan/src/syntax/token.rs
@@ -1,7 +1,7 @@
 use crate::green::{GreenToken, GreenTrivia};
 use crate::syntax::element::SyntaxElementKey;
 use crate::syntax::SyntaxTrivia;
-use crate::syntax_token_text::SyntaxTokenText;
+use crate::token_text::TokenText;
 use crate::{
     chain_trivia_pieces, cursor, Direction, Language, NodeOrToken, SyntaxElement, SyntaxKind,
     SyntaxNode, SyntaxTriviaPiece, TriviaPiece, TriviaPieceKind,
@@ -119,11 +119,11 @@ impl<L: Language> SyntaxToken<L> {
     ///     format!("{:?}", token.token_text())
     /// );
     /// ```
-    pub fn token_text(&self) -> SyntaxTokenText {
+    pub fn token_text(&self) -> TokenText {
         self.raw.token_text()
     }
 
-    pub fn token_text_trimmed(&self) -> SyntaxTokenText {
+    pub fn token_text_trimmed(&self) -> TokenText {
         self.raw.token_text_trimmed()
     }
 


### PR DESCRIPTION
## Summary

This PR follows the discussion in https://github.com/rome/tools/pull/4721#issuecomment-1648213843

I renamed `SyntaxTokenText` to `TextToken` to communicate the fact that it is not related to `SyntaxToken`: there is no reference to parent nodes, and there is no way to get the absolute range of the text.

Following this renaming, I also renamed `SyntaxTokenTextSlice` to `LocatedTokenText`.

## Test Plan

All test passed.
