### PR TITLE
feat(rome_js_analyze): useExportType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@ if no error diagnostics are emitted.
 
 	This rule disallows useless `export {}`.
 
+- Add [`useExportType`](https://docs.rome.tools/lint/rules/useExportType/)
+
+  This rule requires the usage of `export type` when the exported element is only a type.
+
 - Add [`useIsArray`](https://docs.rome.tools/lint/rules/useIsArray/)
 
   This rule proposes using `Array.isArray()` instead of `instanceof Array`.

--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -101,6 +101,7 @@ define_categories! {
     "lint/nursery/useArrowFunction": "https://docs.rome.tools/lint/rules/useArrowFunction",
     "lint/nursery/useCamelCase": "https://docs.rome.tools/lint/rules/useCamelCase",
     "lint/nursery/useExhaustiveDependencies": "https://docs.rome.tools/lint/rules/useExhaustiveDependencies",
+    "lint/nursery/useExportType": "https://docs.rome.tools/lint/rules/useExportType",
     "lint/nursery/useGroupedTypeImport": "https://docs.rome.tools/lint/rules/useGroupedTypeImport",
     "lint/nursery/useHeadingContent": "https://docs.rome.tools/lint/rules/useHeadingContent",
     "lint/nursery/useHookAtTopLevel": "https://docs.rome.tools/lint/rules/useHookAtTopLevel",

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery.rs
@@ -11,6 +11,7 @@ pub(crate) mod no_global_is_nan;
 pub(crate) mod no_unsafe_declaration_merging;
 pub(crate) mod use_camel_case;
 pub(crate) mod use_exhaustive_dependencies;
+pub(crate) mod use_export_type;
 pub(crate) mod use_hook_at_top_level;
 pub(crate) mod use_is_array;
 pub(crate) mod use_is_nan;
@@ -29,6 +30,7 @@ declare_group! {
             self :: no_unsafe_declaration_merging :: NoUnsafeDeclarationMerging ,
             self :: use_camel_case :: UseCamelCase ,
             self :: use_exhaustive_dependencies :: UseExhaustiveDependencies ,
+            self :: use_export_type :: UseExportType ,
             self :: use_hook_at_top_level :: UseHookAtTopLevel ,
             self :: use_is_array :: UseIsArray ,
             self :: use_is_nan :: UseIsNan ,

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_export_type.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/use_export_type.rs
@@ -1,0 +1,127 @@
+use crate::{semantic_services::Semantic, JsRuleAction};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule, RuleDiagnostic};
+use rome_console::markup;
+use rome_diagnostics::Applicability;
+use rome_js_factory::make;
+use rome_js_syntax::{
+    AnyJsExportNamedSpecifier, JsExportNamedClause, JsExportNamedSpecifierList, JsFileSource, T,
+};
+use rome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TextRange, TriviaPieceKind};
+
+declare_rule! {
+    /// Promotes the use of `export type` for type-only types.
+    ///
+    /// _TypeScript_ allows specifying a `type` keyword on an `export` to indicate that
+    /// the `export` doesn't exist at runtime.
+    /// This will enable transpilers to safely drop exports of types without looking for its definition.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```ts,expect_diagnostic
+    /// interface I {}
+    /// export { I };
+    /// ```
+    ///
+    /// ```ts,expect_diagnostic
+    /// type T = number;
+    /// export { T };
+    /// ```
+    ///
+    /// ```ts,expect_diagnostic
+    /// import type { T } from "./mod.js";
+    /// export { T };
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```js
+    /// class C {}
+    /// function f() {}
+    /// export { C, f };
+    /// ```
+    ///
+    /// This rules applies only to identifiers locally defined.
+    /// It doesn't warn against a type exported as a value in re-export clause such as:
+    ///
+    /// ```ts
+    /// export { TypeA } from "./mod.ts"
+    /// ```
+    pub(crate) UseExportType {
+        version: "next",
+        name: "useExportType",
+        recommended: true,
+    }
+}
+
+impl Rule for UseExportType {
+    type Query = Semantic<AnyJsExportNamedSpecifier>;
+    type State = TextRange;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let source_type = ctx.source_type::<JsFileSource>();
+        if !source_type.language().is_typescript() {
+            return None;
+        }
+        let specifier = ctx.query();
+        let model = ctx.model();
+        if specifier.is_type_only() {
+            return None;
+        }
+        let reference = specifier.local_name().ok()?;
+        let binding = model.binding(&reference)?;
+        let binding = binding.tree();
+        if binding.is_type_only() {
+            return Some(binding.range());
+        }
+        None
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, declaration: &Self::State) -> Option<RuleDiagnostic> {
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                ctx.query().range(),
+                markup! {
+                    "This export is only a type and should thus use "<Emphasis>"export type"</Emphasis>"."
+                },
+            ).detail(declaration, markup! {
+                "The type is defined here."
+            })
+        )
+    }
+
+    fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
+        let specifier = ctx.query();
+        let mut mutation = ctx.root().begin();
+        let type_token =
+            Some(make::token(T![type]).with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")]));
+        if let Some(specifier_list) = specifier.parent::<JsExportNamedSpecifierList>() {
+            if specifier_list.iter().count() == 1 {
+                if let Some(export) = specifier_list.parent::<JsExportNamedClause>() {
+                    let new_export = export.clone().with_type_token(type_token);
+                    mutation.replace_node(export, new_export);
+                    return Some(JsRuleAction {
+                        category: ActionCategory::QuickFix,
+                        applicability: Applicability::Always,
+                        message: markup! { "Use "<Emphasis>"export type"</Emphasis>"." }.to_owned(),
+                        mutation,
+                    });
+                }
+            }
+        }
+        mutation.replace_node_discard_trivia(
+            specifier.clone(),
+            specifier.clone().with_type_token(type_token),
+        );
+        Some(JsRuleAction {
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::Always,
+            message: markup! { "Use an inline type export." }.to_owned(),
+            mutation,
+        })
+    }
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/useExportType/invalid.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExportType/invalid.ts
@@ -1,0 +1,18 @@
+import { type T1, V1 } from "./mod.ts";
+export { T1, V1 };
+
+import type { T2, T3 } from "./mod.ts";
+export { T2, T3 };
+
+import type T4 from "./mod.ts";
+export { T4 };
+
+import type * as ns from "./mod.ts";
+export { ns };
+
+interface Interface {}
+type TypeAlias = {}
+enum Enum {}
+function func() {}
+class Class {}
+export { Interface, TypeAlias, Enum, func as f, Class };

--- a/crates/rome_js_analyze/tests/specs/nursery/useExportType/invalid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExportType/invalid.ts.snap
@@ -1,0 +1,215 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```js
+import { type T1, V1 } from "./mod.ts";
+export { T1, V1 };
+
+import type { T2, T3 } from "./mod.ts";
+export { T2, T3 };
+
+import type T4 from "./mod.ts";
+export { T4 };
+
+import type * as ns from "./mod.ts";
+export { ns };
+
+interface Interface {}
+type TypeAlias = {}
+enum Enum {}
+function func() {}
+class Class {}
+export { Interface, TypeAlias, Enum, func as f, Class };
+
+```
+
+# Diagnostics
+```
+invalid.ts:2:10 lint/nursery/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This export is only a type and should thus use export type.
+  
+    1 │ import { type T1, V1 } from "./mod.ts";
+  > 2 │ export { T1, V1 };
+      │          ^^
+    3 │ 
+    4 │ import type { T2, T3 } from "./mod.ts";
+  
+  i The type is defined here.
+  
+  > 1 │ import { type T1, V1 } from "./mod.ts";
+      │               ^^
+    2 │ export { T1, V1 };
+    3 │ 
+  
+  i Safe fix: Use an inline type export.
+  
+    2 │ export·{·type·T1,·V1·};
+      │          +++++         
+
+```
+
+```
+invalid.ts:5:10 lint/nursery/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This export is only a type and should thus use export type.
+  
+    4 │ import type { T2, T3 } from "./mod.ts";
+  > 5 │ export { T2, T3 };
+      │          ^^
+    6 │ 
+    7 │ import type T4 from "./mod.ts";
+  
+  i The type is defined here.
+  
+    2 │ export { T1, V1 };
+    3 │ 
+  > 4 │ import type { T2, T3 } from "./mod.ts";
+      │               ^^
+    5 │ export { T2, T3 };
+    6 │ 
+  
+  i Safe fix: Use an inline type export.
+  
+    5 │ export·{·type·T2,·T3·};
+      │          +++++         
+
+```
+
+```
+invalid.ts:5:14 lint/nursery/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This export is only a type and should thus use export type.
+  
+    4 │ import type { T2, T3 } from "./mod.ts";
+  > 5 │ export { T2, T3 };
+      │              ^^
+    6 │ 
+    7 │ import type T4 from "./mod.ts";
+  
+  i The type is defined here.
+  
+    2 │ export { T1, V1 };
+    3 │ 
+  > 4 │ import type { T2, T3 } from "./mod.ts";
+      │                   ^^
+    5 │ export { T2, T3 };
+    6 │ 
+  
+  i Safe fix: Use an inline type export.
+  
+    5 │ export·{·T2,·type·T3·};
+      │              +++++     
+
+```
+
+```
+invalid.ts:8:10 lint/nursery/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This export is only a type and should thus use export type.
+  
+     7 │ import type T4 from "./mod.ts";
+   > 8 │ export { T4 };
+       │          ^^
+     9 │ 
+    10 │ import type * as ns from "./mod.ts";
+  
+  i The type is defined here.
+  
+    5 │ export { T2, T3 };
+    6 │ 
+  > 7 │ import type T4 from "./mod.ts";
+      │             ^^
+    8 │ export { T4 };
+    9 │ 
+  
+  i Safe fix: Use export type.
+  
+    8 │ export·type·{·T4·};
+      │        +++++       
+
+```
+
+```
+invalid.ts:11:10 lint/nursery/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This export is only a type and should thus use export type.
+  
+    10 │ import type * as ns from "./mod.ts";
+  > 11 │ export { ns };
+       │          ^^
+    12 │ 
+    13 │ interface Interface {}
+  
+  i The type is defined here.
+  
+     8 │ export { T4 };
+     9 │ 
+  > 10 │ import type * as ns from "./mod.ts";
+       │                  ^^
+    11 │ export { ns };
+    12 │ 
+  
+  i Safe fix: Use export type.
+  
+    11 │ export·type·{·ns·};
+       │        +++++       
+
+```
+
+```
+invalid.ts:18:10 lint/nursery/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This export is only a type and should thus use export type.
+  
+    16 │ function func() {}
+    17 │ class Class {}
+  > 18 │ export { Interface, TypeAlias, Enum, func as f, Class };
+       │          ^^^^^^^^^
+    19 │ 
+  
+  i The type is defined here.
+  
+    11 │ export { ns };
+    12 │ 
+  > 13 │ interface Interface {}
+       │           ^^^^^^^^^
+    14 │ type TypeAlias = {}
+    15 │ enum Enum {}
+  
+  i Safe fix: Use an inline type export.
+  
+    18 │ export·{·type·Interface,·TypeAlias,·Enum,·func·as·f,·Class·};
+       │          +++++                                               
+
+```
+
+```
+invalid.ts:18:21 lint/nursery/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This export is only a type and should thus use export type.
+  
+    16 │ function func() {}
+    17 │ class Class {}
+  > 18 │ export { Interface, TypeAlias, Enum, func as f, Class };
+       │                     ^^^^^^^^^
+    19 │ 
+  
+  i The type is defined here.
+  
+    13 │ interface Interface {}
+  > 14 │ type TypeAlias = {}
+       │      ^^^^^^^^^
+    15 │ enum Enum {}
+    16 │ function func() {}
+  
+  i Safe fix: Use an inline type export.
+  
+    18 │ export·{·Interface,·type·TypeAlias,·Enum,·func·as·f,·Class·};
+       │                     +++++                                    
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/useExportType/valid.ts
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExportType/valid.ts
@@ -1,0 +1,41 @@
+export { Foo } from 'foo';
+
+export type { Type1 } from './consistent-type-exports';
+
+export { value1 } from './consistent-type-exports';
+
+export type { value1 } from './consistent-type-exports';
+
+const variable = 1;
+class Class {}
+enum Enum {}
+function func() {}
+namespace ns {
+  export const x = 1;
+}
+export { variable, Class, Enum, func, ns };
+
+type Alias = 1;
+interface IFace {}
+export type { Alias, IFace };
+
+const foo = 1;
+export type { foo };
+
+namespace NonTypeNS {
+  export const x = 1;
+}
+export { NonTypeNS };
+
+function f2() {}
+class Class2 {}
+namespace typeNs {
+    export type x = 1;
+}
+export type { f2, Class2, typeNs };
+
+// we ignore ambient types that are values in non-ambient contexts
+declare class AmbientClass {}
+declare enum AmbientEnum {}
+declare class AmbientFunction {}
+export { AmbientClass, AmbientEnum, AmbientFunction }

--- a/crates/rome_js_analyze/tests/specs/nursery/useExportType/valid.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/useExportType/valid.ts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```js
+export { Foo } from 'foo';
+
+export type { Type1 } from './consistent-type-exports';
+
+export { value1 } from './consistent-type-exports';
+
+export type { value1 } from './consistent-type-exports';
+
+const variable = 1;
+class Class {}
+enum Enum {}
+function func() {}
+namespace ns {
+  export const x = 1;
+}
+export { variable, Class, Enum, func, ns };
+
+type Alias = 1;
+interface IFace {}
+export type { Alias, IFace };
+
+const foo = 1;
+export type { foo };
+
+namespace NonTypeNS {
+  export const x = 1;
+}
+export { NonTypeNS };
+
+function f2() {}
+class Class2 {}
+namespace typeNs {
+    export type x = 1;
+}
+export type { f2, Class2, typeNs };
+
+// we ignore ambient types that are values in non-ambient contexts
+declare class AmbientClass {}
+declare enum AmbientEnum {}
+declare class AmbientFunction {}
+export { AmbientClass, AmbientEnum, AmbientFunction }
+
+```
+
+

--- a/crates/rome_js_syntax/src/export_ext.rs
+++ b/crates/rome_js_syntax/src/export_ext.rs
@@ -1,0 +1,90 @@
+use rome_rowan::{AstNode, SyntaxResult};
+
+use crate::{
+    AnyJsExportNamedSpecifier, JsExportNamedClause, JsExportNamedSpecifierList,
+    JsReferenceIdentifier, JsSyntaxToken,
+};
+
+impl AnyJsExportNamedSpecifier {
+    pub fn type_token(&self) -> Option<JsSyntaxToken> {
+        match self {
+            AnyJsExportNamedSpecifier::JsExportNamedShorthandSpecifier(specifier) => {
+                specifier.type_token()
+            }
+            AnyJsExportNamedSpecifier::JsExportNamedSpecifier(specifier) => specifier.type_token(),
+        }
+    }
+
+    /// Returns the local name of the export.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rome_js_syntax::{AnyJsExportNamedSpecifier, T};
+    /// use rome_js_factory::make;
+    ///
+    /// let specifier = make::js_export_named_shorthand_specifier(
+    ///     make::js_reference_identifier(make::ident("a"))
+    /// ).with_type_token(make::token(T![type])).build();
+    /// let export = AnyJsExportNamedSpecifier::from(specifier.clone());
+    ///
+    /// assert_eq!(export.local_name(), specifier.name());
+    ///
+    /// let specifier = make::js_export_named_specifier(
+    ///     make::js_reference_identifier(make::ident("a")),
+    ///     make::token(T![as]),
+    ///     make::js_literal_export_name(make::ident("b")),
+    /// ).build();
+    /// let export = AnyJsExportNamedSpecifier::from(specifier.clone());
+    ///
+    /// assert_eq!(export.local_name(), specifier.local_name());
+    /// ```
+    pub fn local_name(&self) -> SyntaxResult<JsReferenceIdentifier> {
+        match self {
+            AnyJsExportNamedSpecifier::JsExportNamedShorthandSpecifier(specifier) => {
+                specifier.name()
+            }
+            AnyJsExportNamedSpecifier::JsExportNamedSpecifier(specifier) => specifier.local_name(),
+        }
+    }
+
+    /// Returns `true` if this export is an inline type export or an export part of an `export type`.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rome_js_syntax::{AnyJsExportNamedSpecifier, T};
+    /// use rome_js_factory::make;
+    ///
+    /// let specifier = make::js_export_named_shorthand_specifier(
+    ///     make::js_reference_identifier(make::ident("a"))
+    /// ).with_type_token(make::token(T![type])).build();
+    /// let export = AnyJsExportNamedSpecifier::from(specifier);
+    ///
+    /// assert!(export.is_type_only());
+    /// ```
+    pub fn is_type_only(&self) -> bool {
+        if self.type_token().is_some() {
+            return true;
+        }
+        if let Some(export) = self.parent::<JsExportNamedSpecifierList>() {
+            if let Some(export) = export.parent::<JsExportNamedClause>() {
+                if export.type_token().is_some() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn with_type_token(self, type_token: Option<JsSyntaxToken>) -> Self {
+        match self {
+            AnyJsExportNamedSpecifier::JsExportNamedShorthandSpecifier(specifier) => {
+                specifier.with_type_token(type_token).into()
+            }
+            AnyJsExportNamedSpecifier::JsExportNamedSpecifier(specifier) => {
+                specifier.with_type_token(type_token).into()
+            }
+        }
+    }
+}

--- a/crates/rome_js_syntax/src/lib.rs
+++ b/crates/rome_js_syntax/src/lib.rs
@@ -6,6 +6,7 @@
 mod generated;
 pub mod binding_ext;
 pub mod directive_ext;
+pub mod export_ext;
 pub mod expr_ext;
 pub mod file_source;
 pub mod function_ext;

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -1951,6 +1951,10 @@ pub struct Nursery {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_exhaustive_dependencies: Option<RuleConfiguration>,
+    #[doc = "Promotes the use of export type for type-only types."]
+    #[bpaf(long("use-export-type"), argument("on|off|warn"), optional, hide)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_export_type: Option<RuleConfiguration>,
     #[doc = "Enforce the use of import type when an import only has specifiers with type qualifier."]
     #[bpaf(
         long("use-grouped-type-import"),
@@ -2014,7 +2018,7 @@ pub struct Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 36] = [
+    pub(crate) const GROUP_RULES: [&'static str; 37] = [
         "noAccumulatingSpread",
         "noAriaUnsupportedElements",
         "noBannedTypes",
@@ -2041,6 +2045,7 @@ impl Nursery {
         "useArrowFunction",
         "useCamelCase",
         "useExhaustiveDependencies",
+        "useExportType",
         "useGroupedTypeImport",
         "useHeadingContent",
         "useHookAtTopLevel",
@@ -2052,7 +2057,7 @@ impl Nursery {
         "useNamingConvention",
         "useSimpleNumberKeys",
     ];
-    const RECOMMENDED_RULES: [&'static str; 21] = [
+    const RECOMMENDED_RULES: [&'static str; 22] = [
         "noAriaUnsupportedElements",
         "noBannedTypes",
         "noConstantCondition",
@@ -2069,13 +2074,14 @@ impl Nursery {
         "noUselessEmptyExport",
         "useArrowFunction",
         "useExhaustiveDependencies",
+        "useExportType",
         "useGroupedTypeImport",
         "useIsArray",
         "useIsNan",
         "useLiteralEnumMembers",
         "useLiteralKeys",
     ];
-    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 21] = [
+    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 22] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
@@ -2093,12 +2099,13 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 36] = [
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 37] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -2135,6 +2142,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
@@ -2275,54 +2283,59 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_export_type.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.use_heading_content.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_heading_content.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.use_is_array.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.use_is_nan.as_ref() {
+        if let Some(rule) = self.use_is_array.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.use_literal_enum_members.as_ref() {
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.use_literal_keys.as_ref() {
+        if let Some(rule) = self.use_literal_enum_members.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_literal_keys.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
+            }
+        }
+        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
         index_set
@@ -2459,54 +2472,59 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_export_type.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.use_heading_content.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_heading_content.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.use_is_array.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.use_is_nan.as_ref() {
+        if let Some(rule) = self.use_is_array.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.use_literal_enum_members.as_ref() {
+        if let Some(rule) = self.use_is_nan.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.use_literal_keys.as_ref() {
+        if let Some(rule) = self.use_literal_enum_members.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_literal_keys.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
+            }
+        }
+        if let Some(rule) = self.use_simple_number_keys.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
         index_set
@@ -2517,10 +2535,10 @@ impl Nursery {
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
     }
-    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 21] {
+    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 22] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 36] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 37] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2567,6 +2585,7 @@ impl Nursery {
             "useArrowFunction" => self.use_arrow_function.as_ref(),
             "useCamelCase" => self.use_camel_case.as_ref(),
             "useExhaustiveDependencies" => self.use_exhaustive_dependencies.as_ref(),
+            "useExportType" => self.use_export_type.as_ref(),
             "useGroupedTypeImport" => self.use_grouped_type_import.as_ref(),
             "useHeadingContent" => self.use_heading_content.as_ref(),
             "useHookAtTopLevel" => self.use_hook_at_top_level.as_ref(),

--- a/crates/rome_service/src/configuration/parse/json/rules.rs
+++ b/crates/rome_service/src/configuration/parse/json/rules.rs
@@ -1670,6 +1670,7 @@ impl VisitNode<JsonLanguage> for Nursery {
                 "useArrowFunction",
                 "useCamelCase",
                 "useExhaustiveDependencies",
+                "useExportType",
                 "useGroupedTypeImport",
                 "useHeadingContent",
                 "useHookAtTopLevel",
@@ -2289,6 +2290,29 @@ impl VisitNode<JsonLanguage> for Nursery {
                         diagnostics,
                     )?;
                     self.use_exhaustive_dependencies = Some(rule_configuration);
+                }
+                _ => {
+                    diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
+                        "object or string",
+                        value.range(),
+                    ));
+                }
+            },
+            "useExportType" => match value {
+                AnyJsonValue::JsonStringValue(_) => {
+                    let mut configuration = RuleConfiguration::default();
+                    self.map_to_known_string(&value, name_text, &mut configuration, diagnostics)?;
+                    self.use_export_type = Some(configuration);
+                }
+                AnyJsonValue::JsonObjectValue(_) => {
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "useExportType",
+                        diagnostics,
+                    )?;
+                    self.use_export_type = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -974,6 +974,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useExportType": {
+					"description": "Promotes the use of export type for type-only types.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useGroupedTypeImport": {
 					"description": "Enforce the use of import type when an import only has specifiers with type qualifier.",
 					"anyOf": [

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -632,6 +632,10 @@ export interface Nursery {
 	 */
 	useExhaustiveDependencies?: RuleConfiguration;
 	/**
+	 * Promotes the use of export type for type-only types.
+	 */
+	useExportType?: RuleConfiguration;
+	/**
 	 * Enforce the use of import type when an import only has specifiers with type qualifier.
 	 */
 	useGroupedTypeImport?: RuleConfiguration;
@@ -1203,6 +1207,7 @@ export type Category =
 	| "lint/nursery/useArrowFunction"
 	| "lint/nursery/useCamelCase"
 	| "lint/nursery/useExhaustiveDependencies"
+	| "lint/nursery/useExportType"
 	| "lint/nursery/useGroupedTypeImport"
 	| "lint/nursery/useHeadingContent"
 	| "lint/nursery/useHookAtTopLevel"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -974,6 +974,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useExportType": {
+					"description": "Promotes the use of export type for type-only types.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useGroupedTypeImport": {
 					"description": "Enforce the use of import type when an import only has specifiers with type qualifier.",
 					"anyOf": [

--- a/website/src/components/generated/NumberOfRules.astro
+++ b/website/src/components/generated/NumberOfRules.astro
@@ -1,2 +1,2 @@
 <!-- this file is auto generated, use `cargo lintdoc` to update it -->
- <p>Rome's linter has a total of <strong><a href='/lint/rules'>155 rules</a></strong><p>
+ <p>Rome's linter has a total of <strong><a href='/lint/rules'>156 rules</a></strong><p>

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -1053,6 +1053,12 @@ Enforce camel case naming convention.
 Enforce all dependencies are correctly specified.
 </section>
 <section class="rule">
+<h3 data-toc-exclude id="useExportType">
+	<a href="/lint/rules/useExportType">useExportType</a>
+</h3>
+Promotes the use of <code>export type</code> for type-only types.
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="useGroupedTypeImport">
 	<a href="/lint/rules/useGroupedTypeImport">useGroupedTypeImport</a>
 </h3>

--- a/website/src/pages/lint/rules/useExportType.md
+++ b/website/src/pages/lint/rules/useExportType.md
@@ -1,0 +1,117 @@
+---
+title: Lint Rule useExportType
+parent: lint/rules/index
+---
+
+# useExportType (since vnext)
+
+Promotes the use of `export type` for type-only types.
+
+_TypeScript_ allows specifying a `type` keyword on an `export` to indicate that
+the `export` doesn't exist at runtime.
+This will enable transpilers to safely drop exports of types without looking for its definition.
+
+## Examples
+
+### Invalid
+
+```ts
+interface I {}
+export { I };
+```
+
+<pre class="language-text"><code class="language-text">nursery/useExportType.js:2:10 <a href="https://docs.rome.tools/lint/rules/useExportType">lint/nursery/useExportType</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This export is only a type and should thus use </span><span style="color: Tomato;"><strong>export type</strong></span><span style="color: Tomato;">.</span>
+  
+    <strong>1 │ </strong>interface I {}
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>export { I };
+   <strong>   │ </strong>         <strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The type is defined here.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>interface I {}
+   <strong>   │ </strong>          <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>export { I };
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>export type</strong></span><span style="color: rgb(38, 148, 255);">.</span>
+  
+<strong>  </strong><strong>  2 │ </strong>export<span style="opacity: 0.8;">·</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;">y</span><span style="color: MediumSeaGreen;">p</span><span style="color: MediumSeaGreen;">e</span><span style="opacity: 0.8;"><span style="color: MediumSeaGreen;">·</span></span>{<span style="opacity: 0.8;">·</span>I<span style="opacity: 0.8;">·</span>};
+<strong>  </strong><strong>    │ </strong>       <span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span>      
+</code></pre>
+
+```ts
+type T = number;
+export { T };
+```
+
+<pre class="language-text"><code class="language-text">nursery/useExportType.js:2:10 <a href="https://docs.rome.tools/lint/rules/useExportType">lint/nursery/useExportType</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This export is only a type and should thus use </span><span style="color: Tomato;"><strong>export type</strong></span><span style="color: Tomato;">.</span>
+  
+    <strong>1 │ </strong>type T = number;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>export { T };
+   <strong>   │ </strong>         <strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The type is defined here.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>type T = number;
+   <strong>   │ </strong>     <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>export { T };
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>export type</strong></span><span style="color: rgb(38, 148, 255);">.</span>
+  
+<strong>  </strong><strong>  2 │ </strong>export<span style="opacity: 0.8;">·</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;">y</span><span style="color: MediumSeaGreen;">p</span><span style="color: MediumSeaGreen;">e</span><span style="opacity: 0.8;"><span style="color: MediumSeaGreen;">·</span></span>{<span style="opacity: 0.8;">·</span>T<span style="opacity: 0.8;">·</span>};
+<strong>  </strong><strong>    │ </strong>       <span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span>      
+</code></pre>
+
+```ts
+import type { T } from "./mod.js";
+export { T };
+```
+
+<pre class="language-text"><code class="language-text">nursery/useExportType.js:2:10 <a href="https://docs.rome.tools/lint/rules/useExportType">lint/nursery/useExportType</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This export is only a type and should thus use </span><span style="color: Tomato;"><strong>export type</strong></span><span style="color: Tomato;">.</span>
+  
+    <strong>1 │ </strong>import type { T } from &quot;./mod.js&quot;;
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>2 │ </strong>export { T };
+   <strong>   │ </strong>         <strong><span style="color: Tomato;">^</span></strong>
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">The type is defined here.</span>
+  
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>1 │ </strong>import type { T } from &quot;./mod.js&quot;;
+   <strong>   │ </strong>              <strong><span style="color: Tomato;">^</span></strong>
+    <strong>2 │ </strong>export { T };
+    <strong>3 │ </strong>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>export type</strong></span><span style="color: rgb(38, 148, 255);">.</span>
+  
+<strong>  </strong><strong>  2 │ </strong>export<span style="opacity: 0.8;">·</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;">y</span><span style="color: MediumSeaGreen;">p</span><span style="color: MediumSeaGreen;">e</span><span style="opacity: 0.8;"><span style="color: MediumSeaGreen;">·</span></span>{<span style="opacity: 0.8;">·</span>T<span style="opacity: 0.8;">·</span>};
+<strong>  </strong><strong>    │ </strong>       <span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span><span style="color: MediumSeaGreen;">+</span>      
+</code></pre>
+
+## Valid
+
+```jsx
+class C {}
+function f() {}
+export { C, f };
+```
+
+This rules applies only to identifiers locally defined.
+It doesn't warn against a type exported as a value in re-export clause such as:
+
+```ts
+export { TypeA } from "./mod.ts"
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)

--- a/xtask/codegen/src/generate_new_lintrule.rs
+++ b/xtask/codegen/src/generate_new_lintrule.rs
@@ -68,7 +68,6 @@ impl Rule for {rule_name_upper_camel} {{
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {{
         let binding = ctx.query();
         let model = ctx.model();
-
         binding.all_references(model).collect()
     }}
 
@@ -76,7 +75,7 @@ impl Rule for {rule_name_upper_camel} {{
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
-                reference.syntax().text_trimmed_range(),
+                reference.range(),
                 markup! {{
                     "Variable is read here."
                 }},


### PR DESCRIPTION
## Summary

This rule implements some part of [consistent-type-exports](https://typescript-eslint.io/rules/consistent-type-exports/).
In contrast to the ESLint rule:

- we use `export { type }` by default. ESLint provides an option for this and split an export between a value export and a `export type`.

  For example, given the following code:

  ```ts
  interface I {}
  class C {}
  export { I, C }
  ```

  ESlint proposes the following fix:

  ```ts
  interface I {}
  class C {}
  export { C }
  export type { I }
  ```

  While this rules proposes the following fix:

  ```ts
  interface I {}
  class C {}
  export { type I, C }
  ```

- The ESLint rule seems aware of which re-export name is a type. Rome has no information on re-exported names.

## Test Plan

Tests included.