### PR TITLE
fix: image urls are broken in meta tags

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -50,8 +50,8 @@ const { default: favicon } = await import("/public/img/favicon.svg?raw");
 		<meta name="theme-color" content="#FFC905">
 		<meta property="og:title" content={title}>
 		<meta property="og:description" content={description}>
-		<meta property="og:image" content={`${import.meta.env.SITE}img/${socialImage}`}>
-		<meta property="twitter:image" content={`${import.meta.env.SITE}img/${socialImage}`}>
+		<meta property="og:image" content={`${import.meta.env.SITE}/img/${socialImage}`}>
+		<meta property="twitter:image" content={`${import.meta.env.SITE}/img/${socialImage}`}>
 		<meta property="twitter:site" content="@rometools">
 		<meta property="twitter:creator" content="@rometools">
 		<meta property="twitter:image:alt" content="Logo for Rome Tools">


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
The image meta tags urls in the rome tools website are broken and link to https://rome.toolsimg/social-logo.png instead of https://rome.tools/img/social-logo.png
```html
<meta content="https://rome.toolsimg/social-logo.png" property="og:image">
```
![image](https://github.com/rome/tools/assets/10563728/ed9cfa8e-8ad6-4bd5-b6f5-0bab3c2352f6)

The site url in the astro.config.ts is set to https://rome.tools, so a slash needs to be added for it to work properly
```js
	site: "https://rome.tools",
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
The fix is to add a slash to a broken URL, I made sure that the updated url works and navigates to the social-logo.png image.