### PR TITLE
feat(rome_js_analyze): noUselessThisAlias

### DIFF
--- a/crates/rome_diagnostics_categories/src/categories.rs
+++ b/crates/rome_diagnostics_categories/src/categories.rs
@@ -98,6 +98,7 @@ define_categories! {
     "lint/nursery/noStaticOnlyClass": "https://docs.rome.tools/lint/rules/noStaticOnlyClass",
     "lint/nursery/noUnsafeDeclarationMerging": "https://docs.rome.tools/lint/rules/noUnsafeDeclarationMerging",
     "lint/nursery/noUselessEmptyExport": "https://docs.rome.tools/lint/rules/noUselessEmptyExport",
+    "lint/nursery/noUselessThisAlias": "https://docs.rome.tools/lint/rules/noUselessThisAlias",
     "lint/nursery/noVoid": "https://docs.rome.tools/lint/rules/noVoid",
     "lint/nursery/useAriaPropTypes": "https://docs.rome.tools/lint/rules/useAriaPropTypes",
     "lint/nursery/useArrowFunction": "https://docs.rome.tools/lint/rules/useArrowFunction",

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery.rs
@@ -8,6 +8,7 @@ pub(crate) mod no_constant_condition;
 pub(crate) mod no_global_is_finite;
 pub(crate) mod no_global_is_nan;
 pub(crate) mod no_unsafe_declaration_merging;
+pub(crate) mod no_useless_this_alias;
 pub(crate) mod use_exhaustive_dependencies;
 pub(crate) mod use_hook_at_top_level;
 pub(crate) mod use_is_array;
@@ -23,6 +24,7 @@ declare_group! {
             self :: no_global_is_finite :: NoGlobalIsFinite ,
             self :: no_global_is_nan :: NoGlobalIsNan ,
             self :: no_unsafe_declaration_merging :: NoUnsafeDeclarationMerging ,
+            self :: no_useless_this_alias :: NoUselessThisAlias ,
             self :: use_exhaustive_dependencies :: UseExhaustiveDependencies ,
             self :: use_hook_at_top_level :: UseHookAtTopLevel ,
             self :: use_is_array :: UseIsArray ,

--- a/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_useless_this_alias.rs
+++ b/crates/rome_js_analyze/src/semantic_analyzers/nursery/no_useless_this_alias.rs
@@ -1,0 +1,176 @@
+use crate::{control_flow::AnyJsControlFlowRoot, semantic_services::Semantic, JsRuleAction};
+use rome_analyze::{context::RuleContext, declare_rule, ActionCategory, Rule, RuleDiagnostic};
+use rome_console::markup;
+use rome_diagnostics::Applicability;
+use rome_js_factory::make;
+use rome_js_semantic::ReferencesExtensions;
+use rome_js_syntax::{
+    AnyJsBinding, AnyJsBindingPattern, AnyJsExpression, JsArrowFunctionExpression,
+    JsAssignmentExpression, JsExpressionStatement, JsIdentifierBinding, JsIdentifierExpression,
+    JsThisExpression, JsVariableDeclaration, JsVariableDeclarator, T,
+};
+use rome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
+
+declare_rule! {
+    /// Disallow useless `this` aliasing.
+    ///
+    /// Arrow functions inherits `this` from their enclosing scope.
+    /// This makes `this` aliasing useless in this situation.
+    ///
+    /// Credits: https://typescript-eslint.io/rules/no-this-alias/
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// class A {
+    ///     method() {
+    ///         const self = this;
+    ///         return () => {
+    ///             return self;
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ## Valid
+    ///
+    /// ```js
+    /// class A {
+    ///     method() {
+    ///         const self = this;
+    ///         return function() {
+    ///             this.g();
+    ///             return self;
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    pub(crate) NoUselessThisAlias {
+        version: "next",
+        name: "noUselessThisAlias",
+        recommended: true,
+    }
+}
+
+impl Rule for NoUselessThisAlias {
+    type Query = Semantic<JsVariableDeclarator>;
+    type State = JsIdentifierBinding;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let declarator = ctx.query();
+        let model = ctx.model();
+        let mut is_this_alias = false;
+        if let Some(initializer) = declarator.initializer() {
+            let initializer = initializer.expression().ok()?.omit_parentheses();
+            if !JsThisExpression::can_cast(initializer.syntax().kind()) {
+                return None;
+            }
+            is_this_alias = true;
+        };
+        let Ok(AnyJsBindingPattern::AnyJsBinding(AnyJsBinding::JsIdentifierBinding(id))) = declarator.id() else {
+            // Ignore destructuring
+            return None;
+        };
+        let this_scope = declarator
+            .syntax()
+            .ancestors()
+            .find_map(AnyJsControlFlowRoot::cast)?;
+        for write in id.all_writes(model) {
+            let assign = JsAssignmentExpression::cast(write.syntax().parent()?)?;
+            let assign_right = assign.right().ok()?.omit_parentheses();
+            if !JsThisExpression::can_cast(assign_right.syntax().kind()) {
+                return None;
+            }
+            is_this_alias = true;
+        }
+        if !is_this_alias {
+            return None;
+        }
+        for reference in id.all_references(model) {
+            let current_this_scope = reference
+                .syntax()
+                .ancestors()
+                .filter(|x| !JsArrowFunctionExpression::can_cast(x.kind()))
+                .find_map(AnyJsControlFlowRoot::cast)?;
+            if this_scope != current_this_scope {
+                // The aliasing is required because they have not the same `this` scope.
+                return None;
+            }
+        }
+        Some(id)
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
+        let declarator = ctx.query();
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                declarator.range(),
+                markup! {
+                    "This aliasing of "<Emphasis>"this"</Emphasis>" is unnecessary."
+                },
+            )
+            .note(markup! {
+                "This note will give you more information."
+            }),
+        )
+    }
+
+    fn action(ctx: &RuleContext<Self>, id: &Self::State) -> Option<JsRuleAction> {
+        let declarator = ctx.query();
+        let model = ctx.model();
+        let Some(var_decl) = declarator.syntax().ancestors().find_map(JsVariableDeclaration::cast) else {
+            return None;
+        };
+        let mut mutation = ctx.root().begin();
+        let this_expr = AnyJsExpression::from(make::js_this_expression(make::token(T![this])));
+        for read in id.all_reads(model) {
+            let syntax = read.syntax();
+            let syntax = syntax.parent()?;
+            let Some(expr) = JsIdentifierExpression::cast(syntax) else {
+                return None;
+            };
+            mutation.replace_node(expr.into(), this_expr.clone());
+        }
+        for write in id.all_writes(model) {
+            let syntax = write.syntax();
+            let syntax = syntax.parent()?;
+            let Some(statement) = JsExpressionStatement::cast(syntax.parent()?) else {
+                return None;
+            };
+            mutation.remove_node(statement);
+        }
+        let var_declarator_list = var_decl.declarators();
+        if var_declarator_list.len() == 1 {
+            mutation.remove_node(var_decl);
+        } else {
+            let mut deleted_comma = None;
+            for (current_declarator, current_comma) in var_declarator_list
+                .iter()
+                .zip(var_declarator_list.separators())
+            {
+                deleted_comma = current_comma.ok();
+                let current_declarator = current_declarator.ok()?;
+                if &current_declarator == declarator {
+                    break;
+                }
+            }
+            mutation.remove_node(declarator.clone());
+            mutation.remove_token(deleted_comma?);
+        }
+        Some(JsRuleAction {
+            category: ActionCategory::QuickFix,
+            applicability: Applicability::Always,
+            message: markup! {
+                "Use "<Emphasis>"this"</Emphasis>" instead of an alias."
+            }
+            .to_owned(),
+            mutation,
+        })
+    }
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessThisAlias/invalid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessThisAlias/invalid.js
@@ -1,0 +1,25 @@
+const self = this, v = 0, /*u*/ u = 2, self2 = this;
+
+function f() {
+    // assignment comment
+    const self = this;
+    return () => {
+        /*a*/self/*b*/.g();
+    }
+}
+
+function f() {
+    let self = this;
+    return () => {
+        self.g();
+    }
+}
+
+function f() {
+    var self;
+    self = this;
+    self = this;
+    return () => {
+        self.g();
+    }
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessThisAlias/invalid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessThisAlias/invalid.js.snap
@@ -1,0 +1,166 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```js
+const self = this, v = 0, /*u*/ u = 2, self2 = this;
+
+function f() {
+    // assignment comment
+    const self = this;
+    return () => {
+        /*a*/self/*b*/.g();
+    }
+}
+
+function f() {
+    let self = this;
+    return () => {
+        self.g();
+    }
+}
+
+function f() {
+    var self;
+    self = this;
+    self = this;
+    return () => {
+        self.g();
+    }
+}
+
+```
+
+# Diagnostics
+```
+invalid.js:1:7 lint/nursery/noUselessThisAlias  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This aliasing of this is unnecessary.
+  
+  > 1 │ const self = this, v = 0, /*u*/ u = 2, self2 = this;
+      │       ^^^^^^^^^^^
+    2 │ 
+    3 │ function f() {
+  
+  i This note will give you more information.
+  
+  i Safe fix: Use this instead of an alias.
+  
+    1 │ const·self·=·this,·v·=·0,·/*u*/·u·=·2,·self2·=·this;
+      │       -------------                                 
+
+```
+
+```
+invalid.js:1:40 lint/nursery/noUselessThisAlias  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This aliasing of this is unnecessary.
+  
+  > 1 │ const self = this, v = 0, /*u*/ u = 2, self2 = this;
+      │                                        ^^^^^^^^^^^^
+    2 │ 
+    3 │ function f() {
+  
+  i This note will give you more information.
+  
+  i Safe fix: Use this instead of an alias.
+  
+    1 │ const·self·=·this,·v·=·0,·/*u*/·u·=·2,·self2·=·this;
+      │                                      -------------- 
+
+```
+
+```
+invalid.js:5:11 lint/nursery/noUselessThisAlias  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This aliasing of this is unnecessary.
+  
+    3 │ function f() {
+    4 │     // assignment comment
+  > 5 │     const self = this;
+      │           ^^^^^^^^^^^
+    6 │     return () => {
+    7 │         /*a*/self/*b*/.g();
+  
+  i This note will give you more information.
+  
+  i Safe fix: Use this instead of an alias.
+  
+     1  1 │   const self = this, v = 0, /*u*/ u = 2, self2 = this;
+     2  2 │   
+     3    │ - function·f()·{
+     4    │ - ····//·assignment·comment
+     5    │ - ····const·self·=·this;
+        3 │ + function·f()·{;
+     6  4 │       return () => {
+     7    │ - ········/*a*/self/*b*/.g();
+        5 │ + ········/*a*/this/*b*/.g();
+     8  6 │       }
+     9  7 │   }
+  
+
+```
+
+```
+invalid.js:12:9 lint/nursery/noUselessThisAlias  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This aliasing of this is unnecessary.
+  
+    11 │ function f() {
+  > 12 │     let self = this;
+       │         ^^^^^^^^^^^
+    13 │     return () => {
+    14 │         self.g();
+  
+  i This note will give you more information.
+  
+  i Safe fix: Use this instead of an alias.
+  
+     9  9 │   }
+    10 10 │   
+    11    │ - function·f()·{
+    12    │ - ····let·self·=·this;
+       11 │ + function·f()·{;
+    13 12 │       return () => {
+    14    │ - ········self.g();
+       13 │ + ········this.g();
+    15 14 │       }
+    16 15 │   }
+  
+
+```
+
+```
+invalid.js:19:9 lint/nursery/noUselessThisAlias  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This aliasing of this is unnecessary.
+  
+    18 │ function f() {
+  > 19 │     var self;
+       │         ^^^^
+    20 │     self = this;
+    21 │     self = this;
+  
+  i This note will give you more information.
+  
+  i Safe fix: Use this instead of an alias.
+  
+    16 16 │   }
+    17 17 │   
+    18    │ - function·f()·{
+    19    │ - ····var·self;
+    20    │ - ····self·=·this;
+    21    │ - ····self·=·this;
+    22    │ - ····return·()·=>·{
+    23    │ - ········self.g();
+       18 │ + function·f()·{;
+       19 │ + ····return·()·=>·{
+       20 │ + ········this.g();
+    24 21 │       }
+    25 22 │   }
+  
+
+```
+
+

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessThisAlias/valid.js
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessThisAlias/valid.js
@@ -1,0 +1,54 @@
+const { a, b } = this;
+const [c, d] = this;
+const property = this.property;
+const firstItem = this[0];
+const object = { property: this };
+foo.bar = this;
+
+function f() {
+    const self = this;
+    return function distinctThisScope() {
+      self.g();
+    }
+}
+
+function f() {
+    const self = this;
+    function f() {
+        self.g();
+    }
+    return () => {
+        self.g();
+    }
+}
+
+function f() {
+    let self = this;
+    self = {}
+    return () => {
+        self.g();
+    }
+}
+
+function f() {
+    let self;
+    return () => {
+        self.g();
+    }
+}
+
+class Class {
+    a = this;
+    #priv = this;
+
+    constructor() {
+      this.b = this;
+      this.c = [this];
+    }
+
+    act(self = this) {
+        self.f()
+    }
+
+    f() {}
+}

--- a/crates/rome_js_analyze/tests/specs/nursery/noUselessThisAlias/valid.js.snap
+++ b/crates/rome_js_analyze/tests/specs/nursery/noUselessThisAlias/valid.js.snap
@@ -1,0 +1,64 @@
+---
+source: crates/rome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```js
+const { a, b } = this;
+const [c, d] = this;
+const property = this.property;
+const firstItem = this[0];
+const object = { property: this };
+foo.bar = this;
+
+function f() {
+    const self = this;
+    return function distinctThisScope() {
+      self.g();
+    }
+}
+
+function f() {
+    const self = this;
+    function f() {
+        self.g();
+    }
+    return () => {
+        self.g();
+    }
+}
+
+function f() {
+    let self = this;
+    self = {}
+    return () => {
+        self.g();
+    }
+}
+
+function f() {
+    let self;
+    return () => {
+        self.g();
+    }
+}
+
+class Class {
+    a = this;
+    #priv = this;
+
+    constructor() {
+      this.b = this;
+      this.c = [this];
+    }
+
+    act(self = this) {
+        self.f()
+    }
+
+    f() {}
+}
+
+```
+
+

--- a/crates/rome_service/src/configuration/linter/rules.rs
+++ b/crates/rome_service/src/configuration/linter/rules.rs
@@ -2005,6 +2005,10 @@ pub struct Nursery {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_useless_empty_export: Option<RuleConfiguration>,
+    #[doc = "Disallow useless this aliasing."]
+    #[bpaf(long("no-useless-this-alias"), argument("on|off|warn"), optional, hide)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_useless_this_alias: Option<RuleConfiguration>,
     #[doc = "Disallow the use of void operators, which is not a familiar operator."]
     #[bpaf(long("no-void"), argument("on|off|warn"), optional, hide)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2068,7 +2072,7 @@ pub struct Nursery {
 }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
-    pub(crate) const GROUP_RULES: [&'static str; 28] = [
+    pub(crate) const GROUP_RULES: [&'static str; 29] = [
         "noAccumulatingSpread",
         "noAriaUnsupportedElements",
         "noBannedTypes",
@@ -2087,6 +2091,7 @@ impl Nursery {
         "noStaticOnlyClass",
         "noUnsafeDeclarationMerging",
         "noUselessEmptyExport",
+        "noUselessThisAlias",
         "noVoid",
         "useAriaPropTypes",
         "useArrowFunction",
@@ -2098,7 +2103,7 @@ impl Nursery {
         "useLiteralEnumMembers",
         "useNamingConvention",
     ];
-    const RECOMMENDED_RULES: [&'static str; 18] = [
+    const RECOMMENDED_RULES: [&'static str; 19] = [
         "noAriaUnsupportedElements",
         "noBannedTypes",
         "noConstantCondition",
@@ -2112,13 +2117,14 @@ impl Nursery {
         "noStaticOnlyClass",
         "noUnsafeDeclarationMerging",
         "noUselessEmptyExport",
+        "noUselessThisAlias",
         "useArrowFunction",
         "useExhaustiveDependencies",
         "useGroupedTypeImport",
         "useIsArray",
         "useLiteralEnumMembers",
     ];
-    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 18] = [
+    const RECOMMENDED_RULES_AS_FILTERS: [RuleFilter<'static>; 19] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
@@ -2132,13 +2138,14 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
     ];
-    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 28] = [
+    const ALL_RULES_AS_FILTERS: [RuleFilter<'static>; 29] = [
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -2167,6 +2174,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended(&self) -> bool { matches!(self.recommended, Some(true)) }
@@ -2267,54 +2275,59 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_void.as_ref() {
+        if let Some(rule) = self.no_useless_this_alias.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+        if let Some(rule) = self.no_void.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_arrow_function.as_ref() {
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+        if let Some(rule) = self.use_arrow_function.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.use_is_array.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.use_literal_enum_members.as_ref() {
+        if let Some(rule) = self.use_is_array.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_literal_enum_members.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
+            }
+        }
+        if let Some(rule) = self.use_naming_convention.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
         index_set
@@ -2411,54 +2424,59 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_void.as_ref() {
+        if let Some(rule) = self.no_useless_this_alias.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.use_aria_prop_types.as_ref() {
+        if let Some(rule) = self.no_void.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.use_arrow_function.as_ref() {
+        if let Some(rule) = self.use_aria_prop_types.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
+        if let Some(rule) = self.use_arrow_function.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.use_grouped_type_import.as_ref() {
+        if let Some(rule) = self.use_exhaustive_dependencies.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
+        if let Some(rule) = self.use_grouped_type_import.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_hook_at_top_level.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.use_is_array.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.use_literal_enum_members.as_ref() {
+        if let Some(rule) = self.use_is_array.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_literal_enum_members.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
+            }
+        }
+        if let Some(rule) = self.use_naming_convention.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
         index_set
@@ -2469,10 +2487,10 @@ impl Nursery {
     pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
         Self::RECOMMENDED_RULES.contains(&rule_name)
     }
-    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 18] {
+    pub(crate) fn recommended_rules_as_filters() -> [RuleFilter<'static>; 19] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
-    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 28] { Self::ALL_RULES_AS_FILTERS }
+    pub(crate) fn all_rules_as_filters() -> [RuleFilter<'static>; 29] { Self::ALL_RULES_AS_FILTERS }
     #[doc = r" Select preset rules"]
     pub(crate) fn collect_preset_rules(
         &self,
@@ -2511,6 +2529,7 @@ impl Nursery {
             "noStaticOnlyClass" => self.no_static_only_class.as_ref(),
             "noUnsafeDeclarationMerging" => self.no_unsafe_declaration_merging.as_ref(),
             "noUselessEmptyExport" => self.no_useless_empty_export.as_ref(),
+            "noUselessThisAlias" => self.no_useless_this_alias.as_ref(),
             "noVoid" => self.no_void.as_ref(),
             "useAriaPropTypes" => self.use_aria_prop_types.as_ref(),
             "useArrowFunction" => self.use_arrow_function.as_ref(),

--- a/crates/rome_service/src/configuration/parse/json/rules.rs
+++ b/crates/rome_service/src/configuration/parse/json/rules.rs
@@ -1782,6 +1782,7 @@ impl VisitNode<JsonLanguage> for Nursery {
                 "noStaticOnlyClass",
                 "noUnsafeDeclarationMerging",
                 "noUselessEmptyExport",
+                "noUselessThisAlias",
                 "noVoid",
                 "useAriaPropTypes",
                 "useArrowFunction",
@@ -2217,6 +2218,29 @@ impl VisitNode<JsonLanguage> for Nursery {
                         diagnostics,
                     )?;
                     self.no_useless_empty_export = Some(rule_configuration);
+                }
+                _ => {
+                    diagnostics.push(DeserializationDiagnostic::new_incorrect_type(
+                        "object or string",
+                        value.range(),
+                    ));
+                }
+            },
+            "noUselessThisAlias" => match value {
+                AnyJsonValue::JsonStringValue(_) => {
+                    let mut configuration = RuleConfiguration::default();
+                    self.map_to_known_string(&value, name_text, &mut configuration, diagnostics)?;
+                    self.no_useless_this_alias = Some(configuration);
+                }
+                AnyJsonValue::JsonObjectValue(_) => {
+                    let mut rule_configuration = RuleConfiguration::default();
+                    rule_configuration.map_rule_configuration(
+                        &value,
+                        name_text,
+                        "noUselessThisAlias",
+                        diagnostics,
+                    )?;
+                    self.no_useless_this_alias = Some(rule_configuration);
                 }
                 _ => {
                     diagnostics.push(DeserializationDiagnostic::new_incorrect_type(

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -949,6 +949,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noUselessThisAlias": {
+					"description": "Disallow useless this aliasing.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noVoid": {
 					"description": "Disallow the use of void operators, which is not a familiar operator.",
 					"anyOf": [

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -616,6 +616,10 @@ export interface Nursery {
 	 */
 	noUselessEmptyExport?: RuleConfiguration;
 	/**
+	 * Disallow useless this aliasing.
+	 */
+	noUselessThisAlias?: RuleConfiguration;
+	/**
 	 * Disallow the use of void operators, which is not a familiar operator.
 	 */
 	noVoid?: RuleConfiguration;
@@ -1196,6 +1200,7 @@ export type Category =
 	| "lint/nursery/noStaticOnlyClass"
 	| "lint/nursery/noUnsafeDeclarationMerging"
 	| "lint/nursery/noUselessEmptyExport"
+	| "lint/nursery/noUselessThisAlias"
 	| "lint/nursery/noVoid"
 	| "lint/nursery/useAriaPropTypes"
 	| "lint/nursery/useArrowFunction"

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -949,6 +949,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noUselessThisAlias": {
+					"description": "Disallow useless this aliasing.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noVoid": {
 					"description": "Disallow the use of void operators, which is not a familiar operator.",
 					"anyOf": [

--- a/website/src/components/generated/NumberOfRules.astro
+++ b/website/src/components/generated/NumberOfRules.astro
@@ -1,2 +1,2 @@
 <!-- this file is auto generated, use `cargo lintdoc` to update it -->
- <p>Rome's linter has a total of <strong><a href='/lint/rules'>154 rules</a></strong><p>
+ <p>Rome's linter has a total of <strong><a href='/lint/rules'>155 rules</a></strong><p>

--- a/website/src/pages/lint/rules/index.mdx
+++ b/website/src/pages/lint/rules/index.mdx
@@ -1054,6 +1054,12 @@ Disallow unsafe declaration merging between interfaces and classes.
 Disallow empty exports that don't change anything in a module file.
 </section>
 <section class="rule">
+<h3 data-toc-exclude id="noUselessThisAlias">
+	<a href="/lint/rules/noUselessThisAlias">noUselessThisAlias</a>
+</h3>
+Disallow useless <code>this</code> aliasing.
+</section>
+<section class="rule">
 <h3 data-toc-exclude id="noVoid">
 	<a href="/lint/rules/noVoid">noVoid</a>
 </h3>

--- a/website/src/pages/lint/rules/noUselessThisAlias.md
+++ b/website/src/pages/lint/rules/noUselessThisAlias.md
@@ -1,0 +1,74 @@
+---
+title: Lint Rule noUselessThisAlias
+parent: lint/rules/index
+---
+
+# noUselessThisAlias (since vnext)
+
+Disallow useless `this` aliasing.
+
+Arrow functions inherits `this` from their enclosing scope.
+This makes `this` aliasing useless in this situation.
+
+Credits: https://typescript-eslint.io/rules/no-this-alias/
+
+## Examples
+
+### Invalid
+
+```jsx
+class A {
+    method() {
+        const self = this;
+        return () => {
+            return self;
+        }
+    }
+}
+```
+
+<pre class="language-text"><code class="language-text">nursery/noUselessThisAlias.js:3:15 <a href="https://docs.rome.tools/lint/rules/noUselessThisAlias">lint/nursery/noUselessThisAlias</a> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">✖</span></strong> <span style="color: Tomato;">This aliasing of </span><span style="color: Tomato;"><strong>this</strong></span><span style="color: Tomato;"> is unnecessary.</span>
+  
+    <strong>1 │ </strong>class A {
+    <strong>2 │ </strong>    method() {
+<strong><span style="color: Tomato;">  </span></strong><strong><span style="color: Tomato;">&gt;</span></strong> <strong>3 │ </strong>        const self = this;
+   <strong>   │ </strong>              <strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong><strong><span style="color: Tomato;">^</span></strong>
+    <strong>4 │ </strong>        return () =&gt; {
+    <strong>5 │ </strong>            return self;
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">This note will give you more information.</span>
+  
+<strong><span style="color: rgb(38, 148, 255);">  </span></strong><strong><span style="color: rgb(38, 148, 255);">ℹ</span></strong> <span style="color: rgb(38, 148, 255);">Safe fix</span><span style="color: rgb(38, 148, 255);">: </span><span style="color: rgb(38, 148, 255);">Use </span><span style="color: rgb(38, 148, 255);"><strong>this</strong></span><span style="color: rgb(38, 148, 255);"> instead of an alias.</span>
+  
+    <strong>1</strong> <strong>1</strong><strong> │ </strong>  class A {
+    <strong>2</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">m</span><span style="color: Tomato;">e</span><span style="color: Tomato;">t</span><span style="color: Tomato;">h</span><span style="color: Tomato;">o</span><span style="color: Tomato;">d</span><span style="color: Tomato;">(</span><span style="color: Tomato;">)</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">{</span>
+    <strong>3</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>c</strong></span><span style="color: Tomato;"><strong>o</strong></span><span style="color: Tomato;"><strong>n</strong></span><span style="color: Tomato;"><strong>s</strong></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>s</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>l</strong></span><span style="color: Tomato;"><strong>f</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>=</strong></span><span style="color: Tomato;"><span style="opacity: 0.8;"><strong>·</strong></span></span><span style="color: Tomato;"><strong>t</strong></span><span style="color: Tomato;"><strong>h</strong></span><span style="color: Tomato;"><strong>i</strong></span><span style="color: Tomato;"><strong>s</strong></span><span style="color: Tomato;">;</span>
+      <strong>2</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">m</span><span style="color: MediumSeaGreen;">e</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;">h</span><span style="color: MediumSeaGreen;">o</span><span style="color: MediumSeaGreen;">d</span><span style="color: MediumSeaGreen;">(</span><span style="color: MediumSeaGreen;">)</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">{</span><span style="color: MediumSeaGreen;">;</span>
+    <strong>4</strong> <strong>3</strong><strong> │ </strong>          return () =&gt; {
+    <strong>5</strong>  <strong> │ </strong><span style="color: Tomato;">-</span> <span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;">r</span><span style="color: Tomato;">e</span><span style="color: Tomato;">t</span><span style="color: Tomato;">u</span><span style="color: Tomato;">r</span><span style="color: Tomato;">n</span><span style="color: Tomato;"><span style="opacity: 0.8;">·</span></span><span style="color: Tomato;"><strong>s</strong></span><span style="color: Tomato;"><strong>e</strong></span><span style="color: Tomato;"><strong>l</strong></span><span style="color: Tomato;"><strong>f</strong></span><span style="color: Tomato;">;</span>
+      <strong>4</strong><strong> │ </strong><span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;">r</span><span style="color: MediumSeaGreen;">e</span><span style="color: MediumSeaGreen;">t</span><span style="color: MediumSeaGreen;">u</span><span style="color: MediumSeaGreen;">r</span><span style="color: MediumSeaGreen;">n</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">·</span></span><span style="color: MediumSeaGreen;"><strong>t</strong></span><span style="color: MediumSeaGreen;"><strong>h</strong></span><span style="color: MediumSeaGreen;"><strong>i</strong></span><span style="color: MediumSeaGreen;"><strong>s</strong></span><span style="color: MediumSeaGreen;">;</span>
+    <strong>6</strong> <strong>5</strong><strong> │ </strong>          }
+    <strong>7</strong> <strong>6</strong><strong> │ </strong>      }
+  
+</code></pre>
+
+## Valid
+
+```jsx
+class A {
+    method() {
+        const self = this;
+        return function() {
+            this.g();
+            return self;
+        }
+    }
+}
+```
+
+## Related links
+
+- [Disable a rule](/linter/#disable-a-lint-rule)
+- [Rule options](/linter/#rule-options)


### PR DESCRIPTION
## Summary

This closes #4481 by implementing `noUselessThisAlias`.
As discussed in #4481 we diverge from [eslint](https://typescript-eslint.io/rules/no-this-alias/) and unicorn by allowing `this` aliasing where required.

The rule ignores complex cases such as:

```js
function f() {
    const [self] = [this];
    return () => {
        self.g();
    }
}
```

The rule could be smarter. However, this code is unlikely to exist.

## Test Plan

Tests included.