### PR TITLE
feat(rome_lsp): send message to the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ if no error diagnostics are emitted.
 #### Other changes
 
 - The Rome LSP is now able to show diagnostics that belong to JSON lint rules.
+- Fix [#4564](https://github.com/rome/tools/issues/4564), now files too large don't emit errors.
+- The Rome LSP now sends client messages when files are ignored or too big.
 
 ### Formatter
 

--- a/crates/rome_lsp/src/diagnostics.rs
+++ b/crates/rome_lsp/src/diagnostics.rs
@@ -1,0 +1,60 @@
+use crate::utils::into_lsp_error;
+use anyhow::Error;
+use rome_service::WorkspaceError;
+use std::fmt::{Display, Formatter};
+use tower_lsp::lsp_types::MessageType;
+
+#[derive(Debug)]
+pub enum LspError {
+    WorkspaceError(WorkspaceError),
+    Anyhow(anyhow::Error),
+}
+
+impl From<WorkspaceError> for LspError {
+    fn from(value: WorkspaceError) -> Self {
+        Self::WorkspaceError(value)
+    }
+}
+
+impl From<anyhow::Error> for LspError {
+    fn from(value: Error) -> Self {
+        Self::Anyhow(value)
+    }
+}
+
+impl Display for LspError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LspError::WorkspaceError(err) => {
+                write!(f, "{}", err)
+            }
+            LspError::Anyhow(err) => {
+                write!(f, "{}", err)
+            }
+        }
+    }
+}
+
+/// Receives an error coming from a LSP query, and converts it into a JSON-RPC error.
+///
+/// It accepts a `Client`, so contextual messages are sent to the user.
+pub(crate) async fn handle_lsp_error<T>(
+    err: LspError,
+    client: &tower_lsp::Client,
+) -> Result<Option<T>, tower_lsp::jsonrpc::Error> {
+    match err {
+        LspError::WorkspaceError(err) => match err {
+            // diagnostics that shouldn't raise an hard error, but send a message to the user
+            WorkspaceError::FormatWithErrorsDisabled(_)
+            | WorkspaceError::FileIgnored(_)
+            | WorkspaceError::FileTooLarge(_) => {
+                let message = format!("{}", err);
+                client.show_message(MessageType::WARNING, message).await;
+                Ok(None)
+            }
+
+            _ => Err(into_lsp_error(err)),
+        },
+        LspError::Anyhow(err) => Err(into_lsp_error(err)),
+    }
+}

--- a/crates/rome_lsp/src/lib.rs
+++ b/crates/rome_lsp/src/lib.rs
@@ -1,5 +1,6 @@
 mod capabilities;
 mod converters;
+mod diagnostics;
 mod documents;
 mod extension_settings;
 mod handlers;

--- a/crates/rome_service/src/diagnostics.rs
+++ b/crates/rome_service/src/diagnostics.rs
@@ -386,9 +386,10 @@ pub struct CantReadFile {
 #[diagnostic(
     category = "internalError/fs",
     message(
-        message("The file "{self.path}" was ignored"),
-        description = "The file {path} was ignored"
-    )
+        message("The file "{self.path}" was ignored."),
+        description = "The file {path} was ignored."
+    ),
+    severity = Warning
 )]
 pub struct FileIgnored {
     #[location(resource)]

--- a/crates/rome_service/src/snapshots/file_ignored.snap
+++ b/crates/rome_service/src/snapshots/file_ignored.snap
@@ -4,7 +4,7 @@ expression: content
 ---
 example.js internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The file example.js was ignored
+  ! The file example.js was ignored.
   
 
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/rome/tools/issues/4564

I created a function to handle errors coming from the single query operations of the LSP, in this way we can pass the `Client` and send messages if we see fit.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested locally and manually on my VSCode extension.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
