### PR TITLE
Fix "performance reason" typo

### DIFF
--- a/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -20,7 +20,7 @@ The configuration that is contained inside the file `rome.json`
                               working directory. If no current working directory can't be found, Rome
                               won't use the VCS integration, and a diagnostic will be emitted
         --files-max-size=NUMBER  The maximum allowed size for source code files in bytes. Files above
-                              this limit will be ignored for performance reason. Defaults to 1 MiB
+                              this limit will be ignored for performance reasons. Defaults to 1 MiB
         --files-ignore-unknown=<true|false>  Tells Rome to not emit diagnostics when handling files that
                               doesn't know
         --indent-style=<tab|space>  The indent style.

--- a/crates/rome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -21,7 +21,7 @@ The configuration that is contained inside the file `rome.json`
                               working directory. If no current working directory can't be found, Rome
                               won't use the VCS integration, and a diagnostic will be emitted
         --files-max-size=NUMBER  The maximum allowed size for source code files in bytes. Files above
-                              this limit will be ignored for performance reason. Defaults to 1 MiB
+                              this limit will be ignored for performance reasons. Defaults to 1 MiB
         --files-ignore-unknown=<true|false>  Tells Rome to not emit diagnostics when handling files that
                               doesn't know
         --indent-style=<tab|space>  The indent style.

--- a/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -27,7 +27,7 @@ Set of properties to integrate Rome with a VCS software.
 
 The configuration of the filesystem
         --files-max-size=NUMBER  The maximum allowed size for source code files in bytes. Files above
-                              this limit will be ignored for performance reason. Defaults to 1 MiB
+                              this limit will be ignored for performance reasons. Defaults to 1 MiB
         --files-ignore-unknown=<true|false>  Tells Rome to not emit diagnostics when handling files that
                               doesn't know
 

--- a/crates/rome_cli/tests/snapshots/main_commands_lint/check_help.snap
+++ b/crates/rome_cli/tests/snapshots/main_commands_lint/check_help.snap
@@ -20,7 +20,7 @@ The configuration that is contained inside the file `rome.json`
                               working directory. If no current working directory can't be found, Rome
                               won't use the VCS integration, and a diagnostic will be emitted
         --files-max-size=NUMBER  The maximum allowed size for source code files in bytes. Files above
-                              this limit will be ignored for performance reason. Defaults to 1 MiB
+                              this limit will be ignored for performance reasons. Defaults to 1 MiB
         --files-ignore-unknown=<true|false>  Tells Rome to not emit diagnostics when handling files that
                               doesn't know
         --indent-style=<tab|space>  The indent style.

--- a/crates/rome_service/src/configuration/mod.rs
+++ b/crates/rome_service/src/configuration/mod.rs
@@ -247,7 +247,7 @@ impl MergeWith<Option<JavascriptFormatter>> for Configuration {
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct FilesConfiguration {
     /// The maximum allowed size for source code files in bytes. Files above
-    /// this limit will be ignored for performance reason. Defaults to 1 MiB
+    /// this limit will be ignored for performance reasons. Defaults to 1 MiB
     #[bpaf(long("files-max-size"), argument("NUMBER"))]
     pub max_size: Option<NonZeroU64>,
 

--- a/editors/vscode/configuration_schema.json
+++ b/editors/vscode/configuration_schema.json
@@ -595,7 +595,7 @@
 					"type": ["boolean", "null"]
 				},
 				"maxSize": {
-					"description": "The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB",
+					"description": "The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB",
 					"default": null,
 					"type": ["integer", "null"],
 					"format": "uint64",

--- a/npm/backend-jsonrpc/src/workspace.ts
+++ b/npm/backend-jsonrpc/src/workspace.ts
@@ -74,7 +74,7 @@ export interface FilesConfiguration {
 	 */
 	ignoreUnknown?: boolean;
 	/**
-	 * The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB
+	 * The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB
 	 */
 	maxSize?: number;
 }

--- a/npm/rome/configuration_schema.json
+++ b/npm/rome/configuration_schema.json
@@ -595,7 +595,7 @@
 					"type": ["boolean", "null"]
 				},
 				"maxSize": {
-					"description": "The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB",
+					"description": "The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB",
 					"default": null,
 					"type": ["integer", "null"],
 					"format": "uint64",

--- a/website/src/pages/cli.md
+++ b/website/src/pages/cli.md
@@ -163,7 +163,7 @@ Run various checks on a set of files.
 
   If Rome can't find the configuration, it will attempt to use the current working directory. If no current working directory can't be found, Rome won't use the VCS integration, and a diagnostic will be emitted
 - **`    --files-max-size`**=_`NUMBER`_ &mdash; 
-  The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB
+  The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB
 - **`    --files-ignore-unknown`**=_`<true|false>`_ &mdash; 
   Tells Rome to not emit diagnostics when handling files that doesn't know
 - **`    --indent-style`**=_`<tab|space>`_ &mdash; 
@@ -248,7 +248,7 @@ Run various checks on a set of files.
 
   If Rome can't find the configuration, it will attempt to use the current working directory. If no current working directory can't be found, Rome won't use the VCS integration, and a diagnostic will be emitted
 - **`    --files-max-size`**=_`NUMBER`_ &mdash; 
-  The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB
+  The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB
 - **`    --files-ignore-unknown`**=_`<true|false>`_ &mdash; 
   Tells Rome to not emit diagnostics when handling files that doesn't know
 - **`    --indent-style`**=_`<tab|space>`_ &mdash; 
@@ -343,7 +343,7 @@ Run the formatter on a set of files.
 
 **The configuration of the filesystem**
 - **`    --files-max-size`**=_`NUMBER`_ &mdash; 
-  The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB
+  The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB
 - **`    --files-ignore-unknown`**=_`<true|false>`_ &mdash; 
   Tells Rome to not emit diagnostics when handling files that doesn't know
 
@@ -412,7 +412,7 @@ Command to use in CI environments. Run various checks of a set of files.
 
   If Rome can't find the configuration, it will attempt to use the current working directory. If no current working directory can't be found, Rome won't use the VCS integration, and a diagnostic will be emitted
 - **`    --files-max-size`**=_`NUMBER`_ &mdash; 
-  The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reason. Defaults to 1 MiB
+  The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB
 - **`    --files-ignore-unknown`**=_`<true|false>`_ &mdash; 
   Tells Rome to not emit diagnostics when handling files that doesn't know
 - **`    --indent-style`**=_`<tab|space>`_ &mdash; 

--- a/website/src/pages/configuration.mdx
+++ b/website/src/pages/configuration.mdx
@@ -96,7 +96,7 @@ If you have problems with resolving the physical file, you can use the one publi
 ### `files.maxSize`
 
 The maximum allowed size for source code files in bytes. Files above
-this limit will be ignored for performance reason.
+this limit will be ignored for performance reasons.
 
 > Default: 1024*1024 (1MB)
 

--- a/website/src/pages/formatter/index.mdx
+++ b/website/src/pages/formatter/index.mdx
@@ -58,7 +58,7 @@ Available options:
                        configuration, it will attempt to use the current working directory. If no
                        current working directory can't be found, Rome won't use the VCS integration.
         --files-max-size <NUMBER>  The maximum allowed size for source code files in bytes. Files
-                       above this limit will be ignored for performance reason. Defaults to 1 MiB
+                       above this limit will be ignored for performance reasons. Defaults to 1 MiB
         --stdin-file-path <PATH>  A file name with its extension to pass when reading from standard
                        in, e.g. echo 'let a;' | rome format --stdin-file-path=file.js"
         --colors <off|force>  Set the formatting mode for markup: "off" prints everything as plain

--- a/website/src/pages/linter/index.mdx
+++ b/website/src/pages/linter/index.mdx
@@ -42,7 +42,7 @@ Available options:
                         configuration, it will attempt to use the current working directory. If no
                         current working directory can't be found, Rome won't use the VCS integration.
         --files-max-size <NUMBER>  The maximum allowed size for source code files in bytes. Files
-                        above this limit will be ignored for performance reason. Defaults to 1 MiB
+                        above this limit will be ignored for performance reasons. Defaults to 1 MiB
         --indent-style <tab|space>  The indent style.
         --indent-size <NUMBER>  The size of the indentation, 2 by default
         --line-width <NUMBER>  What's the max width of a line. Defaults to 80.


### PR DESCRIPTION
## Summary

I saw a typo while reading the Rome docs website - I think. "For performance reason" seems like it ought to be "for performance reasons", so I replaced this everywhere it occurs.