### PR TITLE
refactor(rome_js_analyze): handle ambient declarations in noInnerDecl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,15 @@ if no error diagnostics are emitted.
 
 -  Fix [`noDuplicateCase`](https://docs.rome.tools/lint/rules/noDuplicateCase/) rule that erroneously reported as equals the strings literals `"'"` and `'"'` [#4706](https://github.com/rome/tools/issues/4706).
 
+- Improve [`noInnerDeclarations`](https://docs.rome.tools/lint/rules/noInnerDeclarations/)
+
+  Now, the rule doesn't report false-positives about ambient _TypeScript_ declarations.
+  For example, the following code is no longer reported by the rule:
+
+  ```ts
+  declare var foo;
+  ```
+
 - Improve [`useEnumInitializers`](https://docs.rome.tools/lint/rules/useEnumInitializers/)
 
   The rule now reports all uninitialized members of an enum in a single diagnostic.

--- a/crates/rome_js_analyze/tests/specs/correctness/noInnerDeclarations/valid-moduke.ts
+++ b/crates/rome_js_analyze/tests/specs/correctness/noInnerDeclarations/valid-moduke.ts
@@ -1,0 +1,7 @@
+declare var x;
+
+export declare var y;
+
+declare function f();
+
+export declare function g();

--- a/crates/rome_js_analyze/tests/specs/correctness/noInnerDeclarations/valid-moduke.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/correctness/noInnerDeclarations/valid-moduke.ts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid-moduke.ts
+---
+# Input
+```js
+declare var x;
+
+export declare var y;
+
+declare function f();
+
+export declare function g();
+
+```
+
+


### PR DESCRIPTION
## Summary

I take some time to test _rome_ against the TypeScript Compiler code-base and I noted that `noInnerDeclarations` reported false-positives about ambient variable declarations.
This PR fixes this issue.

## Test Plan

New tests included.