### PR TITLE
feat: add support for `.jsonc` files

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,8 +28,11 @@ jobs:
         uses: moonrepo/setup-rust@v0
         with:
           components: rustfmt
-      - name: Run rustfmt
-        run: cargo fmt --all --check
+          bins: taplo-cli
+      - name: Run format
+        run: |
+          cargo fmt --all --check
+          taplo fmt -- --locked
 
   lint:
     name: Lint Rust Files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,10 @@ rome_parser                 = { version = "0.0.1", path = "./crates/rome_parser"
 rome_rowan                  = { version = "0.0.1", path = "./crates/rome_rowan" }
 rome_service                = { path = "./crates/rome_service" }
 rome_suppression            = { version = "0.0.1", path = "./crates/rome_suppression" }
+rome_test_utils             = { path = "./crates/rome_test_utils" }
 rome_text_edit              = { version = "0.0.1", path = "./crates/rome_text_edit" }
 rome_text_size              = { version = "0.0.1", path = "./crates/rome_text_size" }
 tests_macros                = { path = "./crates/tests_macros" }
-rome_test_utils                = { path = "./crates/rome_test_utils" }
 
 # Crates needed in the workspace
 bitflags          = "2.3.1"

--- a/crates/rome_cli/src/configuration.rs
+++ b/crates/rome_cli/src/configuration.rs
@@ -72,7 +72,7 @@ impl LoadedConfiguration {
 					)
 
 				})?;
-            let deserialized = deserialize_from_json_str::<Configuration>(content.as_str());
+            let deserialized = deserialize_from_json_str::<Configuration>(content.as_str(), true);
             deserialized_configurations.push(deserialized)
         }
         Ok(deserialized_configurations)

--- a/crates/rome_cli/src/configuration.rs
+++ b/crates/rome_cli/src/configuration.rs
@@ -5,6 +5,7 @@ use rome_deserialize::json::deserialize_from_json_str;
 use rome_deserialize::Deserialized;
 use rome_diagnostics::{DiagnosticExt, Error, PrintDiagnostic};
 use rome_fs::{FileSystem, OpenOptions};
+use rome_json_parser::JsonParserOptions;
 use rome_service::configuration::diagnostics::CantLoadExtendFile;
 use rome_service::configuration::ConfigurationPayload;
 use rome_service::{
@@ -72,7 +73,10 @@ impl LoadedConfiguration {
 					)
 
 				})?;
-            let deserialized = deserialize_from_json_str::<Configuration>(content.as_str(), true);
+            let deserialized = deserialize_from_json_str::<Configuration>(
+                content.as_str(),
+                JsonParserOptions::default(),
+            );
             deserialized_configurations.push(deserialized)
         }
         Ok(deserialized_configurations)

--- a/crates/rome_cli/tests/commands/format.rs
+++ b/crates/rome_cli/tests/commands/format.rs
@@ -1866,11 +1866,86 @@ fn ignore_comments_error_when_allow_comments() {
         Args::from([("format"), file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
-    // assert!(result.is_ok(), "run_cli returned {result:?}");
+    assert!(result.is_ok(), "run_cli returned {result:?}");
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "ignore_comments_error_when_allow_comments",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_jsonc_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let code = r#"
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	"#;
+    let file_path = Path::new("file.jsonc");
+    fs.insert(file_path.into(), code.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from([("format"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_jsonc_files",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn treat_known_json_files_as_jsonc_files() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let code = r#"
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	"#;
+    let ts = Path::new("files/typescript.json");
+    fs.insert(ts.into(), code.as_bytes());
+    let eslint = Path::new("files/.eslintrc.json");
+    fs.insert(eslint.into(), code.as_bytes());
+    let jshint = Path::new("files/.jshintrc");
+    fs.insert(jshint.into(), code.as_bytes());
+    let babel = Path::new("files/.babelrc");
+    fs.insert(babel.into(), code.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                ("format"),
+                ts.as_os_str().to_str().unwrap(),
+                eslint.as_os_str().to_str().unwrap(),
+                jshint.as_os_str().to_str().unwrap(),
+                babel.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "treat_known_json_files_as_jsonc_files",
         fs,
         console,
         result,

--- a/crates/rome_cli/tests/snapshots/main_commands_format/format_jsonc_files.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/format_jsonc_files.snap
@@ -1,0 +1,37 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.jsonc`
+
+```jsonc
+
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	
+```
+
+# Emitted Messages
+
+```block
+file.jsonc format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - 
+    2   │ - /*test*/·[
+    3   │ - 
+    4   │ - /*·some·other·comment*/1,·2,·3]
+    5   │ - → 
+      1 │ + /*test*/·[/*·some·other·comment*/·1,·2,·3]
+      2 │ + 
+  
+
+```
+
+```block
+Compared 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/treat_known_json_files_as_jsonc_files.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/treat_known_json_files_as_jsonc_files.snap
@@ -1,0 +1,115 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `files/.babelrc`
+
+```babelrc
+
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	
+```
+
+## `files/.eslintrc.json`
+
+```json
+
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	
+```
+
+## `files/.jshintrc`
+
+```jshintrc
+
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	
+```
+
+## `files/typescript.json`
+
+```json
+
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	
+```
+
+# Emitted Messages
+
+```block
+files/typescript.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - 
+    2   │ - /*test*/·[
+    3   │ - 
+    4   │ - /*·some·other·comment*/1,·2,·3]
+    5   │ - → 
+      1 │ + /*test*/·[/*·some·other·comment*/·1,·2,·3]
+      2 │ + 
+  
+
+```
+
+```block
+files/.eslintrc.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - 
+    2   │ - /*test*/·[
+    3   │ - 
+    4   │ - /*·some·other·comment*/1,·2,·3]
+    5   │ - → 
+      1 │ + /*test*/·[/*·some·other·comment*/·1,·2,·3]
+      2 │ + 
+  
+
+```
+
+```block
+files/.jshintrc format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - 
+    2   │ - /*test*/·[
+    3   │ - 
+    4   │ - /*·some·other·comment*/1,·2,·3]
+    5   │ - → 
+      1 │ + /*test*/·[/*·some·other·comment*/·1,·2,·3]
+      2 │ + 
+  
+
+```
+
+```block
+files/.babelrc format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - 
+    2   │ - /*test*/·[
+    3   │ - 
+    4   │ - /*·some·other·comment*/1,·2,·3]
+    5   │ - → 
+      1 │ + /*test*/·[/*·some·other·comment*/·1,·2,·3]
+      2 │ + 
+  
+
+```
+
+```block
+Compared 4 file(s) in <TIME>
+```
+
+

--- a/crates/rome_cli/tests/snapshots/main_commands_format/treats_typescript_json_like_jsonc.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/treats_typescript_json_like_jsonc.snap
@@ -1,0 +1,37 @@
+---
+source: crates/rome_cli/tests/snap_test.rs
+expression: content
+---
+## `typescript.json`
+
+```json
+
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	
+```
+
+# Emitted Messages
+
+```block
+typescript.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Formatter would have printed the following content:
+  
+    1   │ - 
+    2   │ - /*test*/·[
+    3   │ - 
+    4   │ - /*·some·other·comment*/1,·2,·3]
+    5   │ - → 
+      1 │ + /*test*/·[/*·some·other·comment*/·1,·2,·3]
+      2 │ + 
+  
+
+```
+
+```block
+Compared 1 file(s) in <TIME>
+```
+
+

--- a/crates/rome_css_parser/Cargo.toml
+++ b/crates/rome_css_parser/Cargo.toml
@@ -12,8 +12,8 @@ version              = "0.0.1"
 
 [dependencies]
 rome_console          = { workspace = true }
-rome_css_syntax       = { workspace = true }
 rome_css_factory      = { workspace = true }
+rome_css_syntax       = { workspace = true }
 rome_diagnostics      = { workspace = true }
 rome_js_unicode_table = { workspace = true }
 rome_parser           = { workspace = true }

--- a/crates/rome_deserialize/src/json.rs
+++ b/crates/rome_deserialize/src/json.rs
@@ -588,8 +588,8 @@ pub fn with_only_known_variants(
 /// }
 ///
 /// # fn main() -> Result<(), DeserializationDiagnostic> {
-/// let source = r#"{ "lorem": true }"#;
-///  let deserialized = deserialize_from_json_str::<NewConfiguration>(&source);
+///  let source = r#"{ "lorem": true }"#;
+///  let deserialized = deserialize_from_json_str::<NewConfiguration>(&source, false);
 ///  assert!(!deserialized.has_errors());
 ///  assert_eq!(deserialized.into_deserialized(), NewConfiguration { lorem: true });
 /// # Ok(())
@@ -597,13 +597,18 @@ pub fn with_only_known_variants(
 ///
 ///
 /// ```
-pub fn deserialize_from_json_str<Output>(source: &str) -> Deserialized<Output>
+pub fn deserialize_from_json_str<Output>(source: &str, allow_comments: bool) -> Deserialized<Output>
 where
     Output: Default + VisitJsonNode + JsonDeserialize,
 {
     let mut output = Output::default();
     let mut diagnostics = vec![];
-    let parse = parse_json(source, JsonParserOptions::default());
+    let options = if allow_comments {
+        JsonParserOptions::default().with_allow_comments()
+    } else {
+        JsonParserOptions::default()
+    };
+    let parse = parse_json(source, options);
     Output::deserialize_from_ast(&parse.tree(), &mut output, &mut diagnostics);
     let mut errors = parse
         .into_diagnostics()

--- a/crates/rome_deserialize/src/json.rs
+++ b/crates/rome_deserialize/src/json.rs
@@ -587,9 +587,10 @@ pub fn with_only_known_variants(
 ///     }
 /// }
 ///
+///  use rome_json_parser::JsonParserOptions;
 /// # fn main() -> Result<(), DeserializationDiagnostic> {
-///  let source = r#"{ "lorem": true }"#;
-///  let deserialized = deserialize_from_json_str::<NewConfiguration>(&source, false);
+/// let source = r#"{ "lorem": true }"#;
+///  let deserialized = deserialize_from_json_str::<NewConfiguration>(&source, JsonParserOptions::default());
 ///  assert!(!deserialized.has_errors());
 ///  assert_eq!(deserialized.into_deserialized(), NewConfiguration { lorem: true });
 /// # Ok(())
@@ -597,17 +598,15 @@ pub fn with_only_known_variants(
 ///
 ///
 /// ```
-pub fn deserialize_from_json_str<Output>(source: &str, allow_comments: bool) -> Deserialized<Output>
+pub fn deserialize_from_json_str<Output>(
+    source: &str,
+    options: JsonParserOptions,
+) -> Deserialized<Output>
 where
     Output: Default + VisitJsonNode + JsonDeserialize,
 {
     let mut output = Output::default();
     let mut diagnostics = vec![];
-    let options = if allow_comments {
-        JsonParserOptions::default().with_allow_comments()
-    } else {
-        JsonParserOptions::default()
-    };
     let parse = parse_json(source, options);
     Output::deserialize_from_ast(&parse.tree(), &mut output, &mut diagnostics);
     let mut errors = parse

--- a/crates/rome_js_analyze/Cargo.toml
+++ b/crates/rome_js_analyze/Cargo.toml
@@ -31,12 +31,12 @@ serde_json            = { workspace = true }
 smallvec              = { workspace = true }
 
 [dev-dependencies]
-countme          = { workspace = true, features = ["enable"] }
-insta            = { workspace = true, features = ["glob"] }
-rome_js_parser   = { workspace = true, features = ["tests"] }
-rome_text_edit   = { workspace = true }
-tests_macros     = { workspace = true }
-rome_test_utils =  { workspace = true }
+countme         = { workspace = true, features = ["enable"] }
+insta           = { workspace = true, features = ["glob"] }
+rome_js_parser  = { workspace = true, features = ["tests"] }
+rome_test_utils = { workspace = true }
+rome_text_edit  = { workspace = true }
+tests_macros    = { workspace = true }
 
 [features]
 schema = ["schemars", "rome_deserialize/schema"]

--- a/crates/rome_js_transform/Cargo.toml
+++ b/crates/rome_js_transform/Cargo.toml
@@ -11,17 +11,17 @@ version              = "0.1.0"
 [dependencies]
 lazy_static      = { workspace = true }
 rome_analyze     = { workspace = true }
+rome_console     = { workspace = true }
 rome_diagnostics = { workspace = true }
 rome_js_factory  = { workspace = true }
 rome_js_syntax   = { workspace = true }
 rome_rowan       = { workspace = true }
-rome_console = {workspace= true}
 
 
 [dev-dependencies]
+insta             = { workspace = true }
+rome_analyze      = { workspace = true }
 rome_js_formatter = { workspace = true }
 rome_js_parser    = { workspace = true }
-rome_analyze =  { workspace = true }
-rome_test_utils = { workspace = true }
-tests_macros= { workspace = true }
-insta = { workspace = true }
+rome_test_utils   = { workspace = true }
+tests_macros      = { workspace = true }

--- a/crates/rome_json_analyze/Cargo.toml
+++ b/crates/rome_json_analyze/Cargo.toml
@@ -21,5 +21,5 @@ insta             = { workspace = true, features = ["glob"] }
 rome_json_factory = { workspace = true }
 rome_json_parser  = { workspace = true }
 rome_service      = { workspace = true }
+rome_test_utils   = { workspace = true }
 tests_macros      = { workspace = true }
-rome_test_utils = { workspace = true }

--- a/crates/rome_json_syntax/src/file_source.rs
+++ b/crates/rome_json_syntax/src/file_source.rs
@@ -28,6 +28,10 @@ impl JsonFileSource {
             variant: JsonVariant::Jsonc,
         }
     }
+
+    pub const fn is_jsonc(&self) -> bool {
+        matches!(self.variant, JsonVariant::Jsonc)
+    }
 }
 
 impl<'a> FileSource<'a, JsonLanguage> for JsonFileSource {}

--- a/crates/rome_service/src/configuration/diagnostics.rs
+++ b/crates/rome_service/src/configuration/diagnostics.rs
@@ -340,7 +340,7 @@ mod test {
     #[test]
     fn deserialization_error() {
         let content = "{ \n\n\"formatter\" }";
-        let result = deserialize_from_json_str::<Configuration>(content);
+        let result = deserialize_from_json_str::<Configuration>(content, false);
 
         assert!(result.has_errors());
         for diagnostic in result.into_diagnostics() {
@@ -363,6 +363,7 @@ mod test {
     }
   }
 }"#;
-        let _result = deserialize_from_json_str::<Configuration>(content).into_deserialized();
+        let _result =
+            deserialize_from_json_str::<Configuration>(content, false).into_deserialized();
     }
 }

--- a/crates/rome_service/src/configuration/diagnostics.rs
+++ b/crates/rome_service/src/configuration/diagnostics.rs
@@ -289,6 +289,7 @@ mod test {
     use crate::{Configuration, MatchOptions, Matcher};
     use rome_deserialize::json::deserialize_from_json_str;
     use rome_diagnostics::{print_diagnostic_to_string, DiagnosticExt, Error};
+    use rome_json_parser::JsonParserOptions;
 
     fn snap_diagnostic(test_name: &str, diagnostic: Error) {
         let content = print_diagnostic_to_string(&diagnostic);
@@ -340,7 +341,8 @@ mod test {
     #[test]
     fn deserialization_error() {
         let content = "{ \n\n\"formatter\" }";
-        let result = deserialize_from_json_str::<Configuration>(content, false);
+        let result =
+            deserialize_from_json_str::<Configuration>(content, JsonParserOptions::default());
 
         assert!(result.has_errors());
         for diagnostic in result.into_diagnostics() {
@@ -364,6 +366,7 @@ mod test {
   }
 }"#;
         let _result =
-            deserialize_from_json_str::<Configuration>(content, false).into_deserialized();
+            deserialize_from_json_str::<Configuration>(content, JsonParserOptions::default())
+                .into_deserialized();
     }
 }

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -348,7 +348,7 @@ pub fn load_config(
             directory_path,
             file_path,
         } = auto_search_result;
-        let deserialized = deserialize_from_json_str::<Configuration>(&content);
+        let deserialized = deserialize_from_json_str::<Configuration>(&content, true);
         Ok(Some(ConfigurationPayload {
             deserialized,
             configuration_file_path: file_path,

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -348,7 +348,8 @@ pub fn load_config(
             directory_path,
             file_path,
         } = auto_search_result;
-        let deserialized = deserialize_from_json_str::<Configuration>(&content, true);
+        let deserialized =
+            deserialize_from_json_str::<Configuration>(&content, JsonParserOptions::default());
         Ok(Some(ConfigurationPayload {
             deserialized,
             configuration_file_path: file_path,

--- a/crates/rome_service/src/file_handlers/json.rs
+++ b/crates/rome_service/src/file_handlers/json.rs
@@ -114,7 +114,7 @@ fn parse(
     let options: JsonParserOptions = JsonParserOptions {
         allow_comments: parser.allow_comments
             || source_type.is_jsonc()
-            || is_file_allowed_as_jsonc(&rome_path),
+            || is_file_allowed_as_jsonc(rome_path),
     };
     let parse = rome_json_parser::parse_json_with_cache(text, cache, options);
     let root = parse.syntax();

--- a/crates/rome_service/src/file_handlers/mod.rs
+++ b/crates/rome_service/src/file_handlers/mod.rs
@@ -44,6 +44,23 @@ pub enum Language {
 }
 
 impl Language {
+    /// Files that can be bypassed, because correctly handled by the JSON parser
+    pub(crate) const ALLOWED_FILES: &'static [&'static str; 13] = &[
+        "typescript.json",
+        "tslint.json",
+        "babel.config.json",
+        ".babelrc.json",
+        ".ember-cli",
+        "typedoc.json",
+        ".eslintrc.json",
+        ".eslintrc",
+        ".jsfmtrc",
+        ".jshintrc",
+        ".swcrc",
+        ".hintrc",
+        ".babelrc",
+    ];
+
     /// Returns the language corresponding to this file extension
     pub fn from_extension(s: &str) -> Self {
         match s.to_lowercase().as_str() {
@@ -52,7 +69,16 @@ impl Language {
             "ts" | "mts" | "cts" => Language::TypeScript,
             "tsx" => Language::TypeScriptReact,
             "json" => Language::Json,
+            "jsonc" => Language::Jsonc,
             _ => Language::Unknown,
+        }
+    }
+
+    pub fn from_known_filename(s: &str) -> Self {
+        if Self::ALLOWED_FILES.contains(&s.to_lowercase().as_str()) {
+            Language::Jsonc
+        } else {
+            Language::Unknown
         }
     }
 
@@ -77,6 +103,7 @@ impl Language {
             "javascriptreact" => Language::JavaScriptReact,
             "typescriptreact" => Language::TypeScriptReact,
             "json" => Language::Json,
+            "jsonc" => Language::Jsonc,
             _ => Language::Unknown,
         }
     }
@@ -294,6 +321,10 @@ impl Features {
             .extension()
             .and_then(OsStr::to_str)
             .map(Language::from_extension)
+            .or(rome_path
+                .file_name()
+                .and_then(OsStr::to_str)
+                .map(Language::from_known_filename))
             .unwrap_or_default()
     }
 

--- a/crates/rome_service/tests/spec_tests.rs
+++ b/crates/rome_service/tests/spec_tests.rs
@@ -14,7 +14,8 @@ fn run_invalid_configurations(input: &'static str, _: &str, _: &str, _: &str) {
         .unwrap_or_else(|err| panic!("failed to read {:?}: {:?}", input_file, err));
 
     let result = match extension {
-        "json" => deserialize_from_json_str::<Configuration>(input_code.as_str()),
+        "json" => deserialize_from_json_str::<Configuration>(input_code.as_str(), false),
+        "jsonc" => deserialize_from_json_str::<Configuration>(input_code.as_str(), true),
         _ => {
             panic!("Extension not supported");
         }

--- a/crates/rome_service/tests/spec_tests.rs
+++ b/crates/rome_service/tests/spec_tests.rs
@@ -1,5 +1,6 @@
 use rome_deserialize::json::deserialize_from_json_str;
 use rome_diagnostics::{print_diagnostic_to_string, DiagnosticExt};
+use rome_json_parser::JsonParserOptions;
 use rome_service::Configuration;
 use std::ffi::OsStr;
 use std::fs::read_to_string;
@@ -14,8 +15,14 @@ fn run_invalid_configurations(input: &'static str, _: &str, _: &str, _: &str) {
         .unwrap_or_else(|err| panic!("failed to read {:?}: {:?}", input_file, err));
 
     let result = match extension {
-        "json" => deserialize_from_json_str::<Configuration>(input_code.as_str(), false),
-        "jsonc" => deserialize_from_json_str::<Configuration>(input_code.as_str(), true),
+        "json" => deserialize_from_json_str::<Configuration>(
+            input_code.as_str(),
+            JsonParserOptions::default(),
+        ),
+        "jsonc" => deserialize_from_json_str::<Configuration>(
+            input_code.as_str(),
+            JsonParserOptions::default().with_allow_comments(),
+        ),
         _ => {
             panic!("Extension not supported");
         }

--- a/crates/rome_test_utils/Cargo.toml
+++ b/crates/rome_test_utils/Cargo.toml
@@ -1,25 +1,24 @@
 [package]
-name = "rome_test_utils"
-version = "0.1.0"
 edition = "2021"
+name    = "rome_test_utils"
 publish = false
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rome_js_parser = {workspace = true }
-rome_json_parser = {workspace = true }
-rome_js_syntax = {workspace = true }
-rome_json_syntax = {workspace = true }
-rome_analyze = {workspace = true }
-rome_rowan = {workspace = true }
-rome_diagnostics = {workspace = true }
-rome_service = {workspace = true }
-rome_console = {workspace = true }
-rome_deserialize = {workspace = true }
-countme = { workspace = true, features = ["enable"] }
-similar = { version = "2.2.1" }
+countme          = { workspace = true, features = ["enable"] }
 json_comments    = "0.2.1"
-serde = { workspace = true }
-serde_json = { workspace = true }
-
+rome_analyze     = { workspace = true }
+rome_console     = { workspace = true }
+rome_deserialize = { workspace = true }
+rome_diagnostics = { workspace = true }
+rome_js_parser   = { workspace = true }
+rome_js_syntax   = { workspace = true }
+rome_json_parser = { workspace = true }
+rome_json_syntax = { workspace = true }
+rome_rowan       = { workspace = true }
+rome_service     = { workspace = true }
+serde            = { workspace = true }
+serde_json       = { workspace = true }
+similar          = { version = "2.2.1" }

--- a/crates/rome_test_utils/src/lib.rs
+++ b/crates/rome_test_utils/src/lib.rs
@@ -36,7 +36,7 @@ pub fn create_analyzer_options(
     let options_file = input_file.with_extension("options.json");
     if let Ok(json) = std::fs::read_to_string(options_file.clone()) {
         let deserialized =
-            rome_deserialize::json::deserialize_from_json_str::<Configuration>(json.as_str());
+            rome_deserialize::json::deserialize_from_json_str::<Configuration>(json.as_str(), true);
         if deserialized.has_errors() {
             diagnostics.extend(
                 deserialized

--- a/crates/rome_test_utils/src/lib.rs
+++ b/crates/rome_test_utils/src/lib.rs
@@ -4,7 +4,7 @@ use rome_console::fmt::{Formatter, Termcolor};
 use rome_console::markup;
 use rome_diagnostics::termcolor::Buffer;
 use rome_diagnostics::{DiagnosticExt, Error, PrintDiagnostic};
-use rome_json_parser::ParseDiagnostic;
+use rome_json_parser::{JsonParserOptions, ParseDiagnostic};
 use rome_rowan::{SyntaxKind, SyntaxNode, SyntaxSlot};
 use rome_service::configuration::to_analyzer_configuration;
 use rome_service::settings::{Language, WorkspaceSettings};
@@ -35,8 +35,10 @@ pub fn create_analyzer_options(
     // that configures that specific rule.
     let options_file = input_file.with_extension("options.json");
     if let Ok(json) = std::fs::read_to_string(options_file.clone()) {
-        let deserialized =
-            rome_deserialize::json::deserialize_from_json_str::<Configuration>(json.as_str(), true);
+        let deserialized = rome_deserialize::json::deserialize_from_json_str::<Configuration>(
+            json.as_str(),
+            JsonParserOptions::default(),
+        );
         if deserialized.has_errors() {
             diagnostics.extend(
                 deserialized

--- a/justfile
+++ b/justfile
@@ -73,11 +73,11 @@ _touch file:
 
 # Run tests of all crates
 test:
-	cargo nextest run
+	cargo nextest run --no-fail-fast
 
 # Run tests for the crate passed as argument e.g. just test-create rome_cli
 test-crate name:
-	cargo nextest run -E 'package({{name}})'
+	cargo nextest run -E 'package({{name}})' --no-fail-fast
 
 # Run doc tests
 test-doc:


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds support for parsing `.jsonc` files.

Additionally, I added some "known files" that should be parse as `jsonc` files. The list of files was copied from the VSCode repository: https://github.com/microsoft/vscode/blob/67d7cbc82247f6695854ebe70a66d275ebd5f479/extensions/json/package.json#L47-L69

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added new test cases

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
