### PR TITLE
fix(noRedeclare): allow merging namespace + variable

### DIFF
--- a/crates/rome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts
+++ b/crates/rome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts
@@ -81,6 +81,16 @@ declare namespace bodyParser {
 }
 declare const bodyParser: bodyParser.BodyParser
 
+namespace ConcreteNamespaceMergeVar {
+    export interface Foo {
+        foo: string
+    }
+}
+
+export const ConcreteNamespaceMergeVar = { foo: 'bar' }
+ConcreteNamespaceMergeVar.foo = 'baz'
+type Bar = ConcreteNamespaceMergeVar.Foo
+
 // namespace merging
 export namespace X {
 	export function f(): void {}

--- a/crates/rome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts
+++ b/crates/rome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts
@@ -69,6 +69,18 @@ export namespace Orientation {
 	export function f(): void {}
 }
 
+// variable and namespace merging
+declare namespace bodyParser {
+	interface BodyParser {
+		/** @deprecated */
+		(): void
+	}
+	interface Options {
+		inflate?: boolean | undefined
+	}
+}
+declare const bodyParser: bodyParser.BodyParser
+
 // namespace merging
 export namespace X {
 	export function f(): void {}

--- a/crates/rome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts.snap
@@ -88,6 +88,16 @@ declare namespace bodyParser {
 }
 declare const bodyParser: bodyParser.BodyParser
 
+namespace ConcreteNamespaceMergeVar {
+    export interface Foo {
+        foo: string
+    }
+}
+
+export const ConcreteNamespaceMergeVar = { foo: 'bar' }
+ConcreteNamespaceMergeVar.foo = 'baz'
+type Bar = ConcreteNamespaceMergeVar.Foo
+
 // namespace merging
 export namespace X {
 	export function f(): void {}

--- a/crates/rome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts.snap
+++ b/crates/rome_js_analyze/tests/specs/suspicious/noRedeclare/valid-declaration-merging.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_analyze/tests/spec_tests.rs
-assertion_line: 91
+assertion_line: 80
 expression: valid-declaration-merging.ts
 ---
 # Input
@@ -75,6 +75,18 @@ export enum Orientation {
 export namespace Orientation {
 	export function f(): void {}
 }
+
+// variable and namespace merging
+declare namespace bodyParser {
+	interface BodyParser {
+		/** @deprecated */
+		(): void
+	}
+	interface Options {
+		inflate?: boolean | undefined
+	}
+}
+declare const bodyParser: bodyParser.BodyParser
 
 // namespace merging
 export namespace X {

--- a/crates/rome_js_syntax/src/binding_ext.rs
+++ b/crates/rome_js_syntax/src/binding_ext.rs
@@ -135,6 +135,7 @@ impl AnyJsBindingDeclaration {
                 AnyJsBindingDeclaration::TsModuleDeclaration(_),
                 AnyJsBindingDeclaration::JsClassDeclaration(_)
                 | AnyJsBindingDeclaration::JsFunctionDeclaration(_)
+                | AnyJsBindingDeclaration::JsVariableDeclarator(_)
                 | AnyJsBindingDeclaration::TsDeclareFunctionDeclaration(_)
                 | AnyJsBindingDeclaration::TsEnumDeclaration(_)
                 | AnyJsBindingDeclaration::TsInterfaceDeclaration(_)


### PR DESCRIPTION
fixes #4771

Note: [`tsc` doesn't always allow merging namespaces and variables](https://github.com/microsoft/TypeScript/issues/55190#issuecomment-1684904258). Either way, checking this shouldn't fall under the linter - either it's a type error or it's a declaration merge, but it's never a shadow.